### PR TITLE
Add warnings about access right on idTeamItem into swagger docs of groupInvitationAccept, groupsJoinByCode, groupRequestCreate, groupRequestsAccept, groupInviteUsers

### DIFF
--- a/app/api/currentuser/accept_group_invitation.go
+++ b/app/api/currentuser/accept_group_invitation.go
@@ -22,6 +22,9 @@ import (
 //     Otherwise the unprocessable entity error is returned.
 //
 //   * If `groups_groups.sType` is `invitationAccepted` already, the "unchanged" (200) response is returned.
+//
+//
+//   _Warning:_ The service doesn't check if the user has access rights on `idTeamItem` when the group is a team.
 // parameters:
 // - name: group_id
 //   in: path

--- a/app/api/currentuser/join_group_by_code.go
+++ b/app/api/currentuser/join_group_by_code.go
@@ -29,6 +29,9 @@ import (
 //   * If there is already a row in `groups_groups` with the found team as a parent
 //     and the authenticated user’s selfGroup’s ID as a child with `sType`=`invitationAccepted`/`requestAccepted`/`direct`,
 //     the unprocessable entity error is returned.
+//
+//
+//   _Warning:_ The service doesn't check if the user has access rights on `idTeamItem` of the team.
 // parameters:
 // - name: code
 //   in: query

--- a/app/api/currentuser/send_group_request.go
+++ b/app/api/currentuser/send_group_request.go
@@ -40,6 +40,9 @@ import (
 //     * If `groups_groups.sType` is `requestAccepted` already, the "unchanged" (201) response is returned.
 //
 //     On success, the service propagates group ancestors in this case.
+//
+//
+//   _Warning:_ The service doesn't check if the user has access rights on `idTeamItem` when the group is a team.
 // parameters:
 // - name: group_id
 //   in: path

--- a/app/api/groups/accept_requests.go
+++ b/app/api/groups/accept_requests.go
@@ -31,6 +31,10 @@ import (
 //   The action should not create cycles in the groups relations graph, otherwise
 //   the `group_id` gets skipped with `cycle` as the result.
 //   The response status code on success (200) doesn't depend on per-group results.
+//
+//
+//   _Warning:_ The service doesn't check if the authenticated user or requesting users have access rights
+//   on `idTeamItem` when the `parent_group_id` represents a team.
 // parameters:
 // - name: parent_group_id
 //   in: path

--- a/app/api/groups/invite_users.go
+++ b/app/api/groups/invite_users.go
@@ -63,6 +63,10 @@ const maxAllowedLoginsToInvite = 100
 //
 //
 //   The authenticated user should be an owner of the `parent_group_id`, otherwise the 'forbidden' error is returned.
+//
+//
+//   _Warning:_ The service doesn't check if the authenticated user or listed users have access rights
+//   on `idTeamItem` when the `parent_group_id` represents a team.
 // consumes:
 // - application/json
 // parameters:


### PR DESCRIPTION
Note that the groupAddChild service is not affected because it doesn't allow to childs into teams.

Fixes #251 