### PR TITLE
 Handle Root* group types

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ Environment-specific configurations can be defined using `conf/config.ENV.yml` f
 
 ## Seeding the database
 
-An empty dump (schema without data) can be loaded using the `./bin/AlgoreaBackend db-restore` followed by `./bin/AlgoreaBackend db-migrate`.
+An empty dump (schema without data) can be loaded using the
+```
+./bin/AlgoreaBackend db-restore
+```
+followed by
+```
+./bin/AlgoreaBackend db-migrate
+```
+Probably you may also want to run
+```
+./bin/AlgoreaBackend install
+```
+to insert the data required by the config.
 
 ## Testing
 

--- a/app/api/auth/create_temp_user.feature
+++ b/app/api/auth/create_temp_user.feature
@@ -1,11 +1,21 @@
 Feature: Create a temporary user
 
   Background:
+    Given the application config is:
+      """
+      domains:
+        -
+          domains: [127.0.0.1]
+          rootGroup: 1
+          rootSelfGroup: 2
+          rootAdminGroup: 3
+          rootTempGroup: 4
+      """
     And the database has the following table 'groups':
       | ID | sName      | sType     | sTextId   |
-      | 1  | Root       | Root      | Root      |
-      | 2  | RootSelf   | RootSelf  | RootSelf  |
-      | 3  | RootAdmin  | RootAdmin | RootAdmin |
+      | 1  | Root       | Base      | Root      |
+      | 2  | RootSelf   | Base      | RootSelf  |
+      | 3  | RootAdmin  | Base      | RootAdmin |
       | 4  | RootTemp   | UserSelf  | RootTemp  |
     And the database has the following table 'groups_groups':
       | ID | idGroupParent | idGroupChild | iChildOrder |

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -11,6 +11,7 @@ import (
 
 	authlib "github.com/France-ioi/AlgoreaBackend/app/auth"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
@@ -73,13 +74,9 @@ func (srv *Service) createTempUser(w http.ResponseWriter, r *http.Request) servi
 		}))
 		service.MustNotBeError(store.Users().ByID(userID).UpdateColumn("idGroupSelf", selfGroupID).Error())
 
-		var rootTempGroupID int64
-		service.MustNotBeError(store.Groups().
-			Where("sType = 'UserSelf'").
-			Where("sName = 'RootTemp'").
-			Where("sTextId = 'RootTemp'").PluckFirst("ID", &rootTempGroupID).Error())
+		domainConfig := domain.ConfigFromContext(r.Context())
 		service.MustNotBeError(store.GroupGroups().CreateRelationsWithoutChecking(
-			[]database.ParentChild{{ParentID: rootTempGroupID, ChildID: selfGroupID}}))
+			[]database.ParentChild{{ParentID: domainConfig.RootTempGroupID, ChildID: selfGroupID}}))
 
 		var err error
 		token, expiresIn, err = authlib.CreateNewTempSession(store.Sessions(), userID)

--- a/app/api/auth/login_callback.feature
+++ b/app/api/auth/login_callback.feature
@@ -2,8 +2,8 @@ Feature: Login callback
   Background:
     Given the database has the following table 'groups':
       | ID | sType     | sName     | sDateCreated         |
-      | 2  | RootSelf  | RootSelf  | 2015-08-10T12:34:55Z |
-      | 3  | RootAdmin | RootAdmin | 2015-08-10T12:34:56Z |
+      | 2  | Base      | RootSelf  | 2015-08-10T12:34:55Z |
+      | 3  | Base      | RootAdmin | 2015-08-10T12:34:56Z |
     And the application config is:
       """
       auth:
@@ -11,6 +11,11 @@ Feature: Login callback
         clientID: "1"
         clientSecret: "tzxsLyFtJiGnmD6sjZMqSEidVpVsL3hEoSxIXCpI"
         callbackURL: "https://backend.algorea.org/auth/login-callback"
+      domains:
+        -
+          domains: [127.0.0.1]
+          rootSelfGroup: 2
+          rootAdminGroup: 3
       """
 
   Scenario: Create a new user
@@ -72,8 +77,8 @@ Feature: Login callback
       | 3916589616287113937 | 5577006791947779410 | 8674665223082153551 | 2019-07-16T22:02:28Z | 2019-07-16T22:02:28Z | 0        | 2019-07-16T22:02:28Z | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02T00:00:00Z | 2020            | 0      | null     | null     | null  | null            | null             | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 |
     And the table "groups" should be:
       | ID                  | sName          | sType     | sDescription   | sDateCreated         | bOpened | bSendEmails |
-      | 2                   | RootSelf       | RootSelf  | null           | 2015-08-10T12:34:55Z | false   | false       |
-      | 3                   | RootAdmin      | RootAdmin | null           | 2015-08-10T12:34:56Z | false   | false       |
+      | 2                   | RootSelf       | Base      | null           | 2015-08-10T12:34:55Z | false   | false       |
+      | 3                   | RootAdmin      | Base      | null           | 2015-08-10T12:34:56Z | false   | false       |
       | 5577006791947779410 | mohammed       | UserSelf  | mohammed       | 2019-07-16T22:02:28Z | false   | false       |
       | 8674665223082153551 | mohammed-admin | UserAdmin | mohammed-admin | 2019-07-16T22:02:28Z | false   | false       |
     And the table "groups_groups" should be:
