### PR TITLE
Always call createNewAncestors() if at least one relation is modified in GroupGroupStore.Transition()

### DIFF
--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -522,6 +522,11 @@ func TestGroupGroupStore_transition(t *testing.T) {
 			assert.NoError(t, dataStore.GroupAncestors().Select("idGroupAncestor, idGroupChild, bIsSelf").
 				Order("idGroupAncestor, idGroupChild").Scan(&groupAncestors).Error())
 			assert.Equal(t, tt.wantGroupAncestors, groupAncestors)
+
+			var count int64
+			assert.NoError(t, dataStore.Table("groups_propagate").
+				Where("sAncestorsComputationState != 'done'").Count(&count).Error())
+			assert.Zero(t, count)
 		})
 	}
 }


### PR DESCRIPTION
We need to do this because our triggers mark relations as "todo" no matter what sType they have.