### PR TITLE
Result propagation: Do not create attempts for explicit-entry items, set latest_activity_at correctly

### DIFF
--- a/app/api/items/add_item.feature
+++ b/app/api/items/add_item.feature
@@ -192,6 +192,7 @@ Feature: Add item
       | group_id | item_id             | result_propagation_state |
       | 11       | 12                  | done                     |
       | 11       | 21                  | done                     |
+      | 11       | 5577006791947779410 | done                     |
 
   Scenario: Valid with empty full_screen
     Given I am the user with id "11"

--- a/app/api/items/add_item.feature
+++ b/app/api/items/add_item.feature
@@ -192,7 +192,6 @@ Feature: Add item
       | group_id | item_id             | result_propagation_state |
       | 11       | 12                  | done                     |
       | 11       | 21                  | done                     |
-      | 11       | 5577006791947779410 | done                     |
 
   Scenario: Valid with empty full_screen
     Given I am the user with id "11"

--- a/app/database/attempt_store_compute_all_attempts.go
+++ b/app/database/attempt_store_compute_all_attempts.go
@@ -50,12 +50,14 @@ func (s *AttemptStore) ComputeAllAttempts() (err error) {
 				WITH RECURSIVE ancestors (ancestor_item_id, child_item_id) AS (
 					SELECT items_items.parent_item_id, items_items.child_item_id
 					FROM items_items
-					JOIN items ON items.id = items_items.parent_item_id AND NOT items.requires_explicit_entry
+					JOIN items ON items.id = items_items.parent_item_id
+					WHERE NOT items.requires_explicit_entry
 					UNION
 					SELECT items_items.parent_item_id, ancestors.child_item_id
 					FROM items_items
 					JOIN ancestors ON ancestors.ancestor_item_id = items_items.child_item_id
-					JOIN items ON items.id = items_items.parent_item_id AND NOT items.requires_explicit_entry)
+					JOIN items ON items.id = items_items.parent_item_id
+					WHERE NOT items.requires_explicit_entry)
 				SELECT
 					FLOOR(RAND() * 1000000000) + FLOOR(RAND() * 1000000000) * 1000000000,
 					descendants.group_id, ancestors.ancestor_item_id, '1000-01-01 00:00:00', 1, 'to_be_recomputed'

