### PR TITLE
Apply the "orange changes" to contestGetGroupByName & contestSetAdditionalTime services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-bdd: $(GODOG)
 	# to pass args: make ARGS="--tags=wip" test-bdd
 	$(GODOG) --format=progress $(ARGS) .
 lint: $(GOLANGCILINT)
-	$(GOLANGCILINT) run --deadline 5m0s
+	$(GOLANGCILINT) run --deadline 10m0s
 
 clean:
 	$(GOCLEAN)

--- a/app/api/contests/contests.go
+++ b/app/api/contests/contests.go
@@ -24,18 +24,15 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Get("/contests/{item_id}/group-by-name", service.AppHandler(srv.getGroupByName).ServeHTTP)
 }
 
-func (srv *Service) checkThatUserCanManageTimedContest(itemID int64, user *database.User) service.APIError {
-	ok, err := srv.Store.Items().ByID(itemID).Where("items.sDuration IS NOT NULL").
+func (srv *Service) getTeamModeForTimedContestManagedByUser(itemID int64, user *database.User) (bool, error) {
+	var isTeamOnly bool
+	err := srv.Store.Items().ByID(itemID).Where("items.sDuration IS NOT NULL").
 		Joins("JOIN groups_items ON groups_items.idItem = items.ID").
 		Joins(`
 			JOIN groups_ancestors ON groups_ancestors.idGroupAncestor = groups_items.idGroup AND
 				groups_ancestors.idGroupChild = ?`, user.SelfGroupID).
 		Group("items.ID").
 		Having("MIN(groups_items.sCachedFullAccessDate) <= NOW() OR MIN(groups_items.sCachedAccessSolutionsDate) <= NOW()").
-		HasRows()
-	service.MustNotBeError(err)
-	if !ok {
-		return service.InsufficientAccessRightsError
-	}
-	return service.NoError
+		PluckFirst("items.bHasAttempts", &isTeamOnly).Error()
+	return isTeamOnly, err
 }

--- a/app/api/contests/get_group_by_name.feature
+++ b/app/api/contests/get_group_by_name.feature
@@ -3,42 +3,83 @@ Feature: Get group by name (contestGetGroupByName)
     Given the database has the following table 'users':
       | ID | sLogin | idGroupSelf | idGroupOwned |
       | 1  | owner  | 21          | 22           |
+      | 2  | john   | 31          | 32           |
+      | 3  | jane   | 41          | 42           |
     And the database has the following table 'groups':
-      | ID | sName      |
-      | 10 | Parent     |
-      | 11 | Group A    |
-      | 13 | Group B    |
-      | 14 | Group B    |
+      | ID | sName       | sType     | idTeamItem |
+      | 10 | Parent      | Club      | null       |
+      | 11 | Group A     | Friends   | null       |
+      | 13 | Group B     | Team      | 60         |
+      | 14 | Group B     | Other     | null       |
+      | 15 | Team        | Team      | 60         |
+      | 21 | owner       | UserSelf  | null       |
+      | 22 | owner-admin | UserAdmin | null       |
+      | 31 | john        | UserSelf  | null       |
+      | 32 | john-admin  | UserAdmin | null       |
+      | 41 | jane        | UserSelf  | null       |
+      | 42 | jane-admin  | UserAdmin | null       |
+    And the database has the following table 'groups_groups':
+      | idGroupParent | idGroupChild | sType              |
+      | 10            | 11           | direct             |
+      | 10            | 13           | direct             |
+      | 11            | 13           | direct             |
+      | 11            | 15           | direct             |
+      | 14            | 14           | direct             |
+      | 15            | 31           | invitationAccepted |
+      | 15            | 41           | requestAccepted    |
+      | 22            | 13           | direct             |
+      | 22            | 14           | direct             |
+      | 22            | 15           | direct             |
+      | 22            | 31           | direct             |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |
       | 10              | 10           | 1       |
       | 10              | 11           | 0       |
       | 10              | 13           | 0       |
+      | 10              | 15           | 0       |
       | 11              | 11           | 1       |
       | 11              | 13           | 0       |
+      | 11              | 15           | 0       |
       | 13              | 13           | 1       |
       | 14              | 14           | 1       |
+      | 15              | 15           | 1       |
+      | 15              | 31           | 0       |
+      | 15              | 41           | 0       |
       | 21              | 21           | 1       |
+      | 22              | 11           | 0       |
       | 22              | 13           | 0       |
       | 22              | 14           | 0       |
+      | 22              | 15           | 0       |
       | 22              | 22           | 1       |
+      | 22              | 31           | 0       |
+      | 31              | 31           | 1       |
+      | 32              | 32           | 1       |
+      | 41              | 41           | 1       |
+      | 42              | 42           | 1       |
     And the database has the following table 'items':
-      | ID | sDuration |
-      | 50 | 00:00:00  |
-      | 60 | 00:00:01  |
-      | 10 | 00:00:02  |
-      | 70 | 00:00:03  |
+      | ID | sDuration | bHasAttempts |
+      | 50 | 00:00:00  | 0            |
+      | 60 | 00:00:01  | 1            |
+      | 10 | 00:00:02  | 0            |
+      | 70 | 00:00:03  | 1            |
+    And the database has the following table 'items_ancestors':
+      | idItemAncestor | idItemChild |
+      | 60             | 70          |
     And the database has the following table 'groups_items':
       | idGroup | idItem | sCachedPartialAccessDate | sCachedGrayedAccessDate | sCachedFullAccessDate | sCachedAccessSolutionsDate | sAdditionalTime |
-      | 10      | 50     | null                     | null                    | null                  | null                       | 01:00:00        |
+      | 10      | 50     | 2017-05-29T06:38:38Z     | null                    | null                  | null                       | 01:00:00        |
       | 11      | 50     | null                     | null                    | null                  | null                       | 00:01:00        |
-      | 13      | 50     | 2017-05-29T06:38:38Z     | null                    | null                  | null                       | 00:00:01        |
-      | 11      | 60     | null                     | null                    | null                  | null                       | null            |
-      | 13      | 60     | null                     | 2017-05-29T06:38:38Z    | null                  | null                       | 00:00:30        |
+      | 11      | 60     | null                     | 2017-05-29T06:38:38Z    | null                  | null                       | null            |
       | 11      | 70     | null                     | null                    | 2017-05-29T06:38:38Z  | null                       | null            |
+      | 13      | 50     | 2017-05-29T06:38:38Z     | null                    | null                  | null                       | 00:00:01        |
+      | 13      | 60     | null                     | 2017-05-29T06:38:38Z    | null                  | null                       | 00:00:30        |
+      | 15      | 60     | null                     | 2018-05-29T06:38:38Z    | null                  | null                       | 00:00:45        |
       | 21      | 50     | null                     | null                    | null                  | 2018-05-29T06:38:38Z       | 00:01:00        |
       | 21      | 60     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | 00:01:00        |
       | 21      | 70     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | 00:01:00        |
+      | 31      | 50     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | 00:01:00        |
+      | 31      | 70     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | 00:01:00        |
+      | 41      | 70     | 2018-05-29T06:38:38Z     | null                    | null                  | null                       | 00:01:00        |
 
   Scenario: Partial access for group, solutions access for user, additional time from parent groups
     Given I am the user with ID "1"
@@ -48,6 +89,8 @@ Feature: Get group by name (contestGetGroupByName)
     """
     {
       "group_id": "13",
+      "name": "Group B",
+      "type": "Team",
       "additional_time": 1,
       "total_additional_time": 3661
     }
@@ -61,6 +104,8 @@ Feature: Get group by name (contestGetGroupByName)
     """
     {
       "group_id": "13",
+      "name": "Group B",
+      "type": "Team",
       "additional_time": 30,
       "total_additional_time": 30
     }
@@ -74,6 +119,8 @@ Feature: Get group by name (contestGetGroupByName)
     """
     {
       "group_id": "13",
+      "name": "Group B",
+      "type": "Team",
       "additional_time": 0,
       "total_additional_time": 0
     }
@@ -87,7 +134,84 @@ Feature: Get group by name (contestGetGroupByName)
     """
     {
       "group_id": "13",
+      "name": "Group B",
+      "type": "Team",
       "additional_time": 1,
       "total_additional_time": 3661
+    }
+    """
+
+  Scenario: Group is a user group (non-team contest)
+    Given I am the user with ID "1"
+    When I send a GET request to "/contests/50/group-by-name?name=john"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "group_id": "31",
+      "name": "john",
+      "type": "UserSelf",
+      "additional_time": 60,
+      "total_additional_time": 60
+    }
+    """
+
+  Scenario: Group is a user group (team contest) [through invitationAccepted]
+    Given I am the user with ID "1"
+    When I send a GET request to "/contests/60/group-by-name?name=john"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "group_id": "15",
+      "name": "Team",
+      "type": "Team",
+      "additional_time": 45,
+      "total_additional_time": 45
+    }
+    """
+
+  Scenario: Group is a user group (team contest) [through requestAccepted]
+    Given I am the user with ID "1"
+    When I send a GET request to "/contests/60/group-by-name?name=jane"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "group_id": "15",
+      "name": "Team",
+      "type": "Team",
+      "additional_time": 45,
+      "total_additional_time": 45
+    }
+    """
+
+  Scenario: Group is an ancestor group (team contest)
+    Given I am the user with ID "1"
+    When I send a GET request to "/contests/60/group-by-name?name=Group%20A"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "group_id": "11",
+      "name": "Group A",
+      "type": "Friends",
+      "additional_time": 0,
+      "total_additional_time": 0
+    }
+    """
+
+  Scenario: Group is an ancestor group (non-team contest)
+    Given I am the user with ID "1"
+    When I send a GET request to "/contests/50/group-by-name?name=Group%20A"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "group_id": "11",
+      "name": "Group A",
+      "type": "Friends",
+      "additional_time": 60,
+      "total_additional_time": 3660
     }
     """

