### PR TITLE
Return "forbidden" error if a parent group is a team/user or a child group is a user in groupAddChild & groupRemoveChild

### DIFF
--- a/app/api/groups/add_child.go
+++ b/app/api/groups/add_child.go
@@ -20,8 +20,8 @@ import (
 //   Restrictions (otherwise the 'forbidden' error is returned):
 //     * the authenticated user should be an owner of both `parent_group_id` and `child_group_id,
 //     * the authenticated user should have `users.allowSubgroups` set to 1,
-//     * the parent group should not be of type "UserSelf",
-//     * the child group should not be of types "Base" or "UserAdmin",
+//     * the parent group should not be of type "UserSelf" or "Team",
+//     * the child group should not be of types "Base", "UserSelf", or "UserAdmin",
 //     * the action should not create cycles in the groups relations graph.
 // parameters:
 // - name: parent_group_id

--- a/app/api/groups/add_child.go
+++ b/app/api/groups/add_child.go
@@ -21,7 +21,8 @@ import (
 //     * the authenticated user should be an owner of both `parent_group_id` and `child_group_id,
 //     * the authenticated user should have `users.allowSubgroups` set to 1,
 //     * the parent group should not be of type "UserSelf" or "Team",
-//     * the child group should not be of types "Base", "UserSelf", or "UserAdmin",
+//     * the child group should not be of types "Base", "UserAdmin, or "UserSelf"
+//       (since users should join groups only by code or by invitation/request),
 //     * the action should not create cycles in the groups relations graph.
 // parameters:
 // - name: parent_group_id

--- a/app/api/groups/add_child.robustness.feature
+++ b/app/api/groups/add_child.robustness.feature
@@ -8,22 +8,45 @@ Feature: Add a parent-child relation between two groups - robustness
       | 3  | student | 25          | 26           | Jane        | Doe       | 1              |
       | 4  | admin   | 27          | 28           | John        | Doe       | 1              |
     And the database has the following table 'groups':
-      | ID | sName     | sType     |
-      | 11 | Group A   | Class     |
-      | 13 | Group B   | Class     |
-      | 14 | UserAdmin | UserAdmin |
-      | 15 | Root      | Base      |
-      | 16 | RootSelf  | Base      |
-      | 17 | RootAdmin | Base      |
-      | 18 | UserSelf  | UserSelf  |
+      | ID | sName         | sType     |
+      | 11 | Group A       | Class     |
+      | 13 | Group B       | Class     |
+      | 14 | UserAdmin     | UserAdmin |
+      | 15 | Root          | Base      |
+      | 16 | RootSelf      | Base      |
+      | 17 | RootAdmin     | Base      |
+      | 18 | UserSelf      | UserSelf  |
+      | 19 | Team          | Team      |
+      | 21 | owner         | UserSelf  |
+      | 22 | owner-admin   | UserAdmin |
+      | 23 | teacher       | UserSelf  |
+      | 24 | teacher-admin | UserAdmin |
+      | 25 | student       | UserSelf  |
+      | 26 | student-admin | UserAdmin |
+      | 27 | admin         | UserSelf  |
+      | 28 | admin-admin   | UserAdmin |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |
-      | 13              | 11           | 1       |
+      | 11              | 11           | 1       |
+      | 13              | 11           | 0       |
+      | 13              | 13           | 1       |
+      | 14              | 14           | 1       |
+      | 15              | 15           | 1       |
+      | 16              | 16           | 1       |
+      | 17              | 17           | 1       |
+      | 18              | 18           | 1       |
+      | 19              | 19           | 1       |
       | 21              | 21           | 1       |
       | 22              | 11           | 0       |
       | 22              | 13           | 0       |
+      | 22              | 22           | 1       |
+      | 23              | 23           | 1       |
       | 24              | 13           | 0       |
+      | 24              | 24           | 1       |
+      | 25              | 25           | 1       |
       | 26              | 11           | 0       |
+      | 26              | 26           | 1       |
+      | 27              | 27           | 1       |
       | 28              | 11           | 0       |
       | 28              | 13           | 0       |
       | 28              | 14           | 0       |
@@ -31,6 +54,8 @@ Feature: Add a parent-child relation between two groups - robustness
       | 28              | 16           | 0       |
       | 28              | 17           | 0       |
       | 28              | 18           | 0       |
+      | 28              | 19           | 0       |
+      | 28              | 28           | 1       |
     And the database has the following table 'groups_groups':
       | idGroupParent | idGroupChild | iChildOrder |
       | 13            | 11           | 1           |
@@ -115,9 +140,25 @@ Feature: Add a parent-child relation between two groups - robustness
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
 
+  Scenario: Child group is UserSelf
+    Given I am the user with ID "4"
+    When I send a POST request to "/groups/13/relations/18"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+
   Scenario: Parent group is UserSelf
     Given I am the user with ID "4"
     When I send a POST request to "/groups/18/relations/11"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+
+  Scenario: Parent group is Team
+    Given I am the user with ID "4"
+    When I send a POST request to "/groups/19/relations/11"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
     And the table "groups_groups" should stay unchanged

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -82,9 +82,9 @@ func checkThatUserHasRightsForDirectRelation(
 	}
 
 	for _, groupRow := range groupData {
-		if (groupRow.ID == parentGroupID && groupRow.Type == "UserSelf") ||
+		if (groupRow.ID == parentGroupID && map[string]bool{"UserSelf": true, "Team": true}[groupRow.Type]) ||
 			(groupRow.ID == childGroupID &&
-				map[string]bool{"Base": true, "UserAdmin": true}[groupRow.Type]) {
+				map[string]bool{"Base": true, "UserAdmin": true, "UserSelf": true}[groupRow.Type]) {
 			return service.InsufficientAccessRightsError
 		}
 	}

--- a/app/api/groups/remove_child.go
+++ b/app/api/groups/remove_child.go
@@ -32,7 +32,8 @@ import (
 //   Restrictions (otherwise the 'forbidden' error is returned):
 //     * the authenticated user should be an owner of both `parent_group_id` and `child_group_id,
 //     * the parent group should not be of type "UserSelf" or "Team",
-//     * the child group should not be of types "Base", "UserSelf" or "UserAdmin",
+//     * the child group should not be of types "Base", "UserAdmin, or "UserSelf"
+//       (since there are more appropriate services for removing users from groups: groupLeave and groupRemoveMembers),
 //     * the relation should be direct (`sType` = "direct").
 // parameters:
 // - name: parent_group_id

--- a/app/api/groups/remove_child.go
+++ b/app/api/groups/remove_child.go
@@ -31,8 +31,8 @@ import (
 //
 //   Restrictions (otherwise the 'forbidden' error is returned):
 //     * the authenticated user should be an owner of both `parent_group_id` and `child_group_id,
-//     * the parent group should not be of type "UserSelf",
-//     * the child group should not be of types "Base" or "UserAdmin",
+//     * the parent group should not be of type "UserSelf" or "Team",
+//     * the child group should not be of types "Base", "UserSelf" or "UserAdmin",
 //     * the relation should be direct (`sType` = "direct").
 // parameters:
 // - name: parent_group_id

--- a/app/api/groups/remove_child.robustness.feature
+++ b/app/api/groups/remove_child.robustness.feature
@@ -10,6 +10,7 @@ Feature: Remove a direct parent-child relation between two groups - robustness
       | 11 | Group A   | Class     |
       | 13 | Group B   | Class     |
       | 14 | Group C   | Class     |
+      | 15 | Team      | Team      |
       | 21 | Self      | UserSelf  |
       | 22 | Owned     | UserAdmin |
       | 51 | UserAdmin | UserAdmin |
@@ -18,29 +19,35 @@ Feature: Remove a direct parent-child relation between two groups - robustness
       | 54 | RootAdmin | Base      |
       | 55 | UserSelf  | UserSelf  |
     And the database has the following table 'groups_groups':
-      | idGroupParent | idGroupChild | sType       |
-      | 13            | 11           | direct      |
-      | 13            | 14           | requestSent |
-      | 22            | 11           | direct      |
-      | 22            | 13           | direct      |
-      | 22            | 14           | direct      |
-      | 22            | 51           | direct      |
-      | 22            | 52           | direct      |
-      | 22            | 53           | direct      |
-      | 22            | 54           | direct      |
-      | 22            | 55           | direct      |
-      | 24            | 11           | direct      |
-      | 55            | 14           | direct      |
+      | idGroupParent | idGroupChild | sType              |
+      | 13            | 11           | direct             |
+      | 13            | 14           | requestSent        |
+      | 13            | 55           | invitationAccepted |
+      | 15            | 55           | requestAccepted    |
+      | 22            | 11           | direct             |
+      | 22            | 13           | direct             |
+      | 22            | 14           | direct             |
+      | 22            | 51           | direct             |
+      | 22            | 52           | direct             |
+      | 22            | 53           | direct             |
+      | 22            | 54           | direct             |
+      | 22            | 55           | direct             |
+      | 24            | 11           | direct             |
+      | 55            | 14           | direct             |
     And the database has the following table 'groups_ancestors':
       | idGroupAncestor | idGroupChild | bIsSelf |
       | 11              | 11           | 1       |
       | 13              | 11           | 0       |
       | 13              | 13           | 1       |
+      | 13              | 55           | 0       |
       | 14              | 14           | 1       |
+      | 15              | 15           | 1       |
+      | 15              | 55           | 0       |
       | 21              | 21           | 1       |
       | 22              | 11           | 0       |
       | 22              | 13           | 0       |
       | 22              | 14           | 0       |
+      | 22              | 15           | 0       |
       | 22              | 22           | 1       |
       | 22              | 51           | 0       |
       | 22              | 52           | 0       |
@@ -137,9 +144,25 @@ Feature: Remove a direct parent-child relation between two groups - robustness
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
 
+  Scenario: Child group is UserSelf
+    Given I am the user with ID "1"
+    When I send a DELETE request to "/groups/13/relations/55"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+
   Scenario: Parent group is UserSelf
     Given I am the user with ID "1"
     When I send a DELETE request to "/groups/55/relations/14"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+
+  Scenario: Parent group is Team
+    Given I am the user with ID "1"
+    When I send a DELETE request to "/groups/55/relations/15"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
     And the table "groups_groups" should stay unchanged


### PR DESCRIPTION
Fixes #244 

The groupRemoveChild service was changed too for the sake of symmetry.