--- a/app/database/attempt_store_compute_all_attempts.go
+++ b/app/database/attempt_store_compute_all_attempts.go
@@ -42,20 +42,28 @@ func (s *AttemptStore) ComputeAllAttempts() (err error) {
 
 		// Insert missing attempts for chapters having descendants with attempts marked as 'to_be_recomputed'/'to_be_propagated'.
 		// We only create attempts for chapters which are (or have ancestors which are) visible to the group that attempted
-		// to solve the descendant items. Chapters with explicit entry (items.entry_participant_type IS NOT NULL) are skipped).
+		// to solve the descendant items. Chapters requiring explicit entry are skipped).
 		// (this query can take more than 25 seconds when executed for the first time after the db migration)
 		mustNotBeError(ds.RetryOnDuplicatePrimaryKeyError(func(retryStore *DataStore) error {
 			return retryStore.Exec(`
 				INSERT INTO attempts (id, group_id, item_id, latest_activity_at, ` + "`order`, " + `result_propagation_state)
+				WITH RECURSIVE ancestors (ancestor_item_id, child_item_id) AS (
+					SELECT items_items.parent_item_id, items_items.child_item_id
+					FROM items_items
+					JOIN items ON items.id = items_items.parent_item_id AND NOT items.requires_explicit_entry
+					UNION
+					SELECT items_items.parent_item_id, ancestors.child_item_id
+					FROM items_items
+					JOIN ancestors ON ancestors.ancestor_item_id = items_items.child_item_id
+					JOIN items ON items.id = items_items.parent_item_id AND NOT items.requires_explicit_entry)
 				SELECT
 					FLOOR(RAND() * 1000000000) + FLOOR(RAND() * 1000000000) * 1000000000,
-					descendants.group_id, items_ancestors.ancestor_item_id, '1000-01-01 00:00:00', 1, 'to_be_recomputed'
+					descendants.group_id, ancestors.ancestor_item_id, '1000-01-01 00:00:00', 1, 'to_be_recomputed'
 				FROM attempts AS descendants
-				JOIN items_ancestors ON items_ancestors.child_item_id = descendants.item_id
-				JOIN items ON items.id = items_ancestors.ancestor_item_id AND items.entry_participant_type IS NULL
+				JOIN ancestors ON ancestors.child_item_id = descendants.item_id
 				LEFT JOIN attempts AS existing ON (
 					existing.group_id = descendants.group_id AND
-					existing.item_id = items_ancestors.ancestor_item_id
+					existing.item_id = ancestors.ancestor_item_id
 				)
 				WHERE (
 					descendants.result_propagation_state = 'to_be_recomputed' OR
@@ -66,7 +74,7 @@ func (s *AttemptStore) ComputeAllAttempts() (err error) {
 						JOIN groups_ancestors_active
 							ON groups_ancestors_active.ancestor_group_id = permissions_generated.group_id
 						WHERE
-							permissions_generated.item_id = items_ancestors.ancestor_item_id AND
+							permissions_generated.item_id = ancestors.ancestor_item_id AND
 							permissions_generated.can_view_generated != 'none' AND
 							groups_ancestors_active.child_group_id = descendants.group_id
 						LIMIT 1
@@ -78,12 +86,12 @@ func (s *AttemptStore) ComputeAllAttempts() (err error) {
 							permissions_generated.item_id IN (
 								SELECT grand_ancestors.ancestor_item_id
 								FROM items_ancestors AS grand_ancestors
-								WHERE grand_ancestors.child_item_id = items_ancestors.ancestor_item_id
+								WHERE grand_ancestors.child_item_id = ancestors.ancestor_item_id
 							) AND permissions_generated.can_view_generated != 'none' AND
 							groups_ancestors_active.child_group_id = descendants.group_id
 						LIMIT 1
 				))
-				GROUP BY descendants.group_id, items_ancestors.ancestor_item_id
+				GROUP BY descendants.group_id, ancestors.ancestor_item_id
 			`).Error()
 		}))
 

--- a/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
+++ b/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
@@ -36,19 +36,20 @@ func testAttemptStoreComputeAllAttemptsCreatesNew(t *testing.T, fixtures []strin
 			- {id: 111, default_language_tag: fr}
 			- {id: 222, default_language_tag: fr}
 			- {id: 333, default_language_tag: fr}
-			- {id: 444, default_language_tag: fr, entry_participant_type: User}
-			- {id: 555, default_language_tag: fr, entry_participant_type: Team}
+			- {id: 444, default_language_tag: fr, requires_explicit_entry: 1}
+			- {id: 555, default_language_tag: fr}
 		items_items:
 			- {parent_item_id: 111, child_item_id: 222, child_order: 1}
 			- {parent_item_id: 222, child_item_id: 333, child_order: 1}
 			- {parent_item_id: 444, child_item_id: 333, child_order: 1}
-			- {parent_item_id: 555, child_item_id: 333, child_order: 1}
+			- {parent_item_id: 555, child_item_id: 444, child_order: 1}
 		items_ancestors:
 			- {ancestor_item_id: 111, child_item_id: 222}
 			- {ancestor_item_id: 111, child_item_id: 333}
 			- {ancestor_item_id: 222, child_item_id: 333}
 			- {ancestor_item_id: 444, child_item_id: 333}
 			- {ancestor_item_id: 555, child_item_id: 333}
+			- {ancestor_item_id: 555, child_item_id: 444}
 		attempts:
 			- {group_id: 3, item_id: 333, order: 1, latest_activity_at: "2019-05-30 11:00:00", result_propagation_state: to_be_propagated}
 	`)
@@ -115,6 +116,10 @@ func TestAttemptStore_ComputeAllAttempts_CreatesNew(t *testing.T) {
 				"but only for visible items's descendants",
 			fixtures:            []string{`permissions_generated: [{group_id: 1, item_id: 222, can_view_generated: info}]`},
 			expectedNewAttempts: []existingAttemptsRow{{GroupID: 3, ItemID: 222}},
+		},
+		{
+			name:     "should not create new attempts for items requiring explicit entry",
+			fixtures: []string{`permissions_generated: [{group_id: 1, item_id: 555, can_view_generated: info}]`},
 		},
 	} {
 		test := test

--- a/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
+++ b/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
@@ -35,13 +35,19 @@ func testAttemptStoreComputeAllAttemptsCreatesNew(t *testing.T, fixtures []strin
 			- {id: 111, default_language_tag: fr}
 			- {id: 222, default_language_tag: fr}
 			- {id: 333, default_language_tag: fr}
+			- {id: 444, default_language_tag: fr, entry_participant_type: User}
+			- {id: 555, default_language_tag: fr, entry_participant_type: Team}
 		items_items:
 			- {parent_item_id: 111, child_item_id: 222, child_order: 1}
 			- {parent_item_id: 222, child_item_id: 333, child_order: 1}
+			- {parent_item_id: 444, child_item_id: 333, child_order: 1}
+			- {parent_item_id: 555, child_item_id: 333, child_order: 1}
 		items_ancestors:
 			- {ancestor_item_id: 111, child_item_id: 222}
 			- {ancestor_item_id: 111, child_item_id: 333}
 			- {ancestor_item_id: 222, child_item_id: 333}
+			- {ancestor_item_id: 444, child_item_id: 333}
+			- {ancestor_item_id: 555, child_item_id: 333}
 		attempts:
 			- {group_id: 3, item_id: 333, order: 1, result_propagation_state: to_be_propagated}
 	`)

--- a/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
+++ b/app/database/attempt_store_compute_all_attempts_creates_new_integration_test.go
@@ -14,6 +14,7 @@ import (
 type existingAttemptsRow struct {
 	GroupID                int64
 	ItemID                 int64
+	LatestActivityAt       string
 	ResultPropagationState string
 }
 
@@ -49,7 +50,7 @@ func testAttemptStoreComputeAllAttemptsCreatesNew(t *testing.T, fixtures []strin
 			- {ancestor_item_id: 444, child_item_id: 333}
 			- {ancestor_item_id: 555, child_item_id: 333}
 		attempts:
-			- {group_id: 3, item_id: 333, order: 1, result_propagation_state: to_be_propagated}
+			- {group_id: 3, item_id: 333, order: 1, latest_activity_at: "2019-05-30 11:00:00", result_propagation_state: to_be_propagated}
 	`)
 	mergedFixtures = append(mergedFixtures, fixtures...)
 	db := testhelpers.SetupDBWithFixtureString(mergedFixtures...)
@@ -61,13 +62,15 @@ func testAttemptStoreComputeAllAttemptsCreatesNew(t *testing.T, fixtures []strin
 	})
 	assert.NoError(t, err)
 
+	const expectedDate = "2019-05-30 11:00:00"
 	for i := range expectedNewAttempts {
 		expectedNewAttempts[i].ResultPropagationState = "done"
+		expectedNewAttempts[i].LatestActivityAt = expectedDate
 	}
 	expectedNewAttempts = append(expectedNewAttempts,
-		existingAttemptsRow{GroupID: 3, ItemID: 333, ResultPropagationState: "done"})
+		existingAttemptsRow{GroupID: 3, ItemID: 333, LatestActivityAt: expectedDate, ResultPropagationState: "done"})
 	var result []existingAttemptsRow
-	assert.NoError(t, attemptStore.Select("group_id, item_id, result_propagation_state").
+	assert.NoError(t, attemptStore.Select("group_id, item_id, latest_activity_at, result_propagation_state").
 		Order("group_id, item_id").Scan(&result).Error())
 	assert.Equal(t, expectedNewAttempts, result)
 }


### PR DESCRIPTION
Fixes #405 