### PR TITLE
Fix cucumber tests instability caused by db concurrency issues

### DIFF
--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -194,7 +194,7 @@ func (ctx *TestContext) tableAtIDShouldBe(tableName string, ids []int64, exclude
 	selectsJoined := strings.Join(selects, ", ")
 
 	// exec sql
-	query := fmt.Sprintf("SELECT %s FROM `%s` %s ORDER BY %s", selectsJoined, tableName, where, selectsJoined) // nolint: gosec
+	query := fmt.Sprintf("SELECT %s FROM `%s` %s ORDER BY %s FOR UPDATE", selectsJoined, tableName, where, selectsJoined) // nolint: gosec
 	sqlRows, err := db.Query(query)
 	if err != nil {
 		return err


### PR DESCRIPTION
Can be tested with
```
for i in `seq 1 1000`; do godog --stop-on-failure ./app/api/groups/reject_requests.feature; if [[ "$?" != '0' ]]; then break; fi; done
```