### PR TITLE
Config: default domain

### DIFF
--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -35,6 +35,22 @@ func TestMiddleware(t *testing.T) {
 			shouldEnterService: true,
 		},
 		{
+			name: "use default",
+			domains: []ConfigItem{
+				{
+					Domains:   []string{"france-ioi.org", "www.france-ioi.org"},
+					RootGroup: 5, RootSelfGroup: 6, RootTempGroup: 7,
+				},
+				{
+					Domains:   []string{"default"},
+					RootGroup: 1, RootSelfGroup: 2, RootTempGroup: 4,
+				},
+			},
+			expectedConfig:     &CtxConfig{RootGroupID: 1, RootSelfGroupID: 2, RootTempGroupID: 4},
+			expectedStatusCode: http.StatusOK,
+			shouldEnterService: true,
+		},
+		{
 			name: "wrong domain",
 			domains: []ConfigItem{
 				{

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -30,7 +30,7 @@ logging:
   logRawSQLQueries: false
 domains:
   -
-    domains: [127.0.0.1]
+    domains: [default] # of a list of domains
     rootGroup: 1
     rootSelfGroup: 2
     rootTempGroup: 4


### PR DESCRIPTION
Allow usage of a 'default' domain (in config) that matches all if no direct match