### PR TITLE
Do not add the 'id' column implicitly either into the list of accepted fields or into the sorting spec in service.ApplySortingAndPaging() + provide a way to prohibit setting the 'sort' parameter in some services

### DIFF
--- a/app/api/answers/get_answers.go
+++ b/app/api/answers/get_answers.go
@@ -112,7 +112,7 @@ func (srv *Service) getAnswers(rw http.ResponseWriter, httpReq *http.Request) se
 	dataQuery, apiError := service.ApplySortingAndPaging(httpReq, dataQuery, map[string]*service.FieldSortingParams{
 		"submitted_at": {ColumnName: "users_answers.submitted_at", FieldType: "time"},
 		"id":           {ColumnName: "users_answers.id", FieldType: "int64"},
-	}, "-submitted_at,id")
+	}, "-submitted_at,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/answers/get_answers_with_user_group_id_and_item_id.feature
+++ b/app/api/answers/get_answers_with_user_group_id_and_item_id.feature
@@ -168,7 +168,7 @@ Background:
 
   Scenario: Full access on the item+user_group pair (same user) [with limit and reversed order]
     Given I am the user with id "11"
-    When I send a GET request to "/answers?item_id=200&user_id=11&limit=1&sort=submitted_at"
+    When I send a GET request to "/answers?item_id=200&user_id=11&limit=1&sort=submitted_at,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/contests/get_administered_list.go
+++ b/app/api/contests/get_administered_list.go
@@ -101,7 +101,7 @@ func (srv *Service) getAdministeredList(w http.ResponseWriter, r *http.Request) 
 			FieldType:             "string",
 		},
 		"id": {ColumnName: "items.id", FieldType: "int64"},
-	}, "title,id")
+	}, "title,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/contests/get_members_additional_times.feature
+++ b/app/api/contests/get_members_additional_times.feature
@@ -186,7 +186,7 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
 
   Scenario: Non-team contest (only the first row, inverse order)
     Given I am the user with id "21"
-    When I send a GET request to "/contests/50/groups/11/members/additional-times?limit=1&sort=-name"
+    When I send a GET request to "/contests/50/groups/11/members/additional-times?limit=1&sort=-name,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/contests/get_members_additional_times.go
+++ b/app/api/contests/get_members_additional_times.go
@@ -145,7 +145,7 @@ func (srv *Service) getMembersAdditionalTimes(w http.ResponseWriter, r *http.Req
 		map[string]*service.FieldSortingParams{
 			"name": {ColumnName: "found_group.name", FieldType: "string"},
 			"id":   {ColumnName: "found_group.id", FieldType: "int64"}},
-		"name,id")
+		"name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_group_invitations.go
+++ b/app/api/currentuser/get_group_invitations.go
@@ -91,7 +91,7 @@ func (srv *Service) getGroupInvitations(w http.ResponseWriter, r *http.Request) 
 		map[string]*service.FieldSortingParams{
 			"type_changed_at": {ColumnName: "groups_groups.type_changed_at", FieldType: "time"},
 			"id":              {ColumnName: "groups_groups.id", FieldType: "int64"}},
-		"-type_changed_at")
+		"-type_changed_at,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_group_memberships.go
+++ b/app/api/currentuser/get_group_memberships.go
@@ -74,7 +74,7 @@ func (srv *Service) getGroupMemberships(w http.ResponseWriter, r *http.Request) 
 		map[string]*service.FieldSortingParams{
 			"type_changed_at": {ColumnName: "groups_groups_active.type_changed_at", FieldType: "time"},
 			"id":              {ColumnName: "groups_groups_active.id", FieldType: "int64"}},
