### PR TITLE
Apply "orange" changes in groupChildrenView

### DIFF
--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -1,97 +1,233 @@
 Feature: Get group children (groupChildrenView)
   Background:
     Given the database has the following table 'users':
-      | ID | sLogin | tempUser | idGroupSelf | idGroupOwned | sFirstName  | sLastName | sDefaultLanguage |
-      | 1  | owner  | 0        | 21          | 22           | Jean-Michel | Blanquer  | fr               |
+      | ID | sLogin | idGroupSelf | idGroupOwned | sFirstName  | sLastName |
+      | 1  | owner  | 21          | 22           | Jean-Michel | Blanquer  |
+      | 2  | john   | 51          | 52           | John        | Doe       |
+      | 3  | jane   | 53          | 54           | Jane        | Doe       |
     And the database has the following table 'groups_ancestors':
-      | ID | idGroupAncestor | idGroupChild | bIsSelf | iVersion |
-      | 75 | 22              | 13           | 0       | 0        |
-      | 76 | 13              | 11           | 0       | 0        |
-      | 77 | 22              | 14           | 0       | 0        |
+      | idGroupAncestor | idGroupChild | bIsSelf |
+      | 11              | 11           | 1       |
+      | 13              | 11           | 0       |
+      | 13              | 13           | 1       |
+      | 13              | 21           | 0       |
+      | 13              | 23           | 0       |
+      | 13              | 24           | 0       |
+      | 13              | 25           | 0       |
+      | 13              | 26           | 0       |
+      | 13              | 27           | 0       |
+      | 13              | 28           | 0       |
+      | 13              | 29           | 0       |
+      | 13              | 30           | 0       |
+      | 13              | 31           | 0       |
+      | 13              | 51           | 0       |
+      | 13              | 53           | 0       |
+      | 13              | 90           | 0       |
+      | 14              | 14           | 1       |
+      | 14              | 22           | 0       |
+      | 21              | 21           | 1       |
+      | 22              | 13           | 0       |
+      | 22              | 14           | 0       |
+      | 22              | 21           | 0       |
+      | 22              | 22           | 1       |
+      | 22              | 23           | 0       |
+      | 22              | 24           | 0       |
+      | 22              | 25           | 0       |
+      | 22              | 26           | 0       |
+      | 22              | 27           | 0       |
+      | 22              | 28           | 0       |
+      | 22              | 29           | 0       |
+      | 22              | 30           | 0       |
+      | 22              | 31           | 0       |
+      | 22              | 51           | 0       |
+      | 22              | 53           | 0       |
+      | 22              | 90           | 0       |
+      | 23              | 23           | 1       |
+      | 23              | 51           | 0       |
+      | 23              | 53           | 0       |
+      | 23              | 90           | 0       |
+      | 24              | 24           | 1       |
+      | 25              | 25           | 1       |
+      | 26              | 26           | 1       |
+      | 27              | 27           | 1       |
+      | 27              | 53           | 0       |
+      | 28              | 28           | 1       |
+      | 29              | 29           | 1       |
+      | 30              | 30           | 1       |
+      | 31              | 31           | 1       |
+      | 42              | 42           | 1       |
+      | 43              | 43           | 1       |
+      | 44              | 44           | 1       |
+      | 45              | 45           | 1       |
+      | 46              | 46           | 1       |
+      | 47              | 47           | 1       |
+      | 51              | 51           | 1       |
+      | 52              | 52           | 1       |
+      | 53              | 53           | 1       |
+      | 54              | 54           | 1       |
+      | 90              | 51           | 0       |
+      | 90              | 53           | 0       |
+      | 90              | 90           | 1       |
     And the database has the following table 'groups':
