### PR TITLE
Initial demo of OpenAPI using goswagger

### DIFF
--- a/app/api/doc.go
+++ b/app/api/doc.go
@@ -1,0 +1,29 @@
+// Package api AlgoreaBackend API.
+// API for the Algorea backend.
+//
+//     Schemes: http, https
+//     Host: localhost
+//     BasePath: /
+//     Version: 0.0.1
+//     License: MIT http://opensource.org/licenses/MIT
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+// swagger:meta
+package api
+
+import (
+	"github.com/France-ioi/AlgoreaBackend/app/api/groups"
+)
+
+// Not actually a response, just a hack to get go-swagger to include definitions
+//
+// swagger:response parameterBodies
+type paramBodies struct { //nolint: deadcode
+	// in: body
+	GroupUpdateInput groups.GroupUpdateInput
+}

--- a/app/service/responses.go
+++ b/app/service/responses.go
@@ -8,10 +8,11 @@ import (
 
 // Response is used for generating non-data responses, i.e. on error or on POST/PUT/PATCH/DELETE request
 type Response struct {
-	HTTPStatusCode int         `json:"-"`
-	Success        bool        `json:"success"`
-	Message        string      `json:"message"`
-	Data           interface{} `json:"data,omitempty"`
+	HTTPStatusCode int  `json:"-"`
+	Success        bool `json:"success"`
+	// example: success
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
 }
 
 // Render generates the HTTP response from Response
@@ -31,6 +32,13 @@ func CreationSuccess(data interface{}) render.Renderer {
 		Message:        "created",
 		Data:           data,
 	}
+}
+
+// This response format is both used for responses on actions (POST/PUT/PATCH/DELETE) and for errors
+// swagger:response defaultResponse
+type defaultResponse struct { //nolint: deadcode
+	// in: body
+	Body Response
 }
 
 // UpdateSuccess generated a success response for a PUT updating


### PR DESCRIPTION
An initial demo of how OpenAPI may look like.

The objective is to have a developer doc (so for people using the backend but not dev on it) which can be served through HTTP. Being OpenAPI-compatible allow using, from the spec file, one of the many tools, to render nice HTML doc, generating client lib, API testers, ... Generating this spec file from the code (instead of writing it 100% by hand) would allow being a bit DRY, so decrease a bit of the doc work and prevent inconsistency. This last part of the objective is probably is a bit questionable as the info inside the validation struct and the written spec are not exactly of the same type. Anyway, there are two important parts in these specs, the attribute type/format (which could be, in theory, interpreted from request/response structs) and all the logic (e.g, "if 'xyz' is false than 'abc' is set to null"). This logic has to be written anyway and is the major part which is "lost" for now in our heads and may be hard to catch from code and test scenarios.

The OpenAPI tools in Go (go-swagger or swaggo) are more mainly designed for generating skeletons (responses, requests struct) from the spec than generating doc from code. So they cannot really parse our custom (or any lib) validations, nor use custom code to parse our types, tags, ... without a major rework of how these documentations are generated, which would probably need large non-cost-effective development. 

So I have tried to do it with what we have. The idea is mainly to put doc inside the code (for instance, service specification in service file) to help the dev updating both at the same time, while trying to reuse some structs when we can. 

This PR modifies does the work for one service. The output generated by the [Redoc](https://github.com/Redocly/redoc) generator is captured on the image below.

For the input parameters, the tags used for validation are basically not used. The attributes are documented by hand (explanation of constraints + example), `required: true` has to be put as well if the attribute is mandatory. The goal, for now, is **not** to re-explain the semantic of each db column in the context of the algorea project. For the parameters (both the path one and the body), they can be described either in the service spec as done here (`swagger:operation... ` block) or as a documented struct (which would be not used by the code itself).

For the response, just documenting our generic response as I did does not really help the API user to figure out what are the possible outputs of this service. Probably re-usable "updated", "forbidden", ... responses would have to be written but it would require writing unused (by the prod code) documented structs.

![Screenshot of spec generated and render by go-swagger](https://user-images.githubusercontent.com/1053150/59335229-71c69e00-8cfc-11e9-8e4c-0e6c7ca5dca2.png)