### PR TITLE
Automatically accept a request created by groupRequestCreate if the user owns the group. + Fix swagger docs

### DIFF
--- a/app/api/currentuser/render_group_group_transition_result.go
+++ b/app/api/currentuser/render_group_group_transition_result.go
@@ -13,7 +13,9 @@ import (
 // RenderGroupGroupTransitionResult renders database.GroupGroupTransitionResult as a response or returns an APIError
 func RenderGroupGroupTransitionResult(w http.ResponseWriter, r *http.Request, result database.GroupGroupTransitionResult,
 	action userGroupRelationAction) service.APIError {
-	isCreateAction := action == createGroupRequestAction || action == joinGroupByCodeAction
+	isCreateAction := map[userGroupRelationAction]bool{
+		createGroupRequestAction: true, joinGroupByCodeAction: true, createAcceptedGroupRequestAction: true,
+	}[action]
 	switch result {
 	case database.Cycle:
 		return service.ErrUnprocessableEntity(errors.New("cycles in the group relations graph are not allowed"))

--- a/app/api/currentuser/send_group_request.feature
+++ b/app/api/currentuser/send_group_request.feature
@@ -52,3 +52,37 @@ Feature: User sends a request to join a group
     """
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
+
+  Scenario: Automatically accepts the request if the user owns the group
+    Given I am the user with ID "1"
+    And the database table 'groups_groups' has also the following row:
+      | ID | idGroupParent | idGroupChild | sType  | sStatusDate          |
+      | 8  | 22            | 11           | direct | 2017-02-21T06:38:38Z |
+    And the database table 'groups_ancestors' has also the following row:
+      | idGroupAncestor | idGroupChild | bIsSelf |
+      | 22              | 11           | 0       |
+    When I send a POST request to "/current-user/group-requests/11"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+    """
+    {
+      "success": true,
+      "message": "created",
+      "data": {"changed": true}
+    }
+    """
+    And the table "groups_groups" should be:
+      | idGroupParent | idGroupChild | sType           | ABS(TIMESTAMPDIFF(SECOND, sStatusDate, NOW())) < 3 |
+      | 11            | 21           | requestAccepted | 1                                                  |
+      | 14            | 21           | requestSent     | 0                                                  |
+      | 22            | 11           | direct          | 0                                                  |
+    And the table "groups_ancestors" should be:
+      | idGroupAncestor | idGroupChild | bIsSelf |
+      | 11              | 11           | 1       |
+      | 11              | 21           | 0       |
+      | 14              | 14           | 1       |
+      | 14              | 21           | 0       |
+      | 21              | 21           | 1       |
+      | 22              | 11           | 0       |
+      | 22              | 21           | 0       |
+      | 22              | 22           | 1       |

--- a/app/api/currentuser/send_group_request.go
+++ b/app/api/currentuser/send_group_request.go
@@ -9,21 +9,34 @@ import (
 // swagger:operation POST /current-user/group-requests/{group_id} groups users groupRequestCreate
 // ---
 // summary: Create a request to join a group
-// description:
-//   Lets a user create a request to join a group.
-//   On success the service creates a new row in `groups_groups` with `idGroupParent` = user's self group ID,
-//   `idGroupChild` = `group_id`, `groups_groups.sType` = `requestSent` and `sStatusDate` equal to current UTC time.
+// description: >
+//   Lets a user create a request to join a group. There are two possible cases:
 //
-//   * `groups.bFreeAccess` should be 1, otherwise the 'forbidden' response is returned.
+//   #### The user doesn't own the group
 //
-//   * There should be a row in `groups_groups` with the `group_id` as a parent
-//     and the authenticated user’s selfGroup’s `ID` as a child with `sType`=`invitationSent`/`invitationRefused`.
-//     Otherwise the unprocessable entity error is returned.
+//     On success the service creates a new row in `groups_groups` with `idGroupParent` = user's self group ID,
+//     `idGroupChild` = `group_id`, `groups_groups.sType` = `requestSent` and `sStatusDate` equal to current UTC time.
 //
-//   * If `groups_groups.sType` = 'invitationSent'/'invitationAccepted'/'requestAccepted'/'direct',
-//     the unprocessable entity error is returned
+//     * `groups.bFreeAccess` should be 1, otherwise the 'forbidden' response is returned.
 //
-//   * If `groups_groups.sType` is `requestSent` already, the "unchanged" (201) response is returned.
+//     * If there is already a row in `groups_groups` with
+//       `sType` = 'invitationSent'/'invitationAccepted'/'requestAccepted'/'joinedByCode'/'direct',
+//       the unprocessable entity error is returned.
+//
+//     * If `groups_groups.sType` is `requestSent` already, the "unchanged" (201) response is returned.
+//
+//   #### The user owns the group
+//
+//     On success the service creates a new row in `groups_groups` with `idGroupParent` = user's self group ID,
+//     `idGroupChild` = `group_id`, `groups_groups.sType` = `requestAccepted` and `sStatusDate` equal to current UTC time.
+//
+//     * If there is already a row in `groups_groups` with
+//       `sType` = 'invitationAccepted'/'joinedByCode'/'direct',
+//       the unprocessable entity error is returned.
+//
+//     * If `groups_groups.sType` is `requestAccepted` already, the "unchanged" (201) response is returned.
+//
+//     On success, the service propagates group ancestors in this case.
 // parameters:
 // - name: group_id
 //   in: path

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -48,6 +48,9 @@ const (
 	AdminCreatesInvitation GroupGroupTransitionAction = iota
 	// UserCreatesRequest means a user sends request to become a group member
 	UserCreatesRequest
+	// UserCreatesAcceptedRequest means a user adds himself into a group that he owns
+	// It doesn't check if the user owns the group (a calling service should check that)
+	UserCreatesAcceptedRequest
 	// UserAcceptsInvitation means a user accepts a group invitation
 	UserAcceptsInvitation
 	// AdminAcceptsRequest means a group admin accepts a request
@@ -108,6 +111,18 @@ var groupGroupTransitionRules = map[GroupGroupTransitionAction]groupGroupTransit
 			RequestRefused:    RequestSent,
 			Removed:           RequestSent,
 			Left:              RequestSent,
+		},
+	},
+	UserCreatesAcceptedRequest: {
+		Transitions: map[GroupGroupType]GroupGroupType{
+			NoRelation:        RequestAccepted,
+			RequestSent:       RequestAccepted,
+			InvitationSent:    RequestAccepted,
+			InvitationRefused: RequestAccepted,
+			RequestRefused:    RequestAccepted,
+			RequestAccepted:   RequestAccepted,
+			Removed:           RequestAccepted,
+			Left:              RequestAccepted,
 		},
 	},
 	UserJoinsGroupByCode: {

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -349,6 +349,29 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 			shouldRunListeners: true,
 		},
 		{
+			name:              "UserCreatesAcceptedRequest",
+			action:            database.UserCreatesAcceptedRequest,
+			relationsToChange: allTheIDs,
+			wantResult: database.GroupGroupTransitionResults{
+				1: "success", 2: "success", 3: "success", 6: "success", 7: "success", 8: "success", 9: "success",
+				5: "unchanged",
+				4: "invalid", 10: "invalid", 11: "invalid", 20: "invalid",
+				30: "cycle",
+			},
+			wantGroupGroups: patchGroupGroups(groupsGroupsUnchanged, "", map[string]*groupGroup{
+				"20_2": {ParentGroupID: 20, ChildGroupID: 2, Type: "requestAccepted", ChildOrder: 2, StatusDate: currentTimePtr},
+				"20_3": {ParentGroupID: 20, ChildGroupID: 3, Type: "requestAccepted", ChildOrder: 3, StatusDate: currentTimePtr},
+				"20_6": {ParentGroupID: 20, ChildGroupID: 6, Type: "requestAccepted", ChildOrder: 4, StatusDate: currentTimePtr},
+				"20_7": {ParentGroupID: 20, ChildGroupID: 7, Type: "requestAccepted", ChildOrder: 5, StatusDate: currentTimePtr},
+				"20_8": {ParentGroupID: 20, ChildGroupID: 8, Type: "requestAccepted", ChildOrder: 6, StatusDate: currentTimePtr},
+				"20_9": {ParentGroupID: 20, ChildGroupID: 9, Type: "requestAccepted", ChildOrder: 7, StatusDate: currentTimePtr},
+			}, []groupGroup{
+				{ParentGroupID: 20, ChildGroupID: 1, Type: "requestAccepted", ChildOrder: 1, StatusDate: currentTimePtr},
+			}),
+			wantGroupAncestors: allPossibleGroupsAncestors,
+			shouldRunListeners: true,
+		},
+		{
 			name:              "UserJoinsGroupByCode",
 			action:            database.UserJoinsGroupByCode,
 			relationsToChange: allTheIDs,


### PR DESCRIPTION
Fixes #246.

Note:
The groupInviteUsers service is not changed here because groupInviteUsers and groupRequestCreate are not similar. The groupInviteUsers service is a bulk service inviting users from a list (by logins) so it is not a convenient way for an owner to add himself into a group. Also, there is no actual need for the UI to have multiple ways for adding an owner into their group.
Instead of modifying the groupInviteUsers service, I allowed a transition from 'invitationSent' to 'requestAccepted' for group owners in groupRequestCreate.