-      | ID | sName       | iGrade | sType     | bOpened | bFreeAccess | sPassword  |
-      | 11 | Group A     | -3     | Class     | true    | true        | ybqybxnlyo |
-      | 13 | Group B     | -2     | Class     | true    | true        | ybabbxnlyo |
-      | 14 | Group C     | -4     | UserAdmin | true    | false       | null       |
-      | 21 | user-admin  | -2     | UserAdmin | true    | false       | null       |
-      | 22 | C's Child   | -4     | UserAdmin | true    | false       | null       |
-      | 23 | Our Class   | -3     | Class     | true    | false       | null       |
-      | 24 | Root        | -2     | Root      | true    | false       | 3456789abc |
-      | 25 | Our Team    | -1     | Team      | true    | false       | 456789abcd |
-      | 26 | Our Club    |  0     | Club      | true    | false       | null       |
-      | 27 | Our Friends |  0     | Friends   | true    | false       | 56789abcde |
-      | 28 | Other       |  0     | Other     | true    | false       | null       |
-      | 29 | UserSelf    |  0     | UserSelf  | true    | false       | null       |
-      | 30 | RootSelf    |  0     | RootSelf  | true    | false       | null       |
-      | 31 | RootAdmin   |  0     | RootAdmin | true    | false       | null       |
+      | ID | sName         | iGrade | sType     | bOpened | bFreeAccess | sPassword  |
+      | 11 | Group A       | -3     | Class     | true    | true        | ybqybxnlyo |
+      | 13 | Group B       | -2     | Class     | true    | true        | ybabbxnlyo |
+      | 14 | Group C       | -4     | UserAdmin | true    | false       | null       |
+      | 21 | user-admin    | -2     | UserAdmin | true    | false       | null       |
+      | 22 | C's Child     | -4     | UserAdmin | true    | false       | null       |
+      | 23 | Our Class     | -3     | Class     | true    | false       | null       |
+      | 24 | Root          | -2     | Root      | true    | false       | 3456789abc |
+      | 25 | Our Team      | -1     | Team      | true    | false       | 456789abcd |
+      | 26 | Our Club      |  0     | Club      | true    | false       | null       |
+      | 27 | Our Friends   |  0     | Friends   | true    | false       | 56789abcde |
+      | 28 | Other         |  0     | Other     | true    | false       | null       |
+      | 29 | UserSelf      |  0     | UserSelf  | true    | false       | null       |
+      | 30 | RootSelf      |  0     | RootSelf  | true    | false       | null       |
+      | 31 | RootAdmin     |  0     | RootAdmin | true    | false       | null       |
+      | 42 | Their Class   | -3     | Class     | true    | false       | null       |
+      | 43 | Other Root    | -2     | Root      | true    | false       | 3456789abc |
+      | 44 | Other Team    | -1     | Team      | true    | false       | 456789abcd |
+      | 45 | Their Club    |  0     | Club      | true    | false       | null       |
+      | 46 | Their Friends |  0     | Friends   | true    | false       | 56789abcde |
+      | 47 | Other         |  0     | Other     | true    | false       | null       |
+      | 51 | john          |  0     | UserSelf  | false   | false       | null       |
+      | 52 | john-admin    |  0     | UserAdmin | false   | false       | null       |
+      | 53 | jane          |  0     | UserSelf  | false   | false       | null       |
+      | 54 | jane-admin    |  0     | UserAdmin | false   | false       | null       |
+      | 90 | Sub-Class     |  0     | Team      | false   | false       | null       |
     And the database has the following table 'groups_groups':
-      | ID | idGroupParent | idGroupChild |
-      | 75 | 13            | 21           |
-      | 77 | 13            | 23           |
-      | 78 | 13            | 24           |
-      | 79 | 14            | 22           |
-      | 80 | 13            | 25           |
-      | 81 | 13            | 26           |
-      | 82 | 13            | 27           |
-      | 83 | 13            | 28           |
-      | 84 | 13            | 29           |
-      | 85 | 13            | 30           |
-      | 86 | 13            | 31           |
+      | idGroupParent | idGroupChild | sType              |
+      | 13            | 21           | invitationAccepted |
+      | 13            | 23           | direct             |
+      | 13            | 24           | direct             |
+      | 14            | 22           | direct             |
+      | 13            | 25           | direct             |
+      | 13            | 26           | direct             |
+      | 13            | 27           | direct             |
+      | 13            | 28           | direct             |
+      | 13            | 29           | requestAccepted    |
+      | 13            | 30           | direct             |
+      | 13            | 31           | direct             |
+      | 13            | 42           | invitationSent     |
+      | 13            | 43           | requestSent        |
+      | 13            | 44           | invitationRefused  |
+      | 13            | 45           | requestRefused     |
+      | 13            | 46           | left               |
+      | 13            | 47           | removed            |
+      | 23            | 51           | invitationAccepted |
+      | 23            | 90           | direct             |
+      | 27            | 53           | invitationAccepted |
+      | 90            | 51           | requestAccepted    |
 
   Scenario: User is an owner of the parent group, rows are sorted by name by default, UserSelf is skipped
