### PR TITLE
Config: load default

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -12,6 +12,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus" //nolint:depguard
 	"github.com/spf13/viper"
 	assertlib "github.com/stretchr/testify/assert"
@@ -70,14 +71,12 @@ func TestNew_DBErr(t *testing.T) {
 
 func TestNew_DBConfigError(t *testing.T) {
 	assert := assertlib.New(t)
-	patch := monkey.Patch(LoadConfig, func() *viper.Viper {
-		globalConfig := viper.New()
-		globalConfig.Set("database.Timeout", "invalid")
-		return globalConfig
+	patch := monkey.Patch(DBConfig, func(_ *viper.Viper) (config *mysql.Config, err error) {
+		return nil, errors.New("dberror")
 	})
 	defer patch.Unpatch()
 	_, err := New()
-	assert.Contains(err.Error(), "unable to load the 'database' configuration: 1 error(s) decoding")
+	assert.EqualError(err, "unable to load the 'database' configuration: dberror")
 }
 
 func TestNew_TokenConfigError(t *testing.T) {

--- a/app/config.go
+++ b/app/config.go
@@ -110,9 +110,10 @@ func subconfig(globalConfig *viper.Viper, subconfigKey string) *viper.Viper {
 
 // DBConfig returns the db connection fixed config from the global config.
 func DBConfig(globalConfig *viper.Viper) (config *mysql.Config, err error) {
-	// Env variables are not loaded if the key do not exist in the config file
-	// To fix this issue, all expected attributes are loaded in the config and
-	// are overridden by what is defined in the config (file or env)
+	// Env variables are not loaded if the keys do not exist in the config file
+	// To fix this issue, instead of loading config files and overriding with env vars,
+	// we load all possible keys (with their default value), override with config files,
+	// and then environmenent variables.
 	emptyConfig := &map[string]interface{}{}
 	if err = mapstructure.Decode(mysql.NewConfig(), &emptyConfig); err != nil {
 		return // unexpected

--- a/app/config.go
+++ b/app/config.go
@@ -116,7 +116,6 @@ func DBConfig(globalConfig *viper.Viper) (config *mysql.Config, err error) {
 }
 
 // TokenConfig returns the token fixed config from the global config
-// Panic in case of unmarshalling error
 func TokenConfig(globalConfig *viper.Viper) (*token.Config, error) {
 	sub := subconfig(globalConfig, tokenConfigKey)
 	return token.Initialize(sub, RootDirectory)


### PR DESCRIPTION
Fixes #63 
For DB config, the only one which is unmarshalled and which can be overriden by env var (and very typical for DB config), do not require a default value to be put in the config file to load the env variables.