### PR TITLE
Improve code org around getRawNavigationData

### DIFF
--- a/app/api/items/get-navigation-data.go
+++ b/app/api/items/get-navigation-data.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 
-	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
@@ -83,7 +82,7 @@ func (srv *Service) getNavigationData(rw http.ResponseWriter, httpReq *http.Requ
 	}
 
 	user := srv.getUser(httpReq)
-	rawData, err := srv.Store.Items().GetRawNavigationData(req.ID, user.UserID, user.DefaultLanguageID(), user)
+	rawData, err := getRawNavigationData(srv.Store, req.ID, user.UserID, user.DefaultLanguageID(), user)
 	if err != nil {
 		return service.ErrUnexpected(err)
 	}
@@ -95,7 +94,7 @@ func (srv *Service) getNavigationData(rw http.ResponseWriter, httpReq *http.Requ
 	response := navigationDataResponse{
 		srv.fillNavigationCommonFieldsWithDBData(&(*rawData)[0]),
 	}
-	idMap := map[int64]*database.RawNavigationItem{}
+	idMap := map[int64]*rawNavigationItem{}
 	for index := range *rawData {
 		idMap[(*rawData)[index].ID] = &(*rawData)[index]
 	}
@@ -106,8 +105,8 @@ func (srv *Service) getNavigationData(rw http.ResponseWriter, httpReq *http.Requ
 	return service.NoError
 }
 
-func (srv *Service) fillNavigationSubtreeWithChildren(rawData *[]database.RawNavigationItem,
-	idMap map[int64]*database.RawNavigationItem,
+func (srv *Service) fillNavigationSubtreeWithChildren(rawData *[]rawNavigationItem,
+	idMap map[int64]*rawNavigationItem,
 	idsToResponseData map[int64]*navigationItemCommonFields) {
 	for index, item := range *rawData {
 		if index == 0 {
@@ -132,9 +131,7 @@ func (srv *Service) fillNavigationSubtreeWithChildren(rawData *[]database.RawNav
 	}
 }
 
-func (srv *Service) fillNavigationCommonFieldsWithDBData(
-	  rawData *database.RawNavigationItem,
-	)*navigationItemCommonFields {
+func (srv *Service) fillNavigationCommonFieldsWithDBData(rawData *rawNavigationItem) *navigationItemCommonFields {
 	return &navigationItemCommonFields{
 		ID: rawData.ID,
 		Type: rawData.Type,

--- a/app/api/items/navigationDataMapper.go
+++ b/app/api/items/navigationDataMapper.go
@@ -1,0 +1,76 @@
+package items
+
+import (
+	"github.com/France-ioi/AlgoreaBackend/app/auth"
+	"github.com/France-ioi/AlgoreaBackend/app/database"
+)
+
+// rawNavigationItem represents one row of a navigation subtree returned from the DB
+type rawNavigationItem struct {
+	// items
+	ID                int64  `sql:"column:ID"`
+	Type              string `sql:"column:sType"`
+	TransparentFolder bool   `sql:"column:bTransparentFolder"`
+	// whether items.idItemUnlocked is empty
+	HasUnlockedItems bool `sql:"column:hasUnlockedItems"`
+	AccessRestricted bool `sql:"column:bAccessRestricted"`
+
+	// title (from items_strings) in the user’s default language or (if not available) default language of the item
+	Title string `sql:"column:sTitle"`
+
+	// from users_items for current user
+	UserScore               float32 `sql:"column:iScore"`
+	UserValidated           bool    `sql:"column:bValidated"`
+	UserFinished            bool    `sql:"column:bFinished"`
+	UserKeyObtained         bool    `sql:"column:bKeyObtained"`
+	UserSubmissionsAttempts int64   `sql:"column:nbSubmissionsAttempts"`
+	UserStartDate           string  `sql:"column:sStartDate"`      // iso8601 str
+	UserValidationDate      string  `sql:"column:sValidationDate"` // iso8601 str
+	UserFinishDate          string  `sql:"column:sFinishDate"`     // iso8601 str
+
+	// items_items
+	IDItemParent int64 `sql:"column:idItemParent"`
+	Order        int64 `sql:"column:iChildOrder"`
+
+	*database.ItemAccessDetails
+}
+
+// getRawNavigationData reads a navigation subtree from the DB and returns an array of rawNavigationItem's
+func getRawNavigationData(dataStore *database.DataStore, rootID int64, userID, userLanguageID int64, user *auth.User) (*[]rawNavigationItem, error) {
+	var result []rawNavigationItem
+	items := dataStore.Items()
+
+	// This query can be simplified if we add a column for relation degrees into `items_ancestors`
+
+	commonAttributes := "items.ID, items.sType, items.bTransparentFolder, items.idItemUnlocked, items.idDefaultLanguage, fullAccess, partialAccess, grayedAccess"
+	itemQ := items.VisibleByID(user, rootID).Select(commonAttributes + ", NULL AS idItemParent, NULL AS idItemGrandparent, NULL AS iChildOrder, NULL AS bAccessRestricted")
+	childrenQ := items.VisibleChildrenOfID(user, rootID).Select(commonAttributes + ",	idItemParent, NULL AS idItemGrandparent, iChildOrder, bAccessRestricted")
+	gChildrenQ := items.VisibleGrandChildrenOfID(user, rootID).Select(commonAttributes + ", ii1.idItemParent, ii2.idItemParent AS idItemGrandparent, ii1.iChildOrder, ii1.bAccessRestricted")
+	itemThreeGenQ := itemQ.Union(childrenQ.Query()).Union(gChildrenQ.Query())
+
+	query := dataStore.DB.Raw(`
+		SELECT union_table.ID, union_table.sType, union_table.bTransparentFolder,
+			COALESCE(union_table.idItemUnlocked, '')<>'' as hasUnlockedItems,
+			COALESCE(ustrings.sTitle, dstrings.sTitle) AS sTitle,
+			users_items.iScore AS iScore, users_items.bValidated AS bValidated,
+			users_items.bFinished AS bFinished, users_items.bKeyObtained AS bKeyObtained,
+			users_items.nbSubmissionsAttempts AS nbSubmissionsAttempts,
+			users_items.sStartDate AS sStartDate, users_items.sValidationDate AS sValidationDate,
+			users_items.sFinishDate AS sFinishDate,
+			union_table.iChildOrder AS iChildOrder,
+			union_table.bAccessRestricted,
+			union_table.idItemParent AS idItemParent,
+			union_table.fullAccess, union_table.partialAccess, union_table.grayedAccess
+		FROM ? union_table
+		LEFT JOIN users_items ON users_items.idItem=union_table.ID AND users_items.idUser=?
+		LEFT JOIN items_strings dstrings FORCE INDEX (idItem)
+			 ON dstrings.idItem=union_table.ID AND dstrings.idLanguage=union_table.idDefaultLanguage
+		LEFT JOIN items_strings ustrings ON ustrings.idItem=union_table.ID AND ustrings.idLanguage=?
+		ORDER BY idItemGrandparent, idItemParent, iChildOrder`,
+		itemThreeGenQ.SubQuery(), userID, userLanguageID)
+
+	if err := query.Scan(&result).Error(); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -22,6 +22,7 @@ type DB interface {
 	Where(query interface{}, args ...interface{}) DB
 	Joins(query string, args ...interface{}) DB
 	Group(query string) DB
+	Union(query interface{}) DB
 	Raw(query string, args ...interface{}) DB
 
 	Query() interface{}
@@ -99,6 +100,10 @@ func (conn *db) Select(query interface{}, args ...interface{}) DB {
 
 func (conn *db) Group(query string) DB {
 	return &db{conn.DB.Group(query)}
+}
+
+func (conn *db) Union(query interface{}) DB {
+	return &db{conn.DB.New().Raw("? UNION (?)", conn.DB.QueryExpr(), query)}
 }
 
 func (conn *db) Raw(query string, args ...interface{}) DB {

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -24,6 +24,7 @@ type DB interface {
 	Group(query string) DB
 	Raw(query string, args ...interface{}) DB
 
+	Query() interface{}
 	SubQuery() interface{}
 	Scan(dest interface{}) DB
 	Count(dest interface{}) DB
@@ -106,6 +107,10 @@ func (conn *db) Raw(query string, args ...interface{}) DB {
 
 func (conn *db) SubQuery() interface{} {
 	return conn.DB.SubQuery()
+}
+
+func (conn *db) Query() interface{} {
+	return conn.DB.QueryExpr()
 }
 
 func (conn *db) Scan(dest interface{}) DB {

--- a/app/database/itemStore.go
+++ b/app/database/itemStore.go
@@ -109,9 +109,10 @@ func (s *ItemStore) GetRawNavigationData(rootID int64, userID, userLanguageID in
 
 	// This query can be simplified if we add a column for relation degrees into `items_ancestors`
 
-	itemQ := s.visibleByID(user, rootID).Select("items.ID, items.sType, items.bTransparentFolder, items.idItemUnlocked, items.idDefaultLanguage, NULL AS idItemParent, NULL AS idItemGrandparent, NULL AS iChildOrder, NULL AS bAccessRestricted, fullAccess, partialAccess, grayedAccess")
-	childrenQ := s.visibleChildrenOfID(user, rootID).Select("items.ID, items.sType, items.bTransparentFolder, items.idItemUnlocked, items.idDefaultLanguage,	idItemParent, NULL AS idItemGrandparent, iChildOrder, bAccessRestricted, fullAccess, partialAccess, grayedAccess")
-	gChildrenQ := s.visibleGrandChildrenOfID(user, rootID).Select("items.ID, items.sType, items.bTransparentFolder, items.idItemUnlocked, items.idDefaultLanguage, ii1.idItemParent, ii2.idItemParent AS idItemGrandparent, ii1.iChildOrder, ii1.bAccessRestricted, fullAccess, partialAccess, grayedAccess")
+	commonAttributes := "items.ID, items.sType, items.bTransparentFolder, items.idItemUnlocked, items.idDefaultLanguage, fullAccess, partialAccess, grayedAccess"
+	itemQ := s.visibleByID(user, rootID).Select(commonAttributes + ", NULL AS idItemParent, NULL AS idItemGrandparent, NULL AS iChildOrder, NULL AS bAccessRestricted")
+	childrenQ := s.visibleChildrenOfID(user, rootID).Select(commonAttributes + ",	idItemParent, NULL AS idItemGrandparent, iChildOrder, bAccessRestricted")
+	gChildrenQ := s.visibleGrandChildrenOfID(user, rootID).Select(commonAttributes + ", ii1.idItemParent, ii2.idItemParent AS idItemGrandparent, ii1.iChildOrder, ii1.bAccessRestricted")
 
 	query := s.Raw(
 		`


### PR DESCRIPTION
Re-organize code around `getRawNavigationData`. Use composition and then move service-specific queries and mapping to a specific mapper file in the service package while keeping the service itself db-agnostic.

Let's try to merge that already.

Will be done in a separated PR: have tests on `Visible*(...)` functions on `ItemStore`