### PR TITLE
Speed up propagations

### DIFF
--- a/app/api/answers/submit.feature
+++ b/app/api/answers/submit.feature
@@ -24,9 +24,9 @@ Feature: Submit a new answer
       | id | participant_id |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | latest_activity_at  | started_at          | result_propagation_state |
-      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 2           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 1          | 101            | 10      | null                            | 0            | 0           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | latest_activity_at  | started_at          |
+      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 2           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 1          | 101            | 10      | null                            | 0            | 0           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
   Scenario: User is able to submit a new answer
     Given I am the user with id "101"
@@ -75,9 +75,10 @@ Feature: Submit a new answer
       | author_id | participant_id | attempt_id | item_id | type       | answer  | ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 |
       | 101       | 101            | 1          | 50      | Submission | print 1 | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | result_propagation_state |
-      | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        | done                     |
-      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           | done                     |
+      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 |
+      | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        |
+      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           |
+    And the table "results_propagate" should be empty
 
   Scenario: User is able to submit a new answer (with all fields filled in the token)
     Given I am the user with id "101"
@@ -130,6 +131,7 @@ Feature: Submit a new answer
       | author_id | participant_id | attempt_id | item_id | type       | answer   | ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 |
       | 101       | 101            | 1          | 50      | Submission | print(2) | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | result_propagation_state |
-      | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        | done                     |
-      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           | done                     |
+      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 |
+      | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        |
+      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           |
+    And the table "results_propagate" should be empty

--- a/app/api/contests/set_additional_time.feature
+++ b/app/api/contests/set_additional_time.feature
@@ -83,13 +83,13 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 1  | 31             | 3017-05-29 06:38:38 | 21         | 0                 | 70           | 9999-12-31 23:59:59      | null                |
       | 2  | 14             | 3019-05-29 06:38:38 | 21         | 0                 | 50           | 9999-12-31 23:59:59      | null                |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | started_at          | result_propagation_state |
-      | 1          | 13             | 50      | 3018-05-29 06:38:38 | done                     |
-      | 1          | 13             | 70      | 3018-05-29 06:38:38 | done                     |
-      | 1          | 14             | 50      | 3019-05-29 06:38:38 | done                     |
-      | 1          | 15             | 70      | 2018-10-31 23:59:59 | done                     |
-      | 1          | 16             | 70      | 3019-10-31 23:59:59 | done                     |
-      | 1          | 31             | 70      | 3017-05-29 06:38:38 | done                     |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 1          | 13             | 50      | 3018-05-29 06:38:38 |
+      | 1          | 13             | 70      | 3018-05-29 06:38:38 |
+      | 1          | 14             | 50      | 3019-05-29 06:38:38 |
+      | 1          | 15             | 70      | 2018-10-31 23:59:59 |
+      | 1          | 16             | 70      | 3019-10-31 23:59:59 |
+      | 1          | 31             | 70      | 3017-05-29 06:38:38 |
 
   Scenario: Updates an existing row
     Given I am the user with id "21"

--- a/app/api/currentuser/accept_group_invitation.feature
+++ b/app/api/currentuser/accept_group_invitation.feature
@@ -33,8 +33,8 @@ Feature: User accepts an invitation to join a group
       | id | participant_id |
       | 0  | 21             |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 30      |
 
   Scenario: Successfully accept an invitation
     Given I am the user with id "21"
@@ -70,9 +70,10 @@ Feature: User accepts an invitation to join a group
       | 22                | 22             | 1       |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 20      | done                     |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 20      |
+      | 0          | 21             | 30      |
+    And the table "results_propagate" should be empty
 
   Scenario: Successfully accept an invitation into a group that requires approvals
     Given I am the user with id "21"
@@ -108,6 +109,7 @@ Feature: User accepts an invitation to join a group
       | 22                | 22             | 1       |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 20      | done                     |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 20      |
+      | 0          | 21             | 30      |
+    And the table "results_propagate" should be empty

--- a/app/api/currentuser/create_group_join_request.feature
+++ b/app/api/currentuser/create_group_join_request.feature
@@ -30,8 +30,8 @@ Feature: User sends a request to join a group
       | id | participant_id |
       | 0  | 21             |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 30      |
 
   Scenario: Successfully send a request
     Given I am the user with id "21"
@@ -105,6 +105,7 @@ Feature: User sends a request to join a group
       | 21                | 21             | 1       |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 20      | done                     |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 20      |
+      | 0          | 21             | 30      |
+    And the table "results_propagate" should be empty

--- a/app/api/currentuser/get_full_dump.feature
+++ b/app/api/currentuser/get_full_dump.feature
@@ -59,10 +59,10 @@ Feature: Export the current user's data
       | 0  | 2              | 2019-05-28 11:00:00 |
       | 0  | 1              | 2019-05-28 11:00:00 |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | latest_activity_at  | result_propagation_state |
-      | 0          | 11             | 404     | 2019-05-30 11:00:00 | done                     |
-      | 0          | 2              | 404     | 2019-05-29 11:00:00 | done                     |
-      | 0          | 1              | 405     | 2019-05-28 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | latest_activity_at  |
+      | 0          | 11             | 404     | 2019-05-30 11:00:00 |
+      | 0          | 2              | 404     | 2019-05-29 11:00:00 |
+      | 0          | 1              | 405     | 2019-05-28 11:00:00 |
     And the database has the following table 'answers':
       | id | author_id | participant_id | attempt_id | item_id | created_at          |
       | 1  | 11        | 11             | 0          | 404     | 2019-07-09 21:02:28 |
@@ -108,8 +108,7 @@ Feature: Export the current user's data
           "score_computed": 0, "score_edit_rule": null, "score_edit_value": null,
           "participant_id": "2", "item_id": "404",
           "hints_cached": 0, "submissions": 0, "tasks_tried": 0,
-          "tasks_with_help": 0, "result_propagation_state": "done",
-          "score_obtained_at": null, "hints_requested": null,
+          "tasks_with_help": 0, "score_obtained_at": null, "hints_requested": null,
           "latest_activity_at": "2019-05-29T11:00:00Z", "latest_submission_at": null,
           "latest_hint_at": null, "score_edit_comment": null,
           "started_at": null, "validated_at": null
@@ -119,8 +118,7 @@ Feature: Export the current user's data
           "score_computed": 0, "score_edit_rule": null, "score_edit_value": null,
           "participant_id": "11", "item_id": "404",
           "hints_cached": 0, "submissions": 0, "tasks_tried": 0,
-          "tasks_with_help": 0, "result_propagation_state": "done",
-          "score_obtained_at": null, "hints_requested": null,
+          "tasks_with_help": 0, "score_obtained_at": null, "hints_requested": null,
           "latest_activity_at": "2019-05-30T11:00:00Z", "latest_submission_at": null,
           "latest_hint_at": null, "score_edit_comment": null,
           "started_at": null, "validated_at": null

--- a/app/api/currentuser/join_group_by_code.feature
+++ b/app/api/currentuser/join_group_by_code.feature
@@ -46,10 +46,10 @@ Feature: Join a group using a code (groupsJoinByCode)
       | 1  | 16             | 30           |
       | 1  | 21             | 30           |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state | started_at          |
-      | 0          | 17             | 30      | done                     | 2019-05-30 11:00:00 |
-      | 0          | 21             | 30      | done                     | 2019-05-30 11:00:00 |
-      | 1          | 16             | 30      | done                     | 2019-05-30 11:00:00 |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 17             | 30      | 2019-05-30 11:00:00 |
+      | 0          | 21             | 30      | 2019-05-30 11:00:00 |
+      | 1          | 16             | 30      | 2019-05-30 11:00:00 |
 
   Scenario: Successfully join a team
     Given I am the user with id "21"
@@ -111,11 +111,12 @@ Feature: Join a group using a code (groupsJoinByCode)
       | 21                | 21             | 9999-12-31 23:59:59 |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state | started_at          |
-      | 0          | 17             | 30      | done                     | 2019-05-30 11:00:00 |
-      | 0          | 21             | 20      | done                     | null                |
-      | 0          | 21             | 30      | done                     | 2019-05-30 11:00:00 |
-      | 1          | 16             | 30      | done                     | 2019-05-30 11:00:00 |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 17             | 30      | 2019-05-30 11:00:00 |
+      | 0          | 21             | 20      | null                |
+      | 0          | 21             | 30      | 2019-05-30 11:00:00 |
+      | 1          | 16             | 30      | 2019-05-30 11:00:00 |
+    And the table "results_propagate" should be empty
 
   Scenario: Updates the code_expires_at
     Given I am the user with id "21"

--- a/app/api/groups/accept_join_requests.feature
+++ b/app/api/groups/accept_join_requests.feature
@@ -46,8 +46,8 @@ Feature: Accept group requests
       | id | participant_id |
       | 0  | 31             |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 31             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 31             | 30      |
 
   Scenario: Accept requests
     Given I am the user with id "21"

--- a/app/api/groups/add_child.feature
+++ b/app/api/groups/add_child.feature
@@ -1,5 +1,4 @@
 Feature: Add a parent-child relation between two groups
-
   Background:
     Given the database has the following table 'groups':
       | id | name    | type  |
@@ -60,9 +59,10 @@ Feature: Add a parent-child relation between two groups
       | 21                | 21             | 1       |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 11             | 20      | done                     |
-      | 0          | 11             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 11             | 20      |
+      | 0          | 11             | 30      |
+    And the table "results_propagate" should be empty
     When I send a POST request to "/groups/13/relations/14"
     Then the response code should be 201
     And the response body should be, in JSON:

--- a/app/api/groups/check_code.feature
+++ b/app/api/groups/check_code.feature
@@ -33,8 +33,8 @@ Feature: Check if the group code is valid
       | 2  | 14             | 1234         |
       | 2  | 18             | 1234         |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 30      |
     And the database has the following table 'group_managers':
       | group_id | manager_id |
       | 11       | 21         |

--- a/app/api/groups/create_invitations.feature
+++ b/app/api/groups/create_invitations.feature
@@ -37,8 +37,8 @@ Feature: Invite users
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 101            | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 101            | 30      |
 
   Scenario: Successfully invite users
     Given I am the user with id "21"
@@ -204,6 +204,7 @@ Feature: Invite users
       | 555               | 555            | 1       |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 101            | 20      | done                     |
-      | 0          | 101            | 30      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 101            | 20      |
+      | 0          | 101            | 30      |
+    And the table "results_propagate" should be empty

--- a/app/api/groups/update_permissions.feature
+++ b/app/api/groups/update_permissions.feature
@@ -51,8 +51,8 @@ Feature: Change item access rights for a group
       | id | participant_id |
       | 0  | 21             |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 103     |
 
   Scenario Outline: Create a new permissions_granted row (with results propagation)
     Given I am the user with id "21"
