### PR TITLE
Load configs from cwd/conf/ for normal builds and from project_root/conf for test builds, load tokens specified by relative path similarly

### DIFF
--- a/app/api/answers/bdd_test.go
+++ b/app/api/answers/bdd_test.go
@@ -5,11 +5,9 @@ package answers_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/auth/bdd_test.go
+++ b/app/api/auth/bdd_test.go
@@ -5,11 +5,9 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/bdd_test.go
+++ b/app/api/bdd_test.go
@@ -5,11 +5,9 @@ package api_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/contests/bdd_test.go
+++ b/app/api/contests/bdd_test.go
@@ -5,11 +5,9 @@ package contests_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/currentuser/bdd_test.go
+++ b/app/api/currentuser/bdd_test.go
@@ -5,11 +5,9 @@ package currentuser_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../" // nolint:goconst
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/api/currentuser"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
@@ -16,7 +15,6 @@ import (
 )
 
 func Test_checkPreconditionsForGroupRequests(t *testing.T) {
-	app.RootDirectory = "../../../" // nolint:goconst
 	tests := []struct {
 		name         string
 		fixture      string

--- a/app/api/groups/bdd_test.go
+++ b/app/api/groups/bdd_test.go
@@ -5,11 +5,9 @@ package groups_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../" // nolint:goconst
 	testhelpers.RunGodogTests(m)
 }

--- a/app/api/groups/invite_users_integration_test.go
+++ b/app/api/groups/invite_users_integration_test.go
@@ -8,14 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/api/groups"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func Test_filterOtherTeamsMembersOut(t *testing.T) {
-	app.RootDirectory = "../../../" // nolint:goconst
 	tests := []struct {
 		name           string
 		fixture        string

--- a/app/api/items/bdd_test.go
+++ b/app/api/items/bdd_test.go
@@ -5,11 +5,9 @@ package items_test
 import (
 	"testing"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	app.RootDirectory = "../../../"
 	testhelpers.RunGodogTests(m)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -25,7 +25,6 @@ import (
 /* note that the tests of app.New() are very incomplete (even if all exec path are covered) */
 
 func TestNew_Success(t *testing.T) {
-	RootDirectory = "../"
 	assert := assertlib.New(t)
 	appenv.SetDefaultEnvToTest()
 	app, err := New()

--- a/app/config.go
+++ b/app/config.go
@@ -3,8 +3,9 @@ package app
 import (
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
-	"runtime"
+	"regexp"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
@@ -71,10 +72,14 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 	return config
 }
 
+var configPathTestRegexp = regexp.MustCompile("/app(/[a-z]+)*$")
+
 func configDirectory() string {
-	_, codeFilePath, _, _ := runtime.Caller(0)
-	codeDir := filepath.Dir(codeFilePath)
-	return filepath.Dir(codeDir + "/../conf/")
+	cwd, _ := os.Getwd()
+	if strings.HasSuffix(os.Args[0], ".test") {
+		cwd = configPathTestRegexp.ReplaceAllString(cwd, "")
+	}
+	return filepath.Dir(cwd + "/conf/")
 }
 
 // ReplaceAuthConfig replaces the auth part of the config by the given one.

--- a/app/config.go
+++ b/app/config.go
@@ -72,12 +72,15 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 	return config
 }
 
-var configPathTestRegexp = regexp.MustCompile("/app(/[a-z]+)*$")
+var configPathTestRegexp = regexp.MustCompile(".*(/app(?:/[a-z]+)*?)$")
 
 func configDirectory() string {
 	cwd, _ := os.Getwd()
 	if strings.HasSuffix(os.Args[0], ".test") {
-		cwd = configPathTestRegexp.ReplaceAllString(cwd, "")
+		match := configPathTestRegexp.FindStringSubmatchIndex(cwd)
+		if match != nil {
+			cwd = cwd[:match[2]]
+		}
 	}
 	return filepath.Dir(cwd + "/conf/")
 }

--- a/app/config.go
+++ b/app/config.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 	"log"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
@@ -28,10 +30,6 @@ const (
 	domainsConfigKey  string = "domains"
 )
 
-// RootDirectory is the path to the root of the project (to find config files)
-// may be changed, for tests launched from subdirectories
-var RootDirectory = "./"
-
 // LoadConfig loads and return the global configuration from files, flags, env, ...
 // The precedence of config values in viper is the following:
 // 1) explicit call to Set
@@ -41,7 +39,7 @@ var RootDirectory = "./"
 // 5) key/value store
 // 6) default
 func LoadConfig() *viper.Viper {
-	return loadConfigFrom(defaultConfigName, RootDirectory+"conf/")
+	return loadConfigFrom(defaultConfigName, configDirectory())
 }
 
 func loadConfigFrom(filename, directory string) *viper.Viper {
@@ -71,6 +69,12 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 	}
 
 	return config
+}
+
+func configDirectory() string {
+	_, codeFilePath, _, _ := runtime.Caller(0)
+	codeDir := filepath.Dir(codeFilePath)
+	return filepath.Dir(codeDir + "/../conf/")
 }
 
 // ReplaceAuthConfig replaces the auth part of the config by the given one.
@@ -119,7 +123,7 @@ func DBConfig(globalConfig *viper.Viper) (config *mysql.Config, err error) {
 // Panic in case of unmarshalling error
 func TokenConfig(globalConfig *viper.Viper) (*token.Config, error) {
 	sub := subconfig(globalConfig, tokenConfigKey)
-	return token.Initialize(sub, RootDirectory)
+	return token.Initialize(sub)
 }
 
 // AuthConfig returns an auth dynamic config from the global config

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -132,7 +132,7 @@ func TestDBConfig_Error(t *testing.T) {
 func TestTokenConfig_Success(t *testing.T) {
 	assert := assertlib.New(t)
 	globalConfig := viper.New()
-	monkey.Patch(token.Initialize, func(config *viper.Viper, _ string) (*token.Config, error) {
+	monkey.Patch(token.Initialize, func(config *viper.Viper) (*token.Config, error) {
 		return &token.Config{PlatformName: "test"}, nil
 	})
 	defer monkey.UnpatchAll()

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -252,6 +252,13 @@ func TestReplaceDomainsConfig_Panic(t *testing.T) {
 	})
 }
 
+func Test_configDirectory_StripsOnlyTheLastOccurrenceOfApp(t *testing.T) {
+	monkey.Patch(os.Getwd, func() (string, error) { return "/app/something/app/ab/app/token", nil })
+	defer monkey.UnpatchAll()
+	dir := configDirectory()
+	assertlib.Equal(t, "/app/something/app/ab/conf", dir)
+}
+
 func createTmpFile(pattern string, assert *assertlib.Assertions) (tmpFile *os.File, deferFunc func()) {
 	// create a temp config file
 	tmpFile, err := ioutil.TempFile(os.TempDir(), pattern)

--- a/app/database/database_test.go
+++ b/app/database/database_test.go
@@ -1,7 +1,0 @@
-package database_test
-
-import "github.com/France-ioi/AlgoreaBackend/app"
-
-func init() { // nolint:gochecknoinits
-	app.RootDirectory = "../../" // common setup for all tests of this package
-}

--- a/app/token/token.go
+++ b/app/token/token.go
@@ -65,7 +65,7 @@ func getKey(config *viper.Viper, keyType string) ([]byte, error) {
 	return ioutil.ReadFile(prepareFileName(config.GetString(keyType + "KeyFile")))
 }
 
-var tokenPathTestRegexp = regexp.MustCompile("/app(/[a-z]+)*$")
+var tokenPathTestRegexp = regexp.MustCompile(".*(/app(?:/[a-z]+)*?)$")
 
 func prepareFileName(fileName string) string {
 	if len(fileName) > 0 && fileName[0] == '/' {
@@ -74,7 +74,10 @@ func prepareFileName(fileName string) string {
 
 	cwd, _ := os.Getwd()
 	if strings.HasSuffix(os.Args[0], ".test") {
-		cwd = tokenPathTestRegexp.ReplaceAllString(cwd, "")
+		match := tokenPathTestRegexp.FindStringSubmatchIndex(cwd)
+		if match != nil {
+			cwd = cwd[:match[2]]
+		}
 	}
 	return cwd + "/" + fileName
 }

--- a/app/token/token_integration_test.go
+++ b/app/token/token_integration_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/France-ioi/AlgoreaBackend/app"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/app/payloadstest"
@@ -21,7 +20,6 @@ import (
 )
 
 func TestToken_UnmarshalDependingOnItemPlatform(t *testing.T) {
-	app.RootDirectory = "../../"
 	expectedParsedPayload := payloads.HintToken{}
 	_ = payloads.ParseMap(payloadstest.HintPayloadFromTaskPlatform, &expectedParsedPayload)
 	expectedToken := (*token.Hint)(&expectedParsedPayload)

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -310,6 +310,8 @@ func Test_Initialize_MissingPrivateKey(t *testing.T) {
 	assert.EqualError(t, err, "missing Private key in the token config (PrivateKey or PrivateKeyFile)")
 }
 
+const relFileName = "app/token/token_test.go"
+
 func Test_prepareFileName(t *testing.T) {
 	assert.Equal(t, "/", prepareFileName("/"))
 
@@ -317,10 +319,17 @@ func Test_prepareFileName(t *testing.T) {
 	assert.Equal(t, "/afile.key", prepareFileName("/afile.key"))
 
 	// rel path
-	relFileName := "app/token/token_test.go"
 	preparedFileName := prepareFileName(relFileName)
 	assert.Equal(t, relFileName, preparedFileName[len(preparedFileName)-len(relFileName):])
 	assert.FileExists(t, preparedFileName)
+}
+
+func Test_prepareFileName_StripsOnlyTheLastOccurrenceOfApp(t *testing.T) {
+	monkey.Patch(os.Getwd, func() (string, error) { return "/app/something/app/ab/app/token", nil })
+	defer monkey.UnpatchAll()
+	relFileName := "app/token/token_test.go"
+	preparedFileName := prepareFileName(relFileName)
+	assert.Equal(t, "/app/something/app/ab/"+relFileName, preparedFileName)
 }
 
 func createTmpPublicKeyFile(key []byte) (*os.File, error) {

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -314,14 +313,14 @@ func Test_Initialize_MissingPrivateKey(t *testing.T) {
 func Test_prepareFileName(t *testing.T) {
 	assert.Equal(t, "/", prepareFileName("/"))
 
-	preparedFileName := prepareFileName("")
-	assert.True(t, strings.HasPrefix(preparedFileName, "/"))
-	assert.Equal(t, "/app/token/../../", preparedFileName[len(preparedFileName)-len("/app/token/../../"):])
+	// absolute path
+	assert.Equal(t, "/afile.key", prepareFileName("/afile.key"))
 
-	preparedFileName = prepareFileName("some.file")
-	assert.True(t, strings.HasPrefix(preparedFileName, "/"))
-	assert.Equal(t, "/app/token/../../some.file",
-		preparedFileName[len(preparedFileName)-len("/app/token/../../some.file"):])
+	// rel path
+	relFileName := "app/token/token_test.go"
+	preparedFileName := prepareFileName(relFileName)
+	assert.Equal(t, relFileName, preparedFileName[len(preparedFileName)-len(relFileName):])
+	assert.FileExists(t, preparedFileName)
 }
 
 func createTmpPublicKeyFile(key []byte) (*os.File, error) {


### PR DESCRIPTION
The 'project_root' is calculated by stripping the "/app/..." suffix from the current working directory for test builds.

Checked with 
* make test
* make && ./bin/Algoreabackend serve
* go test -gcflags=all=-l -failfast -v -p 1 -run TestGroupStore ./app/database
* godog --stop-on-failure ./app/api/currentuser/join_group_by_code.robustness.feature