--- a/app/api/contests/get_group_by_name.go
+++ b/app/api/contests/get_group_by_name.go
@@ -14,6 +14,10 @@ type getGroupByNameResult struct {
 	// required: true
 	GroupID int64 `gorm:"column:idGroup" json:"group_id,string"`
 	// required: true
+	Name string `gorm:"column:sName" json:"name"`
+	// required: true
+	Type string `gorm:"column:sType" json:"type"`
+	// required: true
 	AdditionalTime int32 `gorm:"column:iAdditionalTime" json:"additional_time"`
 	// required: true
 	TotalAdditionalTime int32 `gorm:"column:iTotalAdditionalTime" json:"total_additional_time"`
@@ -30,6 +34,10 @@ type getGroupByNameResult struct {
 //                  * the `groups.sName` (matching `sLogin` if a "UserSelf" group) is matching the input `name` parameter (case-insensitive)
 //
 //                If there are several groups or users matching, returns the first one (by `ID`).
+//
+//
+//                If the contest is a team-only contest (`teams.bHasAttempts` is true) and the name matches an end-user,
+//                returns his team instead of user’s 'selfgroup'.
 //
 //
 //                Restrictions:
@@ -78,25 +86,55 @@ func (srv *Service) getGroupByName(w http.ResponseWriter, r *http.Request) servi
 		return service.ErrInvalidRequest(err)
 	}
 
-	if apiError := srv.checkThatUserCanManageTimedContest(itemID, user); apiError != service.NoError {
-		return apiError
+	isTeamOnly, err := srv.getTeamModeForTimedContestManagedByUser(itemID, user)
+	if gorm.IsRecordNotFoundError(err) {
+		return service.InsufficientAccessRightsError
 	}
+	service.MustNotBeError(err)
 
-	var result getGroupByNameResult
-	if err = srv.Store.Groups().OwnedBy(user).Where("groups.sName LIKE ?", groupName).
+	query := srv.Store.Groups().OwnedBy(user).
 		Joins("JOIN groups_ancestors AS found_group_ancestors ON found_group_ancestors.idGroupChild = groups.ID").
 		Joins("LEFT JOIN groups_items ON groups_items.idGroup = found_group_ancestors.idGroupAncestor AND groups_items.idItem = ?", itemID).
 		Joins("LEFT JOIN groups_items AS main_group_item ON main_group_item.idGroup = groups.ID AND main_group_item.idItem = ?", itemID).
+		Select(`
+				groups.ID AS idGroup,
+				groups.sName,
+				groups.sType,
+				IFNULL(TIME_TO_SEC(main_group_item.sAdditionalTime), 0) AS iAdditionalTime,
+				IFNULL(SUM(TIME_TO_SEC(groups_items.sAdditionalTime)), 0) AS iTotalAdditionalTime`).
 		Group("groups.ID").
 		Having(`
 			MIN(groups_items.sCachedFullAccessDate) <= NOW() OR MIN(groups_items.sCachedPartialAccessDate) <= NOW() OR
 			MIN(groups_items.sCachedGrayedAccessDate) <= NOW()`).
-		Order("groups.ID").
-		Select(`
-			groups.ID AS idGroup,
-			IFNULL(TIME_TO_SEC(main_group_item.sAdditionalTime), 0) AS iAdditionalTime,
-			IFNULL(SUM(TIME_TO_SEC(groups_items.sAdditionalTime)), 0) AS iTotalAdditionalTime`).
-		Take(&result).Error(); gorm.IsRecordNotFoundError(err) {
+		Order("groups.ID")
+
+	if isTeamOnly {
+		query = query.
+			Joins(`
+				LEFT JOIN groups_ancestors AS found_group_descendants
+					ON found_group_descendants.idGroupAncestor = groups.ID`).
+			Joins(`
+				LEFT JOIN groups AS team
+					ON team.ID = found_group_descendants.idGroupChild AND team.sType = 'Team' AND
+						(groups.idTeamItem IN (SELECT idItemAncestor FROM items_ancestors WHERE idItemChild = ?) OR
+						 groups.idTeamItem = ?)`, itemID, itemID).
+			Joins(`
+				LEFT JOIN groups_groups
+					ON groups_groups.sType IN ('requestAccepted', 'invitationAccepted') AND
+						groups_groups.idGroupParent = team.ID`).
+			Joins(`
+				LEFT JOIN groups AS user_group
+					ON user_group.ID = groups_groups.idGroupChild AND user_group.sType = 'UserSelf' AND
+						user_group.sName LIKE ?`, groupName).
+			Group("groups.ID, user_group.ID").
+			Having("MAX(user_group.ID) IS NOT NULL OR groups.sName LIKE ?", groupName)
+	} else {
+		query = query.
+			Where("groups.sName LIKE ?", groupName)
+	}
+
+	var result getGroupByNameResult
+	if err = query.Take(&result).Error(); gorm.IsRecordNotFoundError(err) {
 		return service.InsufficientAccessRightsError
 	}
 	service.MustNotBeError(err)

--- a/app/api/contests/set_additional_time.feature
+++ b/app/api/contests/set_additional_time.feature
@@ -3,12 +3,17 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
     Given the database has the following table 'users':
       | ID | sLogin | idGroupSelf | idGroupOwned |
       | 1  | owner  | 21          | 22           |
+      | 2  | john   | 31          | 32           |
     And the database has the following table 'groups':
-      | ID | sName      |
-      | 10 | Parent     |
-      | 11 | Group A    |
-      | 13 | Group B    |
-      | 14 | Group B    |
+      | ID | sName       | sType     |
+      | 10 | Parent      | Club      |
+      | 11 | Group A     | Class     |
+      | 13 | Group B     | Other     |
+      | 14 | Group B     | Friends   |
+      | 21 | owner       | UserSelf  |
+      | 22 | owner-admin | UserAdmin |
+      | 31 | john        | UserSelf  |
+      | 32 | john-admin  | UserAdmin |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |
       | 10              | 10           | 1       |
@@ -21,7 +26,10 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21              | 21           | 1       |
       | 22              | 13           | 0       |
       | 22              | 14           | 0       |
+      | 22              | 31           | 0       |
       | 22              | 22           | 1       |
+      | 31              | 31           | 1       |
+      | 32              | 32           | 1       |
     And the database has the following table 'items':
       | ID | sDuration |
       | 50 | 00:00:00  |
@@ -66,3 +74,13 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
     Then the response code should be 200
     And the response should be "updated"
     And the table "groups_items" should stay unchanged
+
+  Scenario: Creates a new row for a user group
+    Given I am the user with ID "1"
+    When I send a PUT request to "/contests/70/additional-time?group_id=31&seconds=-3020399"
+    Then the response code should be 200
+    And the response should be "updated"
+    And the table "groups_items" should stay unchanged but the row with ID "5577006791947779410"
+    And the table "groups_items" at ID "5577006791947779410" should be:
+      | ID                  | idGroup | idItem | sCachedPartialAccessDate | sCachedGrayedAccessDate | sCachedFullAccessDate | sCachedAccessSolutionsDate | sAdditionalTime |
+      | 5577006791947779410 | 31      | 70     | null                     | null                    | null                  | null                       | -838:59:59      |

--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -23,8 +23,9 @@ import (
 //
 //                Restrictions:
 //                  * `item_id` should be a timed contest;
-//                  * the authenticated user should have `bCachedAccessSolutions` or `bCachedFullAccess` on the input item;
-//                  * the authenticated user should own the `group_id`.
+//                  * the authenticated user should have `solutions` or `full` access on the input item;
+//                  * the authenticated user should own the `group_id`;
+//                  * if the contest is timed (`items.bHasAttempts` = 1), then the group should not be a user group.
 //
 //                Otherwise, the "Forbidden" response is returned.
 // parameters:
@@ -76,17 +77,27 @@ func (srv *Service) setAdditionalTime(w http.ResponseWriter, r *http.Request) se
 		return service.ErrInvalidRequest(fmt.Errorf("'seconds' should be between %d and %d", -maxSeconds, maxSeconds))
 	}
 
-	groupIsOwnedByUser, err := srv.Store.GroupAncestors().OwnedByUser(user).
-		Where("groups_ancestors.idGroupChild = ?", groupID).HasRows()
-	service.MustNotBeError(err)
-	if !groupIsOwnedByUser {
+	var groupType string
+	err = srv.Store.Groups().OwnedBy(user).Where("groups.ID = ?", groupID).
+		PluckFirst("groups.sType", &groupType).Error()
+	if gorm.IsRecordNotFoundError(err) {
 		return service.InsufficientAccessRightsError
 	}
+	service.MustNotBeError(err)
 
-	if apiError := srv.checkThatUserCanManageTimedContest(itemID, user); apiError != service.NoError {
-		return apiError
+	isTeamOnly, err := srv.getTeamModeForTimedContestManagedByUser(itemID, user)
+	if gorm.IsRecordNotFoundError(err) || (isTeamOnly && groupType == "UserSelf") {
+		return service.InsufficientAccessRightsError
 	}
+	service.MustNotBeError(err)
 
+	srv.setAdditionalTimeForGroupInContest(groupID, itemID, seconds)
+
+	render.Respond(w, r, service.UpdateSuccess(nil))
+	return service.NoError
+}
+
+func (srv *Service) setAdditionalTimeForGroupInContest(groupID, itemID, seconds int64) {
 	service.MustNotBeError(srv.Store.InTransaction(func(store *database.DataStore) error {
 		groupItemStore := store.GroupItems()
 		scope := groupItemStore.Where("idGroup = ?", groupID).Where("idItem = ?", itemID)
@@ -104,7 +115,4 @@ func (srv *Service) setAdditionalTime(w http.ResponseWriter, r *http.Request) se
 		}
 		return nil
 	}))
-
-	render.Respond(w, r, service.UpdateSuccess(nil))
-	return service.NoError
 }

--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -25,7 +25,7 @@ import (
 //                  * `item_id` should be a timed contest;
 //                  * the authenticated user should have `solutions` or `full` access on the input item;
 //                  * the authenticated user should own the `group_id`;
-//                  * if the contest is timed (`items.bHasAttempts` = 1), then the group should not be a user group.
+//                  * if the contest is team-only (`items.bHasAttempts` = 1), then the group should not be a user group.
 //
 //                Otherwise, the "Forbidden" response is returned.
 // parameters:

--- a/app/api/contests/set_additional_time.robustness.feature
+++ b/app/api/contests/set_additional_time.robustness.feature
@@ -3,10 +3,15 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
     Given the database has the following table 'users':
       | ID | sLogin | idGroupSelf | idGroupOwned |
       | 1  | owner  | 21          | 22           |
+      | 2  | john   | 31          | 32           |
     And the database has the following table 'groups':
-      | ID | sName      |
-      | 12 | Group A    |
-      | 13 | Group B    |
+      | ID | sName       | sType     |
+      | 12 | Group A     | Class     |
+      | 13 | Group B     | Other     |
+      | 21 | owner       | UserSelf  |
+      | 22 | owner-admin | UserAdmin |
+      | 31 | john        | UserSelf  |
+      | 32 | john-admin  | UserAdmin |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |
       | 12              | 12           | 1       |
@@ -14,12 +19,16 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21              | 21           | 1       |
       | 22              | 13           | 0       |
       | 22              | 22           | 1       |
+      | 22              | 31           | 0       |
+      | 31              | 31           | 1       |
+      | 32              | 32           | 1       |
     And the database has the following table 'items':
-      | ID | sDuration |
-      | 50 | 00:00:00  |
-      | 60 | null      |
-      | 10 | 00:00:02  |
-      | 70 | 00:00:03  |
+      | ID | sDuration | bHasAttempts |
+      | 50 | 00:00:00  | 0            |
+      | 60 | null      | 0            |
+      | 10 | 00:00:02  | 0            |
+      | 70 | 00:00:03  | 0            |
+      | 80 | 00:00:04  | 1            |
     And the database has the following table 'groups_items':
       | idGroup | idItem | sCachedPartialAccessDate | sCachedGrayedAccessDate | sCachedFullAccessDate | sCachedAccessSolutionsDate | sAdditionalTime |
       | 13      | 50     | 2017-05-29T06:38:38Z     | null                    | null                  | null                       | 01:00:00        |
@@ -28,6 +37,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21      | 50     | null                     | null                    | null                  | null                       | null            |
       | 21      | 60     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | null            |
       | 21      | 70     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | null            |
+      | 21      | 80     | null                     | null                    | 2018-05-29T06:38:38Z  | null                       | null            |
 
   Scenario: Wrong item_id
     Given I am the user with ID "1"
@@ -92,5 +102,11 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
   Scenario: No such group
     Given I am the user with ID "1"
     When I send a PUT request to "/contests/70/additional-time?group_id=404&seconds=0"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Team contest and the UserSelf group
+    Given I am the user with ID "1"
+    When I send a PUT request to "/contests/80/additional-time?group_id=31&seconds=0"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"


### PR DESCRIPTION
1. contestSetAdditionalTime: prevent setting additional time for users in team-only contests
2. contestGetGroupByName: return a team if a user has been found by login for a team-only contest; add group's name and type into the result.