### PR TITLE
Run GroupGroupStore.After() and ItemItemStore.After() after applying DB migrations + optimize AttemptStore.ComputeAllAttempts()

### DIFF
--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -61,7 +61,8 @@ func init() { // nolint:gochecknoinits
 				_, err = db.Exec("ANALYZE TABLE `attempts`")
 				assertNoError(err, "Cannot execute ANALYZE TABLE")
 				err = database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
-					assertNoError(store.Attempts().ComputeAllAttempts(), "Cannot compute attempts")
+					assertNoError(store.GroupGroups().After(), "Cannot compute groups_groups")
+					assertNoError(store.ItemItems().After(), "Cannot compute items_items")
 					assertNoError(store.PermissionsGranted().After(), "Cannot compute permissions_generated")
 					return nil
 				})

--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -61,9 +61,8 @@ func init() { // nolint:gochecknoinits
 				_, err = db.Exec("ANALYZE TABLE `attempts`")
 				assertNoError(err, "Cannot execute ANALYZE TABLE")
 				err = database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
-					assertNoError(store.GroupGroups().After(), "Cannot compute groups_groups")
-					assertNoError(store.ItemItems().After(), "Cannot compute items_items")
-					assertNoError(store.PermissionsGranted().After(), "Cannot compute permissions_generated")
+					assertNoError(store.GroupGroups().After(), "Cannot compute groups_groups") // calls createNewAncestors()
+					assertNoError(store.ItemItems().After(), "Cannot compute items_items")     // calls createNewAncestors() & computeAllAccess()
 					return nil
 				})
 				fmt.Printf("%d migration(s) applied successfully!\n", n)


### PR DESCRIPTION
We discovered that some groups_ancestors rows are missing after the initial DB migration. The issues was caused by the fact that the db-migrate command didn't run GroupGroupStore.createNewAncestors(). This PR fixes the db-migrate command so that it will execute GroupGroupStore.createNewAncestors().
Also, it appeared that insertion of missing attempts in AttemptStore.ComputeAllAttempts() worked too slow (took more than 5 hours) after groups_ancestors recalculation. The PR fixes this issue too.