@@ -166,6 +171,10 @@ Feature: Login callback
       | 3                   | 3            | true    |
       | 3                   | 12           | false   |
       | 3                   | 14           | false   |
+      | 11                  | 11           | true    |
+      | 12                  | 12           | true    |
+      | 13                  | 13           | true    |
+      | 14                  | 14           | true    |
     And the database has the following table 'login_states':
       | sCookie                          | sState                           | sExpirationDate      |
       | {{cookie}}                       | {{state}}                        | 2019-07-16T22:02:29Z |

--- a/app/api/groups/add_child.robustness.feature
+++ b/app/api/groups/add_child.robustness.feature
@@ -12,9 +12,9 @@ Feature: Add a parent-child relation between two groups - robustness
       | 11 | Group A   | Class     |
       | 13 | Group B   | Class     |
       | 14 | UserAdmin | UserAdmin |
-      | 15 | Root      | Root      |
-      | 16 | RootSelf  | RootSelf  |
-      | 17 | RootAdmin | RootAdmin |
+      | 15 | Root      | Base      |
+      | 16 | RootSelf  | Base      |
+      | 17 | RootAdmin | Base      |
       | 18 | UserSelf  | UserSelf  |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -76,16 +76,16 @@ Feature: Get group children (groupChildrenView)
       | 21 | user-admin    | -2     | UserAdmin | true    | false       | null       |
       | 22 | C's Child     | -4     | UserAdmin | true    | false       | null       |
       | 23 | Our Class     | -3     | Class     | true    | false       | null       |
-      | 24 | Root          | -2     | Root      | true    | false       | 3456789abc |
+      | 24 | Root          | -2     | Base      | true    | false       | 3456789abc |
       | 25 | Our Team      | -1     | Team      | true    | false       | 456789abcd |
       | 26 | Our Club      |  0     | Club      | true    | false       | null       |
       | 27 | Our Friends   |  0     | Friends   | true    | false       | 56789abcde |
       | 28 | Other         |  0     | Other     | true    | false       | null       |
       | 29 | UserSelf      |  0     | UserSelf  | true    | false       | null       |
-      | 30 | RootSelf      |  0     | RootSelf  | true    | false       | null       |
-      | 31 | RootAdmin     |  0     | RootAdmin | true    | false       | null       |
+      | 30 | RootSelf      |  0     | Base      | true    | false       | null       |
+      | 31 | RootAdmin     |  0     | Base      | true    | false       | null       |
       | 42 | Their Class   | -3     | Class     | true    | false       | null       |
-      | 43 | Other Root    | -2     | Root      | true    | false       | 3456789abc |
+      | 43 | Other Root    | -2     | Base      | true    | false       | 3456789abc |
       | 44 | Other Team    | -1     | Team      | true    | false       | 456789abcd |
       | 45 | Their Club    |  0     | Club      | true    | false       | null       |
       | 46 | Their Friends |  0     | Friends   | true    | false       | 56789abcde |
