### PR TITLE
Logging reorg ++

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
       ALGOREA_DATABASE.CONNECTION.USER: alg_ci_user
       ALGOREA_DATABASE.CONNECTION.PASSWD: dummy_password
       ALGOREA_DATABASE.CONNECTION.DBNAME: ci_db
+      ALGOREA_LOGGING.FORMAT: json
+      ALGOREA_LOGGING.OUTPUT: file
+      ALGOREA_LOGGING.LOGSQLQUERIES: 1
+      ALGOREA_LOGGING.LEVEL: debug
     steps:
       - attach_workspace:
           at: ./
@@ -57,6 +61,8 @@ jobs:
       - store_test_results: &TESTPATH
           path: test-results
       - store_artifacts: *TESTPATH
+      - store_artifacts:
+          path: log
       - run:
           when: on_fail
           name: On failure, run BDD tests with details

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           at: ./
       - restore_cache: *CACHEKEYMOD
       - run: sudo apt-get install mysql-client # required for db-restore
+      - run: cp conf/config.sample.yaml conf/config.yaml # as env var are not loaded for entries not in config file (bug)
       - run:
           name: Wait for MySQL
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 30s

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Logs
 /log/*.log
+
+# Local config
+conf/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Tests artefacts
 /test-results
+
+# Logs
+/log/*.log

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ The application needs a database (MySQL) to run and requires it for a major part
 
 To make testing and development easier, a `docker-compose` file declares a database using the default configuration. Launch `docker-compose up` to run tests without any configuration efforts.
 
-## Database Configuration
+## Configuration
 
-Database configuration currently goes in `conf/default.yml` file or using environment variables (higher priority, see `.circleci/config.yml` for examples)
-The empty dump (schema with data in it) can be loaded using the `./bin/AlgoreaBackend db-restore` followed by `./bin/AlgoreaBackend db-migrate`.
+The app configuration stands in the `conf/config.yml` file. The file `conf/config.sample.yml` is a sample configuration to start from, it is configured to work with the `docker-compose` configuration for local development. All configuration parameter can be also defined using environment variables (with an higher priority), see `.circleci/config.yml` for examples.
+
+## Seeding the database
+
+An empty dump (schema without data) can be loaded using the `./bin/AlgoreaBackend db-restore` followed by `./bin/AlgoreaBackend db-migrate`.
 
 ## Testing
 

--- a/app/app.go
+++ b/app/app.go
@@ -11,7 +11,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/api"
 	"github.com/France-ioi/AlgoreaBackend/app/config"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
-	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 )
 
 // Application is the core state of the app
@@ -33,17 +33,15 @@ func New() (*Application, error) {
 	// Init the PRNG with current time
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	logger := logging.Logger
-
 	var db *database.DB
 	dbConfig := conf.Database.Connection.FormatDSN()
 	if db, err = database.Open(dbConfig); err != nil {
-		logger.WithField("module", "database").Error(err)
+		log.WithField("module", "database").Error(err)
 	}
 
 	var apiCtx *api.Ctx
 	if apiCtx, err = api.NewCtx(conf, db); err != nil {
-		logger.Error(err)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -56,7 +54,7 @@ func New() (*Application, error) {
 	router.Use(middleware.DefaultCompress)
 	router.Use(middleware.Timeout(time.Duration(conf.Timeout) * time.Second))
 
-	router.Use(logging.NewStructuredLogger(logger))
+	router.Use(log.NewStructuredLogger())
 	router.Use(render.SetContentType(render.ContentTypeJSON))
 
 	router.Use(corsConfig().Handler) // no need for CORS if served through the same domain

--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"log"
 	"math/rand"
 	"time"
 
@@ -34,8 +33,7 @@ func New() (*Application, error) {
 	// Init the PRNG with current time
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	logger := logging.New(conf.Logging)
-	log.SetOutput(logger.Writer()) // redirect the stdlib's log to our logger
+	logger := logging.Logger
 
 	var db *database.DB
 	dbConfig := conf.Database.Connection.FormatDSN()

--- a/app/auth/user.go
+++ b/app/auth/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
-	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 )
 
 // User represents the context around the authenticated user making the request
@@ -46,7 +46,7 @@ func (u *User) lazyLoadData() error {
 			Scan(u.data)
 		if err = db.Error(); err != nil {
 			u.data = nil
-			logging.Logger.Errorf("Unable to load user data: %s", db.Error())
+			log.Errorf("Unable to load user data: %s", db.Error())
 		}
 	}
 	return err

--- a/app/auth/user_test.go
+++ b/app/auth/user_test.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/sirupsen/logrus"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	assertlib "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
-	"github.com/France-ioi/AlgoreaBackend/app/logging"
 )
 
 type MockUserStore struct {
@@ -55,7 +53,6 @@ func TestSelfGroupID(t *testing.T) {
 
 func TestSelfGroupIDFail(t *testing.T) {
 	assert := assertlib.New(t)
-	logging.Logger = logrus.New() // fixme: should not be required to set it in tests
 
 	db, dbMock := database.NewDBMock()
 	userStore := database.NewDataStore(db).Users()

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -51,7 +51,7 @@ type Root struct {
 }
 
 var (
-	configName = "default"
+	configName = "config"
 	configDir  = configDirectory()
 )
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -29,10 +29,10 @@ type ReverseProxy struct {
 
 // Logging for all config related to logger
 type Logging struct {
-	TextLogging bool // true: text, false: json
-	LogLevel    string
-	SQLLogLevel int
-	LogSQL      bool
+	Format        string
+	Output        string
+	Level         string
+	LogSQLQueries bool
 }
 
 // Auth is the part of the config related to the user authentication
@@ -99,6 +99,12 @@ func setDefaults() {
 	viper.SetDefault("server.readTimeout", 60)  // in seconds
 	viper.SetDefault("server.writeTimeout", 60) // in seconds
 	viper.SetDefault("server.rootpath", "/")
+
+	// logging
+	viper.SetDefault("logging.format", "json")
+	viper.SetDefault("logging.output", "file")
+	viper.SetDefault("logging.level", "info")
+	viper.SetDefault("logging.logSqlQueries", true)
 }
 
 func configDirectory() string {

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 
-	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/types"
 )
 
@@ -31,9 +31,7 @@ func Open(dsnConfig string) (*DB, error) {
 	dbConn.LogMode(true)
 
 	// setup logging
-	if logging.Logger != nil {
-		dbConn.SetLogger(logging.Logger.WithField("module", "database"))
-	}
+	dbConn.SetLogger(log.WithField("module", "database")) // actually this is wrong, but for a transition
 
 	return newDB(dbConn), err
 }

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 
-	log "github.com/France-ioi/AlgoreaBackend/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/types"
 )
 
@@ -29,10 +29,9 @@ func Open(source interface{}) (*DB, error) {
 	var dbConn *gorm.DB
 	var driverName = "mysql"
 	dbConn, err = gorm.Open(driverName, source)
-	dbConn.LogMode(true)
-
-	// setup logging
-	dbConn.SetLogger(log.WithField("module", "database")) // actually this is wrong, but for a transition
+	dbLogger, logMode := logging.NewDBLogger()
+	dbConn.LogMode(logMode)
+	dbConn.SetLogger(dbLogger)
 
 	return newDB(dbConn), err
 }

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -23,11 +23,12 @@ func newDB(db *gorm.DB) *DB {
 
 // Open connects to the database and tests the connection
 // nolint: gosec
-func Open(dsnConfig string) (*DB, error) {
+func Open(source interface{}) (*DB, error) {
+
 	var err error
 	var dbConn *gorm.DB
 	var driverName = "mysql"
-	dbConn, err = gorm.Open(driverName, dsnConfig)
+	dbConn, err = gorm.Open(driverName, source)
 	dbConn.LogMode(true)
 
 	// setup logging

--- a/app/database/itemStore.go
+++ b/app/database/itemStore.go
@@ -3,7 +3,7 @@ package database
 import (
 	"fmt"
 
-	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/types"
 )
 
@@ -298,13 +298,13 @@ func (s *ItemStore) IsValidHierarchy(ids []int64) (bool, error) {
 func (s *ItemStore) ValidateUserAccess(user AuthUser, itemIDs []int64) (bool, error) {
 	accessDetails, err := s.GetAccessDetailsForIDs(user, itemIDs)
 	if err != nil {
-		logging.Logger.Infof("User access rights loading failed: %v", err)
+		log.Infof("User access rights loading failed: %v", err)
 		return false, err
 	}
 
 	if err := checkAccess(itemIDs, accessDetails); err != nil {
-		logging.Logger.Infof("checkAccess %v %v", itemIDs, accessDetails)
-		logging.Logger.Infof("User access validation failed: %v", err)
+		log.Infof("checkAccess %v %v", itemIDs, accessDetails)
+		log.Infof("User access validation failed: %v", err)
 		return false, nil
 	}
 	return true, nil

--- a/app/database/mockDB.go
+++ b/app/database/mockDB.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/jinzhu/gorm"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
 // NewDBMock generate a DB mock the database engine
@@ -16,11 +15,11 @@ func NewDBMock() (*DB, sqlmock.Sqlmock) {
 		os.Exit(1)
 	}
 
-	dbConn, err := gorm.Open("mysql", dbMock)
+	db, err := Open(dbMock)
 	if err != nil {
 		fmt.Println("Unable to create the gorm connection to the mock: ", err)
 		os.Exit(1)
 	}
 
-	return newDB(dbConn), mock
+	return db, mock
 }

--- a/app/logging/dbLogger.go
+++ b/app/logging/dbLogger.go
@@ -1,9 +1,6 @@
 package logging
 
 import (
-	"log"
-	"os"
-
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 
@@ -30,9 +27,13 @@ func NewDBLogger() (DBLogger, bool) {
 }
 
 func loggerFromConfig(conf config.Logging, logger *logrus.Logger) (DBLogger, bool) {
-	logMode := conf.LogSQL
-	if conf.TextLogging {
-		return gorm.Logger{LogWriter: log.New(os.Stdout, "\r\n", 0)}, logMode
+	logMode := conf.LogSQLQueries
+	switch conf.Format {
+	case "text":
+		return gorm.Logger{LogWriter: logger}, logMode
+	case "json":
+		return NewStructuredDBLogger(logger), logMode
+	default:
+		panic("Logging format must be either 'text' or 'json'. Got: " + conf.Format)
 	}
-	return NewStructuredDBLogger(logger), logMode
 }

--- a/app/logging/dbLogger.go
+++ b/app/logging/dbLogger.go
@@ -1,0 +1,38 @@
+package logging
+
+import (
+	"log"
+	"os"
+
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+
+	"github.com/France-ioi/AlgoreaBackend/app/config"
+)
+
+// DBLogger is the logger interface for the DB logs
+type DBLogger interface {
+	Print(v ...interface{})
+}
+
+// NewDBLogger returns a logger for the database and the `logmode`, according to the config
+func NewDBLogger() (DBLogger, bool) {
+	var (
+		err  error
+		conf *config.Root
+	)
+
+	if conf, err = config.Load(); err != nil {
+		// if cannot parse config, log on error to stdout
+		return gorm.Logger{LogWriter: Logger}, false
+	}
+	return loggerFromConfig(conf.Logging, Logger)
+}
+
+func loggerFromConfig(conf config.Logging, logger *logrus.Logger) (DBLogger, bool) {
+	logMode := conf.LogSQL
+	if conf.TextLogging {
+		return gorm.Logger{LogWriter: log.New(os.Stdout, "\r\n", 0)}, logMode
+	}
+	return NewStructuredDBLogger(logger), logMode
+}

--- a/app/logging/dbLogger_test.go
+++ b/app/logging/dbLogger_test.go
@@ -30,7 +30,8 @@ func TestLoggerFromConfig_TextLog(t *testing.T) {
 	assert := assertlib.New(t)
 	logger := logrus.New()
 	config := config.Logging{
-		TextLogging: true,
+		Format: "text",
+		Output: "file",
 	}
 	dbLogger, _ := loggerFromConfig(config, logger)
 	assert.IsType(gorm.Logger{}, dbLogger)
@@ -40,17 +41,30 @@ func TestLoggerFromConfig_JSONLog(t *testing.T) {
 	assert := assertlib.New(t)
 	logger := logrus.New()
 	config := config.Logging{
-		TextLogging: false,
+		Format: "json",
+		Output: "file",
 	}
 	dbLogger, _ := loggerFromConfig(config, logger)
 	assert.IsType(&StructuredDBLogger{}, dbLogger)
+}
+
+func TestLoggerFromConfig_WrongFormat(t *testing.T) {
+	assert := assertlib.New(t)
+	logger := logrus.New()
+	config := config.Logging{
+		Format: "yml",
+		Output: "file",
+	}
+	assert.Panics(func() { loggerFromConfig(config, logger) })
 }
 
 func TestLoggerFromConfig_WithoutSQL(t *testing.T) {
 	assert := assertlib.New(t)
 	logger := logrus.New()
 	config := config.Logging{
-		LogSQL: false,
+		LogSQLQueries: false,
+		Format:        "text",
+		Output:        "file",
 	}
 	_, logMode := loggerFromConfig(config, logger)
 	assert.False(logMode)
@@ -60,7 +74,9 @@ func TestLoggerFromConfig_WithSQL(t *testing.T) {
 	assert := assertlib.New(t)
 	logger := logrus.New()
 	config := config.Logging{
-		LogSQL: true,
+		LogSQLQueries: true,
+		Format:        "text",
+		Output:        "file",
 	}
 	_, logMode := loggerFromConfig(config, logger)
 	assert.True(logMode)

--- a/app/logging/dbLogger_test.go
+++ b/app/logging/dbLogger_test.go
@@ -1,0 +1,67 @@
+package logging
+
+import (
+	"errors"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+	assertlib "github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/config"
+)
+
+func TestNewDBLogger_ErrorFallback(t *testing.T) {
+	assert := assertlib.New(t)
+
+	fakeFunc := func() (*config.Root, error) {
+		return nil, errors.New("config loading error")
+	}
+	patch := monkey.Patch(config.Load, fakeFunc)
+	defer patch.Unpatch()
+
+	dbLogger, logMode := NewDBLogger()
+	assert.IsType(gorm.Logger{}, dbLogger)
+	assert.Equal(false, logMode)
+}
+
+func TestLoggerFromConfig_TextLog(t *testing.T) {
+	assert := assertlib.New(t)
+	logger := logrus.New()
+	config := config.Logging{
+		TextLogging: true,
+	}
+	dbLogger, _ := loggerFromConfig(config, logger)
+	assert.IsType(gorm.Logger{}, dbLogger)
+}
+
+func TestLoggerFromConfig_JSONLog(t *testing.T) {
+	assert := assertlib.New(t)
+	logger := logrus.New()
+	config := config.Logging{
+		TextLogging: false,
+	}
+	dbLogger, _ := loggerFromConfig(config, logger)
+	assert.IsType(&StructuredDBLogger{}, dbLogger)
+}
+
+func TestLoggerFromConfig_WithoutSQL(t *testing.T) {
+	assert := assertlib.New(t)
+	logger := logrus.New()
+	config := config.Logging{
+		LogSQL: false,
+	}
+	_, logMode := loggerFromConfig(config, logger)
+	assert.False(logMode)
+}
+
+func TestLoggerFromConfig_WithSQL(t *testing.T) {
+	assert := assertlib.New(t)
+	logger := logrus.New()
+	config := config.Logging{
+		LogSQL: true,
+	}
+	_, logMode := loggerFromConfig(config, logger)
+	assert.True(logMode)
+}

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -2,6 +2,9 @@ package logging
 
 import (
 	"log"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 
@@ -26,22 +29,40 @@ func new() *logrus.Logger {
 
 func configureLogger(logger *logrus.Logger, conf config.Logging) {
 
-	if conf.TextLogging {
-		logger.Formatter = &logrus.TextFormatter{
-			DisableTimestamp: true,
-		}
-	} else {
-		logger.Formatter = &logrus.JSONFormatter{}
+	// Format
+	switch conf.Format {
+	case "text":
+		logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	case "json":
+		logger.SetFormatter(&logrus.JSONFormatter{})
+	default:
+		panic("Logging format must be either 'text' or 'json'. Got: " + conf.Format)
 	}
 
-	level := conf.LogLevel
-	if level == "" {
-		level = "error"
+	// Output
+	switch conf.Output {
+	case "stdout":
+		logger.SetOutput(os.Stdout)
+	case "stderr":
+		logger.SetOutput(os.Stderr)
+	case "file":
+		_, codeFilePath, _, _ := runtime.Caller(0)
+		codeDir := filepath.Dir(codeFilePath)
+		f, err := os.OpenFile(codeDir+"/../../log/all.log", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+		if err != nil {
+			logger.SetOutput(os.Stdout)
+			logger.Errorf("Unable to open file for logs, fallback to stdout: %v\n", err)
+		} else {
+			logger.SetOutput(f)
+		}
+	default:
+		panic("Logging output must be either 'stdout', 'stderr' or 'file'. Got: " + conf.Output)
 	}
-	l, err := logrus.ParseLevel(level)
-	if err != nil {
-		panic(err)
+
+	// Level
+	if level, err := logrus.ParseLevel(conf.Level); err != nil {
+		logger.Errorf("Unable to parse logging level config, use default (%s)", logger.GetLevel().String())
 	} else {
-		logger.Level = l
+		logger.SetLevel(level)
 	}
 }

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -1,34 +1,8 @@
 package logging
 
-// MIT License
-
-// Copyright (c) 2017 Dikton Haxhijaj
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 import (
-	"fmt"
 	"log"
-	"net/http"
-	"time"
 
-	"github.com/go-chi/chi/middleware"
 	"github.com/sirupsen/logrus"
 
 	"github.com/France-ioi/AlgoreaBackend/app/config"
@@ -38,11 +12,6 @@ var (
 	// Logger is a configured logrus.Logger.
 	Logger *logrus.Logger
 )
-
-// StructuredLogger is a structured logrus Logger.
-type StructuredLogger struct {
-	Logger *logrus.Logger
-}
 
 // New creates and configures a new logrus Logger.
 func New(conf config.Logging) *logrus.Logger {
@@ -68,90 +37,4 @@ func New(conf config.Logging) *logrus.Logger {
 	}
 	Logger.Level = l
 	return Logger
-}
-
-// NewStructuredLogger implements a custom structured logrus Logger.
-func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
-	return middleware.RequestLogger(&StructuredLogger{logger})
-}
-
-// NewLogEntry sets default request log fields.
-func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &StructuredLoggerEntry{Logger: logrus.NewEntry(l.Logger)}
-	logFields := logrus.Fields{}
-
-	logFields["ts"] = time.Now().UTC().Format(time.RFC1123)
-
-	if reqID := middleware.GetReqID(r.Context()); reqID != "" {
-		logFields["req_id"] = reqID
-	}
-
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-
-	logFields["http_scheme"] = scheme
-	logFields["http_proto"] = r.Proto
-	logFields["http_method"] = r.Method
-
-	logFields["remote_addr"] = r.RemoteAddr
-	logFields["user_agent"] = r.UserAgent()
-
-	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
-
-	entry.Logger = entry.Logger.WithFields(logFields)
-
-	entry.Logger.Infoln("request started")
-
-	return entry
-}
-
-// StructuredLoggerEntry is a logrus.FieldLogger.
-type StructuredLoggerEntry struct {
-	Logger logrus.FieldLogger
-}
-
-func (l *StructuredLoggerEntry) Write(status, bytes int, elapsed time.Duration) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"resp_status":       status,
-		"resp_bytes_length": bytes,
-		"resp_elapsed_ms":   float64(elapsed.Nanoseconds()) / 1000000.0,
-	})
-
-	l.Logger.Infoln("request complete")
-}
-
-// Panic prints stack trace
-func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"stack": string(stack),
-		"panic": fmt.Sprintf("%+v", v),
-	})
-}
-
-// Helper methods used by the application to get the request-scoped
-// logger entry and set additional fields between handlers.
-
-// GetLogEntry return the request scoped logrus.FieldLogger.
-//noinspection GoUnusedExportedFunction
-func GetLogEntry(r *http.Request) logrus.FieldLogger {
-	entry := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
-	return entry.Logger
-}
-
-// LogEntrySetField adds a field to the request scoped logrus.FieldLogger.
-//noinspection GoUnusedExportedFunction
-func LogEntrySetField(r *http.Request, key string, value interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithField(key, value)
-	}
-}
-
-// LogEntrySetFields adds multiple fields to the request scoped logrus.FieldLogger.
-//noinspection GoUnusedExportedFunction
-func LogEntrySetFields(r *http.Request, fields map[string]interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithFields(fields)
-	}
 }

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -32,7 +32,7 @@ func configureLogger(logger *logrus.Logger, conf config.Logging) {
 	// Format
 	switch conf.Format {
 	case "text":
-		logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+		logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true, ForceColors: conf.Output != "file"})
 	case "json":
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	default:

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	// Logger is the actual logrus logger which is used
+	// Logger is the global logger
+	// It should not be used directly by app which should prefer shorthands functions
 	Logger = new()
 )
 

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -1,8 +1,14 @@
 package logging
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
+	"bou.ke/monkey"
 	"github.com/sirupsen/logrus"
 	assertlib "github.com/stretchr/testify/assert"
 
@@ -15,53 +21,142 @@ func TestNew(t *testing.T) {
 	assert.NotNil(new())
 }
 
-func TestConfigureLoggerText(t *testing.T) {
+func TestConfigureLogger_FormatText(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
-		TextLogging: true,
+		Format: "text",
+		Output: "file",
 	}
 	logger := logrus.New()
 	configureLogger(logger, conf)
 	assert.IsType(&logrus.TextFormatter{}, logger.Formatter)
 }
 
-func TestConfigureLoggerJson(t *testing.T) {
+func TestConfigureLogger_FormatJson(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
-		TextLogging: false,
+		Format: "json",
+		Output: "file",
 	}
 	logger := logrus.New()
 	configureLogger(logger, conf)
 	assert.IsType(&logrus.JSONFormatter{}, logger.Formatter)
 }
 
-func TestConfigureLoggerDefaultLevel(t *testing.T) {
+func TestConfigureLogger_FormatInvalid(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
-		LogLevel: "",
+		Format: "yml",
+		Output: "file",
+	}
+	logger := logrus.New()
+	assert.Panics(func() { configureLogger(logger, conf) })
+}
+
+func TestConfigureLogger_OutputStdout(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Format: "json",
+		Output: "stdout",
 	}
 	logger := logrus.New()
 	configureLogger(logger, conf)
-	assert.Equal(logrus.ErrorLevel, logger.Level)
+	assert.Equal(os.Stdout, logger.Out)
 }
 
-func TestConfigureLoggerParsedLevel(t *testing.T) {
+func TestConfigureLogger_OutputStderr(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
-		LogLevel: "warn",
+		Format: "json",
+		Output: "stderr",
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.Equal(os.Stderr, logger.Out)
+}
+
+func TestConfigureLogger_OutputFile(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Format: "json",
+		Output: "file",
+	}
+	// will append time to make sure not to match a prev exec of the test
+	timestamp := time.Now().UnixNano()
+
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	logger.Errorf("logexec1 %d", timestamp)
+
+	// redo another init to check it will not override
+	logger2 := logrus.New()
+	configureLogger(logger2, conf)
+	logger2.Warnf("logexec2 %d", timestamp)
+
+	// check the resulting file
+	content, _ := ioutil.ReadFile("../../log/all.log")
+	assert.Contains(string(content), fmt.Sprintf("logexec1 %d", timestamp))
+	assert.Contains(string(content), fmt.Sprintf("logexec2 %d", timestamp))
+}
+
+func TestConfigureLogger_OutputFileError(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Format: "json",
+		Output: "file",
+	}
+	fakeFunc := func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return nil, errors.New("open error")
+	}
+	patch := monkey.Patch(os.OpenFile, fakeFunc)
+	defer patch.Unpatch()
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.Equal(os.Stdout, logger.Out)
+}
+
+func TestConfigureLogger_OutputInvalid(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Format: "json",
+		Output: "S3",
+	}
+	logger := logrus.New()
+	assert.Panics(func() { configureLogger(logger, conf) })
+}
+
+func TestConfigureLogger_LevelDefault(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Level:  "",
+		Format: "text",
+		Output: "file",
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.Equal(logrus.InfoLevel, logger.Level)
+}
+
+func TestConfigureLogger_LevelParsed(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		Level:  "warn",
+		Format: "text",
+		Output: "file",
 	}
 	logger := logrus.New()
 	configureLogger(logger, conf)
 	assert.Equal(logrus.WarnLevel, logger.Level)
 }
 
-func TestConfigureLoggerInvalidLevel(t *testing.T) {
+func TestConfigureLogger_LevelInvalid(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
-		LogLevel: "invalid_level",
+		Level:  "invalid_level",
+		Format: "text",
+		Output: "file",
 	}
 	logger := logrus.New()
-	assert.Panics(func() {
-		configureLogger(logger, conf)
-	})
+	configureLogger(logger, conf)
+	assert.Equal(logrus.InfoLevel, logger.Level)
 }

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -1,0 +1,67 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	assertlib "github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/config"
+)
+
+func TestNew(t *testing.T) {
+	assert := assertlib.New(t)
+	// just verify it can load the config
+	assert.NotNil(new())
+}
+
+func TestConfigureLoggerText(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		TextLogging: true,
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.IsType(&logrus.TextFormatter{}, logger.Formatter)
+}
+
+func TestConfigureLoggerJson(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		TextLogging: false,
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.IsType(&logrus.JSONFormatter{}, logger.Formatter)
+}
+
+func TestConfigureLoggerDefaultLevel(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		LogLevel: "",
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.Equal(logrus.ErrorLevel, logger.Level)
+}
+
+func TestConfigureLoggerParsedLevel(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		LogLevel: "warn",
+	}
+	logger := logrus.New()
+	configureLogger(logger, conf)
+	assert.Equal(logrus.WarnLevel, logger.Level)
+}
+
+func TestConfigureLoggerInvalidLevel(t *testing.T) {
+	assert := assertlib.New(t)
+	conf := config.Logging{
+		LogLevel: "invalid_level",
+	}
+	logger := logrus.New()
+	assert.Panics(func() {
+		configureLogger(logger, conf)
+	})
+}

--- a/app/logging/middleware.go
+++ b/app/logging/middleware.go
@@ -1,0 +1,126 @@
+package logging
+
+// Code inspired by https://github.com/dhax/go-base/ under MIT Licence:
+//
+// MIT License
+//
+// Copyright (c) 2017 Dikton Haxhijaj
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/middleware"
+	"github.com/sirupsen/logrus"
+)
+
+// StructuredLogger is a structured logrus Logger.
+type StructuredLogger struct {
+	*logrus.Logger
+}
+
+// NewStructuredLogger implements a custom structured logrus Logger.
+func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
+	return middleware.RequestLogger(&StructuredLogger{logger})
+}
+
+// NewLogEntry sets default request log fields.
+func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
+	entry := &StructuredLoggerEntry{Logger: logrus.NewEntry(l.Logger)}
+	logFields := logrus.Fields{}
+
+	logFields["type"] = "web"
+	logFields["ts"] = time.Now().UTC().Format(time.RFC1123)
+
+	if reqID := middleware.GetReqID(r.Context()); reqID != "" {
+		logFields["req_id"] = reqID
+	}
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	logFields["http_scheme"] = scheme
+	logFields["http_proto"] = r.Proto
+	logFields["http_method"] = r.Method
+
+	logFields["remote_addr"] = r.RemoteAddr
+	logFields["user_agent"] = r.UserAgent()
+
+	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+
+	entry.Logger = entry.Logger.WithFields(logFields)
+
+	entry.Logger.Infoln("request started")
+
+	return entry
+}
+
+// StructuredLoggerEntry is a logrus.FieldLogger.
+type StructuredLoggerEntry struct {
+	Logger logrus.FieldLogger
+}
+
+func (l *StructuredLoggerEntry) Write(status, bytes int, elapsed time.Duration) {
+	l.Logger = l.Logger.WithFields(logrus.Fields{
+		"resp_status":       status,
+		"resp_bytes_length": bytes,
+		"resp_elapsed_ms":   float64(elapsed.Nanoseconds()) / 1000000.0,
+	})
+
+	l.Logger.Infoln("request complete")
+}
+
+// Panic prints stack trace
+func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
+	l.Logger = l.Logger.WithFields(logrus.Fields{
+		"stack": string(stack),
+		"panic": fmt.Sprintf("%+v", v),
+	})
+}
+
+// Helper methods used by the application to get the request-scoped
+// logger entry and set additional fields between handlers.
+
+// GetLogEntry return the request scoped logrus.FieldLogger.
+//noinspection GoUnusedExportedFunction
+func GetLogEntry(r *http.Request) logrus.FieldLogger {
+	entry := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
+	return entry.Logger
+}
+
+// LogEntrySetField adds a field to the request scoped logrus.FieldLogger.
+//noinspection GoUnusedExportedFunction
+func LogEntrySetField(r *http.Request, key string, value interface{}) {
+	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
+		entry.Logger = entry.Logger.WithField(key, value)
+	}
+}
+
+// LogEntrySetFields adds multiple fields to the request scoped logrus.FieldLogger.
+//noinspection GoUnusedExportedFunction
+func LogEntrySetFields(r *http.Request, fields map[string]interface{}) {
+	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
+		entry.Logger = entry.Logger.WithFields(fields)
+	}
+}

--- a/app/logging/middleware.go
+++ b/app/logging/middleware.go
@@ -40,11 +40,7 @@ type StructuredLogger struct {
 
 // NewStructuredLogger implements a custom structured logger using the global one.
 func NewStructuredLogger() func(next http.Handler) http.Handler {
-	return structuredLoggerMiddleware(Logger)
-}
-
-func structuredLoggerMiddleware(logger *logrus.Logger) func(next http.Handler) http.Handler {
-	return middleware.RequestLogger(&StructuredLogger{logger})
+	return middleware.RequestLogger(&StructuredLogger{Logger})
 }
 
 // NewLogEntry sets default request log fields.

--- a/app/logging/middleware.go
+++ b/app/logging/middleware.go
@@ -38,8 +38,12 @@ type StructuredLogger struct {
 	*logrus.Logger
 }
 
-// NewStructuredLogger implements a custom structured logrus Logger.
-func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
+// NewStructuredLogger implements a custom structured logger using the global one.
+func NewStructuredLogger() func(next http.Handler) http.Handler {
+	return structuredLoggerMiddleware(Logger)
+}
+
+func structuredLoggerMiddleware(logger *logrus.Logger) func(next http.Handler) http.Handler {
 	return middleware.RequestLogger(&StructuredLogger{logger})
 }
 

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -79,7 +79,7 @@ func doRequest(logger *logrus.Logger, forcePanic bool) {
 	// calling web server
 	mainRequest, _ := http.NewRequest("GET", mainSrv.URL+"/a_path", nil)
 	client := mainSrv.Client()
-	client.Do(mainRequest)
+	_, _ = client.Do(mainRequest)
 }
 
 func checkCommon(assert *assertlib.Assertions, entryData logrus.Fields) {

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -1,0 +1,95 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/middleware"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	assertlib "github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware_Success(t *testing.T) {
+	assert := assertlib.New(t)
+	logger, hook := test.NewNullLogger()
+
+	doRequest(logger, false)
+
+	assert.Len(hook.AllEntries(), 3)
+
+	// First entry: request started
+	entryData := hook.AllEntries()[0].Data
+	checkCommon(assert, entryData)
+	assert.Equal("request started", hook.AllEntries()[0].Message)
+
+	// Second entry: in-service message
+	entryData = hook.AllEntries()[1].Data
+	checkCommon(assert, entryData)
+	assert.Equal("in service log", hook.AllEntries()[1].Message)
+	assert.Equal(42, entryData["my_key"])
+	assert.Equal(1, entryData["opt_one"])
+	assert.Equal("bar", entryData["foo"])
+
+	// Third entry: request complete
+	entryData = hook.AllEntries()[2].Data
+	checkCommon(assert, entryData)
+	assert.Equal("request complete", hook.AllEntries()[2].Message)
+	assert.Equal(10, entryData["resp_bytes_length"])
+	assert.True(entryData["resp_elapsed_ms"].(float64) < 0.5, "Expected <0.5s, got: %f", entryData["resp_elapsed_ms"].(float64))
+	assert.Equal(200, entryData["resp_status"])
+}
+
+func TestMiddleware_Panic(t *testing.T) {
+	assert := assertlib.New(t)
+	logger, hook := test.NewNullLogger()
+
+	doRequest(logger, true)
+
+	assert.Len(hook.AllEntries(), 3)
+
+	// Third entry: panic
+	entryData := hook.LastEntry().Data
+	checkCommon(assert, entryData)
+	assert.NotNil(entryData["stack"])
+	assert.Equal("my panic msg", entryData["panic"])
+}
+
+func doRequest(logger *logrus.Logger, forcePanic bool) {
+	// setting up the server with 1 service and using the logger middleware
+	loggerMiddleware := NewStructuredLogger(logger)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		LogEntrySetField(r, "my_key", 42)
+		LogEntrySetFields(r, map[string]interface{}{"opt_one": 1, "foo": "bar"})
+		GetLogEntry(r).Print("in service log")
+		if forcePanic {
+			panic("my panic msg")
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("dummy body"))
+		}
+	})
+	// use the chi `Recoverer` middleware to catch panic and log it
+	// use the chi `RequestID` middleware to include request id in it (appear in logs)
+	// The order of the middlewares is crucial!
+	mainSrv := httptest.NewTLSServer(middleware.RequestID(loggerMiddleware(middleware.Recoverer(handler))))
+	defer mainSrv.Close()
+
+	// calling web server
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL+"/a_path", nil)
+	client := mainSrv.Client()
+	client.Do(mainRequest)
+}
+
+func checkCommon(assert *assertlib.Assertions, entryData logrus.Fields) {
+	assert.NotNil(entryData["ts"])
+	assert.Equal("web", entryData["type"])
+	assert.Equal("https", entryData["http_scheme"])
+	assert.Equal("HTTP/1.1", entryData["http_proto"])
+	assert.Equal("GET", entryData["http_method"])
+	assert.Regexp("^127.0.0.1:", entryData["remote_addr"].(string))
+	assert.Equal("Go-http-client/1.1", entryData["user_agent"])
+	assert.Regexp("^https://127.0.0.1:\\d*/a_path$", entryData["uri"].(string))
+	assert.NotNil(entryData["req_id"])
+}

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -13,9 +13,10 @@ import (
 
 func TestMiddleware_Success(t *testing.T) {
 	assert := assertlib.New(t)
-	logger, hook := test.NewNullLogger()
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger()
 
-	doRequest(logger, false)
+	doRequest(false)
 
 	assert.Len(hook.AllEntries(), 3)
 
@@ -43,9 +44,10 @@ func TestMiddleware_Success(t *testing.T) {
 
 func TestMiddleware_Panic(t *testing.T) {
 	assert := assertlib.New(t)
-	logger, hook := test.NewNullLogger()
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger()
 
-	doRequest(logger, true)
+	doRequest(true)
 
 	assert.Len(hook.AllEntries(), 3)
 
@@ -56,9 +58,9 @@ func TestMiddleware_Panic(t *testing.T) {
 	assert.Equal("my panic msg", entryData["panic"])
 }
 
-func doRequest(logger *logrus.Logger, forcePanic bool) {
+func doRequest(forcePanic bool) {
 	// setting up the server with 1 service and using the logger middleware
-	loggerMiddleware := structuredLoggerMiddleware(logger)
+	loggerMiddleware := NewStructuredLogger()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		LogEntrySetField(r, "my_key", 42)
 		LogEntrySetFields(r, map[string]interface{}{"opt_one": 1, "foo": "bar"})

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -58,7 +58,7 @@ func TestMiddleware_Panic(t *testing.T) {
 
 func doRequest(logger *logrus.Logger, forcePanic bool) {
 	// setting up the server with 1 service and using the logger middleware
-	loggerMiddleware := NewStructuredLogger(logger)
+	loggerMiddleware := structuredLoggerMiddleware(logger)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		LogEntrySetField(r, "my_key", 42)
 		LogEntrySetFields(r, map[string]interface{}{"opt_one": 1, "foo": "bar"})

--- a/app/logging/shorthands.go
+++ b/app/logging/shorthands.go
@@ -1,0 +1,82 @@
+package logging
+
+import "github.com/sirupsen/logrus"
+
+// Debug logs a message at level Debug on the standard Logger.
+func Debug(args ...interface{}) {
+	Logger.Debug(args...)
+}
+
+// Info logs a message at level Info on the standard Logger.
+func Info(args ...interface{}) {
+	Logger.Info(args...)
+}
+
+// Warn logs a message at level Warn on the standard Logger.
+func Warn(args ...interface{}) {
+	Logger.Warn(args...)
+}
+
+// Error logs a message at level Error on the standard Logger.
+func Error(args ...interface{}) {
+	Logger.Error(args...)
+}
+
+// Fatal logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
+func Fatal(args ...interface{}) {
+	Logger.Fatal(args...)
+}
+
+// Panic logs a message at level Panic on the standard Logger.
+func Panic(args ...interface{}) {
+	Logger.Panic(args...)
+}
+
+// Debugf logs a message at level Debug on the standard Logger.
+func Debugf(format string, args ...interface{}) {
+	Logger.Debugf(format, args...)
+}
+
+// Infof logs a message at level Info on the standard Logger.
+func Infof(format string, args ...interface{}) {
+	Logger.Infof(format, args...)
+}
+
+// Warnf logs a message at level Warn on the standard Logger.
+func Warnf(format string, args ...interface{}) {
+	Logger.Warnf(format, args...)
+}
+
+// Errorf logs a message at level Error on the standard Logger.
+func Errorf(format string, args ...interface{}) {
+	Logger.Errorf(format, args...)
+}
+
+// Panicf logs a message at level Panic on the standard Logger.
+func Panicf(format string, args ...interface{}) {
+	Logger.Panicf(format, args...)
+}
+
+// Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
+func Fatalf(format string, args ...interface{}) {
+	Logger.Fatalf(format, args...)
+}
+
+// WithField creates an entry from the standard logger and adds a field to
+// it. If you want multiple fields, use `WithFields`.
+//
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
+// or Panic on the Entry it returns.
+func WithField(key string, value interface{}) *logrus.Entry {
+	return Logger.WithField(key, value)
+}
+
+// WithFields creates an entry from the standard logger and adds multiple
+// fields to it. This is simply a helper for `WithField`, invoking it
+// once for each field.
+//
+// Note that it doesn't log until you call Debug, Print, Info, Warn, Fatal
+// or Panic on the Entry it returns.
+func WithFields(fields map[string]interface{}) *logrus.Entry {
+	return Logger.WithFields(fields)
+}

--- a/app/logging/shorthands_test.go
+++ b/app/logging/shorthands_test.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"os"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ShorthandsBasic(t *testing.T) {
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger() // replace the global logger
+	Logger.Level = logrus.DebugLevel
+
+	fakeExit := func(int) {
+		panic("os.Exit called")
+	}
+	patch := monkey.Patch(os.Exit, fakeExit)
+	defer patch.Unpatch()
+
+	tests := []struct {
+		name  string
+		fct   func(args ...interface{})
+		level logrus.Level
+		panic bool
+	}{
+		{"Debug", Debug, logrus.DebugLevel, false},
+		{"Info", Info, logrus.InfoLevel, false},
+		{"Warn", Warn, logrus.WarnLevel, false},
+		{"Error", Error, logrus.ErrorLevel, false},
+		{"Fatal", Fatal, logrus.FatalLevel, true}, // does `os.exit(1)`, monkey-patched to panic
+		{"Panic", Panic, logrus.PanicLevel, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook.Reset()
+			if tt.panic {
+				assert.Panics(t, func() { tt.fct("a message") })
+			} else {
+				tt.fct("a message")
+			}
+			assert.Len(t, hook.AllEntries(), 1)
+			assert.Equal(t, tt.level, hook.LastEntry().Level)
+			assert.Equal(t, "a message", hook.LastEntry().Message)
+		})
+	}
+}
+
+func Test_ShorthandsFormatted(t *testing.T) {
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger() // replace the global logger
+	Logger.Level = logrus.DebugLevel
+
+	fakeExit := func(int) {
+		panic("os.Exit called")
+	}
+	patch := monkey.Patch(os.Exit, fakeExit)
+	defer patch.Unpatch()
+
+	tests := []struct {
+		name  string
+		fct   func(format string, args ...interface{})
+		level logrus.Level
+		panic bool
+	}{
+		{"Debugf", Debugf, logrus.DebugLevel, false},
+		{"Infof", Infof, logrus.InfoLevel, false},
+		{"Warnf", Warnf, logrus.WarnLevel, false},
+		{"Errorf", Errorf, logrus.ErrorLevel, false},
+		{"Fatalf", Fatalf, logrus.FatalLevel, true}, // does `os.exit(1)`, monkey-patched to panic
+		{"Panicf", Panicf, logrus.PanicLevel, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook.Reset()
+			if tt.panic {
+				assert.Panics(t, func() { tt.fct("msg: %d", 2) })
+			} else {
+				tt.fct("msg: %d", 2)
+			}
+			assert.Len(t, hook.AllEntries(), 1)
+			assert.Equal(t, tt.level, hook.LastEntry().Level)
+			assert.Equal(t, "msg: 2", hook.LastEntry().Message)
+		})
+	}
+}
+
+func Test_WithField(t *testing.T) {
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger() // replace the global logger
+	WithField("foo", "bar").Error("error msg")
+	assert.Len(t, hook.AllEntries(), 1)
+	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
+	assert.Equal(t, "error msg", hook.LastEntry().Message)
+	assert.Equal(t, "bar", hook.LastEntry().Data["foo"])
+}
+
+func Test_WithFields(t *testing.T) {
+	var hook *test.Hook
+	Logger, hook = test.NewNullLogger() // replace the global logger
+	WithFields(map[string]interface{}{"foo": "bar", "foo2": "bar2"}).Error("error msg")
+	assert.Len(t, hook.AllEntries(), 1)
+	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
+	assert.Equal(t, "error msg", hook.LastEntry().Message)
+	assert.Equal(t, "bar", hook.LastEntry().Data["foo"])
+	assert.Equal(t, "bar2", hook.LastEntry().Data["foo2"])
+}

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -1,0 +1,82 @@
+package logging
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// StructuredDBLogger is a database structured logger
+type StructuredDBLogger struct {
+	logger *logrus.Logger
+}
+
+// NewStructuredDBLogger created a database structured logger
+func NewStructuredDBLogger(logger *logrus.Logger) *StructuredDBLogger {
+	return &StructuredDBLogger{logger}
+}
+
+var (
+	sqlRegexp                = regexp.MustCompile(`\?`)
+	numericPlaceHolderRegexp = regexp.MustCompile(`\$\d+`)
+)
+
+// Print defines how StructuredDBLogger print log entries.
+// values: 0: level, 1: source file, 2: duration in ns, 3: query, 4: slice of parameters, 5: rows affected or returned
+func (l *StructuredDBLogger) Print(values ...interface{}) {
+	level := values[0]
+	logger := l.logger.WithField("type", "db")
+
+	if level == "sql" {
+
+		duration := float64(values[2].(time.Duration).Nanoseconds()/1e4) / 100000.0 // to seconds
+
+		var sql string
+		var formattedValues []string
+		for _, value := range values[4].([]interface{}) {
+			indirectValue := reflect.Indirect(reflect.ValueOf(value))
+			if indirectValue.IsValid() {
+				value = indirectValue.Interface()
+				if t, ok := value.(time.Time); ok {
+					formattedValues = append(formattedValues, fmt.Sprintf("'%v'", t.Format("2006-01-02 15:04:05")))
+				} else if b, ok := value.([]byte); ok {
+					formattedValues = append(formattedValues, fmt.Sprintf("'%v'", string(b)))
+				} else {
+					formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))
+				}
+			} else {
+				formattedValues = append(formattedValues, "NULL")
+			}
+		}
+
+		// differentiate between $n placeholders or else treat like ?
+		if numericPlaceHolderRegexp.MatchString(values[3].(string)) {
+			sql = values[3].(string)
+			for index, value := range formattedValues {
+				placeholder := fmt.Sprintf(`\$%d([^\d]|$)`, index+1)
+				sql = regexp.MustCompile(placeholder).ReplaceAllString(sql, value+"$1")
+			}
+		} else {
+			formattedValuesLength := len(formattedValues)
+			for index, value := range sqlRegexp.Split(values[3].(string), -1) {
+				sql += value
+				if index < formattedValuesLength {
+					sql += formattedValues[index]
+				}
+			}
+		}
+		logger.WithFields(map[string]interface{}{
+			"duration": duration,
+			"ts":       time.Now().Format("2006-01-02 15:04:05"),
+			"rows":     values[5].(int64),
+		}).Println(strings.TrimSpace(sql))
+
+	} else { // level is not "sql", so typically errors
+		logger.Println(values[2:]...)
+	}
+
+}

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -1,0 +1,75 @@
+package logging_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	assertlib "github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/logging"
+)
+
+func TestStructuredDBLogger_Print_SQL(t *testing.T) {
+	assert := assertlib.New(t)
+	var hook *test.Hook
+	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "0")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "1")
+	logging.Logger, hook = test.NewNullLogger()
+	db, mock := database.NewDBMock()
+
+	mock.ExpectQuery("SELECT 1").WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
+
+	var result []interface{}
+	timeParam := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	db.Raw("SELECT $1, $2, $3, $4, $5", 1, timeParam, "foo", []byte("bar"), nil).Scan(&result)
+	assert.Equal("SELECT '1', '2009-11-10 23:00:00', 'foo', 'bar', NULL", hook.LastEntry().Message)
+	data := hook.LastEntry().Data
+	assert.Equal("db", data["type"])
+	assert.True(data["duration"].(float64) < 0.01, "unexpected duration: %v", data["duration"])
+	assert.NotNil(data["ts"])
+	assert.Equal(int64(0), data["rows"].(int64))
+}
+
+func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
+	assert := assertlib.New(t)
+	var hook *test.Hook
+	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "false")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "true")
+	logging.Logger, hook = test.NewNullLogger()
+	db, mock := database.NewDBMock()
+
+	mock.ExpectQuery("SELECT 1").WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
+
+	var result []interface{}
+	db.Raw("SELECT ?", 1).Scan(&result)
+	assert.Equal("SELECT '1'", hook.LastEntry().Message)
+}
+
+func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
+	assert := assertlib.New(t)
+	var hook *test.Hook
+	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "false")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "true")
+	logging.Logger, hook = test.NewNullLogger()
+	db, mock := database.NewDBMock()
+
+	mock.ExpectQuery("SELECT 2").WillReturnError(errors.New("a query error"))
+
+	var result []interface{}
+	db.Raw("SELECT 2").Scan(&result)
+
+	assert.Equal("a query error", hook.Entries[0].Message)
+	data := hook.Entries[0].Data
+	assert.Equal("db", data["type"])
+
+	assert.Equal("SELECT 2", hook.Entries[1].Message)
+	data = hook.Entries[1].Data
+	assert.Equal("db", data["type"])
+	assert.True(data["duration"].(float64) < 0.01, "unexpected duration: %v", data["duration"])
+	assert.NotNil(data["ts"])
+	assert.Equal(int64(0), data["rows"].(int64))
+}

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -16,8 +16,8 @@ import (
 func TestStructuredDBLogger_Print_SQL(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
-	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "0")
-	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "1")
+	_ = os.Setenv("ALGOREA_LOGGING.FORMAT", "json")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQLQUERIES", "1")
 	logging.Logger, hook = test.NewNullLogger()
 	db, mock := database.NewDBMock()
 
