### PR TITLE
Fix Config concurrency problem + try to load it less 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -30,6 +30,9 @@ func New() (*Application, error) {
 		return nil, err
 	}
 
+	// Apply the config to the global logger
+	log.ConfigureGlobal(conf.Logging)
+
 	// Init the PRNG with current time
 	rand.Seed(time.Now().UTC().UnixNano())
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -107,6 +107,10 @@ func setDefaults(c *viper.Viper) {
 	c.SetDefault("logging.output", "file")
 	c.SetDefault("logging.level", "info")
 	c.SetDefault("logging.logSqlQueries", true)
+
+	// reverse proxy
+	c.SetDefault("reverseproxy.server", "http://localhost:3000")
+
 }
 
 func configDirectory() string {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -67,44 +67,46 @@ func Load() (*Root, error) {
 	var err error
 
 	var config *Root
-	setDefaults()
+	viperConfig := viper.New()
+
+	setDefaults(viperConfig)
 
 	// through env variables
-	viper.SetEnvPrefix("algorea") // env variables must be prefixed by "ALGOREA_"
-	viper.AutomaticEnv()          // read in environment variables
+	viperConfig.SetEnvPrefix("algorea") // env variables must be prefixed by "ALGOREA_"
+	viperConfig.AutomaticEnv()          // read in environment variables
 
 	// through the config file
-	viper.SetConfigName(configName)
-	viper.AddConfigPath(configDir)
+	viperConfig.SetConfigName(configName)
+	viperConfig.AddConfigPath(configDir)
 
-	if err = viper.ReadInConfig(); err != nil {
+	if err = viperConfig.ReadInConfig(); err != nil {
 		log.Print("Cannot read the config file, ignoring it.")
 	}
 
 	// map the given config to a static struct
-	if err = viper.Unmarshal(&config); err != nil {
+	if err = viperConfig.Unmarshal(&config); err != nil {
 		log.Fatal("Cannot map the given config to the expected configuration struct:", err)
 		return nil, err
 	}
 	return config, nil
 }
 
-func setDefaults() {
+func setDefaults(c *viper.Viper) {
 
 	// root
-	viper.SetDefault("timeout", 15)
+	c.SetDefault("timeout", 15)
 
 	// server
-	viper.SetDefault("server.port", 8080)
-	viper.SetDefault("server.readTimeout", 60)  // in seconds
-	viper.SetDefault("server.writeTimeout", 60) // in seconds
-	viper.SetDefault("server.rootpath", "/")
+	c.SetDefault("server.port", 8080)
+	c.SetDefault("server.readTimeout", 60)  // in seconds
+	c.SetDefault("server.writeTimeout", 60) // in seconds
+	c.SetDefault("server.rootpath", "/")
 
 	// logging
-	viper.SetDefault("logging.format", "json")
-	viper.SetDefault("logging.output", "file")
-	viper.SetDefault("logging.level", "info")
-	viper.SetDefault("logging.logSqlQueries", true)
+	c.SetDefault("logging.format", "json")
+	c.SetDefault("logging.output", "file")
+	c.SetDefault("logging.level", "info")
+	c.SetDefault("logging.logSqlQueries", true)
 }
 
 func configDirectory() string {

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -43,3 +43,13 @@ func TestLoadConfig(t *testing.T) {
 	// test env
 	assert.EqualValues(999, conf.Server.WriteTimeout)
 }
+
+func TestLoadConfig_Concurrent(t *testing.T) {
+	assert := assertlib.New(t)
+	assert.NotPanics(func() {
+		_, _ = Load()
+		for i := 0; i < 1000; i++ {
+			go func() { _, _ = Load() }()
+		}
+	})
+}

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -14,20 +14,26 @@ import (
 var (
 	// Logger is the global logger
 	// It should not be used directly by app which should prefer shorthands functions
-	Logger = new()
+	Logger = defaultGlobal()
 )
 
-func new() *logrus.Logger {
+// ConfigureGlobal applies the given logging configuration to the global logger
+func ConfigureGlobal(conf config.Logging) {
+	configure(Logger, conf)
+}
+
+// ResetGlobal reset the global logger to its default settings before its configuration
+func ResetGlobal() {
+	Logger = defaultGlobal()
+}
+
+func defaultGlobal() *logrus.Logger {
 	logger := logrus.New()
-	if conf, err := config.Load(); err == nil {
-		// If config, configure logger. Otherwise, use default logger
-		configureLogger(logger, conf.Logging)
-	}
 	log.SetOutput(logger.Writer())
 	return logger
 }
 
-func configureLogger(logger *logrus.Logger, conf config.Logging) {
+func configure(logger *logrus.Logger, conf config.Logging) {
 
 	// Format
 	switch conf.Format {

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -15,67 +15,74 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/config"
 )
 
-func TestNew(t *testing.T) {
+func TestGlobal(t *testing.T) {
 	assert := assertlib.New(t)
-	// just verify it can load the config
-	assert.NotNil(new())
+	ResetGlobal()
+	assert.IsType(&logrus.TextFormatter{}, Logger.Formatter) // TextFormatter is logrus default
+	conf := config.Logging{
+		Format: "json",
+		Output: "file",
+	}
+	ConfigureGlobal(conf)
+	assert.IsType(&logrus.JSONFormatter{}, Logger.Formatter)
+	ResetGlobal()
 }
 
-func TestConfigureLogger_FormatText(t *testing.T) {
+func TestConfigure_FormatText(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "text",
 		Output: "file",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.IsType(&logrus.TextFormatter{}, logger.Formatter)
 }
 
-func TestConfigureLogger_FormatJson(t *testing.T) {
+func TestConfigure_FormatJson(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
 		Output: "file",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.IsType(&logrus.JSONFormatter{}, logger.Formatter)
 }
 
-func TestConfigureLogger_FormatInvalid(t *testing.T) {
+func TestConfigure_FormatInvalid(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "yml",
 		Output: "file",
 	}
 	logger := logrus.New()
-	assert.Panics(func() { configureLogger(logger, conf) })
+	assert.Panics(func() { configure(logger, conf) })
 }
 
-func TestConfigureLogger_OutputStdout(t *testing.T) {
+func TestConfigure_OutputStdout(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
 		Output: "stdout",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(os.Stdout, logger.Out)
 }
 
-func TestConfigureLogger_OutputStderr(t *testing.T) {
+func TestConfigure_OutputStderr(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
 		Output: "stderr",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(os.Stderr, logger.Out)
 }
 
-func TestConfigureLogger_OutputFile(t *testing.T) {
+func TestConfigure_OutputFile(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
@@ -85,12 +92,12 @@ func TestConfigureLogger_OutputFile(t *testing.T) {
 	timestamp := time.Now().UnixNano()
 
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	logger.Errorf("logexec1 %d", timestamp)
 
 	// redo another init to check it will not override
 	logger2 := logrus.New()
-	configureLogger(logger2, conf)
+	configure(logger2, conf)
 	logger2.Warnf("logexec2 %d", timestamp)
 
 	// check the resulting file
@@ -99,7 +106,7 @@ func TestConfigureLogger_OutputFile(t *testing.T) {
 	assert.Contains(string(content), fmt.Sprintf("logexec2 %d", timestamp))
 }
 
-func TestConfigureLogger_OutputFileError(t *testing.T) {
+func TestConfigure_OutputFileError(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
@@ -111,21 +118,21 @@ func TestConfigureLogger_OutputFileError(t *testing.T) {
 	patch := monkey.Patch(os.OpenFile, fakeFunc)
 	defer patch.Unpatch()
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(os.Stdout, logger.Out)
 }
 
-func TestConfigureLogger_OutputInvalid(t *testing.T) {
+func TestConfigure_OutputInvalid(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Format: "json",
 		Output: "S3",
 	}
 	logger := logrus.New()
-	assert.Panics(func() { configureLogger(logger, conf) })
+	assert.Panics(func() { configure(logger, conf) })
 }
 
-func TestConfigureLogger_LevelDefault(t *testing.T) {
+func TestConfigure_LevelDefault(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Level:  "",
@@ -133,11 +140,11 @@ func TestConfigureLogger_LevelDefault(t *testing.T) {
 		Output: "file",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(logrus.InfoLevel, logger.Level)
 }
 
-func TestConfigureLogger_LevelParsed(t *testing.T) {
+func TestConfigure_LevelParsed(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Level:  "warn",
@@ -145,11 +152,11 @@ func TestConfigureLogger_LevelParsed(t *testing.T) {
 		Output: "file",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(logrus.WarnLevel, logger.Level)
 }
 
-func TestConfigureLogger_LevelInvalid(t *testing.T) {
+func TestConfigure_LevelInvalid(t *testing.T) {
 	assert := assertlib.New(t)
 	conf := config.Logging{
 		Level:  "invalid_level",
@@ -157,6 +164,6 @@ func TestConfigureLogger_LevelInvalid(t *testing.T) {
 		Output: "file",
 	}
 	logger := logrus.New()
-	configureLogger(logger, conf)
+	configure(logger, conf)
 	assert.Equal(logrus.InfoLevel, logger.Level)
 }

--- a/testhelpers/steps.go
+++ b/testhelpers/steps.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/go-sql-driver/mysql" // use to force database/sql to use mysql
 	"github.com/jinzhu/gorm"
 	"github.com/pmezard/go-difflib/difflib"
-	"github.com/spf13/viper"
 
 	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/api/groups"
@@ -341,7 +340,7 @@ func (ctx *TestContext) RunFallbackServer() error { // nolint
 	if err != nil {
 		return err
 	}
-	viper.Set("ReverseProxy.Server", backendURL.String())
+	_ = os.Setenv("ALGOREA_REVERSEPROXY.SERVER", backendURL.String()) // nolint
 	return nil
 }
 


### PR DESCRIPTION
To be reviewed commit per commit. 
The abusive calls of `config.Load()` by other parts of the code will be addressed in a separated PR.