-		"-type_changed_at")
+		"-type_changed_at,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_group_memberships_history.feature
+++ b/app/api/currentuser/get_group_memberships_history.feature
@@ -94,7 +94,7 @@ Feature: Get group memberships history for the current user
 
   Scenario: Show all the history in reverse order (with notifications_read_at set)
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/group-memberships-history?sort=type_changed_at"
+    When I send a GET request to "/current-user/group-memberships-history?sort=type_changed_at,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/currentuser/get_group_memberships_history.go
+++ b/app/api/currentuser/get_group_memberships_history.go
@@ -76,7 +76,7 @@ func (srv *Service) getGroupMembershipsHistory(w http.ResponseWriter, r *http.Re
 		map[string]*service.FieldSortingParams{
 			"type_changed_at": {ColumnName: "groups_groups.type_changed_at", FieldType: "time"},
 			"id":              {ColumnName: "groups_groups.id", FieldType: "int64"}},
-		"-type_changed_at")
+		"-type_changed_at,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -116,7 +116,7 @@ func (srv *Service) searchForAvailableGroups(w http.ResponseWriter, r *http.Requ
 	query, apiError := service.ApplySortingAndPaging(r, query,
 		map[string]*service.FieldSortingParams{
 			"id": {ColumnName: "groups.id", FieldType: "int64"}},
-		"id")
+		"id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -198,7 +198,7 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is an owner of the parent group, rows are sorted by grade, UserSelf is skipped
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/children?sort=grade&types_exclude=UserSelf"
+    When I send a GET request to "/groups/13/children?sort=grade,id&types_exclude=UserSelf"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -217,7 +217,7 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is an owner of the parent group, rows are sorted by type, UserSelf is skipped
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/children?sort=type&types_exclude=UserSelf"
+    When I send a GET request to "/groups/13/children?sort=type,id&types_exclude=UserSelf"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -152,7 +152,7 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 			"type":  {ColumnName: "groups.type", FieldType: "string"},
 			"grade": {ColumnName: "groups.grade", FieldType: "int64"},
 			"id":    {ColumnName: "groups.id", FieldType: "int64"}},
-		"name")
+		"name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -153,7 +153,7 @@ func (srv *Service) getGroupProgress(w http.ResponseWriter, r *http.Request) ser
 		// Note that we require the 'from.name' request parameter although the service does not return group names
 		"name": {ColumnName: "group_child.name", FieldType: "string"},
 		"id":   {ColumnName: "group_child.id", FieldType: "int64"},
-	}, "name,id")
+	}, "name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_members.feature
+++ b/app/api/groups/get_members.feature
@@ -109,7 +109,7 @@ Feature: Get members of group_id
 
   Scenario: User is an admin of the group (sort by user's grade)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/members?sort=user.grade"
+    When I send a GET request to "/groups/13/members?sort=user.grade,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -155,7 +155,7 @@ Feature: Get members of group_id
 
   Scenario: User is an admin of the group (sort by user's login in descending order)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/members?sort=-user.login"
+    When I send a GET request to "/groups/13/members?sort=-user.login,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_members.go
+++ b/app/api/groups/get_members.go
@@ -139,7 +139,7 @@ func (srv *Service) getMembers(w http.ResponseWriter, r *http.Request) service.A
 			"user.grade":      {ColumnName: "users.grade"},
 			"type_changed_at": {ColumnName: "groups_groups.type_changed_at", FieldType: "time"},
 			"id":              {ColumnName: "groups_groups.id", FieldType: "int64"}},
-		"-type_changed_at")
+		"-type_changed_at,id", false)
 
 	if apiError != service.NoError {
 		return apiError

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -101,7 +101,7 @@ Feature: Get requests for group_id
 
   Scenario: User is an admin of the group (sort by type)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/requests?sort=type"
+    When I send a GET request to "/groups/13/requests?sort=type,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -172,7 +172,7 @@ Feature: Get requests for group_id
 
   Scenario: User is an admin of the group (sort by joining user's login)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/requests?sort=joining_user.login"
+    When I send a GET request to "/groups/13/requests?sort=joining_user.login,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_requests.go
+++ b/app/api/groups/get_requests.go
@@ -187,7 +187,7 @@ func (srv *Service) getRequests(w http.ResponseWriter, r *http.Request) service.
 			"joining_user.login": {ColumnName: "joining_user.login"},
 			"type_changed_at":    {ColumnName: "groups_groups.type_changed_at", FieldType: "time"},
 			"id":                 {ColumnName: "groups_groups.id", FieldType: "int64"}},
-		"-type_changed_at")
+		"-type_changed_at,id", false)
 
 	if apiError != service.NoError {
 		return apiError

--- a/app/api/groups/get_team_descendants.go
+++ b/app/api/groups/get_team_descendants.go
@@ -82,7 +82,7 @@ func (srv *Service) getTeamDescendants(w http.ResponseWriter, r *http.Request) s
 		map[string]*service.FieldSortingParams{
 			"name": {ColumnName: "groups.name", FieldType: "string"},
 			"id":   {ColumnName: "groups.id", FieldType: "int64"}},
-		"name")
+		"name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_team_progress.go
+++ b/app/api/groups/get_team_progress.go
@@ -125,7 +125,7 @@ func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) serv
 		// Note that we require the 'from.name' request parameter although the service does not return group names
 		"name": {ColumnName: "groups.name", FieldType: "string"},
 		"id":   {ColumnName: "groups.id", FieldType: "int64"},