@@ -37,8 +37,8 @@ func TestStructuredDBLogger_Print_SQL(t *testing.T) {
 func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
-	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "false")
-	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "true")
+	_ = os.Setenv("ALGOREA_LOGGING.FORMAT", "json")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQLQUERIES", "1")
 	logging.Logger, hook = test.NewNullLogger()
 	db, mock := database.NewDBMock()
 
@@ -52,8 +52,8 @@ func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
-	_ = os.Setenv("ALGOREA_LOGGING.TEXTLOGGING", "false")
-	_ = os.Setenv("ALGOREA_LOGGING.LOGSQL", "true")
+	_ = os.Setenv("ALGOREA_LOGGING.FORMAT", "json")
+	_ = os.Setenv("ALGOREA_LOGGING.LOGSQLQUERIES", "1")
 	logging.Logger, hook = test.NewNullLogger()
 	db, mock := database.NewDBMock()
 

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -10,8 +10,8 @@ database:
     allownativepasswords: true
     parseTime: true # required for the migration system
 logging:
-  format: json # text, json
-  output: file # stdout, stderr, file
+  format: text # text, json
+  output: stdout # stdout, stderr, file
   level: debug # debug, info, warning, error, fatal, panic
   logSQLQueries: true
 # reverseProxy: # server to which requests which do not match any route will be sent

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -12,6 +12,7 @@ database:
 logging:
   textlogging: true
   logLevel: debug # debug, info, warning, error, fatal, panic