@@ -85,9 +85,10 @@ Feature: Change item access rights for a group
       | 23       | 103     | <can_view_propagated> | <can_grant_view_propagated> | <can_watch_propagated> | <can_edit_propagated> | false              |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
   Examples:
     | json                                                 | can_view | can_grant_view | can_watch | can_edit | is_owner | can_make_session_official | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | can_view_propagated | can_grant_view_propagated | can_watch_propagated | can_edit_propagated |
     | {"can_view":"solution"}                              | solution | none           | none      | none     | false    | false                     | solution           | none                     | none                | none               | content             | none                      | none                 | none                |
@@ -128,9 +129,9 @@ Feature: Change item access rights for a group
       | 23       | 102     | none               | none                     | none                | none               | false              |
       | 23       | 103     | none               | none                     | none                | none               | false              |
     And the table "attempts" should stay unchanged
-    And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 103     | to_be_propagated         |
+    And the table "results_propagate" should be:
+      | attempt_id | participant_id | item_id | state            |
+      | 0          | 21             | 103     | to_be_propagated |
   Examples:
     | json                                       | can_enter_from      | can_enter_until     |
     | {"can_enter_from":"2019-05-30T11:00:00Z"}  | 2019-05-30 11:00:00 | 9999-12-31 23:59:59 |
@@ -168,9 +169,10 @@ Feature: Change item access rights for a group
       | 23       | 103     | <can_view_propagated> | <can_grant_view_propagated> | <can_watch_propagated> | <can_edit_propagated> | false              |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
   Examples:
     | json                                                           | can_view                 | can_grant_view      | can_watch | can_edit       | is_owner | can_make_session_official | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | can_view_propagated | can_grant_view_propagated | can_watch_propagated | can_edit_propagated |
     | {"can_view":"content_with_descendants"}                        | content_with_descendants | none                | none      | none           | false    | false                     | content_with_descendants | none                     | none                | none               | content             | none                      | none                 | none                |
@@ -219,9 +221,10 @@ Feature: Change item access rights for a group
       | 31       | 103     | content            | none                     | none                | none               | 0                  |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has full access to the item itself)
     Given I am the user with id "21"
@@ -268,11 +271,12 @@ Feature: Change item access rights for a group
       | 31       | 103     | none               | 0                  |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 100     | done                     |
-      | 0          | 21             | 101     | done                     |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 100     |
+      | 0          | 21             | 101     |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has 'content' access to the item itself)
     Given I am the user with id "21"
@@ -319,11 +323,12 @@ Feature: Change item access rights for a group
       | 31       | 103     | none               | 0                  |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 100     | done                     |
-      | 0          | 21             | 101     | done                     |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 100     |
+      | 0          | 21             | 101     |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has info access to the item itself)
     Given I am the user with id "21"
@@ -370,11 +375,12 @@ Feature: Change item access rights for a group
       | 31       | 103     | none               | 0                  |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 100     | done                     |
-      | 0          | 21             | 101     | done                     |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 100     |
+      | 0          | 21             | 101     |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty
 
   Scenario: Drops invalid permissions from an existing permissions_granted row
     Given I am the user with id "21"
@@ -408,6 +414,7 @@ Feature: Change item access rights for a group
       | 23       | 103     | none               | enter                    | none                | none               | false              |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 21             | 102     | done                     |