+    Given I am the user with ID "1"
+    When I send a GET request to "/groups/13/children?types_exclude=UserSelf"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
+      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
+      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0}
+    ]
+    """
+
+  Scenario: User is an owner of the parent group, rows are sorted by name by default, all the types are by default
     Given I am the user with ID "1"
     When I send a GET request to "/groups/13/children"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
-      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null},
-      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde"},
-      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd"},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc"},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null}
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
+      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
+      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
+      {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
+    ]
+    """
+
+  Scenario: User is an owner of the parent group, rows are sorted by name by default, all the types are included explicitly
+    Given I am the user with ID "1"
+    When I send a GET request to "/groups/13/children?types_include=Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
+      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
+      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
+      {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
+    ]
+    """
+
+  Scenario: User is an owner of the parent group, rows are sorted by name by default, some types are excluded
+    Given I am the user with ID "1"
+    When I send a GET request to "/groups/13/children?types_exclude=Root,Class,Team,Club,Friends"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
+      {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 
   Scenario: User is an owner of the parent group, rows are sorted by grade, UserSelf is skipped
     Given I am the user with ID "1"
-    When I send a GET request to "/groups/13/children?sort=grade"
+    When I send a GET request to "/groups/13/children?sort=grade&types_exclude=UserSelf"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
-      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null},
-      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc"},
-      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd"},
-      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde"},
-      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null}
+      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
+      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 
   Scenario: User is an owner of the parent group, rows are sorted by type, UserSelf is skipped
     Given I am the user with ID "1"
-    When I send a GET request to "/groups/13/children?sort=type"
+    When I send a GET request to "/groups/13/children?sort=type&types_exclude=UserSelf"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc"},
-      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null},
-      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd"},
-      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde"},
-      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null}
+      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
+      {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
+      {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 
@@ -102,17 +238,17 @@ Feature: Get group children (groupChildrenView)
     And the response body should be, in JSON:
     """
     [
-      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null}
+      {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 
-  Scenario: User is an owner of the parent group, paging applied
+  Scenario: User is an owner of the parent group, paging applied, UserSelf is skipped
     Given I am the user with ID "1"
-    When I send a GET request to "/groups/13/children?from.name=RootSelf&from.id=30"
+    When I send a GET request to "/groups/13/children?from.name=RootSelf&from.id=30&types_exclude=UserSelf"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
-      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null}
+      {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0}
     ]
     """

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -29,6 +29,7 @@ import (
 //     enum: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
 // - name: types_exclude
 //   in: query
+//   default: []
 //   type: array
 //   items:
 //     type: string

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -36,24 +36,24 @@ import (
 // - name: from.name
 //   description: Start the page from the sub-group next to the sub-group with `sName` = `from.name` and `ID` = `from.id`
 //                (`from.id` is required when `from.name` is present,
-//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//                some other 'from.*' parameters may be required too depending on the `sort`)
 //   in: query
 //   type: string
 // - name: from.type
 //   description: Start the page from the sub-group next to the sub-group with `sType` = `from.type` and `ID` = `from.id`
 //                (`from.id` is required when `from.type` is present,
-//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//                some other 'from.*' parameters may be required too depending on the `sort`)
 //   in: query
 //   type: string
 // - name: from.grade
 //   description: Start the page from the sub-group next to the sub-group with `iGrade` = `from.grade` and `ID` = `from.id`
 //                (`from.id` is required when `from.grade` is present,
-//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//                some other 'from.*' parameters may be required too depending on the `sort`)
 //   in: query
 //   type: string
 // - name: from.id
 //   description: Start the page from the sub-group next to the sub-group with `ID`=`from.id`
-//                (if at least one of other 'sort.*' parameters is present, `sort.id` is required)
+//                (if at least one of other 'from.*' parameters is present, `sort.id` is required)
 //   in: query
 //   type: integer
 // - name: sort

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -8,6 +8,78 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
+// swagger:operation GET /groups/{group_id}/children groups groupChildrenView
+// ---
+// summary: List group's children
+// description: Returns children of the group having types
+//   specified by `types_include` and `types_exclude` parameters.
+//
+//   * The authenticated user should own the parent group.
+// parameters:
+// - name: group_id
+//   in: path
+//   required: true
+//   type: integer
+// - name: types_include
+//   in: query
+//   default: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+//   type: array
+//   items:
+//     type: string
+//     enum: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+// - name: types_exclude
+//   in: query
+//   type: array
+//   items:
+//     type: string
+//     enum: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+// - name: from.name
+//   description: Start the page from the sub-group next to the sub-group with `sName` = `from.name` and `ID` = `from.id`
+//                (`from.id` is required when `from.name` is present,
+//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//   in: query
+//   type: string
+// - name: from.type
+//   description: Start the page from the sub-group next to the sub-group with `sType` = `from.type` and `ID` = `from.id`
+//                (`from.id` is required when `from.type` is present,
+//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//   in: query
+//   type: string
+// - name: from.grade
+//   description: Start the page from the sub-group next to the sub-group with `iGrade` = `from.grade` and `ID` = `from.id`
+//                (`from.id` is required when `from.grade` is present,
+//                some other 'sort.*' parameters may be required too depending on the `sort`)
+//   in: query
+//   type: string
+// - name: from.id
+//   description: Start the page from the sub-group next to the sub-group with `ID`=`from.id`
+//                (if at least one of other 'sort.*' parameters is present, `sort.id` is required)
+//   in: query
+//   type: integer
+// - name: sort
+//   in: query
+//   default: [name,id]
+//   type: array
+//   items:
+//     type: string
+//     enum: [name,-name,type,-type,grade,-grade,id,-id]
+// - name: limit
+//   description: Display the first N sub-groups
+//   in: query
+//   type: integer
+//   maximum: 1000
+//   default: 500
+// responses:
+//   "200":
+//     "$ref": "#/responses/groupChildrenViewResponse"
+//   "400":
+//     "$ref": "#/responses/badRequestResponse"
+//   "401":
+//     "$ref": "#/responses/unauthorizedResponse"
+//   "403":
+//     "$ref": "#/responses/forbiddenResponse"
+//   "500":
+//     "$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.APIError {
 	user := srv.GetUser(r)
 

--- a/app/api/groups/get_children.robustness.feature
+++ b/app/api/groups/get_children.robustness.feature
@@ -34,3 +34,15 @@ Feature: Get group children (groupChildrenView) - robustness
     When I send a GET request to "/groups/13/children?sort=password"
     Then the response code should be 400
     And the response error message should contain "Unallowed field in sorting parameters: "password""
+
+  Scenario: Invalid type in types_include
+    Given I am the user with ID "1"
+    When I send a GET request to "/groups/13/children?types_include=Teacher"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value in 'types_include': "Teacher""
+
+  Scenario: Invalid type in types_exclude
+    Given I am the user with ID "1"
+    When I send a GET request to "/groups/13/children?types_exclude=Manager"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value in 'types_exclude': "Manager""

--- a/app/doc/responses.go
+++ b/app/doc/responses.go
@@ -203,3 +203,30 @@ type groupsGetUserProgressResponse struct {
 		TimeSpent int32 `json:"time_spent"`
 	}
 }
+
+// OK. Success response with group's sub-groups
+// swagger:response groupChildrenViewResponse
+type groupChildrenViewResponse struct {
+	// in: body
+	Body []struct {
+		// The sub-group's `groups.ID`
+		// required:true
+		ID int64 `json:"id,string"`
+		// required:true
+		Name string `json:"name"`
+		// required:true
+		Type string `json:"type"`
+		// required:true
+		Grade int32 `json:"grade"`
+		// required:true
+		Opened bool `json:"opened"`
+		// required:true
+		FreeAccess bool `json:"free_access"`
+		// Nullable
+		// required:true
+		Password *string `json:"password"`
+		// The number of descendant users
+		// required:true
+		UserCount int32 `json:"user_count"`
+	}
+}


### PR DESCRIPTION
[groupChildrenView](https://docs.google.com/document/d/15Xxmatrs_7my5ioriikL6YgOU4I0sAVcq5ySKinc0Nw/edit#heading=h.pmkpy2f6f727)

1. Add new request parameters `types_include` & `types_exclude` taking a comma-separated list of types to include or exclude. 
2. Add a new output field `user_count` (the number of descendant users).
3. Only show sub-groups with groups_groups.sType IN ('direct', 'requestAccepted', 'invitationAccepted')