### PR TITLE
Fix swagger docs of itemStringUpdate to point out that the language_tag parameter is required

### DIFF
--- a/app/api/items/update_item_string.go
+++ b/app/api/items/update_item_string.go
@@ -36,7 +36,7 @@ type itemStringUpdateRequest struct {
 //   creates a new one otherwise.
 //
 //
-//   If `language_tag` is not specified, uses the item’s default language.
+//   If `language_tag` = 'default', uses the item’s default language.
 //
 //
 //   The user should have `can_view` >= 'content' and `can_edit` >= 'all' on the item, otherwise the "forbidden" response is returned.


### PR DESCRIPTION
Fixes #605 