### PR TITLE
Add indexes and improve performance of groupChildrenView

### DIFF
--- a/db/migrations/45_add_index_parent_type_on_groups_groups.sql
+++ b/db/migrations/45_add_index_parent_type_on_groups_groups.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `groups_groups` ADD INDEX  `parent_type` (`parent_group_id`, `type`);
+
+-- +migrate Down
+ALTER TABLE `groups_groups` DROP INDEX `parent_type`;

--- a/db/migrations/46_add_index_grade_on_groups.sql
+++ b/db/migrations/46_add_index_grade_on_groups.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `groups` ADD INDEX  `grade` (`grade`);
+
+-- +migrate Down
+ALTER TABLE `groups` DROP INDEX `grade`;

--- a/db/migrations/47_add_index_attempt_id_on_users_answers.sql
+++ b/db/migrations/47_add_index_attempt_id_on_users_answers.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `users_answers` ADD INDEX  `attempt_id` (`attempt_id`);
+
+-- +migrate Down
+ALTER TABLE `users_answers` DROP INDEX `attempt_id`;


### PR DESCRIPTION
Add indexes: groups_groups.(parent_group_id+type), groups.grade, users_answers.attempt_id; Improve performance of groupChildrenView.

Fixes #268 

Note: the index on groups.name has already been there.
