### PR TITLE
fix path to config/keys which was set at compile time

### DIFF
--- a/app/api/answers/bdd_test.go
+++ b/app/api/answers/bdd_test.go
@@ -5,9 +5,11 @@ package answers_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/auth/bdd_test.go
+++ b/app/api/auth/bdd_test.go
@@ -5,9 +5,11 @@ package auth_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/bdd_test.go
+++ b/app/api/bdd_test.go
@@ -5,9 +5,11 @@ package api_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/contests/bdd_test.go
+++ b/app/api/contests/bdd_test.go
@@ -5,9 +5,11 @@ package contests_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/currentuser/bdd_test.go
+++ b/app/api/currentuser/bdd_test.go
@@ -5,9 +5,11 @@ package currentuser_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../" // nolint:goconst
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/api/currentuser"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
@@ -15,6 +16,7 @@ import (
 )
 
 func Test_checkPreconditionsForGroupRequests(t *testing.T) {
+	app.RootDirectory = "../../../" // nolint:goconst
 	tests := []struct {
 		name         string
 		fixture      string

--- a/app/api/groups/bdd_test.go
+++ b/app/api/groups/bdd_test.go
@@ -5,9 +5,11 @@ package groups_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../" // nolint:goconst
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/groups/invite_users_integration_test.go
+++ b/app/api/groups/invite_users_integration_test.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/api/groups"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func Test_filterOtherTeamsMembersOut(t *testing.T) {
+	app.RootDirectory = "../../../" // nolint:goconst
 	tests := []struct {
 		name           string
 		fixture        string

--- a/app/api/items/bdd_test.go
+++ b/app/api/items/bdd_test.go
@@ -5,9 +5,11 @@ package items_test
 import (
 	"testing"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
+	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -25,6 +25,7 @@ import (
 /* note that the tests of app.New() are very incomplete (even if all exec path are covered) */
 
 func TestNew_Success(t *testing.T) {
+	RootDirectory = "../"
 	assert := assertlib.New(t)
 	appenv.SetDefaultEnvToTest()
 	app, err := New()

--- a/app/config.go
+++ b/app/config.go
@@ -3,8 +3,6 @@ package app
 import (
 	"fmt"
 	"log"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
@@ -30,6 +28,10 @@ const (
 	domainsConfigKey  string = "domains"
 )
 
+// RootDirectory is the path to the root of the project (to find config files)
+// may be changed, for tests launched from subdirectories
+var RootDirectory = "./"
+
 // LoadConfig loads and return the global configuration from files, flags, env, ...
 // The precedence of config values in viper is the following:
 // 1) explicit call to Set
@@ -39,7 +41,7 @@ const (
 // 5) key/value store
 // 6) default
 func LoadConfig() *viper.Viper {
-	return loadConfigFrom(defaultConfigName, configDirectory())
+	return loadConfigFrom(defaultConfigName, RootDirectory+"conf/")
 }
 
 func loadConfigFrom(filename, directory string) *viper.Viper {
@@ -69,12 +71,6 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 	}
 
 	return config
-}
-
-func configDirectory() string {
-	_, codeFilePath, _, _ := runtime.Caller(0)
-	codeDir := filepath.Dir(codeFilePath)
-	return filepath.Dir(codeDir + "/../conf/")
 }
 
 // ReplaceAuthConfig replaces the auth part of the config by the given one.
@@ -123,7 +119,7 @@ func DBConfig(globalConfig *viper.Viper) (config *mysql.Config, err error) {
 // Panic in case of unmarshalling error
 func TokenConfig(globalConfig *viper.Viper) (*token.Config, error) {
 	sub := subconfig(globalConfig, tokenConfigKey)
-	return token.Initialize(sub)
+	return token.Initialize(sub, RootDirectory)
 }
 
 // AuthConfig returns an auth dynamic config from the global config

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -132,7 +132,7 @@ func TestDBConfig_Error(t *testing.T) {
 func TestTokenConfig_Success(t *testing.T) {
 	assert := assertlib.New(t)
 	globalConfig := viper.New()
-	monkey.Patch(token.Initialize, func(config *viper.Viper) (*token.Config, error) {
+	monkey.Patch(token.Initialize, func(config *viper.Viper, _ string) (*token.Config, error) {
 		return &token.Config{PlatformName: "test"}, nil
 	})
 	defer monkey.UnpatchAll()

--- a/app/database/database_test.go
+++ b/app/database/database_test.go
@@ -1,0 +1,7 @@
+package database_test
+
+import "github.com/France-ioi/AlgoreaBackend/app"
+
+func init() { // nolint:gochecknoinits
+	app.RootDirectory = "../../" // common setup for all tests of this package
+}

--- a/app/token/token_integration_test.go
+++ b/app/token/token_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/app/payloadstest"
@@ -20,6 +21,7 @@ import (
 )
 
 func TestToken_UnmarshalDependingOnItemPlatform(t *testing.T) {
+	app.RootDirectory = "../../"
 	expectedParsedPayload := payloads.HintToken{}
 	_ = payloads.ParseMap(payloadstest.HintPayloadFromTaskPlatform, &expectedParsedPayload)
 	expectedToken := (*token.Hint)(&expectedParsedPayload)

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -193,7 +192,7 @@ func Test_Initialize_LoadsKeysFromFile(t *testing.T) {
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
 	config.Set("PublicKeyFile", tmpFilePublic.Name())
 	config.Set("PlatformName", "my platform")
-	tokenConfig, err := Initialize(config)
+	tokenConfig, err := Initialize(config, "../../")
 	assert.NoError(t, err)
 	assert.Equal(t, &Config{
 		PrivateKey:   expectedPrivateKey,
@@ -212,7 +211,7 @@ func Test_Initialize_LoadsKeysFromString(t *testing.T) {
 	config.Set("PrivateKey", tokentest.AlgoreaPlatformPrivateKey)
 	config.Set("PublicKey", tokentest.AlgoreaPlatformPublicKey)
 	config.Set("PlatformName", "my platform")
-	tokenConfig, err := Initialize(config)
+	tokenConfig, err := Initialize(config, "../../")
 	assert.NoError(t, err)
 	assert.Equal(t, &Config{
 		PrivateKey:   expectedPrivateKey,
@@ -232,7 +231,7 @@ func Test_Initialize_CannotLoadPublicKey(t *testing.T) {
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
 	config.Set("PublicKeyFile", "nosuchfile.pem")
 	config.Set("PlatformName", "my platform")
-	_, err = Initialize(config)
+	_, err = Initialize(config, "../../")
 	assert.IsType(t, &os.PathError{}, err)
 }
 
@@ -247,7 +246,7 @@ func Test_Initialize_CannotLoadPrivateKey(t *testing.T) {
 	config.Set("PrivateKeyFile", "nosuchfile.pem")
 	config.Set("PublicKeyFile", tmpFilePublic.Name())
 	config.Set("PlatformName", "my platform")
-	_, err = Initialize(config)
+	_, err = Initialize(config, "../../")
 
 	assert.IsType(t, &os.PathError{}, err)
 }
@@ -269,7 +268,7 @@ func Test_Initialize_CannotParsePublicKey(t *testing.T) {
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
 	config.Set("PublicKeyFile", tmpFilePublic.Name())
 	config.Set("PlatformName", "my platform")
-	_, err = Initialize(config)
+	_, err = Initialize(config, "../../")
 
 	assert.Equal(t, errors.New("invalid key: Key must be PEM encoded PKCS1 or PKCS8 private key"), err)
 }
@@ -291,7 +290,7 @@ func Test_Initialize_CannotParsePrivateKey(t *testing.T) {
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
 	config.Set("PublicKeyFile", tmpFilePublic.Name())
 	config.Set("PlatformName", "my platform")
-	_, err = Initialize(config)
+	_, err = Initialize(config, "../../")
 
 	assert.Equal(t, errors.New("invalid key: Key must be PEM encoded PKCS1 or PKCS8 private key"), err)
 }
@@ -299,7 +298,7 @@ func Test_Initialize_CannotParsePrivateKey(t *testing.T) {
 func Test_Initialize_MissingPublicKey(t *testing.T) {
 	config := viper.New()
 	config.Set("PlatformName", "my platform")
-	_, err := Initialize(config)
+	_, err := Initialize(config, "../../")
 	assert.EqualError(t, err, "missing Public key in the token config (PublicKey or PublicKeyFile)")
 }
 
@@ -307,21 +306,16 @@ func Test_Initialize_MissingPrivateKey(t *testing.T) {
 	config := viper.New()
 	config.Set("PlatformName", "my platform")
 	config.Set("PublicKey", tokentest.AlgoreaPlatformPublicKey)
-	_, err := Initialize(config)
+	_, err := Initialize(config, "../../")
 	assert.EqualError(t, err, "missing Private key in the token config (PrivateKey or PrivateKeyFile)")
 }
 
 func Test_prepareFileName(t *testing.T) {
-	assert.Equal(t, "/", prepareFileName("/"))
+	// absolute path
+	assert.Equal(t, "/afile.key", prepareFileName("/afile.key", "./adir/"))
 
-	preparedFileName := prepareFileName("")
-	assert.True(t, strings.HasPrefix(preparedFileName, "/"))
-	assert.Equal(t, "/app/token/../../", preparedFileName[len(preparedFileName)-len("/app/token/../../"):])
-
-	preparedFileName = prepareFileName("some.file")
-	assert.True(t, strings.HasPrefix(preparedFileName, "/"))
-	assert.Equal(t, "/app/token/../../some.file",
-		preparedFileName[len(preparedFileName)-len("/app/token/../../some.file"):])
+	// rel path
+	assert.Equal(t, "adir/some.file", prepareFileName("some.file", "adir/"))
 }
 
 func createTmpPublicKeyFile(key []byte) (*os.File, error) {


### PR DESCRIPTION
Just use relative path instead of absolute path computed at compilation time to set where configuration and pb/pv key files are stored.