### PR TITLE
Change return type of DB.inTransaction() & DataStore.InTransaction()

### DIFF
--- a/app/api/items/add-item.go
+++ b/app/api/items/add-item.go
@@ -121,19 +121,20 @@ func (srv *Service) addItem(w http.ResponseWriter, r *http.Request) service.APIE
 func (srv *Service) insertItem(user *auth.User, input *NewItemRequest) error {
 	srv.Store.EnsureSetID(&input.ID.Int64)
 
-	return srv.Store.InTransaction(func(store *database.DataStore) error {
+	_, err := srv.Store.InTransaction(func(store *database.DataStore) (interface{}, error) {
 		var err error
 		if err = store.Items().Insert(input.itemData()); err != nil {
-			return err
+			return nil, err
 		}
 		if err = store.GroupItems().Insert(input.groupItemData(store.NewID(), user.UserID, user.SelfGroupID())); err != nil {
-			return err
+			return nil, err
 		}
 		if err = store.ItemStrings().Insert(input.stringData(store.NewID())); err != nil {
-			return err
+			return nil, err
 		}
-		return store.ItemItems().Insert(input.itemItemData(store.NewID()))
+		return nil, store.ItemItems().Insert(input.itemItemData(store.NewID()))
 	})
+	return err
 }
 
 func (srv *Service) checkPermission(user *auth.User, parentItemID int64) service.APIError {

--- a/app/database/dataStore.go
+++ b/app/database/dataStore.go
@@ -92,8 +92,8 @@ func (s *DataStore) EnsureSetID(id *types.Int64) {
 }
 
 // InTransaction executes the given function in a transaction and commits
-func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
-	return s.inTransaction(func(db *DB) error {
+func (s *DataStore) InTransaction(txFunc func(*DataStore) (interface{}, error)) (interface{}, error) {
+	return s.inTransaction(func(db *DB) (interface{}, error) {
 		return txFunc(NewDataStoreWithTable(db, s.tableName))
 	})
 }

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -38,10 +38,10 @@ func Open(dsnConfig string) (*DB, error) {
 	return newDB(dbConn), err
 }
 
-func (conn *DB) inTransaction(txFunc func(*DB) error) (err error) {
+func (conn *DB) inTransaction(txFunc func(*DB) (interface{}, error)) (result interface{}, err error) {
 	var txDB = conn.db.Begin()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if p := recover(); p != nil {
@@ -59,8 +59,8 @@ func (conn *DB) inTransaction(txFunc func(*DB) error) (err error) {
 			err = txDB.Error
 		}
 	}()
-	err = txFunc(newDB(txDB))
-	return err
+	result, err = txFunc(newDB(txDB))
+	return
 }
 
 // Close close current db connection.  If database connection is not an io.Closer, returns an error.


### PR DESCRIPTION
(error) -> (interface{}, error)