### PR TITLE
Note that at least one of parent and as_root_of_group_id should be given in swagger docs of itemCreate

### DIFF
--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -166,7 +166,11 @@ func (in *NewItemRequest) canCreateItemsRelationsWithoutCycles(store *database.D
 //
 //   otherwise the "bad request" response is returned.
 //
+//
 //   The current user should not be temporary, otherwise the "forbidden" error response is returned.
+//
+//
+//   At least one of `parent` and `as_root_of_group_id` should be given, otherwise the "bad request" error response is returned.
 // parameters:
 // - in: body
 //   name: data


### PR DESCRIPTION
Fixes #641 