-      | 0          | 21             | 103     | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
+    And the table "results_propagate" should be empty

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -31,9 +31,9 @@ Feature: Ask for a hint
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          | result_propagation_state |
-      | 0          | 101            | 50      | [0,  1, "hint" , null] | 4            | 2019-05-30 11:00:00 | done                     |
-      | 0          | 101            | 10      | null                   | 0            | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          |
+      | 0          | 101            | 50      | [0,  1, "hint" , null] | 4            | 2019-05-30 11:00:00 |
+      | 0          | 101            | 10      | null                   | 0            | 2019-05-30 11:00:00 |
     And the following token "priorUserTaskToken" signed by the app is distributed:
       """
       {
@@ -84,9 +84,10 @@ Feature: Ask for a hint
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
-      | 0          | 101            | 10      | 1               | 0            | null                               | done                     | 1                                                         | null                                                  |
-      | 0          | 101            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | done                     | 1                                                         | 1                                                     |
+      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
+      | 0          | 101            | 10      | 1               | 0            | null                               | 1                                                         | null                                                  |
+      | 0          | 101            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | 1                                                         | 1                                                     |
+    And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for a hint with a minimal hint token
     Given I am the user with id "101"
@@ -94,9 +95,9 @@ Feature: Ask for a hint
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested        | started_at          | result_propagation_state |
-      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 | done                     |
-      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | hints_requested        | started_at          |
+      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 |
+      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 |
     And the following token "priorUserTaskToken" signed by the app is distributed:
       """
       {
@@ -147,9 +148,10 @@ Feature: Ask for a hint
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
-      | 0          | 101            | 10      | 1               | 0            | null                               | done                     | 1                                                         | null                                                  |
-      | 0          | 101            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | done                     | 1                                                         | 1                                                     |
+      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
+      | 0          | 101            | 10      | 1               | 0            | null                               | 1                                                         | null                                                  |
+      | 0          | 101            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | 1                                                         | 1                                                     |
+    And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for an already given hint
     Given I am the user with id "101"
@@ -157,9 +159,9 @@ Feature: Ask for a hint
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested        | started_at          | result_propagation_state |
-      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 | done                     |
-      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | hints_requested        | started_at          |
+      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 |
+      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 |
     And the following token "priorUserTaskToken" signed by the app is distributed:
       """
       {
@@ -210,9 +212,10 @@ Feature: Ask for a hint
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested   | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
-      | 0          | 101            | 10      | 1               | 0            | null              | done                     | 1                                                         | null                                                  |
-      | 0          | 101            | 50      | 1               | 4            | [0,1,"hint",null] | done                     | 1                                                         | 1                                                     |
+      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested   | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
+      | 0          | 101            | 10      | 1               | 0            | null              | 1                                                         | null                                                  |
+      | 0          | 101            | 50      | 1               | 4            | [0,1,"hint",null] | 1                                                         | 1                                                     |
+    And the table "results_propagate" should be empty
 
   Scenario: Can't parse hints_requested
     Given I am the user with id "101"
@@ -220,9 +223,9 @@ Feature: Ask for a hint
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested | started_at          | result_propagation_state |
-      | 0          | 101            | 50      | not an array    | 2019-05-30 11:00:00 | done                     |
-      | 0          | 101            | 10      | null            | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | hints_requested | started_at          |
+      | 0          | 101            | 50      | not an array    | 2019-05-30 11:00:00 |
+      | 0          | 101            | 10      | null            | 2019-05-30 11:00:00 |
     And the following token "priorUserTaskToken" signed by the app is distributed:
       """
       {
@@ -273,9 +276,10 @@ Feature: Ask for a hint
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested    | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
-      | 0          | 101            | 10      | 1               | 0            | null               | done                     | 1                                                         | null                                                  |
-      | 0          | 101            | 50      | 1               | 1            | [{"rotorIndex":1}] | done                     | 1                                                         | 1                                                     |
+      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested    | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
+      | 0          | 101            | 10      | 1               | 0            | null               | 1                                                         | null                                                  |
+      | 0          | 101            | 50      | 1               | 1            | [{"rotorIndex":1}] | 1                                                         | 1                                                     |
+    And the table "results_propagate" should be empty
     And logs should contain:
       """
       Unable to parse hints_requested ({"idAttempt":"101/0","idItemLocal":"50","idUser":"101"}) having value "not an array": invalid character 'o' in literal null (expecting 'u')

--- a/app/api/items/create_attempt.feature
+++ b/app/api/items/create_attempt.feature
@@ -65,8 +65,9 @@ Feature: Create an attempt for an item
       | 0  | 111            | null         | null              | 0                                                 |
       | 1  | 111            | <item_id>    | 0                 | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 111            | <item_id> | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
+      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 111            | <item_id> | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+    And the table "results_propagate" should be empty
   Examples:
     | item_id |
     | 50      |
@@ -91,9 +92,10 @@ Feature: Create an attempt for an item
       | 0  | 111            | null         | null              | 0                                                 |
       | 1  | 102            | 60           | 0                 | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 1          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+    And the table "results_propagate" should be empty
     When I send a POST request to "/items/60/attempts?as_team_id=102&parent_attempt_id=0"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -112,10 +114,11 @@ Feature: Create an attempt for an item
       | 1  | 102            | 60           | 0                 | 1                                                 |
       | 2  | 102            | 60           | 0                 | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 1          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+    And the table "results_propagate" should be empty
     When I send a POST request to "/items/60/70/attempts?as_team_id=102&parent_attempt_id=2"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -135,8 +138,9 @@ Feature: Create an attempt for an item
       | 2  | 102            | 60           | 0                 | 1                                                 |
       | 3  | 102            | 70           | 2                 | 1                                                 |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 3          | 102            | 70      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 1          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 3          | 102            | 70      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+    And the table "results_propagate" should be empty

--- a/app/api/items/create_item.feature
+++ b/app/api/items/create_item.feature
@@ -21,8 +21,8 @@ Feature: Create item
       | id | participant_id |
       | 0  | 11             |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 11             | 21      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 11             | 21      |
     And the database has the following table 'languages':
       | tag |
       | sl  |
@@ -206,8 +206,8 @@ Feature: Create item
       | 11       | 12      | content_with_descendants | solution            | answer            | all            | 0        | 11              | 2019-05-30 11:00:00 |
       | 11       | 34      | solution                 | solution_with_grant | answer_with_grant | all_with_grant | 0        | 11              | 2019-05-30 11:00:00 |
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 11             | 12      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 11             | 12      |
     When I send a POST request to "/items" with the following body:
       """
       {
@@ -309,9 +309,10 @@ Feature: Create item
       | 8674665223082153551 | 5577006791947779410 | content            | none                                              | none                | none               | 0                  |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id             | result_propagation_state |
-      | 0          | 11             | 12                  | done                     |
-      | 0          | 11             | 21                  | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 11             | 12      |
+      | 0          | 11             | 21      |
+    And the table "results_propagate" should be empty
   Examples:
     | grant_view_propagation | watch_propagation | edit_propagation |
     | true                   | false             | true             |

--- a/app/api/items/delete_item.feature
+++ b/app/api/items/delete_item.feature
@@ -73,10 +73,10 @@ Feature: Delete an item
       | 22      | en           |
       | 22      | fr           |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 10             | 21      | done                     |
-      | 0          | 10             | 22      | done                     |
-      | 1          | 10             | 21      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 10             | 21      |
+      | 0          | 10             | 22      |
+      | 1          | 10             | 21      |
     And the database has the following table 'threads':
       | id | creator_id | type | item_id |
       | 1  | 10         | Help | 21      |
@@ -135,9 +135,10 @@ Feature: Delete an item
       | 0  | 10             | null         |
       | 1  | 10             | null         |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 10             | 21      | done                     |
-      | 1          | 10             | 21      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 10             | 21      |
+      | 1          | 10             | 21      |
+    And the table "results_propagate" should be empty
     And the table "answers" should be:
       | participant_id | attempt_id | item_id | author_id | created_at          |
       | 10             | 0          | 21      | 10        | 2019-05-30 11:00:00 |

--- a/app/api/items/delete_item.robustness.feature
+++ b/app/api/items/delete_item.robustness.feature
@@ -74,10 +74,10 @@ Feature: Delete an item - robustness
       | 22      | en           |
       | 22      | fr           |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | result_propagation_state |
-      | 0          | 10             | 21      | done                     |
-      | 0          | 10             | 22      | done                     |
-      | 1          | 10             | 21      | done                     |
+      | attempt_id | participant_id | item_id |
+      | 0          | 10             | 21      |
+      | 0          | 10             | 22      |
+      | 1          | 10             | 21      |
     And the database has the following table 'threads':
       | id | creator_id | type | item_id |
       | 1  | 10         | Help | 21      |

--- a/app/api/items/enter.feature
+++ b/app/api/items/enter.feature
@@ -47,10 +47,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 0  | 11             | 2019-05-30 11:00:00 |
       | 0  | 31             | 2019-05-30 11:00:00 |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | started_at          | result_propagation_state |
-      | 0          | 11             | 30      | null                | done                     |
-      | 0          | 31             | 10      | 2019-05-30 11:00:00 | done                     |
-      | 0          | 31             | 30      | null                | done                     |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 11             | 30      | null                |
+      | 0          | 31             | 10      | 2019-05-30 11:00:00 |
+      | 0          | 31             | 30      | null                |
     And the DB time now is "3019-10-10 10:10:10"
 
   Scenario: Enter an individual contest
@@ -163,13 +163,14 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 0  | 31             | 2019-05-30 11:00:00 | null       | null              | null         | 9999-12-31 23:59:59      |
       | 1  | 11             | 3019-10-10 10:10:10 | 31         | 0                 | 60           | 3019-10-10 16:16:16      |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | started_at          | result_propagation_state |
-      | 0          | 11             | 10      | null                | done                     |
-      | 0          | 11             | 20      | null                | done                     |
-      | 0          | 11             | 30      | null                | done                     |
-      | 0          | 31             | 10      | 2019-05-30 11:00:00 | done                     |
-      | 0          | 31             | 30      | null                | done                     |
-      | 1          | 11             | 60      | 3019-10-10 10:10:10 | done                     |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 11             | 10      | null                |
+      | 0          | 11             | 20      | null                |
+      | 0          | 11             | 30      | null                |
+      | 0          | 31             | 10      | 2019-05-30 11:00:00 |
+      | 0          | 31             | 30      | null                |
+      | 1          | 11             | 60      | 3019-10-10 10:10:10 |
+    And the table "results_propagate" should be empty
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id | expires_at          |
       | 10              | 31             | 9999-12-31 23:59:59 |
@@ -234,13 +235,14 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 1  | 11             | 2019-05-29 11:00:00 | 31         | 0                 | 60           | 2019-05-30 11:00:00      |
       | 2  | 11             | 3019-10-10 10:10:10 | 31         | 0                 | 60           | 3019-10-10 13:13:13      |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | started_at          | result_propagation_state |
-      | 0          | 11             | 20      | null                | done                     |
-      | 0          | 11             | 30      | null                | done                     |
-      | 0          | 31             | 10      | 2019-05-30 11:00:00 | done                     |
-      | 0          | 31             | 30      | null                | done                     |
-      | 1          | 11             | 60      | 2019-05-29 11:00:00 | done                     |
-      | 2          | 11             | 60      | 3019-10-10 10:10:10 | done                     |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 11             | 20      | null                |
+      | 0          | 11             | 30      | null                |
+      | 0          | 31             | 10      | 2019-05-30 11:00:00 |
+      | 0          | 31             | 30      | null                |
+      | 1          | 11             | 60      | 2019-05-29 11:00:00 |
+      | 2          | 11             | 60      | 3019-10-10 10:10:10 |
+    And the table "results_propagate" should be empty
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id | expires_at          |
       | 10              | 31             | 9999-12-31 23:59:59 |
@@ -296,11 +298,12 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 0  | 31             | 2019-05-30 11:00:00 | null       | null              | null         | 9999-12-31 23:59:59      |
       | 1  | 31             | 3019-10-10 10:10:10 | 31         | 0                 | 50           | 3019-10-10 11:11:11      |
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | started_at          | result_propagation_state |
-      | 0          | 11             | 30      | null                | done                     |
-      | 0          | 31             | 10      | 2019-05-30 11:00:00 | done                     |
-      | 0          | 31             | 30      | null                | done                     |
-      | 1          | 31             | 50      | 3019-10-10 10:10:10 | done                     |
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 11             | 30      | null                |
+      | 0          | 31             | 10      | 2019-05-30 11:00:00 |
+      | 0          | 31             | 30      | null                |
+      | 1          | 31             | 50      | 3019-10-10 10:10:10 |
+    And the table "results_propagate" should be empty
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
     And logs should contain:

--- a/app/api/items/enter.go
+++ b/app/api/items/enter.go
@@ -130,7 +130,7 @@ func (srv *Service) enter(w http.ResponseWriter, r *http.Request) service.APIErr
 
 		service.MustNotBeError(store.Results().InsertMap(map[string]interface{}{
 			"attempt_id": attemptID, "participant_id": entryState.groupID,
-			"item_id": entryState.itemID, "started_at": itemInfo.Now, "result_propagation_state": "done",
+			"item_id": entryState.itemID, "started_at": itemInfo.Now,
 		}))
 
 		if itemInfo.ParticipantsGroupID != nil {

--- a/app/api/items/generate_task_token.feature
+++ b/app/api/items/generate_task_token.feature
@@ -37,11 +37,11 @@ Feature: Generate a task token with a refreshed attempt for an item
       | 0  | 102            |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at | hints_requested | hints_cached | result_propagation_state |
-      | 0          | 101            | 50      | 2017-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 0          | 101            | 51      | 2019-04-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 0          | 102            | 50      | 2019-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 1          | 101            | 50      | 2018-05-29 06:38:38 | 2018-05-29 05:00:00 | 0              | null              | null         | [1,2,3,4]       | 4            | done                     |
+      | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at | hints_requested | hints_cached |
+      | 0          | 101            | 50      | 2017-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 0          | 101            | 51      | 2019-04-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 0          | 102            | 50      | 2019-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 1          | 101            | 50      | 2018-05-29 06:38:38 | 2018-05-29 05:00:00 | 0              | null              | null         | [1,2,3,4]       | 4            |
     When I send a POST request to "/items/50/attempts/1/generate-task-token"
     Then the response code should be 200
     And the response body decoded as "GenerateTaskTokenResponse" should be, in JSON:
@@ -73,8 +73,9 @@ Feature: Generate a task token with a refreshed attempt for an item
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with attempt_id "1"
     And the table "results" at attempt_id "1" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, score_obtained_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, validated_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 101            | 50      | 0              | 0           | done                     | 1                                                         | null                                                        | null                                                     | null                                                | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, score_obtained_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, validated_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 101            | 50      | 0              | 0           | 1                                                         | null                                                        | null                                                     | null                                                | 0                                                 |
+    And the table "results_propagate" should be empty
 
   Scenario: User is able to fetch a task token as a team
     Given I am the user with id "101"
@@ -84,11 +85,11 @@ Feature: Generate a task token with a refreshed attempt for an item
       | 0  | 102            |
       | 1  | 102            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at | hints_requested | hints_cached | result_propagation_state |
-      | 0          | 101            | 60      | 2019-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 0          | 102            | 60      | 2017-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 0          | 102            | 61      | 2019-04-29 06:38:38 | null                | 0              | null              | null         | null            | 0            | done                     |
-      | 1          | 102            | 60      | 2018-05-29 06:38:38 | 2018-05-29 06:38:38 | 0              | null              | null         | [1,2,3,4]       | 4            | done                     |
+      | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at | hints_requested | hints_cached |
+      | 0          | 101            | 60      | 2019-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 0          | 102            | 60      | 2017-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 0          | 102            | 61      | 2019-04-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
+      | 1          | 102            | 60      | 2018-05-29 06:38:38 | 2018-05-29 06:38:38 | 0              | null              | null         | [1,2,3,4]       | 4            |
     When I send a POST request to "/items/60/attempts/1/generate-task-token?as_team_id=102"
     Then the response code should be 200
     And the response body decoded as "GenerateTaskTokenResponse" should be, in JSON:
@@ -120,5 +121,6 @@ Feature: Generate a task token with a refreshed attempt for an item
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with attempt_id "1"
     And the table "results" at attempt_id "1" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, score_obtained_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, validated_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                                                        | null                                                     | null                                                | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, score_obtained_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, validated_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 102            | 60      | 0              | 0           | 1                                                         | null                                                        | null                                                     | null                                                | 0                                                 |
+    And the table "results_propagate" should be empty

--- a/app/api/items/generate_task_token.go
+++ b/app/api/items/generate_task_token.go
@@ -147,10 +147,8 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 		service.MustNotBeError(err)
 
 		// update results
-		service.MustNotBeError(resultScope.UpdateColumn(map[string]interface{}{
-			"latest_activity_at":       database.Now(),
-			"result_propagation_state": "to_be_propagated",
-		}).Error())
+		service.MustNotBeError(resultScope.UpdateColumn("latest_activity_at", database.Now()).Error())
+		service.MustNotBeError(store.Results().MarkAsToBePropagated(participantID, attemptID, itemID))
 
 		return store.Results().Propagate()
 	})

--- a/app/api/items/path_from_root.feature
+++ b/app/api/items/path_from_root.feature
@@ -50,12 +50,12 @@ Feature: Find an item path
       | 2  | 102            | 10           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | 9999-12-31 23:59:59      |
       | 3  | 102            | 10           | 2019-05-30 11:00:00 | null                | 2019-05-30 11:00:00      |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 2          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 3          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 3          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 2          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 3          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 3          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
   Scenario Outline: Find a path as a user
     Given I am the user with id "111"
@@ -86,8 +86,8 @@ Feature: Find an item path
   Scenario: Finds a path with started result
     Given I am the user with id "101"
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a GET request to "/items/60/path-from-root?as_team_id=102"
     Then the response code should be 200
     And the response body should be, in JSON:

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -42,10 +42,10 @@ Feature: Save grading result
       | 0  | 101            |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | latest_activity_at  | hints_requested        | result_propagation_state |
-      | 0          | 101            | 10      | 2019-05-30 11:00:00 | null                   | done                     |
-      | 0          | 101            | 50      | 2019-05-30 11:00:00 | [0,  1, "hint" , null] | done                     |
-      | 1          | 101            | 60      | 2019-05-29 11:00:00 | [0,  1, "hint" , null] | done                     |
+      | attempt_id | participant_id | item_id | latest_activity_at  | hints_requested        |
+      | 0          | 101            | 10      | 2019-05-30 11:00:00 | null                   |
+      | 0          | 101            | 50      | 2019-05-30 11:00:00 | [0,  1, "hint" , null] |
+      | 1          | 101            | 60      | 2019-05-29 11:00:00 | [0,  1, "hint" , null] |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
@@ -105,10 +105,11 @@ Feature: Save grading result
       | 123       | 100   | 1                                                |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | validated | result_propagation_state | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at        |
-      | 0          | 101            | 10      | 50             | 1           | 1         | done                     | 2019-05-30 11:00:00 | null                 | null                | 2017-05-29 06:38:38 |
-      | 0          | 101            | 50      | 100            | 1           | 1         | done                     | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 |
-      | 1          | 101            | 60      | 0              | 0           | 0         | done                     | 2019-05-29 11:00:00 | null                 | null                | null                |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | validated | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at        |
+      | 0          | 101            | 10      | 50             | 1           | 1         | 2019-05-30 11:00:00 | null                 | null                | 2017-05-29 06:38:38 |
+      | 0          | 101            | 50      | 100            | 1           | 1         | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 |
+      | 1          | 101            | 60      | 0              | 0           | 0         | 2019-05-29 11:00:00 | null                 | null                | null                |
+    And the table "results_propagate" should be empty
 
   Scenario Outline: User is able to save the grading result with a low score and idAttempt
     Given I am the user with id "101"
@@ -117,10 +118,10 @@ Feature: Save grading result
       | 0  | 101            |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | hints_requested        | latest_activity_at  | score_edit_rule   | score_edit_value   | result_propagation_state |
-      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 | null              | null               | done                     |
-      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 | <score_edit_rule> | <score_edit_value> | done                     |
-      | 1          | 101            | 60      | [0,  1, "hint" , null] | 2019-05-29 11:00:00 | null              | null               | done                     |
+      | attempt_id | participant_id | item_id | hints_requested        | latest_activity_at  | score_edit_rule   | score_edit_value   |
+      | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 | null              | null               |
+      | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 | <score_edit_rule> | <score_edit_value> |
+      | 1          | 101            | 60      | [0,  1, "hint" , null] | 2019-05-29 11:00:00 | null              | null               |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
@@ -179,10 +180,11 @@ Feature: Save grading result
       | 123       | <score> | 1                                                |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed   | tasks_tried | validated | result_propagation_state | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at |
-      | 0          | 101            | 10      | <parent_score>   | 1           | 0         | done                     | 2019-05-30 11:00:00 | null                 | null                | null         |
-      | 0          | 101            | 50      | <score_computed> | 1           | 0         | done                     | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
-      | 1          | 101            | 60      | 0                | 0           | 0         | done                     | 2019-05-29 11:00:00 | null                 | null                | null         |
+      | attempt_id | participant_id | item_id | score_computed   | tasks_tried | validated | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at |
+      | 0          | 101            | 10      | <parent_score>   | 1           | 0         | 2019-05-30 11:00:00 | null                 | null                | null         |
+      | 0          | 101            | 50      | <score_computed> | 1           | 0         | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+      | 1          | 101            | 60      | 0                | 0           | 0         | 2019-05-29 11:00:00 | null                 | null                | null         |
+    And the table "results_propagate" should be empty
   Examples:
     | score | score_edit_rule | score_edit_value | score_computed | parent_score |
     | 99    | null            | null             | 99             | 49.5         |
@@ -199,9 +201,9 @@ Feature: Save grading result
       | 0  | 101            |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | score_obtained_at   | latest_activity_at  | result_propagation_state |
-      | 0          | 101            | 50      | 2017-04-29 06:38:38 | 2019-05-30 11:00:00 | done                     |
-      | 1          | 101            | 60      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | score_obtained_at   | latest_activity_at  |
+      | 0          | 101            | 50      | 2017-04-29 06:38:38 | 2019-05-30 11:00:00 |
+      | 1          | 101            | 60      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
@@ -260,9 +262,10 @@ Feature: Save grading result
       | 124       | 99    | 1                                                |
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | participant_id | attempt_id | item_id | score_computed | tasks_tried | validated | result_propagation_state | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at |
-      | 101            | 0          | 50      | 0              | 0           | 0         | done                     | 2019-05-30 11:00:00 | null                 | 2017-04-29 06:38:38 | null         |
-      | 101            | 1          | 60      | 99             | 1           | 0         | done                     | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+      | participant_id | attempt_id | item_id | score_computed | tasks_tried | validated | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at |
+      | 101            | 0          | 50      | 0              | 0           | 0         | 2019-05-30 11:00:00 | null                 | 2017-04-29 06:38:38 | null         |
+      | 101            | 1          | 60      | 99             | 1           | 0         | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+    And the table "results_propagate" should be empty
 
   Scenario Outline: Should keep previous score if it is greater
     Given I am the user with id "101"
@@ -279,10 +282,10 @@ Feature: Save grading result
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | participant_id | attempt_id | item_id | score_computed | score_obtained_at   | score_edit_rule   | score_edit_value   | result_propagation_state |
-      | 101            | 0          | 10      | 20             | 2018-05-29 06:38:38 | null              | null               | done                     |
-      | 101            | 0          | 50      | 20             | 2018-05-29 06:38:38 | <score_edit_rule> | <score_edit_value> | done                     |
-      | 101            | 0          | 60      | 20             | 2018-05-29 06:38:38 | null              | null               | done                     |
+      | participant_id | attempt_id | item_id | score_computed | score_obtained_at   | score_edit_rule   | score_edit_value   |
+      | 101            | 0          | 10      | 20             | 2018-05-29 06:38:38 | null              | null               |
+      | 101            | 0          | 50      | 20             | 2018-05-29 06:38:38 | <score_edit_rule> | <score_edit_value> |
+      | 101            | 0          | 60      | 20             | 2018-05-29 06:38:38 | null              | null               |
     And the following token "priorUserTaskToken" signed by the app is distributed:
       """
       {
@@ -353,10 +356,10 @@ Feature: Save grading result
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | validated_at        | result_propagation_state |
-      | 0          | 101            | 10      | 2016-05-29 06:38:37 | done                     |
-      | 0          | 101            | 50      | 2016-05-29 06:38:37 | done                     |
-      | 0          | 101            | 60      | 2015-05-29 06:38:37 | done                     |
+      | attempt_id | participant_id | item_id | validated_at        |
+      | 0          | 101            | 10      | 2016-05-29 06:38:37 |
+      | 0          | 101            | 50      | 2016-05-29 06:38:37 |
+      | 0          | 101            | 60      | 2015-05-29 06:38:37 |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
@@ -422,8 +425,8 @@ Feature: Save grading result
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | validated_at        | result_propagation_state |
-      | 0          | 101            | 50      | 2018-05-29 06:38:38 | done                     |
+      | attempt_id | participant_id | item_id | validated_at        |
+      | 0          | 101            | 50      | 2018-05-29 06:38:38 |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 100        | 50      | 2017-05-29 06:38:38 |
@@ -484,8 +487,8 @@ Feature: Save grading result
       | id | participant_id |
       | 1  | 101            |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | validated_at        | result_propagation_state |
-      | 1          | 101            | 70      | 2018-05-29 06:38:38 | done                     |
+      | attempt_id | participant_id | item_id | validated_at        |
+      | 1          | 101            | 70      | 2018-05-29 06:38:38 |
     And the database has the following table 'answers':
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 125 | 101       | 101            | 100        | 70      | 2017-05-29 06:38:38 |

--- a/app/api/items/start_result.feature
+++ b/app/api/items/start_result.feature
@@ -50,8 +50,8 @@ Feature: Start a result for an item
       | 0  | 111            | 2019-05-30 11:00:00 |
       | 1  | 102            | 2019-05-30 11:00:00 |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
   Scenario Outline: User is able to start a result for his self group
     Given I am the user with id "111"
@@ -66,9 +66,10 @@ Feature: Start a result for an item
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 111            | <item_id> | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 111            | <item_id> | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "result_propagate" should be emptry
   Examples:
     | item_id |
     | 50      |
@@ -88,10 +89,11 @@ Feature: Start a result for an item
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 0          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 0          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
     When I send a POST request to "/items/60/70/start-result?as_team_id=102&attempt_id=0"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -103,17 +105,18 @@ Feature: Start a result for an item
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 0          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 0          | 102            | 70      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 0          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 0          | 102            | 70      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
 
   Scenario: Keeps the previous started_at value
     Given I am the user with id "101"
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result?as_team_id=102&attempt_id=1"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -125,15 +128,16 @@ Feature: Start a result for an item
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 1          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
 
   Scenario: Sets started_at of an existing result
     Given I am the user with id "101"
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | started_at | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 60      | null       | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at | latest_activity_at  |
+      | 1          | 102            | 60      | null       | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result?as_team_id=102&attempt_id=1"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -145,6 +149,7 @@ Feature: Start a result for an item
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 0                                                 |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | 0                                                 |
+      | 1          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+    And the table "results_propagate" should be empty

--- a/app/api/items/start_result_path.feature
+++ b/app/api/items/start_result_path.feature
@@ -50,12 +50,12 @@ Feature: Start results for an item path
       | 2  | 102            | 10           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | 9999-12-31 23:59:59      |
       | 3  | 102            | 10           | 2019-05-30 11:00:00 | null                | 2019-05-30 11:00:00      |
     And the database has the following table 'results':
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 2          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 3          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
-      | 3          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 2          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 3          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 3          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
   Scenario Outline: User is able to start a result for his self group
     Given I am the user with id "111"
@@ -73,13 +73,14 @@ Feature: Start results for an item path
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 111            | <item_id> | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 10        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 60        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 10        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 60        | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id   | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 111            | <item_id> | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60        | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
   Examples:
     | item_id |
     | 50      |
@@ -101,15 +102,16 @@ Feature: Start results for an item path
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 0          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 0          | 102            | 70      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 0          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 0          | 102            | 70      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
     When I send a POST request to "/items/60/70/start-result-path?as_team_id=102"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -124,21 +126,22 @@ Feature: Start results for an item path
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 0          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 0          | 102            | 70      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 0          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 0          | 102            | 70      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
 
   Scenario: Keeps the previous started_at value
     Given I am the user with id "101"
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | result_propagation_state |
-      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | done                     |
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result-path?as_team_id=102"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -153,13 +156,14 @@ Feature: Start results for an item path
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 1          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 1          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
 
   Scenario: Can create new results for all the path
     Given I am the user with id "101"
@@ -177,12 +181,13 @@ Feature: Start results for an item path
       """
     And the table "attempts" should stay unchanged
     And the table "results" should be:
-      | attempt_id | participant_id | item_id | score_computed | tasks_tried | result_propagation_state | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
-      | 0          | 102            | 10      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | null                                              |
-      | 0          | 102            | 60      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 0          | 102            | 70      | 0              | 0           | done                     | 1                                                         | null                 | null              | null         | 1                                                 |
-      | 1          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 2          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 10      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
-      | 3          | 102            | 60      | 0              | 0           | done                     | 0                                                         | null                 | null              | null         | 0                                                 |
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 102            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | null                                              |
+      | 0          | 102            | 60      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 0          | 102            | 70      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty

--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -44,10 +44,10 @@ Background:
     | id | participant_id |
     | 0  | 11             |
   And the database has the following table 'results':
-    | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-    | 0          | 11             | 21      | 0              | done                     |
-    | 0          | 11             | 50      | 10             | done                     |
-    | 0          | 11             | 70      | 20             | done                     |
+    | attempt_id | participant_id | item_id | score_computed |
+    | 0          | 11             | 21      | 0              |
+    | 0          | 11             | 50      | 10             |
+    | 0          | 11             | 70      | 20             |
   And the database has the following table 'languages':
     | tag |
     | en  |
@@ -92,9 +92,9 @@ Background:
       | 11       | 112     | solution | content        | answer    | all      | false    | 11              | 2019-05-30 11:00:00 |
       | 11       | 134     | none     | none           | none      | none     | true     | 11              | 2019-05-30 11:00:00 |
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 112     | 50             | done                     |
-      | 0          | 11             | 134     | 60             | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 112     | 50             |
+      | 0          | 11             | 134     | 60             |
     When I send a PUT request to "/items/50" with the following body:
       """
       {
@@ -172,8 +172,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "50"
     And the table "results" at item_id "50" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 50      | 56.666668      | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 50      | 56.666668      |
+    And the table "results_propagate" should be empty
 
   Scenario: Valid (with skill items)
     Given I am the user with id "11"
@@ -193,9 +194,9 @@ Background:
       | 11       | 112     | solution | content        | answer    | all      | false    | 11              | 2019-05-30 11:00:00 |
       | 11       | 134     | none     | none           | none      | none     | true     | 11              | 2019-05-30 11:00:00 |
     And the database table 'results' has also the following rows:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 112     | 50             | done                     |
-      | 0          | 11             | 134     | 60             | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 112     | 50             |
+      | 0          | 11             | 134     | 60             |
     When I send a PUT request to "/items/70" with the following body:
       """
       {
@@ -243,8 +244,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "70"
     And the table "results" at item_id "70" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 70      | 56.666668      | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 70      | 56.666668      |
+    And the table "results_propagate" should be empty
 
   Scenario: Should set content_view_propagation to 'none' by default if can_grant_view = 'none' for the parent item
     Given I am the user with id "11"
@@ -295,8 +297,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "50"
     And the table "results" at item_id "50" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 50      | 0              | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 50      | 0              |
+    And the table "results_propagate" should be empty
 
   Scenario: Valid without any fields
     Given I am the user with id "11"
@@ -335,8 +338,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "50"
     And the table "results" at item_id "50" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 50      | 0              | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 50      | 0              |
+    And the table "results_propagate" should be empty
 
   Scenario: Keep existing contest participants group
     Given I am the user with id "11"
@@ -391,8 +395,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "50"
     And the table "results" at item_id "50" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 50      | 0              | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 50      | 0              |
+    And the table "results_propagate" should be empty
 
   Scenario: Recomputes results if validation_type is given
     Given I am the user with id "11"
@@ -415,8 +420,9 @@ Background:
     And the table "attempts" should stay unchanged
     And the table "results" should stay unchanged but the row with item_id "50"
     And the table "results" at item_id "50" should be:
-      | attempt_id | participant_id | item_id | score_computed | result_propagation_state |
-      | 0          | 11             | 50      | 0              | done                     |
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 50      | 0              |
+    And the table "results_propagate" should be empty
 
   Scenario Outline: Sets default values of items_items.content_view_propagation/upper_view_levels_propagation/grant_view_propagation correctly for each can_grant_view
     Given I am the user with id "11"

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -250,8 +250,10 @@ func updateChildrenAndRunListeners(formData *formdata.FormData, store *database.
 		})
 	} else if formData.IsSet("no_score") || formData.IsSet("validation_type") {
 		// results data of the task will be zeroed
-		service.MustNotBeError(store.Results().Where("item_id = ?", itemID).
-			UpdateColumn("result_propagation_state", "to_be_recomputed").Error())
+		service.MustNotBeError(
+			store.Exec("INSERT INTO results_propagate ? ON DUPLICATE KEY UPDATE state = 'to_be_recomputed'",
+				store.Results().Where("item_id = ?", itemID).
+					Select("participant_id, attempt_id, item_id, 'to_be_recomputed' AS state").QueryExpr()).Error())
 		service.MustNotBeError(store.Results().Propagate())
 	}
 	return apiError, err

--- a/app/database/attempt_store.go
+++ b/app/database/attempt_store.go
@@ -25,7 +25,8 @@ func (s *AttemptStore) CreateNew(participantID, parentAttemptID, itemID, creator
 
 	mustNotBeError(s.Results().InsertMap(map[string]interface{}{
 		"participant_id": participantID, "attempt_id": attemptID, "item_id": itemID,
-		"started_at": Now(), "latest_activity_at": Now(), "result_propagation_state": "to_be_propagated",
+		"started_at": Now(), "latest_activity_at": Now(),
 	}))
+	mustNotBeError(s.Results().MarkAsToBePropagated(participantID, attemptID, itemID))
 	return attemptID, nil
 }

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -287,30 +287,30 @@ const groupGroupMarksResultsAsChangedFixture = `
 		- {id: 1, participant_id: 107}
 		- {id: 1, participant_id: 108}
 	results:
-		- {attempt_id: 1, participant_id: 101, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 102, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 103, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 104, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 105, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 106, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 107, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 108, item_id: 1, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 101, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 102, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 103, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 104, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 105, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 106, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 107, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 108, item_id: 2, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 101, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 102, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 103, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 104, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 105, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 106, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 107, item_id: 3, result_propagation_state: done}
-		- {attempt_id: 1, participant_id: 108, item_id: 3, result_propagation_state: done}`
+		- {attempt_id: 1, participant_id: 101, item_id: 1}
+		- {attempt_id: 1, participant_id: 102, item_id: 1}
+		- {attempt_id: 1, participant_id: 103, item_id: 1}
+		- {attempt_id: 1, participant_id: 104, item_id: 1}
+		- {attempt_id: 1, participant_id: 105, item_id: 1}
+		- {attempt_id: 1, participant_id: 106, item_id: 1}
+		- {attempt_id: 1, participant_id: 107, item_id: 1}
+		- {attempt_id: 1, participant_id: 108, item_id: 1}
+		- {attempt_id: 1, participant_id: 101, item_id: 2}
+		- {attempt_id: 1, participant_id: 102, item_id: 2}
+		- {attempt_id: 1, participant_id: 103, item_id: 2}
+		- {attempt_id: 1, participant_id: 104, item_id: 2}
+		- {attempt_id: 1, participant_id: 105, item_id: 2}
+		- {attempt_id: 1, participant_id: 106, item_id: 2}
+		- {attempt_id: 1, participant_id: 107, item_id: 2}
+		- {attempt_id: 1, participant_id: 108, item_id: 2}
+		- {attempt_id: 1, participant_id: 101, item_id: 3}
+		- {attempt_id: 1, participant_id: 102, item_id: 3}
+		- {attempt_id: 1, participant_id: 103, item_id: 3}
+		- {attempt_id: 1, participant_id: 104, item_id: 3}
+		- {attempt_id: 1, participant_id: 105, item_id: 3}
+		- {attempt_id: 1, participant_id: 106, item_id: 3}
+		- {attempt_id: 1, participant_id: 107, item_id: 3}
+		- {attempt_id: 1, participant_id: 108, item_id: 3}`
 
 func TestGroupGroupStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 	for _, test := range []struct {
@@ -497,14 +497,13 @@ type resultPrimaryKey struct {
 
 func assertResultsMarkedAsChanged(t *testing.T, dataStore *database.DataStore, expectedChanged []resultPrimaryKey) {
 	type resultRow struct {
-		ParticipantID          int64
-		AttemptID              int64
-		ItemID                 int64
-		ResultPropagationState string
+		ParticipantID int64
+		AttemptID     int64
+		ItemID        int64
+		State         string
 	}
 	var results []resultRow
-	assert.NoError(t, dataStore.Results().Select("participant_id, attempt_id, item_id, result_propagation_state").
-		Order("participant_id, attempt_id, item_id").Scan(&results).Error())
+	queryResultsAndStatesForTests(t, dataStore.Results(), &results, "")
 
 	expectedChangedResultsMap := make(map[resultPrimaryKey]bool, len(expectedChanged))
 	for _, result := range expectedChanged {
@@ -517,7 +516,7 @@ func assertResultsMarkedAsChanged(t *testing.T, dataStore *database.DataStore, e
 		}] {
 			expectedState = "to_be_propagated"
 		}
-		assert.Equal(t, expectedState, dbResult.ResultPropagationState,
+		assert.Equal(t, expectedState, dbResult.State,
 			"Wrong result propagation state for result with participant_id=%d, attempt_id=%d, item_id=%d",
 			dbResult.ParticipantID, dbResult.AttemptID, dbResult.ItemID)
 		delete(expectedChangedResultsMap,
@@ -525,4 +524,18 @@ func assertResultsMarkedAsChanged(t *testing.T, dataStore *database.DataStore, e
 	}
 	assert.Empty(t, expectedChangedResultsMap,
 		"Cannot find results that should be marked as 'to_be_propagated': %#v", expectedChangedResultsMap)
+}
+
+func queryResultsAndStatesForTests(t *testing.T, s *database.ResultStore, result interface{}, customColumns string) {
+	columns := "participant_id, attempt_id, item_id, IFNULL(state, 'done') AS state"
+	if customColumns != "" {
+		columns += "," + customColumns
+	}
+	resultStore := s.Results()
+	assert.NoError(t,
+		resultStore.Select(columns).
+			Joins("LEFT JOIN results_propagate USING(participant_id, attempt_id, item_id)").
+			Union(resultStore.Select(columns).
+				Joins("RIGHT JOIN results_propagate USING(participant_id, attempt_id, item_id)").SubQuery()).
+			Order("participant_id, attempt_id, item_id").Scan(result).Error())
 }

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -92,11 +92,16 @@ func TestGroupGroupStore_CreateRelation(t *testing.T) {
 	mock.ExpectQuery("^"+regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")+"$").
 		WithArgs("listener_propagate", propagateLockTimeout/time.Second).
 		WillReturnRows(sqlmock.NewRows([]string{"SELECT GET_LOCK(?, ?)"}).AddRow(int64(1)))
+	mock.ExpectExec("^DROP TEMPORARY TABLE IF EXISTS results_to_mark").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^CREATE TEMPORARY TABLE results_to_mark").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^INSERT ").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^INSERT ").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("^INSERT ").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectPrepare("^UPDATE ")
 	mock.ExpectExec("^UPDATE ").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("^INSERT ").WillReturnResult(sqlmock.NewResult(-1, 0))
-	mock.ExpectExec("^UPDATE ").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^DELETE FROM results_propagate WHERE ").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^DROP TEMPORARY TABLE results_to_mark").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("^" + regexp.QuoteMeta("SELECT RELEASE_LOCK(?)") + "$").
 		WithArgs("listener_propagate").
 		WillReturnResult(sqlmock.NewResult(-1, 0))

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -99,9 +99,12 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 	defer func() { mustNotBeError(stmtUpdatePermissionsGenerated.Close()) }()
 
 	// marking 'self' permissions_propagate (so all of them) as 'children'
+	// (although all existing rows in permissions_propagate have propagate_to='self' at this moment,
+	//  we still need to use WHERE clause in order for MySQL to use indexes,
+	//  otherwise the query can take minutes to execute)
 	const queryMarkSelfAsChildren = `
 		UPDATE permissions_propagate
-		SET propagate_to = 'children'`
+		SET propagate_to = 'children' WHERE propagate_to='self'`
 	stmtMarkSelfAsChildren, err = s.db.CommonDB().Prepare(queryMarkSelfAsChildren)
 	mustNotBeError(err)
 	defer func() { mustNotBeError(stmtMarkSelfAsChildren.Close()) }()

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -34,14 +34,14 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 		JOIN permissions_generated AS parents
 			ON parents.item_id = items_items.parent_item_id
 		JOIN permissions_propagate AS parents_propagate
-			ON parents_propagate.group_id = parents.group_id AND parents_propagate.item_id = parents.item_id AND
-				 parents_propagate.propagate_to = 'children'
+			ON parents_propagate.group_id = parents.group_id AND parents_propagate.item_id = parents.item_id
+		WHERE parents_propagate.propagate_to = 'children'
 		ON DUPLICATE KEY UPDATE propagate_to='self'`
 	stmtMarkChildrenOfChildrenAsSelf, err = s.db.CommonDB().Prepare(queryMarkChildrenOfChildrenAsSelf)
 	mustNotBeError(err)
 	defer func() { mustNotBeError(stmtMarkChildrenOfChildrenAsSelf.Close()) }()
 
-	// deleting 'children' groups_items_propagate
+	// deleting 'children' permissions_propagate
 	const queryDeleteProcessedChildren = `DELETE FROM permissions_propagate WHERE propagate_to = 'children'`
 	stmtDeleteProcessedChildren, err = s.db.CommonDB().Prepare(queryDeleteProcessedChildren)
 	mustNotBeError(err)

--- a/app/database/result_store.go
+++ b/app/database/result_store.go
@@ -32,3 +32,10 @@ func (s *ResultStore) GetHintsInfoForActiveAttempt(participantID, attemptID, ite
 		Scan(&hintsInfo).Error())
 	return &hintsInfo, nil
 }
+
+// MarkAsToBePropagated marks a given result as 'to_be_propagated'
+func (s *ResultStore) MarkAsToBePropagated(participantID, attemptID, itemID int64) error {
+	return s.Exec(`
+		INSERT IGNORE INTO results_propagate (participant_id, attempt_id, item_id, state)
+		VALUES(?, ?, ?, 'to_be_propagated')`, participantID, attemptID, itemID).Error()
+}

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 type aggregatesResultRow struct {
-	ParticipantID          int64
-	AttemptID              int64
-	ItemID                 int64
-	LatestActivityAt       database.Time
-	TasksTried             int64
-	TasksWithHelp          int64
-	ResultPropagationState string
-	ScoreComputed          float32
+	ParticipantID    int64
+	AttemptID        int64
+	ItemID           int64
+	LatestActivityAt database.Time
+	TasksTried       int64
+	TasksWithHelp    int64
+	State            string
+	ScoreComputed    float32
 }
 
 func TestResultStore_Propagate_Aggregates(t *testing.T) {
@@ -67,28 +67,29 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 			}).Error())
 
 			err := resultStore.InTransaction(func(s *database.DataStore) error {
-				assert.NoError(t, resultStore.UpdateColumn("result_propagation_state", "to_be_propagated").Error())
+				assert.NoError(t, resultStore.Exec(
+					"INSERT IGNORE INTO results_propagate SELECT participant_id, attempt_id, item_id, 'to_be_propagated' AS state FROM results").Error())
 				return s.Results().Propagate()
 			})
 			assert.NoError(t, err)
 
 			expected := []aggregatesResultRow{
 				{ParticipantID: 101, AttemptID: 1, ItemID: 1, LatestActivityAt: database.Time(oldDate), TasksTried: 1, TasksWithHelp: 2,
-					ScoreComputed: 10, ResultPropagationState: "done"},
+					ScoreComputed: 10, State: "done"},
 				{ParticipantID: 101, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(currentDate), TasksTried: 1 + 5 + 9,
-					TasksWithHelp:          2 + 6 + 10,
-					ScoreComputed:          23.3333, /* (10*1 + 20*2 + 30*3) / (1 + 2 + 3) */
-					ResultPropagationState: "done"}, // from 1, 3, 4
+					TasksWithHelp: 2 + 6 + 10,
+					ScoreComputed: 23.3333, /* (10*1 + 20*2 + 30*3) / (1 + 2 + 3) */
+					State:         "done"}, // from 1, 3, 4
 				{ParticipantID: 101, AttemptID: 1, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
-					ScoreComputed: 20, ResultPropagationState: "done"},
+					ScoreComputed: 20, State: "done"},
 				{ParticipantID: 101, AttemptID: 1, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
-					ScoreComputed: 30, ResultPropagationState: "done"},
+					ScoreComputed: 30, State: "done"},
 				{ParticipantID: 101, AttemptID: 2, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
-					ScoreComputed: 20, ResultPropagationState: "done"},
+					ScoreComputed: 20, State: "done"},
 				{ParticipantID: 101, AttemptID: 2, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
-					ScoreComputed: 30, ResultPropagationState: "done"},
+					ScoreComputed: 30, State: "done"},
 				// another user
-				{ParticipantID: 102, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(oldDate), ResultPropagationState: "done"},
+				{ParticipantID: 102, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(oldDate), State: "done"},
 			}
 
 			assertAggregatesEqual(t, resultStore, expected)
@@ -110,9 +111,9 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 	expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
 
 	expected := []aggregatesResultRow{
-		{ParticipantID: 101, AttemptID: 1, ItemID: 1, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt1},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 2, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt1},
-		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt2},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 1, State: "done", LatestActivityAt: expectedLatestActivityAt1},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 2, State: "done", LatestActivityAt: expectedLatestActivityAt1},
+		{ParticipantID: 102, AttemptID: 1, ItemID: 2, State: "done", LatestActivityAt: expectedLatestActivityAt2},
 	}
 	assertAggregatesEqual(t, resultStore, expected)
 }
@@ -135,9 +136,9 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 	assert.NoError(t, err)
 
 	expected := []aggregatesResultRow{
-		{ParticipantID: 101, AttemptID: 1, ItemID: 1, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt1},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 2, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt2},
-		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt2},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 1, State: "done", LatestActivityAt: expectedLatestActivityAt1},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 2, State: "done", LatestActivityAt: expectedLatestActivityAt2},
+		{ParticipantID: 102, AttemptID: 1, ItemID: 2, State: "done", LatestActivityAt: expectedLatestActivityAt2},
 	}
 	assertAggregatesEqual(t, resultStore, expected)
 }
@@ -181,11 +182,11 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 			expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
 
 			expected := []aggregatesResultRow{
-				{ParticipantID: 101, AttemptID: 1, ItemID: 1, ScoreComputed: 10, ResultPropagationState: "done",
+				{ParticipantID: 101, AttemptID: 1, ItemID: 1, ScoreComputed: 10, State: "done",
 					LatestActivityAt: expectedLatestActivityAt1},
 				{ParticipantID: 101, AttemptID: 1, ItemID: 2, ScoreComputed: test.expectedComputedScore,
-					ResultPropagationState: "done", LatestActivityAt: expectedLatestActivityAt1},
-				{ParticipantID: 102, AttemptID: 1, ItemID: 2, ResultPropagationState: "done",
+					State: "done", LatestActivityAt: expectedLatestActivityAt1},
+				{ParticipantID: 102, AttemptID: 1, ItemID: 2, State: "done",
 					LatestActivityAt: expectedLatestActivityAt2},
 			}
 			assertAggregatesEqual(t, resultStore, expected)
@@ -195,9 +196,6 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 
 func assertAggregatesEqual(t *testing.T, resultStore *database.ResultStore, expected []aggregatesResultRow) {
 	var result []aggregatesResultRow
-	assert.NoError(t, resultStore.
-		Select("participant_id, attempt_id, item_id, latest_activity_at, tasks_tried, tasks_with_help, score_computed, result_propagation_state").
-		Order("participant_id, attempt_id, item_id").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "latest_activity_at, tasks_tried, tasks_with_help, score_computed")
 	assert.Equal(t, expected, result)
 }

--- a/app/database/result_store_propagate_cyclic_graph_integration_test.go
+++ b/app/database/result_store_propagate_cyclic_graph_integration_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 type stateResultRow struct {
-	ParticipantID          int64
-	AttemptID              int64
-	ItemID                 int64
-	ResultPropagationState string
+	ParticipantID int64
+	AttemptID     int64
+	ItemID        int64
+	State         string
 }
 
 func TestResultStore_Propagate_WithCyclicGraph(t *testing.T) {
@@ -30,13 +30,11 @@ func TestResultStore_Propagate_WithCyclicGraph(t *testing.T) {
 	assert.NoError(t, err)
 
 	var result []stateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, result_propagation_state").
+	assert.NoError(t, resultStore.Table("results_propagate").
+		Select("participant_id, attempt_id, item_id, state").
 		Order("participant_id, item_id, attempt_id").Scan(&result).Error())
 	assert.Equal(t, []stateResultRow{
-		{ParticipantID: 101, AttemptID: 1, ItemID: 1, ResultPropagationState: "to_be_recomputed"},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 2, ResultPropagationState: "to_be_recomputed"},
-		// another user
-		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ResultPropagationState: "done"},
-		{ParticipantID: 102, AttemptID: 1, ItemID: 3, ResultPropagationState: "done"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 1, State: "to_be_recomputed"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 2, State: "to_be_recomputed"},
 	}, result)
 }

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -13,23 +13,23 @@ import (
 )
 
 type validationDateResultRow struct {
-	ParticipantID          int64
-	AttemptID              int64
-	ItemID                 int64
-	ValidatedAt            *database.Time
-	ResultPropagationState string
+	ParticipantID int64
+	AttemptID     int64
+	ItemID        int64
+	ValidatedAt   *database.Time
+	State         string
 }
 
 func constructExpectedResultsForValidatedAtTests(t11, t12, t13, t14, t23, t24 *time.Time) []validationDateResultRow {
 	return []validationDateResultRow{
-		{ParticipantID: 101, AttemptID: 1, ItemID: 1, ValidatedAt: (*database.Time)(t11), ResultPropagationState: "done"},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 2, ValidatedAt: (*database.Time)(t12), ResultPropagationState: "done"},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 3, ValidatedAt: (*database.Time)(t13), ResultPropagationState: "done"},
-		{ParticipantID: 101, AttemptID: 1, ItemID: 4, ValidatedAt: (*database.Time)(t14), ResultPropagationState: "done"},
-		{ParticipantID: 101, AttemptID: 2, ItemID: 3, ValidatedAt: (*database.Time)(t23), ResultPropagationState: "done"},
-		{ParticipantID: 101, AttemptID: 2, ItemID: 4, ValidatedAt: (*database.Time)(t24), ResultPropagationState: "done"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 1, ValidatedAt: (*database.Time)(t11), State: "done"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 2, ValidatedAt: (*database.Time)(t12), State: "done"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 3, ValidatedAt: (*database.Time)(t13), State: "done"},
+		{ParticipantID: 101, AttemptID: 1, ItemID: 4, ValidatedAt: (*database.Time)(t14), State: "done"},
+		{ParticipantID: 101, AttemptID: 2, ItemID: 3, ValidatedAt: (*database.Time)(t23), State: "done"},
+		{ParticipantID: 101, AttemptID: 2, ItemID: 4, ValidatedAt: (*database.Time)(t24), State: "done"},
 		// another user
-		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ValidatedAt: nil, ResultPropagationState: "done"},
+		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ValidatedAt: nil, State: "done"},
 	}
 }
 func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValidatedAts(t *testing.T) {
@@ -64,8 +64,7 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 	assert.NoError(t, err)
 
 	var result []validationDateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated_at, result_propagation_state").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
 	assert.Equal(t,
 		constructExpectedResultsForValidatedAtTests(&skippedDate, &oldestForItem4AndWinner, &oldestForItem3,
 			&oldestForItem4AndWinner, &skippedInItem3, &skippedInItem4), result)
@@ -95,8 +94,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	assert.NoError(t, err)
 
 	var result []validationDateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated_at, result_propagation_state").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
 	assert.Equal(t,
 		constructExpectedResultsForValidatedAtTests(&expectedDate, nil, &oldDate, nil, nil, nil), result)
 }
@@ -127,8 +125,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 	assert.NoError(t, err)
 
 	var result []validationDateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated_at, result_propagation_state").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
 	assert.Equal(t,
 		constructExpectedResultsForValidatedAtTests(&expectedDate, nil, &oldDate, nil, nil, nil), result)
 }
@@ -164,8 +161,7 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 	assert.NoError(t, err)
 
 	var result []validationDateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated_at, result_propagation_state").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
 	assert.Equal(t,
 		constructExpectedResultsForValidatedAtTests(&oldDate, &expectedDate, &oldDate, nil, nil, &expectedDate), result)
 }
@@ -207,8 +203,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	assert.NoError(t, err)
 
 	var result []validationDateResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated_at, result_propagation_state").
-		Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
 	assert.Equal(t,
 		constructExpectedResultsForValidatedAtTests(&expectedDate, &expectedDate, &oldDate, &oldDate, &oldDatePlusOneDay, nil), result)
 }

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 type validatedResultRow struct {
-	ParticipantID          int64
-	AttemptID              int64
-	ItemID                 int64
-	Validated              bool
-	ResultPropagationState string
+	ParticipantID int64
+	AttemptID     int64
+	ItemID        int64
+	Validated     bool
+	State         string
 }
 
 func (r validatedResultRow) LessThan(other validatedResultRow) bool {
@@ -47,8 +47,7 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	assert.NoError(t, err)
 
 	var result []validatedResultRow
-	assert.NoError(t, resultStore.Select("participant_id, attempt_id, item_id, validated, result_propagation_state").
-		Order("participant_id, attempt_id, item_id").Scan(&result).Error())
+	queryResultsAndStatesForTests(t, resultStore, &result, "validated")
 	assert.Equal(t, expectedResults, result)
 }
 
@@ -258,7 +257,7 @@ func buildExpectedValidatedResultRows(validatedMap map[string]bool) []validatedR
 		_, _ = fmt.Sscanf(id, "%d_%d_%d", &participantID, &attemptID, &itemID)
 		result = append(result, validatedResultRow{
 			ParticipantID: participantID, AttemptID: attemptID, ItemID: itemID,
-			Validated: validated, ResultPropagationState: "done",
+			Validated: validated, State: "done",
 		})
 		if participantID == 102 && attemptID == 1 && itemID == 2 {
 			addResultForAnotherUser = false
@@ -268,7 +267,7 @@ func buildExpectedValidatedResultRows(validatedMap map[string]bool) []validatedR
 	// another user
 	if addResultForAnotherUser {
 		result = append(result, validatedResultRow{
-			ParticipantID: 102, AttemptID: 1, ItemID: 2, Validated: false, ResultPropagationState: "done",
+			ParticipantID: 102, AttemptID: 1, ItemID: 2, Validated: false, State: "done",
 		})
 	}
 

--- a/app/database/testdata/results_propagation/_common/results.yaml
+++ b/app/database/testdata/results_propagation/_common/results.yaml
@@ -1,3 +1,3 @@
-- { attempt_id: 1, item_id: 1, participant_id: 101, latest_activity_at: "2019-05-29 11:00:00", result_propagation_state: to_be_propagated}
-- { attempt_id: 1, item_id: 2, participant_id: 101, latest_activity_at: "2019-05-29 11:00:00",  result_propagation_state: done}
-- { attempt_id: 1, item_id: 2, participant_id: 102, latest_activity_at: "2019-05-30 11:00:00", score_edit_rule: "diff", result_propagation_state: to_be_propagated}
+- { attempt_id: 1, item_id: 1, participant_id: 101, latest_activity_at: "2019-05-29 11:00:00"}
+- { attempt_id: 1, item_id: 2, participant_id: 101, latest_activity_at: "2019-05-29 11:00:00"}
+- { attempt_id: 1, item_id: 2, participant_id: 102, latest_activity_at: "2019-05-30 11:00:00", score_edit_rule: "diff"}

--- a/app/database/testdata/results_propagation/_common/results_propagate.yaml
+++ b/app/database/testdata/results_propagation/_common/results_propagate.yaml
@@ -1,0 +1,2 @@
+- { attempt_id: 1, item_id: 1, participant_id: 101, state: to_be_propagated}
+- { attempt_id: 1, item_id: 2, participant_id: 102, state: to_be_propagated}

--- a/app/database/testdata/results_propagation/aggregates/results.yaml
+++ b/app/database/testdata/results_propagation/aggregates/results.yaml
@@ -1,4 +1,4 @@
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 1, item_id: 4, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 2, item_id: 3, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 2, item_id: 4, participant_id: 101, result_propagation_state: done}
+- {attempt_id: 1, item_id: 3, participant_id: 101}
+- {attempt_id: 1, item_id: 4, participant_id: 101}
+- {attempt_id: 2, item_id: 3, participant_id: 101}
+- {attempt_id: 2, item_id: 4, participant_id: 101}

--- a/app/database/testdata/results_propagation/cyclic/results.yaml
+++ b/app/database/testdata/results_propagation/cyclic/results.yaml
@@ -1,4 +1,4 @@
-- {attempt_id: 1, item_id: 1, participant_id: 101, result_propagation_state: to_be_recomputed}
-- {attempt_id: 1, item_id: 2, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 1, item_id: 2, participant_id: 102, result_propagation_state: to_be_recomputed}
-- {attempt_id: 1, item_id: 3, participant_id: 102, result_propagation_state: to_be_recomputed}
+- {attempt_id: 1, item_id: 1, participant_id: 101}
+- {attempt_id: 1, item_id: 2, participant_id: 101}
+- {attempt_id: 1, item_id: 2, participant_id: 102}
+- {attempt_id: 1, item_id: 3, participant_id: 102}

--- a/app/database/testdata/results_propagation/cyclic/results_propagate.yaml
+++ b/app/database/testdata/results_propagation/cyclic/results_propagate.yaml
@@ -1,0 +1,3 @@
+- {attempt_id: 1, item_id: 1, participant_id: 101, state: to_be_recomputed}
+- {attempt_id: 1, item_id: 2, participant_id: 102, state: to_be_recomputed}
+- {attempt_id: 1, item_id: 3, participant_id: 102, state: to_be_recomputed}

--- a/app/database/testdata/results_propagation/main/results.yaml
+++ b/app/database/testdata/results_propagation/main/results.yaml
@@ -1,10 +1,10 @@
-- {attempt_id: 1, item_id: 1, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 2, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 4, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 5, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 1, participant_id: 102, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 2, participant_id: 102, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 3, participant_id: 102, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 4, participant_id: 102, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 5, participant_id: 102, result_propagation_state: to_be_propagated}
+- {attempt_id: 1, item_id: 1, participant_id: 101}
+- {attempt_id: 1, item_id: 2, participant_id: 101}
+- {attempt_id: 1, item_id: 3, participant_id: 101}
+- {attempt_id: 1, item_id: 4, participant_id: 101}
+- {attempt_id: 1, item_id: 5, participant_id: 101}
+- {attempt_id: 1, item_id: 1, participant_id: 102}
+- {attempt_id: 1, item_id: 2, participant_id: 102}
+- {attempt_id: 1, item_id: 3, participant_id: 102}
+- {attempt_id: 1, item_id: 4, participant_id: 102}
+- {attempt_id: 1, item_id: 5, participant_id: 102}

--- a/app/database/testdata/results_propagation/main/results_propagate.yaml
+++ b/app/database/testdata/results_propagation/main/results_propagate.yaml
@@ -1,0 +1,10 @@
+- {attempt_id: 1, item_id: 1, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 2, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 3, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 4, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 5, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 1, participant_id: 102, state: to_be_propagated}
+- {attempt_id: 1, item_id: 2, participant_id: 102, state: to_be_propagated}
+- {attempt_id: 1, item_id: 3, participant_id: 102, state: to_be_propagated}
+- {attempt_id: 1, item_id: 4, participant_id: 102, state: to_be_propagated}
+- {attempt_id: 1, item_id: 5, participant_id: 102, state: to_be_propagated}

--- a/app/database/testdata/results_propagation/unlocks/results.yaml
+++ b/app/database/testdata/results_propagation/unlocks/results.yaml
@@ -1,2 +1,2 @@
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 4, participant_id: 101, result_propagation_state: to_be_propagated}
+- {attempt_id: 1, item_id: 3, participant_id: 101}
+- {attempt_id: 1, item_id: 4, participant_id: 101}

--- a/app/database/testdata/results_propagation/unlocks/results_propagate.yaml
+++ b/app/database/testdata/results_propagation/unlocks/results_propagate.yaml
@@ -1,0 +1,2 @@
+- {attempt_id: 1, item_id: 3, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 4, participant_id: 101, state: to_be_propagated}

--- a/app/database/testdata/results_propagation/validated/all_and_category/results.yaml
+++ b/app/database/testdata/results_propagation/validated/all_and_category/results.yaml
@@ -1,2 +1,2 @@
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: to_be_propagated}
-- {attempt_id: 1, item_id: 4, participant_id: 101, result_propagation_state: to_be_propagated}
+- {attempt_id: 1, item_id: 3, participant_id: 101}
+- {attempt_id: 1, item_id: 4, participant_id: 101}

--- a/app/database/testdata/results_propagation/validated/all_and_category/results_propagate.yaml
+++ b/app/database/testdata/results_propagation/validated/all_and_category/results_propagate.yaml
@@ -1,0 +1,2 @@
+- {attempt_id: 1, item_id: 3, participant_id: 101, state: to_be_propagated}
+- {attempt_id: 1, item_id: 4, participant_id: 101, state: to_be_propagated}

--- a/app/database/testdata/results_propagation/validated/one/results.yaml
+++ b/app/database/testdata/results_propagation/validated/one/results.yaml
@@ -1,1 +1,1 @@
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: done}
+- {attempt_id: 1, item_id: 3, participant_id: 101}

--- a/app/database/testdata/results_propagation/validated_at/results.yaml
+++ b/app/database/testdata/results_propagation/validated_at/results.yaml
@@ -1,4 +1,4 @@
-- {attempt_id: 1, item_id: 3, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 1, item_id: 4, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 2, item_id: 3, participant_id: 101, result_propagation_state: done}
-- {attempt_id: 2, item_id: 4, participant_id: 101, result_propagation_state: done}
+- {attempt_id: 1, item_id: 3, participant_id: 101}
+- {attempt_id: 1, item_id: 4, participant_id: 101}
+- {attempt_id: 2, item_id: 3, participant_id: 101}
+- {attempt_id: 2, item_id: 4, participant_id: 101}

--- a/db/migrations/2105131302_create_table_results_propagate.sql
+++ b/db/migrations/2105131302_create_table_results_propagate.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+CREATE TABLE `results_propagate` (
+   `participant_id` bigint NOT NULL,
+   `attempt_id` bigint NOT NULL DEFAULT '0',
+   `item_id` bigint NOT NULL,
+   `state` enum('to_be_propagated','to_be_recomputed') NOT NULL COMMENT '"to_be_propagated" means that ancestors should be recomputed',
+   PRIMARY KEY (`participant_id`,`attempt_id`,`item_id`),
+   KEY `state` (`state`),
+   CONSTRAINT `fk_results_propagate_to_results` FOREIGN KEY (`participant_id`, `attempt_id`, `item_id`) REFERENCES `results` (`participant_id`, `attempt_id`, `item_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Used by the algorithm that computes results for items that have children and unlocks items if needed.';
+
+-- +migrate Down
+DROP TABLE `results_propagate`;

--- a/db/migrations/2105131313_copy_result_propagation_states_into_results_propagate_table.sql
+++ b/db/migrations/2105131313_copy_result_propagation_states_into_results_propagate_table.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+INSERT INTO `results_propagate`
+SELECT `participant_id`, `attempt_id`, `item_id`, `result_propagation_state` AS `state`
+FROM `results`
+WHERE `result_propagation_state` = 'to_be_propagated' OR `result_propagation_state` = 'to_be_recomputed';
+
+-- +migrate Down
+INSERT INTO `results` (`participant_id`, `attempt_id`, `item_id`, `result_propagation_state`)
+SELECT `participant_id`, `attempt_id`, `item_id`, `state` AS `result_propagation_state`
+FROM `results_propagate`
+ON DUPLICATE KEY UPDATE `result_propagation_state` = VALUES(`result_propagation_state`);

--- a/db/migrations/2105131319_drop_column_results_result_propagation_state.sql
+++ b/db/migrations/2105131319_drop_column_results_result_propagation_state.sql
@@ -1,0 +1,322 @@
+-- +migrate Up
+ALTER TABLE `results`
+    DROP KEY `result_propagation_state`,
+    DROP COLUMN `result_propagation_state`;
+
+DROP TRIGGER `after_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_groups_groups` AFTER INSERT ON `groups_groups` FOR EACH ROW BEGIN
+    IF NEW.`expires_at` > NOW() THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+        WHERE EXISTS(
+            SELECT 1 FROM `permissions_generated`
+                JOIN `groups_ancestors_active` AS `grand_ancestors`
+                    ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                       `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                JOIN `items_ancestors`
+                    ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+            WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                  `permissions_generated`.`can_view_generated` != 'none'
+        ) AND NOT EXISTS(
+            SELECT 1 FROM `permissions_generated`
+                JOIN `groups_ancestors_active` AS `child_ancestors`
+                    ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                       `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                JOIN `items_ancestors`
+                    ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+            WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                  `permissions_generated`.`can_view_generated` != 'none'
+        );
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_groups_groups` AFTER UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.expires_at != NEW.expires_at THEN
+        IF NEW.`expires_at` > NOW() THEN
+            INSERT IGNORE INTO `results_propagate`
+            SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+            FROM `results`
+                JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                                  `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+            WHERE EXISTS(
+                SELECT 1 FROM `permissions_generated`
+                    JOIN `groups_ancestors_active` AS `grand_ancestors`
+                        ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                           `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                    JOIN `items_ancestors`
+                        ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                      `permissions_generated`.`can_view_generated` != 'none'
+            ) AND NOT EXISTS(
+                SELECT 1 FROM `permissions_generated`
+                    JOIN `groups_ancestors_active` AS `child_ancestors`
+                        ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                           `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                    JOIN `items_ancestors`
+                        ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                      `permissions_generated`.`can_view_generated` != 'none'
+            );
+        END IF;
+
+        INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (OLD.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+        INSERT IGNORE INTO `groups_propagate` (id, ancestors_computation_state) VALUES (NEW.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    INSERT IGNORE INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`child_item_id`;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER IF EXISTS `after_update_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_items_items` AFTER UPDATE ON `items_items` FOR EACH ROW BEGIN
+    IF (OLD.`content_view_propagation` != NEW.`content_view_propagation` OR
+        OLD.`upper_view_levels_propagation` != NEW.`upper_view_levels_propagation` OR
+        OLD.`grant_view_propagation` != NEW.`grant_view_propagation` OR
+        OLD.`watch_propagation` != NEW.`watch_propagation` OR
+        OLD.`edit_propagation` != NEW.`edit_propagation`) THEN
+        INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+        SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+        FROM `permissions_generated`
+        WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id` OR `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+    END IF;
+    IF (OLD.`category` != NEW.`category` OR OLD.`score_weight` != NEW.`score_weight`) THEN
+        INSERT INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+        FROM `results`
+        WHERE `item_id` = NEW.`parent_item_id`
+        ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+    VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+    -- Some results' ancestors should probably be removed
+    -- DELETE FROM `results` WHERE ...
+
+    INSERT INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = OLD.`parent_item_id`
+    ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+    IF NEW.`can_view_generated` != 'none' THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+    IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+ALTER TABLE `results`
+    ADD COLUMN `result_propagation_state` enum('done','to_be_propagated','to_be_recomputed') NOT NULL DEFAULT 'done'
+        COMMENT 'Used by the algorithm that computes results for items that have children and unlocks items if needed ("to_be_propagated" means that ancestors should be recomputed).'
+        AFTER `latest_hint_at`,
+    ADD KEY `result_propagation_state` (`result_propagation_state`);
+
+DROP TRIGGER `after_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_groups_groups` AFTER INSERT ON `groups_groups` FOR EACH ROW BEGIN
+    IF NEW.`expires_at` > NOW() THEN
+        UPDATE `results`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+        SET `result_propagation_state` = 'to_be_propagated'
+        WHERE EXISTS(
+            SELECT 1 FROM `permissions_generated`
+                JOIN `groups_ancestors_active` AS `grand_ancestors`
+                    ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                       `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                JOIN `items_ancestors`
+                    ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+            WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                  `permissions_generated`.`can_view_generated` != 'none'
+        ) AND NOT EXISTS(
+            SELECT 1 FROM `permissions_generated`
+                JOIN `groups_ancestors_active` AS `child_ancestors`
+                    ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                       `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                JOIN `items_ancestors`
+                    ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+            WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                  `permissions_generated`.`can_view_generated` != 'none'
+        );
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_groups_groups` AFTER UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.expires_at != NEW.expires_at THEN
+        IF NEW.`expires_at` > NOW() THEN
+            UPDATE `results`
+                JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                                  `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+            SET `result_propagation_state` = 'to_be_propagated'
+            WHERE EXISTS(
+                SELECT 1 FROM `permissions_generated`
+                    JOIN `groups_ancestors_active` AS `grand_ancestors`
+                        ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                           `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                    JOIN `items_ancestors`
+                        ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                      `permissions_generated`.`can_view_generated` != 'none'
+            ) AND NOT EXISTS(
+                SELECT 1 FROM `permissions_generated`
+                    JOIN `groups_ancestors_active` AS `child_ancestors`
+                        ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                           `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                    JOIN `items_ancestors`
+                        ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                WHERE `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                      `permissions_generated`.`can_view_generated` != 'none'
+            );
+        END IF;
+
+        INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (OLD.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+        INSERT IGNORE INTO `groups_propagate` (id, ancestors_computation_state) VALUES (NEW.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    UPDATE `results` SET `result_propagation_state` = 'to_be_propagated'
+    WHERE `item_id` = NEW.`child_item_id`;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER IF EXISTS `after_update_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_items_items` AFTER UPDATE ON `items_items` FOR EACH ROW BEGIN
+    IF (OLD.`content_view_propagation` != NEW.`content_view_propagation` OR
+        OLD.`upper_view_levels_propagation` != NEW.`upper_view_levels_propagation` OR
+        OLD.`grant_view_propagation` != NEW.`grant_view_propagation` OR
+        OLD.`watch_propagation` != NEW.`watch_propagation` OR
+        OLD.`edit_propagation` != NEW.`edit_propagation`) THEN
+        INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+        SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+        FROM `permissions_generated`
+        WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id` OR `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+    END IF;
+    IF (OLD.`category` != NEW.`category` OR OLD.`score_weight` != NEW.`score_weight`) THEN
+        UPDATE `results` SET `result_propagation_state` = 'to_be_recomputed' WHERE `item_id` = NEW.`parent_item_id`;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+    VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+    -- Some results' ancestors should probably be removed
+    -- DELETE FROM `results` WHERE ...
+
+    UPDATE `results` SET `result_propagation_state` = 'to_be_recomputed'
+    WHERE `item_id` = OLD.`parent_item_id`;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+    IF NEW.`can_view_generated` != 'none' THEN
+        UPDATE `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`
+        SET `result_propagation_state` = 'to_be_propagated';
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+    IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+        UPDATE `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`
+        SET `result_propagation_state` = 'to_be_propagated';
+    END IF;
+END
+-- +migrate StatementEnd


### PR DESCRIPTION
Fixes #715

This PR make the request mentioned in #715 twice faster on my compute (7 seconds vs 15 seconds on my computer). Note that the request takes as long only for the first, on next runs it completes immediately since the items relations stay unchanged even if we change the ordering.