@@ -131,9 +131,9 @@ Feature: Get group children (groupChildrenView)
       {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
       {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0}
     ]
     """
@@ -150,9 +150,9 @@ Feature: Get group children (groupChildrenView)
       {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
       {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
       {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
@@ -160,7 +160,7 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is an owner of the parent group, rows are sorted by name by default, all the types are included explicitly
     Given I am the user with ID "1"
-    When I send a GET request to "/groups/13/children?types_include=Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin"
+    When I send a GET request to "/groups/13/children?types_include=Base,Class,Team,Club,Friends,Other,UserSelf,UserAdmin"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -170,9 +170,9 @@ Feature: Get group children (groupChildrenView)
       {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
       {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
       {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
@@ -180,14 +180,15 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is an owner of the parent group, rows are sorted by name by default, some types are excluded
     Given I am the user with ID "1"
-    When I send a GET request to "/groups/13/children?types_exclude=Root,Class,Team,Club,Friends"
+    When I send a GET request to "/groups/13/children?types_exclude=Class,Team,Club,Friends"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
       {"id": "29", "name": "UserSelf", "type": "UserSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
@@ -202,13 +203,13 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
       {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
       {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
       {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 
@@ -219,15 +220,15 @@ Feature: Get group children (groupChildrenView)
     And the response body should be, in JSON:
     """
     [
-      {"id": "24", "name": "Root", "type": "Root", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
       {"id": "23", "name": "Our Class", "type": "Class", "free_access": false, "grade": -3, "opened": true, "password": null, "user_count": 2},
       {"id": "25", "name": "Our Team", "type": "Team", "free_access": false, "grade": -1, "opened": true, "password": "456789abcd", "user_count": 0},
       {"id": "26", "name": "Our Club", "type": "Club", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "27", "name": "Our Friends", "type": "Friends", "free_access": false, "grade": 0, "opened": true, "password": "56789abcde", "user_count": 1},
       {"id": "28", "name": "Other", "type": "Other", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
       {"id": "21", "name": "user-admin", "type": "UserAdmin", "free_access": false, "grade": -2, "opened": true, "password": null, "user_count": 0},
-      {"id": "30", "name": "RootSelf", "type": "RootSelf", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
-      {"id": "31", "name": "RootAdmin", "type": "RootAdmin", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
+      {"id": "24", "name": "Root", "type": "Base", "free_access": false, "grade": -2, "opened": true, "password": "3456789abc", "user_count": 0},
+      {"id": "30", "name": "RootSelf", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0},
+      {"id": "31", "name": "RootAdmin", "type": "Base", "free_access": false, "grade": 0, "opened": true, "password": null, "user_count": 0}
     ]
     """
 

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -22,18 +22,18 @@ import (
 //   type: integer
 // - name: types_include
 //   in: query
-//   default: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+//   default: [Class,Team,Club,Friends,Other,UserSelf,UserAdmin,Base]
 //   type: array
 //   items:
 //     type: string
-//     enum: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+//     enum: [Class,Team,Club,Friends,Other,UserSelf,UserAdmin,Base]
 // - name: types_exclude
 //   in: query
 //   default: []
 //   type: array
 //   items:
 //     type: string
-//     enum: [Root,Class,Team,Club,Friends,Other,UserSelf,UserAdmin,RootSelf,RootAdmin]
+//     enum: [Class,Team,Club,Friends,Other,UserSelf,UserAdmin,Base]
 // - name: from.name
 //   description: Start the page from the sub-group next to the sub-group with `sName` = `from.name` and `ID` = `from.id`
 //                (`from.id` is required when `from.name` is present,
@@ -91,8 +91,8 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 
 	typesList, err := service.ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(r, "types",
 		map[string]bool{
-			"Root": true, "Class": true, "Team": true, "Club": true, "Friends": true,
-			"Other": true, "UserSelf": true, "UserAdmin": true, "RootSelf": true, "RootAdmin": true,
+			"Base": true, "Class": true, "Team": true, "Club": true, "Friends": true,
+			"Other": true, "UserSelf": true, "UserAdmin": true,
 		})
 	if err != nil {
 		return service.ErrInvalidRequest(err)

--- a/app/api/groups/get_team_descendants.feature
+++ b/app/api/groups/get_team_descendants.feature
@@ -15,8 +15,8 @@ Feature: List team descendants of the group (groupTeamDescendantView)
       | 20 | janee  | 69          | 70           | Jane        | Edwards   | null   |
     And the database has the following table 'groups':
       | ID | sType     | sName          | iGrade |
-      | 1  | Root      | Root 1         | -2     |
-      | 3  | Root      | Root 2         | -2     |
+      | 1  | Base      | Root 1         | -2     |
+      | 3  | Base      | Root 2         | -2     |
       | 11 | Class     | Our Class      | -2     |
       | 12 | Class     | Other Class    | -2     |
       | 13 | Class     | Special Class  | -2     |

--- a/app/api/groups/get_team_progress.feature
+++ b/app/api/groups/get_team_progress.feature
@@ -15,8 +15,8 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 20 | janee  | 69          | 70           |
     And the database has the following table 'groups':
       | ID | sType     | sName          |
-      | 1  | Root      | Root 1         |
-      | 3  | Root      | Root 2         |
+      | 1  | Base      | Root 1         |
+      | 3  | Base      | Root 2         |
       | 11 | Class     | Our Class      |
       | 12 | Class     | Other Class    |
       | 13 | Class     | Special Class  |

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -81,7 +81,7 @@ func checkThatUserHasRightsForDirectRelation(
 	for _, groupRow := range groupData {
 		if (groupRow.ID == parentGroupID && groupRow.Type == "UserSelf") ||
 			(groupRow.ID == childGroupID &&
-				map[string]bool{"Root": true, "RootSelf": true, "RootAdmin": true, "UserAdmin": true}[groupRow.Type]) {
+				map[string]bool{"Base": true, "UserAdmin": true}[groupRow.Type]) {
 			return service.InsufficientAccessRightsError
 		}
 	}

--- a/app/api/groups/remove_child.robustness.feature
+++ b/app/api/groups/remove_child.robustness.feature
@@ -13,9 +13,9 @@ Feature: Remove a direct parent-child relation between two groups - robustness
       | 21 | Self      | UserSelf  |
       | 22 | Owned     | UserAdmin |
       | 51 | UserAdmin | UserAdmin |
-      | 52 | Root      | Root      |
-      | 53 | RootSelf  | RootSelf  |
-      | 54 | RootAdmin | RootAdmin |
+      | 52 | Root      | Base      |
+      | 53 | RootSelf  | Base      |
+      | 54 | RootAdmin | Base      |
       | 55 | UserSelf  | UserSelf  |
     And the database has the following table 'groups_groups':
       | idGroupParent | idGroupChild | sType       |

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -27,11 +27,9 @@ func Test_validateUpdateGroupInput(t *testing.T) {
 		{"sType=Friends", `{"type":"Friends"}`, false},
 		{"sType=Other", `{"type":"Other"}`, false},
 
-		{"sType=Root", `{"type":"Root"}`, true},
+		{"sType=Base", `{"type":"Base"}`, true},
 		{"sType=UserSelf", `{"type":"UserSelf"}`, true},
 		{"sType=UserAdmin", `{"type":"UserAdmin"}`, true},
-		{"sType=RootSelf", `{"type":"RootSelf"}`, true},
-		{"sType=RootAdmin", `{"type":"RootAdmin"}`, true},
 		{"sType=unknown", `{"type":"unknown"}`, true},
 		{"sType=", `{"type":""}`, true},
 

--- a/app/app.go
+++ b/app/app.go
@@ -96,8 +96,7 @@ func (app *Application) CheckConfig() error {
 			{name: "RootAdmin", id: domainConfig.RootAdminGroup},
 			{name: "RootTemp", id: domainConfig.RootTempGroup},
 		} {
-			hasRows, err := groupStore.ByID(spec.id).
-				Where("sTextId = ?", spec.name).HasRows()
+			hasRows, err := groupStore.ByID(spec.id).HasRows()
 			if err != nil {
 				return err
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -97,9 +97,7 @@ func (app *Application) SelfCheck() error {
 			{name: "RootTemp", id: domainConfig.RootTempGroup},
 		} {
 			hasRows, err := groupStore.ByID(spec.id).
-				Where("sType = 'Base'").
-				Where("sName = ?", spec.name).
-				Where("sTextId = ?", spec.name).Limit(1).HasRows()
+				Where("sTextId = ?", spec.name).HasRows()
 			if err != nil {
 				return err
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/config"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	_ "github.com/France-ioi/AlgoreaBackend/app/doc" // for doc generation
+	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
 )
@@ -65,6 +66,7 @@ func New() (*Application, error) {
 	router.Use(middleware.Recoverer)          // must be before logger so that it an log panics
 
 	router.Use(corsConfig().Handler) // no need for CORS if served through the same domain
+	router.Use(domain.Middleware(conf.Domains))
 
 	if appenv.IsEnvDev() {
 		router.Mount("/debug", middleware.Profiler())

--- a/app/app.go
+++ b/app/app.go
@@ -82,8 +82,8 @@ func New() (*Application, error) {
 	}, nil
 }
 
-// SelfCheck checks that the database contains all the required data
-func (app *Application) SelfCheck() error {
+// CheckConfig checks that the database contains all the data needed by the config
+func (app *Application) CheckConfig() error {
 	groupStore := database.NewDataStore(app.Database).Groups()
 	groupGroupStore := groupStore.GroupGroups()
 	for _, domainConfig := range app.Config.Domains {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -27,7 +27,7 @@ func TestNew_Success(t *testing.T) {
 	assert.NotNil(app.Config)
 	assert.NotNil(app.Database)
 	assert.NotNil(app.HTTPHandler)
-	assert.Len(app.HTTPHandler.Middlewares(), 6)
+	assert.Len(app.HTTPHandler.Middlewares(), 7)
 	assert.True(len(app.HTTPHandler.Routes()) > 0)
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -192,7 +192,7 @@ type relationSpec struct {
 	error  bool
 }
 
-func TestApplication_SelfCheck(t *testing.T) {
+func TestApplication_CheckConfig(t *testing.T) {
 	type groupSpec struct {
 		textID string
 		id     int64
@@ -422,7 +422,7 @@ func TestApplication_SelfCheck(t *testing.T) {
 				Config:   tt.config,
 				Database: db,
 			}
-			err := app.SelfCheck()
+			err := app.CheckConfig()
 			assertlib.Equal(t, tt.expectedError, err)
 			assertlib.NoError(t, mock.ExpectationsWereMet())
 		})

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -194,7 +194,7 @@ type relationSpec struct {
 
 func TestApplication_SelfCheck(t *testing.T) {
 	type groupSpec struct {
-		name   string
+		textID string
 		id     int64
 		exists bool
 		error  bool
@@ -220,10 +220,10 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4, exists: true},
-				{name: "Root", id: 5, exists: true}, {name: "RootSelf", id: 6, exists: true},
-				{name: "RootAdmin", id: 7, exists: true}, {name: "RootTemp", id: 8, exists: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
+				{textID: "Root", id: 5, exists: true}, {textID: "RootSelf", id: 6, exists: true},
+				{textID: "RootAdmin", id: 7, exists: true}, {textID: "RootTemp", id: 8, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -243,7 +243,7 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1},
+				{textID: "Root", id: 1},
 			},
 			expectedError: errors.New("no Root group for domain \"192.168.0.1\""),
 		},
@@ -256,7 +256,7 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2},
 			},
 			expectedError: errors.New("no RootSelf group for domain \"192.168.0.1\""),
 		},
@@ -269,8 +269,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3},
 			},
 			expectedError: errors.New("no RootAdmin group for domain \"127.0.0.1\""),
 		},
@@ -283,8 +283,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4},
 			},
 			expectedError: errors.New("no RootTemp group for domain \"127.0.0.1\""),
 		},
@@ -297,8 +297,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4, exists: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}},
@@ -314,8 +314,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4, exists: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -332,8 +332,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4, exists: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -351,7 +351,7 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, error: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, error: true},
 			},
 			expectedError: errors.New("some error"),
 		},
@@ -364,8 +364,8 @@ func TestApplication_SelfCheck(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{name: "Root", id: 1, exists: true}, {name: "RootSelf", id: 2, exists: true},
-				{name: "RootAdmin", id: 3, exists: true}, {name: "RootTemp", id: 4, exists: true},
+				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
+				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -385,9 +385,9 @@ func TestApplication_SelfCheck(t *testing.T) {
 
 			for _, expectedGroupToCheck := range tt.expectedGroupsToCheck {
 				queryMock := mock.ExpectQuery("^"+regexp.QuoteMeta(
-					"SELECT 1 FROM `groups`  WHERE (groups.ID = ?) AND (sType = 'Base') AND (sName = ?) AND (sTextId = ?) LIMIT 1",
+					"SELECT 1 FROM `groups`  WHERE (groups.ID = ?) AND (sTextId = ?) LIMIT 1",
 				)+"$").
-					WithArgs(expectedGroupToCheck.id, expectedGroupToCheck.name, expectedGroupToCheck.name)
+					WithArgs(expectedGroupToCheck.id, expectedGroupToCheck.textID)
 				if !expectedGroupToCheck.error {
 					rowsToReturn := mock.NewRows([]string{"1"})
 					if expectedGroupToCheck.exists {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -194,7 +194,6 @@ type relationSpec struct {
 
 func TestApplication_CheckConfig(t *testing.T) {
 	type groupSpec struct {
-		textID string
 		id     int64
 		exists bool
 		error  bool
@@ -220,10 +219,10 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
-				{textID: "Root", id: 5, exists: true}, {textID: "RootSelf", id: 6, exists: true},
-				{textID: "RootAdmin", id: 7, exists: true}, {textID: "RootTemp", id: 8, exists: true},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4, exists: true},
+				{id: 5, exists: true}, {id: 6, exists: true},
+				{id: 7, exists: true}, {id: 8, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -243,7 +242,7 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1},
+				{id: 1},
 			},
 			expectedError: errors.New("no Root group for domain \"192.168.0.1\""),
 		},
@@ -256,7 +255,7 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2},
+				{id: 1, exists: true}, {id: 2},
 			},
 			expectedError: errors.New("no RootSelf group for domain \"192.168.0.1\""),
 		},
@@ -269,8 +268,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3},
 			},
 			expectedError: errors.New("no RootAdmin group for domain \"127.0.0.1\""),
 		},
@@ -283,8 +282,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4},
 			},
 			expectedError: errors.New("no RootTemp group for domain \"127.0.0.1\""),
 		},
@@ -297,8 +296,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}},
@@ -314,8 +313,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -332,8 +331,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -351,7 +350,7 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, error: true},
+				{id: 1, exists: true}, {id: 2, error: true},
 			},
 			expectedError: errors.New("some error"),
 		},
@@ -364,8 +363,8 @@ func TestApplication_CheckConfig(t *testing.T) {
 				},
 			}},
 			expectedGroupsToCheck: []groupSpec{
-				{textID: "Root", id: 1, exists: true}, {textID: "RootSelf", id: 2, exists: true},
-				{textID: "RootAdmin", id: 3, exists: true}, {textID: "RootTemp", id: 4, exists: true},
+				{id: 1, exists: true}, {id: 2, exists: true},
+				{id: 3, exists: true}, {id: 4, exists: true},
 			},
 			expectedRelationsToCheck: []relationSpec{
 				{ParentChild: database.ParentChild{ParentID: 1, ChildID: 2}, exists: true},
@@ -384,10 +383,9 @@ func TestApplication_CheckConfig(t *testing.T) {
 			var expectedError error
 
 			for _, expectedGroupToCheck := range tt.expectedGroupsToCheck {
-				queryMock := mock.ExpectQuery("^"+regexp.QuoteMeta(
-					"SELECT 1 FROM `groups`  WHERE (groups.ID = ?) AND (sTextId = ?) LIMIT 1",
-				)+"$").
-					WithArgs(expectedGroupToCheck.id, expectedGroupToCheck.textID)
+				queryMock := mock.ExpectQuery("^" + regexp.QuoteMeta(
+					"SELECT 1 FROM `groups`  WHERE (groups.ID = ?) LIMIT 1",
+				) + "$").WithArgs(expectedGroupToCheck.id)
 				if !expectedGroupToCheck.error {
 					rowsToReturn := mock.NewRows([]string{"1"})
 					if expectedGroupToCheck.exists {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -54,6 +54,15 @@ type Token struct {
 	PrivateKeyFile string
 }
 
+// Domain is the part of the config related to domains
+type Domain struct {
+	Domains        []string
+	RootGroup      int64
+	RootSelfGroup  int64
+	RootAdminGroup int64
+	RootTempGroup  int64
+}
+
 // Root is the root of the app configuration
 type Root struct {
 	Server       Server
@@ -62,6 +71,7 @@ type Root struct {
 	Logging      Logging
 	Auth         Auth
 	Token        Token
+	Domains      []Domain
 }
 
 const defaultConfigName = "config"

--- a/app/database/group_group_store.go
+++ b/app/database/group_group_store.go
@@ -130,7 +130,7 @@ func (s *GroupGroupStore) DeleteRelation(parentGroupID, childGroupID int64, shou
 						ancestors.idGroupChild = groups.ID AND
 						ancestors.bIsSelf = 0 AND
 						ancestors.idGroupAncestor = ?`, childGroupID).
-				Where("groups.sType NOT IN('Root', 'RootSelf', 'RootAdmin', 'UserAdmin', 'UserSelf')").
+				Where("groups.sType NOT IN('Base', 'UserAdmin', 'UserSelf')").
 				Pluck("groups.ID", &candidatesForDeletion).Error())
 		}
 

--- a/app/database/testdata/group_group_store/delete_relation/deletes_only_orphans_of_accepted_types/groups.yaml
+++ b/app/database/testdata/group_group_store/delete_relation/deletes_only_orphans_of_accepted_types/groups.yaml
@@ -6,8 +6,8 @@
 - {ID: 6, sType: "Class"}
 - {ID: 7, sType: "Other"}
 
-- {ID: 8, sType: "Root"}
+- {ID: 8, sType: "Base", sName: "Root"}
 - {ID: 9, sType: "UserSelf"}
 - {ID: 10, sType: "UserAdmin"}
-- {ID: 11, sType: "RootSelf"}
-- {ID: 12, sType: "RootAdmin"}
+- {ID: 11, sType: "Base", sName: "RootSelf"}
+- {ID: 12, sType: "Base", sName: "RootAdmin"}

--- a/app/domain/domain.go
+++ b/app/domain/domain.go
@@ -1,0 +1,10 @@
+package domain
+
+import "context"
+
+// ConfigFromContext retrieves the current domain configuration from a context set by the middleware
+func ConfigFromContext(ctx context.Context) *Configuration {
+	conf := ctx.Value(ctxDomainConfig).(*Configuration)
+	confCopy := *conf
+	return &confCopy
+}

--- a/app/domain/domain_test.go
+++ b/app/domain/domain_test.go
@@ -1,0 +1,17 @@
+package domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromContext(t *testing.T) {
+	expectedConfig := &Configuration{RootGroupID: 100, RootSelfGroupID: 101, RootAdminGroupID: 102, RootTempGroupID: 103}
+	ctx := context.WithValue(context.Background(), ctxDomainConfig, expectedConfig)
+	conf := ConfigFromContext(ctx)
+
+	assert.False(t, expectedConfig == conf)
+	assert.EqualValues(t, expectedConfig, conf)
+}

--- a/app/domain/middleware.go
+++ b/app/domain/middleware.go
@@ -24,7 +24,7 @@ type Configuration struct {
 	RootTempGroupID  int64
 }
 
-// Middleware is a middleware
+// Middleware is a middleware setting domain-specific configuration into the request context
 func Middleware(domains []config.Domain) func(next http.Handler) http.Handler {
 	domainsMap := map[string]*Configuration{}
 	for _, domain := range domains {

--- a/app/domain/middleware.go
+++ b/app/domain/middleware.go
@@ -1,0 +1,59 @@
+package domain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/France-ioi/AlgoreaBackend/app/config"
+)
+
+type ctxKey int
+
+const (
+	ctxDomainConfig ctxKey = iota
+)
+
+// Configuration contains domain-specific settings
+type Configuration struct {
+	RootGroupID      int64
+	RootSelfGroupID  int64
+	RootAdminGroupID int64
+	RootTempGroupID  int64
+}
+
+// Middleware is a middleware
+func Middleware(domains []config.Domain) func(next http.Handler) http.Handler {
+	domainsMap := map[string]*Configuration{}
+	for _, domain := range domains {
+		for _, host := range domain.Domains {
+			domainsMap[host] = &Configuration{
+				RootGroupID:      domain.RootGroup,
+				RootSelfGroupID:  domain.RootSelfGroup,
+				RootAdminGroupID: domain.RootAdminGroup,
+				RootTempGroupID:  domain.RootTempGroup,
+			}
+		}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			domain := strings.SplitN(r.Host, ":", 2)[0]
+			configuration := domainsMap[domain]
+			if configuration == nil {
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusNotImplemented)
+				data, _ := json.Marshal(struct {
+					Success   bool   `json:"success"`
+					Message   string `json:"message"`
+					ErrorText string `json:"error_text"`
+				}{Success: false, Message: "Not implemented", ErrorText: fmt.Sprintf("Wrong domain %q", domain)})
+				_, _ = w.Write(data)
+				return
+			}
+			ctx := context.WithValue(r.Context(), ctxDomainConfig, configuration)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -1,0 +1,92 @@
+package domain
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/config"
+)
+
+func TestMiddleware(t *testing.T) {
+	tests := []struct {
+		name               string
+		domains            []config.Domain
+		expectedConfig     *Configuration
+		expectedStatusCode int
+		expectedBody       string
+		shouldEnterService bool
+	}{
+		{
+			name: "ok",
+			domains: []config.Domain{
+				{
+					Domains:   []string{"france-ioi.org", "www.france-ioi.org"},
+					RootGroup: 5, RootSelfGroup: 6, RootAdminGroup: 7, RootTempGroup: 7,
+				},
+				{
+					Domains:   []string{"192.168.0.1", "127.0.0.1"},
+					RootGroup: 1, RootSelfGroup: 2, RootAdminGroup: 3, RootTempGroup: 4,
+				},
+			},
+			expectedConfig:     &Configuration{RootGroupID: 1, RootSelfGroupID: 2, RootAdminGroupID: 3, RootTempGroupID: 4},
+			expectedStatusCode: http.StatusOK,
+			shouldEnterService: true,
+		},
+		{
+			name: "wrong domain",
+			domains: []config.Domain{
+				{
+					Domains:   []string{"france-ioi.org", "www.france-ioi.org"},
+					RootGroup: 4, RootSelfGroup: 5, RootAdminGroup: 6, RootTempGroup: 7,
+				},
+				{
+					Domains:   []string{"192.168.0.1"},
+					RootGroup: 1, RootSelfGroup: 2, RootAdminGroup: 3, RootTempGroup: 4,
+				},
+			},
+			expectedStatusCode: http.StatusNotImplemented,
+			expectedBody:       "{\"success\":false,\"message\":\"Not implemented\",\"error_text\":\"Wrong domain \\\"127.0.0.1\\\"\"}",
+			shouldEnterService: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assertMiddleware(t, tt.domains, tt.shouldEnterService, tt.expectedStatusCode, tt.expectedBody, tt.expectedConfig)
+		})
+	}
+}
+
+func assertMiddleware(t *testing.T, domains []config.Domain, shouldEnterService bool,
+	expectedStatusCode int, expectedBody string, expectedConfig *Configuration) {
+	// dummy server using the middleware
+	middleware := Middleware(domains)
+	enteredService := false // used to log if the service has been reached
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enteredService = true // has passed into the service
+		configuration := r.Context().Value(ctxDomainConfig).(*Configuration)
+		assert.Equal(t, expectedConfig, configuration)
+		w.WriteHeader(http.StatusOK)
+	})
+	mainSrv := httptest.NewServer(middleware(handler))
+	defer mainSrv.Close()
+
+	// calling web server
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, nil)
+	client := &http.Client{}
+	response, err := client.Do(mainRequest)
+	var body string
+	if err == nil {
+		bodyData, _ := ioutil.ReadAll(response.Body)
+		_ = response.Body.Close()
+		body = string(bodyData)
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBody, body)
+	assert.Equal(t, expectedStatusCode, response.StatusCode)
+	assert.Equal(t, shouldEnterService, enteredService)
+}

--- a/cmd/db_gen_load.go
+++ b/cmd/db_gen_load.go
@@ -61,10 +61,10 @@ func init() { // nolint:gochecknoinits,gocyclo
 			db := testhelpers.SetupDBWithFixtureString(`
 			users: [{ID: 1, sLogin: owner, idGroupSelf: 21, idGroupOwned: 22}]
 			groups:
-				- {ID: 1, sType: Root, sName: Root, sTextId: Root}
-				- {ID: 2, sType: RootSelf, sName: RootSelf, sTextId: RootSelf}
-				- {ID: 3, sType: RootAdmin, sName: RootAdmin, sTextId: RootAdmin}
-				- {ID: 4, sType: UserSelf, sName: RootTemp, sTextId: RootTemp}
+				- {ID: 1, sType: Base, sName: Root, sTextId: Root}
+				- {ID: 2, sType: Base, sName: RootSelf, sTextId: RootSelf}
+				- {ID: 3, sType: Base, sName: RootAdmin, sTextId: RootAdmin}
+				- {ID: 4, sType: Base, sName: RootTemp, sTextId: RootTemp}
 				- {ID: 5, sType: Class}
 				- {ID: 11, sType: Class}
 				- {ID: 12, sType: Class}

--- a/cmd/db_seed.go
+++ b/cmd/db_seed.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	_ "github.com/go-sql-driver/mysql" // use to force database/sql to use mysql
+	"github.com/spf13/cobra"
+
+	"github.com/France-ioi/AlgoreaBackend/app"
+	"github.com/France-ioi/AlgoreaBackend/app/appenv"
+)
+
+// nolint:gosec
+func init() { // nolint:gochecknoinits,gocyclo
+
+	var dbSeedCmd = &cobra.Command{
+		Use:   "db-seed  [environment]",
+		Short: "fill the database with required data",
+		Run: func(cmd *cobra.Command, args []string) {
+			// if arg given, replace the env
+			if len(args) > 0 {
+				appenv.SetEnv(args[0])
+			}
+
+			appenv.SetDefaultEnv("dev")
+
+			var application *app.Application
+			var err error
+			application, err = app.New()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			err = application.SeedDatabase()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Success
+			fmt.Println("DONE")
+		},
+	}
+
+	rootCmd.AddCommand(dbSeedCmd)
+}

--- a/cmd/db_seed.go
+++ b/cmd/db_seed.go
@@ -32,7 +32,7 @@ func init() { // nolint:gochecknoinits,gocyclo
 				log.Fatal(err)
 			}
 
-			err = application.SeedDatabase()
+			err = application.CreateMissingData()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,6 +17,9 @@ func init() { // nolint:gochecknoinits,gocyclo
 	var installCmd = &cobra.Command{
 		Use:   "install [environment]",
 		Short: "fill the database with required data",
+		Long: `If the root group IDs specified in the config file
+do not exist or have missing relations, creates them all
+(groups, groups_groups, and groups_ancestors)`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// if arg given, replace the env
 			if len(args) > 0 {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -14,8 +14,8 @@ import (
 // nolint:gosec
 func init() { // nolint:gochecknoinits,gocyclo
 
-	var dbSeedCmd = &cobra.Command{
-		Use:   "db-seed  [environment]",
+	var installCmd = &cobra.Command{
+		Use:   "install [environment]",
 		Short: "fill the database with required data",
 		Run: func(cmd *cobra.Command, args []string) {
 			// if arg given, replace the env
@@ -42,5 +42,5 @@ func init() { // nolint:gochecknoinits,gocyclo
 		},
 	}
 
-	rootCmd.AddCommand(dbSeedCmd)
+	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 )
 
 func init() { // nolint:gochecknoinits
+	var skipChecks bool
 
 	var serveCmd = &cobra.Command{
 		Use:   "serve [environment]",
@@ -31,9 +32,11 @@ func init() { // nolint:gochecknoinits
 				log.Fatal(err)
 			}
 
-			err = application.SelfCheck()
-			if err != nil {
-				log.Fatal(err)
+			if !skipChecks {
+				err = application.SelfCheck()
+				if err != nil {
+					log.Fatalf("Integrity check failed: %s\nUse --skip-checks to bypass the integrity check\n", err)
+				}
 			}
 
 			var server *app.Server
@@ -45,5 +48,6 @@ func init() { // nolint:gochecknoinits
 		},
 	}
 
+	serveCmd.Flags().BoolVar(&skipChecks, "skip-checks", false, "skip the integrity check at startup")
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -33,7 +33,7 @@ func init() { // nolint:gochecknoinits
 			}
 
 			if !skipChecks {
-				err = application.SelfCheck()
+				err = application.CheckConfig()
 				if err != nil {
 					log.Fatalf("Integrity check failed: %s\nUse --skip-checks to bypass the integrity check\n", err)
 				}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -31,6 +31,11 @@ func init() { // nolint:gochecknoinits
 				log.Fatal(err)
 			}
 
+			err = application.SelfCheck()
+			if err != nil {
+				log.Fatal(err)
+			}
+
 			var server *app.Server
 			server, err = app.NewServer(application)
 			if err != nil {

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -25,5 +25,12 @@ logging:
   level: debug # debug, info, warning, error, fatal, panic
   logSQLQueries: true
   logRawSQLQueries: false
+domains:
+  -
+    domains: [127.0.0.1]
+    rootGroup: 1
+    rootSelfGroup: 2
+    rootAdminGroup: 3
+    rootTempGroup: 4
 # reverseProxy: # server to which requests which do not match any route will be sent
 #   server: "http://localhost:3000"

--- a/db/migrations/14_alter_table_groups_modify_sType_add_Base.sql
+++ b/db/migrations/14_alter_table_groups_modify_sType_add_Base.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+ALTER TABLE `groups` MODIFY COLUMN `sType` enum('Root','Class','Team','Club','Friends','Other','UserSelf','UserAdmin','RootSelf','RootAdmin', 'Base') NOT NULL;
+UPDATE `groups` SET `sType` = 'Base' WHERE `sType` IN ('Root', 'RootSelf', 'RootAdmin');
+UPDATE `groups` SET `sType` = 'Base' WHERE `sType` = 'UserSelf' AND `sName` = 'RootTemp' AND `sTextId` = 'RootTemp';
+ALTER TABLE `groups` MODIFY COLUMN `sType` enum('Class','Team','Club','Friends','Other','UserSelf','UserAdmin','Base') NOT NULL;
+
+-- +migrate Down
+ALTER TABLE `groups` MODIFY COLUMN `sType` enum('Root','Class','Team','Club','Friends','Other','UserSelf','UserAdmin','RootSelf','RootAdmin', 'Base') NOT NULL;
+UPDATE `groups` SET `sType` = 'UserSelf' WHERE `sType` = 'Base' AND `sName` = 'RootTemp' AND `sTextId` = 'RootTemp';
+UPDATE `groups` SET `sType` = 'Root' WHERE `sType` = 'Base' AND `sName` = 'Root' AND `sTextId` = 'Root';
+UPDATE `groups` SET `sType` = 'RootSelf' WHERE `sType` = 'Base' AND `sName` = 'RootSelf' AND `sTextId` = 'RootSelf';
+UPDATE `groups` SET `sType` = 'RootAdmin' WHERE `sType` = 'Base' AND `sName` = 'RootAdmin' AND `sTextId` = 'RootAdmin';
+ALTER TABLE `groups` MODIFY COLUMN `sType` enum('Root','Class','Team','Club','Friends','Other','UserSelf','UserAdmin','RootSelf','RootAdmin') NOT NULL;


### PR DESCRIPTION
1. Add a middleware providing domain-related config settings to the application
2. Modify groups.sType column: change type for groups with sType = 'Root'/'RootSelf'/'RootAdmin' (or 'UserSelf' with sName='RootTemp' & sTextId='RootTemp') to the type "Base".
3. Create links to domain root groups when an existing user logs in to some domain for the first time.
4. Perform integrity checking before starting the app server.
5. Introduce a new command to create root groups for all the domains (db-seed).