+  logSQL: false
 
 # reverseProxy: # server to which requests which do not match any route will be sent
 #   server: "http://localhost:3000"

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -10,9 +10,9 @@ database:
     allownativepasswords: true
     parseTime: true # required for the migration system
 logging:
-  textlogging: true
-  logLevel: debug # debug, info, warning, error, fatal, panic
-  logSQL: false
-
+  format: json # text, json
+  output: file # stdout, stderr, file
+  level: debug # debug, info, warning, error, fatal, panic
+  logSQLQueries: true
 # reverseProxy: # server to which requests which do not match any route will be sent
 #   server: "http://localhost:3000"

--- a/testhelpers/steps.go
+++ b/testhelpers/steps.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/France-ioi/AlgoreaBackend/app"
+	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
@@ -44,7 +45,9 @@ const (
 	noID int64 = -1
 )
 
-func (ctx *TestContext) SetupTestContext(interface{}) { // nolint
+func (ctx *TestContext) SetupTestContext(data interface{}) { // nolint
+	scenario := data.(*gherkin.Scenario)
+	log.WithField("type", "test").Infof("Starting test scenario: %s", scenario.Name)
 	ctx.application = nil
 	ctx.userID = 999 // the default for the moment
 	ctx.lastResponse = nil


### PR DESCRIPTION
The global goal was to reorganize the logging so that it can be stored in a log file instead of outputting it to stderr. 
Many related had to be fixed to have something proper:
- cleaner way to log
- multiple formats for logging
- 100% test coverage for logging
- db logger working correctly
- saner config for logging
- use local config file to allow each dev to have its own config

To be reviewed commit per commit, should be quite clean.