### PR TITLE
Test undo only for new migrations 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,11 +117,11 @@ jobs:
       - run:
           name: Apply all migrations
           command: make db-migrate
-          no_output_timeout: 2h
+          no_output_timeout: 10m
       - run:
           name: Undo all migrations
           command: for m in `git diff --name-only HEAD..origin/master | grep "db/migrations/"`; do if ! make db-migrate-undo; then break; fi; done
-          no_output_timeout: 30m
+          no_output_timeout: 10m
       - run:
           name: Re-apply all migrations
           command: make db-migrate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,9 @@ jobs:
           at: ./
       - restore_cache: *CACHEKEYMOD
       - run: sudo apt-get update
+      - run:
+          name: Skip if no new migrations added
+          command: git diff --name-only HEAD..origin/master | grep -q "db/migrations/" || circleci-agent step halt
       - run: sudo apt-get install default-mysql-client             # required for db-restore
       - run: cp conf/config.sample.yaml conf/config.yaml           # as env var are not loaded for entries not in config file (bug)
       - run: cp conf/config.test.sample.yaml conf/config.test.yaml # the dbname is specified in conf/config.test.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           no_output_timeout: 10m
       - run:
           name: Undo all migrations
-          command: for m in `git diff --name-only HEAD..origin/master | grep "db/migrations/"`; do if ! make db-migrate-undo; then break; fi; done
+          command: for m in `git diff --name-only HEAD..origin/master | grep "db/migrations/"`; do if ! make db-migrate-undo; then exit 1; fi; done
           no_output_timeout: 10m
       - run:
           name: Re-apply all migrations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           no_output_timeout: 2h
       - run:
           name: Undo all migrations
-          command: for m in db/migrations/*.sql; do if ! make db-migrate-undo; then break; fi; done
+          command: for m in `git diff --name-only HEAD..origin/master | grep "db/migrations/"`; do if ! make db-migrate-undo; then break; fi; done
           no_output_timeout: 30m
       - run:
           name: Re-apply all migrations

--- a/db/migrations/2001161438_rework_languages.sql
+++ b/db/migrations/2001161438_rework_languages.sql
@@ -126,6 +126,7 @@ SET `default_language_id` = `languages`.`id`;
 
 ALTER TABLE `items`
     DROP FOREIGN KEY `fk_items_id_default_language_tag_items_strings_item_language_tag`,
+    DROP INDEX `fk_items_id_default_language_tag_items_strings_item_language_tag`,
     DROP COLUMN `default_language_tag`,
     DROP COLUMN `is_root`,
     ADD COLUMN `display_children_as_tabs` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0'

--- a/db/migrations/2003110348_extract_results_from_attempts.sql
+++ b/db/migrations/2003110348_extract_results_from_attempts.sql
@@ -252,7 +252,9 @@ SET `results`.`id` = FLOOR(RAND() * 1000000000) + FLOOR(RAND() * 1000000000) * 1
 
 DROP TABLE `attempts`;
 
-ALTER TABLE `answers` DROP FOREIGN KEY `fk_answers_participant_id_attempt_id_item_id_results`;
+ALTER TABLE `answers`
+    DROP FOREIGN KEY `fk_answers_participant_id_attempt_id_item_id_results`,
+    DROP INDEX `fk_answers_participant_id_attempt_id_item_id_results`;
 
 # 2,392,792 rows :/
 UPDATE `answers` JOIN `results` USING(`participant_id`, `attempt_id`, `item_id`)


### PR DESCRIPTION
- only try to undo the migrations which are new to this branch (not perfect but does the job)
- adapt new timeout to the new db dump