### PR TITLE
Convert Service.checkThatUserOwnsTheGroup() into a static method

### DIFF
--- a/app/api/groups/change_password.go
+++ b/app/api/groups/change_password.go
@@ -21,7 +21,7 @@ func (srv *Service) changePassword(w http.ResponseWriter, r *http.Request) servi
 		return service.ErrInvalidRequest(err)
 	}
 
-	if apiError := srv.checkThatUserOwnsTheGroup(user, groupID); apiError != service.NoError {
+	if apiError := checkThatUserOwnsTheGroup(srv.Store, user, groupID); apiError != service.NoError {
 		return apiError
 	}
 

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -16,7 +16,7 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 		return service.ErrInvalidRequest(err)
 	}
 
-	if apiError := srv.checkThatUserOwnsTheGroup(user, groupID); apiError != service.NoError {
+	if apiError := checkThatUserOwnsTheGroup(srv.Store, user, groupID); apiError != service.NoError {
 		return apiError
 	}
 

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -28,10 +28,10 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Get("/groups/{group_id}/children", service.AppHandler(srv.getChildren).ServeHTTP)
 }
 
-func (srv *Service) checkThatUserOwnsTheGroup(user *database.User, groupID int64) service.APIError {
+func checkThatUserOwnsTheGroup(store *database.DataStore, user *database.User, groupID int64) service.APIError {
 	var count int64
 	service.MustNotBeError(
-		srv.Store.GroupAncestors().OwnedByUser(user).
+		store.GroupAncestors().OwnedByUser(user).
 			Where("idGroupChild = ?", groupID).Count(&count).Error())
 	if count == 0 {
 		return service.ErrForbidden(errors.New("insufficient access rights"))

--- a/app/api/groups/groups_test.go
+++ b/app/api/groups/groups_test.go
@@ -21,9 +21,8 @@ func TestService_checkThatUserOwnsTheGroup_HandlesError(t *testing.T) {
 		WillReturnError(expectedError)
 
 	user := database.NewUser(1, database.NewDataStore(db).Users(), nil)
-	srv := Service{service.Base{Store: database.NewDataStore(db)}}
 
-	apiErr := srv.checkThatUserOwnsTheGroup(user, 123)
+	apiErr := checkThatUserOwnsTheGroup(database.NewDataStore(db), user, 123)
 
 	assert.Equal(t, service.ErrUnexpected(expectedError), apiErr)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/app/api/groups/recent_activity.go
+++ b/app/api/groups/recent_activity.go
@@ -22,7 +22,7 @@ func (srv *Service) getRecentActivity(w http.ResponseWriter, r *http.Request) se
 		return service.ErrInvalidRequest(err)
 	}
 
-	if apiError := srv.checkThatUserOwnsTheGroup(user, groupID); apiError != service.NoError {
+	if apiError := checkThatUserOwnsTheGroup(srv.Store, user, groupID); apiError != service.NoError {
 		return apiError
 	}
 


### PR DESCRIPTION
We are going to use it inside transaction, so we don't want it to use Service.Store as the DB connection