### PR TITLE
Allow disabling compression

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -62,8 +62,10 @@ func New() (*Application, error) {
 	// Set up middlewares
 	router := chi.NewRouter()
 
-	router.Use(middleware.RealIP)             // must be before logger or any middleware using remote IP
-	router.Use(middleware.DefaultCompress)    // apply last on response
+	router.Use(middleware.RealIP) // must be before logger or any middleware using remote IP
+	if serverConfig.GetBool("compress") {
+		router.Use(middleware.DefaultCompress) // apply last on response
+	}
 	router.Use(middleware.RequestID)          // must be before any middleware using the request id (the logger and the recoverer do)
 	router.Use(logging.NewStructuredLogger()) //
 	router.Use(middleware.Recoverer)          // must be before logger so that it an log panics

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -28,6 +28,8 @@ import (
 func TestNew_Success(t *testing.T) {
 	assert := assertlib.New(t)
 	appenv.SetDefaultEnvToTest()
+	_ = os.Setenv("ALGOREA_SERVER__COMPRESS", "1")
+	defer func() { _ = os.Unsetenv("ALGOREA_SERVER__COMPRESS") }()
 	app, err := New()
 	assert.NotNil(app)
 	assert.NoError(err)
@@ -38,6 +40,15 @@ func TestNew_Success(t *testing.T) {
 	assert.Len(app.HTTPHandler.Middlewares(), 7)
 	assert.True(len(app.HTTPHandler.Routes()) > 0)
 	assert.Equal("/*", app.HTTPHandler.Routes()[0].Pattern) // test default val
+}
+
+func TestNew_SuccessNoCompress(t *testing.T) {
+	assert := assertlib.New(t)
+	appenv.SetDefaultEnvToTest()
+	_ = os.Setenv("ALGOREA_SERVER__COMPRESS", "false")
+	defer func() { _ = os.Unsetenv("ALGOREA_SERVER__COMPRESS") }()
+	app, _ := New()
+	assert.Len(app.HTTPHandler.Middlewares(), 6)
 }
 
 func TestNew_NotDefaultRootPath(t *testing.T) {
@@ -146,6 +157,8 @@ func TestMiddlewares_OnPanic(t *testing.T) {
 
 func TestMiddlewares_OnSuccess(t *testing.T) {
 	assert := assertlib.New(t)
+	_ = os.Setenv("ALGOREA_SERVER__COMPRESS", "1")
+	defer func() { _ = os.Unsetenv("ALGOREA_SERVER__COMPRESS") }()
 	hook, restoreFct := logging.MockSharedLoggerHook()
 	defer restoreFct()
 	app, _ := New()

--- a/app/cors.go
+++ b/app/cors.go
@@ -6,7 +6,7 @@ func corsConfig() *cors.Cors {
 	return cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"}, // to be set to something more specific
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "Content-Encoding"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
 		MaxAge:           86400,

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -1,6 +1,7 @@
 server:
   port: 8080
   rootpath: "/" # the path at which the router is mounted
+  compress: false # whether compression is enabled by default
 auth:
   loginModuleURL: "http://127.0.0.1:8000"
   clientID: "1"


### PR DESCRIPTION
Add an option to disable compression. Required to use the app behind proxies not handling correctly the content encoding.