-	}, "name,id")
+	}, "name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_user_descendants.go
+++ b/app/api/groups/get_user_descendants.go
@@ -85,7 +85,7 @@ func (srv *Service) getUserDescendants(w http.ResponseWriter, r *http.Request) s
 		map[string]*service.FieldSortingParams{
 			"name": {ColumnName: "groups.name", FieldType: "string"},
 			"id":   {ColumnName: "groups.id", FieldType: "int64"}},
-		"name")
+		"name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_user_progress.go
+++ b/app/api/groups/get_user_progress.go
@@ -130,7 +130,7 @@ func (srv *Service) getUserProgress(w http.ResponseWriter, r *http.Request) serv
 		// Note that we require the 'from.name' request parameter although the service does not return group names
 		"name": {ColumnName: "groups.name", FieldType: "string"},
 		"id":   {ColumnName: "groups.id", FieldType: "int64"},
-	}, "name,id")
+	}, "name,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/recent_activity.go
+++ b/app/api/groups/recent_activity.go
@@ -156,7 +156,7 @@ func (srv *Service) getRecentActivity(w http.ResponseWriter, r *http.Request) se
 		map[string]*service.FieldSortingParams{
 			"submitted_at": {ColumnName: "users_answers.submitted_at", FieldType: "time"},
 			"id":           {ColumnName: "users_answers.id", FieldType: "int64"}},
-		"-submitted_at")
+		"-submitted_at,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/items/get_attempts.feature
+++ b/app/api/items/get_attempts.feature
@@ -109,7 +109,7 @@ Feature: Get groups attempts for current user and item_id
 
   Scenario: User has access to the item and the users_answers.user_id = authenticated user's group_id (reverse order)
     Given I am the user with id "11"
-    When I send a GET request to "/items/200/attempts?sort=-order"
+    When I send a GET request to "/items/200/attempts?sort=-order,id"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -139,7 +139,7 @@ Feature: Get groups attempts for current user and item_id
 
   Scenario: User has access to the item and the users_answers.user_id = authenticated user's group_id (reverse order, start from the second row)
     Given I am the user with id "11"
-    When I send a GET request to "/items/200/attempts?sort=-order&from.order=1&from.id=150"
+    When I send a GET request to "/items/200/attempts?sort=-order,id&from.order=1&from.id=150"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/items/get_attempts.go
+++ b/app/api/items/get_attempts.go
@@ -106,7 +106,7 @@ func (srv *Service) getAttempts(w http.ResponseWriter, r *http.Request) service.
 	query, apiError := service.ApplySortingAndPaging(r, query, map[string]*service.FieldSortingParams{
 		"order": {ColumnName: "groups_attempts.order", FieldType: "int64"},
 		"id":    {ColumnName: "groups_attempts.id", FieldType: "int64"},
-	}, "order")
+	}, "order,id", false)
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -43,7 +43,8 @@ func (d sortingDirection) conditionSign() string {
 }
 
 // ApplySortingAndPaging applies ordering and paging according to given accepted fields and sorting rules
-// taking into the account the URL parameters 'from.*'
+// taking into the account the URL parameters 'from.*'.
+// When the `skipSortParameter` is true, the 'sort' request parameter is ignored.
 func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields map[string]*FieldSortingParams,
 	defaultRules string, skipSortParameter bool) (*database.DB, APIError) {
 	sortingRules := prepareSortingRulesAndAcceptedFields(r, defaultRules, skipSortParameter)

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -45,8 +45,8 @@ func (d sortingDirection) conditionSign() string {
 // ApplySortingAndPaging applies ordering and paging according to given accepted fields and sorting rules
 // taking into the account the URL parameters 'from.*'
 func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields map[string]*FieldSortingParams,
-	defaultRules string) (*database.DB, APIError) {
-	sortingRules, acceptedFields := prepareSortingRulesAndAcceptedFields(r, acceptedFields, defaultRules)
+	defaultRules string, skipSortParameter bool) (*database.DB, APIError) {
+	sortingRules := prepareSortingRulesAndAcceptedFields(r, defaultRules, skipSortParameter)
 
 	usedFields, fieldsDirections, err := parseSortingRules(sortingRules, acceptedFields)
 	if err != nil {
@@ -65,19 +65,14 @@ func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields m
 
 // prepareSortingRulesAndAcceptedFields builds sorting rules and a map of accepted fields.
 // If urlQuery["sort"] is not present, the default sorting rules are used.
-func prepareSortingRulesAndAcceptedFields(r *http.Request, acceptedFields map[string]*FieldSortingParams,
-	defaultRules string) (sortingRules string, newAcceptedFields map[string]*FieldSortingParams) {
-	newAcceptedFields = make(map[string]*FieldSortingParams, len(acceptedFields)+1)
-	for field, params := range acceptedFields {
-		newAcceptedFields[field] = params
-	}
+func prepareSortingRulesAndAcceptedFields(r *http.Request, defaultRules string, skipSortParameter bool) (sortingRules string) {
 	urlQuery := r.URL.Query()
-	if len(urlQuery["sort"]) > 0 {
+	if !skipSortParameter && len(urlQuery["sort"]) > 0 {
 		sortingRules = urlQuery["sort"][0]
 	} else {
 		sortingRules = defaultRules
 	}
-	return sortingRules, newAcceptedFields
+	return sortingRules
 }
 
 // parseSortingRules returns a slice with used fields and a map fieldName -> direction

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -42,8 +42,6 @@ func (d sortingDirection) conditionSign() string {
 	return "<"
 }
 
-const idFieldName = "id"
-
 // ApplySortingAndPaging applies ordering and paging according to given accepted fields and sorting rules
 // taking into the account the URL parameters 'from.*'
 func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields map[string]*FieldSortingParams,
@@ -66,26 +64,18 @@ func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields m
 }
 
 // prepareSortingRulesAndAcceptedFields builds sorting rules and a map of accepted fields.
-// It adds the 'id' field into a copy of the given map of accepted fields if this field is not listed.
 // If urlQuery["sort"] is not present, the default sorting rules are used.
-// If sorting rules are empty, the "id" (ORDER BY id ASC) rule is used.
 func prepareSortingRulesAndAcceptedFields(r *http.Request, acceptedFields map[string]*FieldSortingParams,
 	defaultRules string) (sortingRules string, newAcceptedFields map[string]*FieldSortingParams) {
 	newAcceptedFields = make(map[string]*FieldSortingParams, len(acceptedFields)+1)
 	for field, params := range acceptedFields {
 		newAcceptedFields[field] = params
 	}
-	if _, ok := newAcceptedFields[idFieldName]; !ok {
-		newAcceptedFields[idFieldName] = &FieldSortingParams{ColumnName: "id", FieldType: "int64"}
-	}
 	urlQuery := r.URL.Query()
 	if len(urlQuery["sort"]) > 0 {
 		sortingRules = urlQuery["sort"][0]
 	} else {
 		sortingRules = defaultRules
-	}
-	if sortingRules == "" {
-		sortingRules = idFieldName
 	}
 	return sortingRules, newAcceptedFields
 }
@@ -107,10 +97,6 @@ func parseSortingRules(sortingRules string,
 		}
 		fieldsDirections[fieldName] = direction
 		usedFields = append(usedFields, fieldName)
-	}
-	if fieldsDirections[idFieldName] == 0 {
-		fieldsDirections[idFieldName] = 1
-		usedFields = append(usedFields, idFieldName)
 	}
 	return
 }

--- a/app/service/sorting_test.go
+++ b/app/service/sorting_test.go
@@ -81,27 +81,6 @@ func TestApplySorting(t *testing.T) {
 				defaultRules: "-name,id",
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`unallowed field in sorting parameters: "class"`))},
-		{name: "add id field",
-			args: args{
-				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-				},
-				defaultRules: "-name",
-			},
-			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, id ASC",
-			wantSQLArguments: nil,
-			wantAPIError:     NoError},
-		{name: "no rules (adds id)",
-			args: args{
-				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-				},
-			},
-			wantSQL:      "SELECT id FROM `users` ORDER BY id ASC",
-			wantAPIError: NoError},
 		{name: "sorting + paging",
 			args: args{
 				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
@@ -152,6 +131,7 @@ func TestApplySorting(t *testing.T) {
 			args: args{
 				urlParameters: "?from.field=Joe&from.version=2&from.name=Jane",
 				acceptedFields: map[string]*FieldSortingParams{
+					"id":   {ColumnName: "id", FieldType: "int64"},
 					"name": {ColumnName: "name", FieldType: "string"},
 				},
 				defaultRules: "id",
@@ -162,8 +142,9 @@ func TestApplySorting(t *testing.T) {
 				urlParameters: "?from.submitted_at=" + url.QueryEscape("2006-01-02T15:04:05+03:00") + "&from.id=1",
 				acceptedFields: map[string]*FieldSortingParams{
 					"submitted_at": {ColumnName: "submitted_at", FieldType: "time"},
+					"id":           {ColumnName: "id", FieldType: "int64"},
 				},
-				defaultRules: "submitted_at",
+				defaultRules: "submitted_at,id",
 			},
 			wantSQL: "SELECT id FROM `users`  WHERE ((submitted_at > ?) OR (submitted_at = ? AND id > ?)) " +
 				"ORDER BY submitted_at ASC, id ASC",


### PR DESCRIPTION
Fixes #323 