### PR TITLE
Add results for parent items in progress-related services + bug-fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache: *CACHEKEYMOD
-      - run: sudo apt-get update
+      - run: sudo apt-get --allow-releaseinfo-change update
       - run: sudo apt-get install default-mysql-client             # required for db-restore
       - run: cp conf/config.sample.yaml conf/config.yaml           # as env var are not loaded for entries not in config file (bug)
       - run: cp conf/config.test.sample.yaml conf/config.test.yaml # the dbname is specified in conf/config.test.yaml
@@ -115,7 +115,7 @@ jobs:
             )
             [ -z "$MIGRATIONS_TO_UNDO" ] && MIGRATIONS_TO_UNDO=0
             echo "export MIGRATIONS_TO_UNDO=\"$MIGRATIONS_TO_UNDO\"" >> $BASH_ENV
-      - run: sudo apt-get update
+      - run: sudo apt-get --allow-releaseinfo-change update
       - run: sudo apt-get install default-mysql-client             # required for db-restore
       - run: cp conf/config.sample.yaml conf/config.yaml           # as env var are not loaded for entries not in config file (bug)
       - run: cp conf/config.test.sample.yaml conf/config.test.yaml # the dbname is specified in conf/config.test.yaml
@@ -197,7 +197,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache: *CACHEKEYMOD
-      - run: sudo apt-get update
+      - run: sudo apt-get --allow-releaseinfo-change update
       - run: sudo apt-get install default-mysql-client             # required for db-restore
       - run: cp conf/config.sample.yaml conf/config.yaml           # as env var are not loaded for entries not in config file (bug)
       - run: cp conf/config.test.sample.yaml conf/config.test.yaml # the dbname is specified in conf/config.test.yaml

--- a/app/api/groups/get_group_progress.feature
+++ b/app/api/groups/get_group_progress.feature
@@ -965,6 +965,16 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     ]
     """
 
+  Scenario: No parent item ids given
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/1/group-progress?parent_item_ids="
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+    ]
+    """
+
   Scenario: No groups
     Given I am the user with id "21"
     # here we fixate avg_time_spent even if it depends on NOW()

--- a/app/api/groups/get_group_progress.feature
+++ b/app/api/groups/get_group_progress.feature
@@ -223,6 +223,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 8  | 15             | 2017-03-29 06:38:38 |
     And the database has the following table 'results':
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        |
+      | 0          | 14             | 210     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 125          | 127         | null                |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                |
       | 1          | 14             | 211     | 2017-05-29 06:38:38 | 40             | 2017-05-29 06:38:38 | 2            | 3           | null                |
       | 2          | 14             | 211     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 3            | 4           | 2017-05-30 06:38:38 | # hints_cached & submissions for 14,211 come from this line
@@ -259,6 +260,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     And the response body should be, in JSON:
     """
     [
+      {
+        "average_score": 25,
+        "avg_hints_requested": 62.5,
+        "avg_submissions": 63.5,
+        "avg_time_spent": 31603814,
+        "group_id": "17",
+        "item_id": "210",
+        "validation_rate": 0
+      },
       {
         "average_score": 25,
         "avg_hints_requested": 1.5,
@@ -310,6 +320,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_submissions": 0,
         "avg_time_spent": 0,
         "group_id": "17",
+        "item_id": "220",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "17",
         "item_id": "221",
         "validation_rate": 0
       },
@@ -347,6 +366,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_time_spent": 0,
         "group_id": "17",
         "item_id": "225",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "17",
+        "item_id": "310",
         "validation_rate": 0
       },
       {
@@ -398,6 +426,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
 
       {
         "average_score": 25,
+        "avg_hints_requested": 62.5,
+        "avg_submissions": 63.5,
+        "avg_time_spent": 31603814,
+        "group_id": "11",
+        "item_id": "210",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 25,
         "avg_hints_requested": 1.5,
         "avg_submissions": 2,
         "avg_time_spent": 43200,
@@ -447,6 +484,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_submissions": 0,
         "avg_time_spent": 0,
         "group_id": "11",
+        "item_id": "220",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "11",
         "item_id": "221",
         "validation_rate": 0
       },
@@ -484,6 +530,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_time_spent": 0,
         "group_id": "11",
         "item_id": "225",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "11",
+        "item_id": "310",
         "validation_rate": 0
       },
       {
@@ -545,6 +600,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     [
       {
         "average_score": 25,
+        "avg_hints_requested": 62.5,
+        "avg_submissions": 63.5,
+        "avg_time_spent": 31603814,
+        "group_id": "17",
+        "item_id": "210",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 25,
         "avg_hints_requested": 1.5,
         "avg_submissions": 2,
         "avg_time_spent": 43200,
@@ -594,6 +658,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_submissions": 0,
         "avg_time_spent": 0,
         "group_id": "17",
+        "item_id": "220",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "17",
         "item_id": "221",
         "validation_rate": 0
       },
@@ -631,6 +704,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_time_spent": 0,
         "group_id": "17",
         "item_id": "225",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "17",
+        "item_id": "310",
         "validation_rate": 0
       },
       {
@@ -692,6 +774,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     [
       {
         "average_score": 25,
+        "avg_hints_requested": 62.5,
+        "avg_submissions": 63.5,
+        "avg_time_spent": 31603814,
+        "group_id": "11",
+        "item_id": "210",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 25,
         "avg_hints_requested": 1.5,
         "avg_submissions": 2,
         "avg_time_spent": 43200,
@@ -733,6 +824,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_time_spent": 0,
         "group_id": "11",
         "item_id": "215",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "11",
+        "item_id": "220",
         "validation_rate": 0
       },
       {
@@ -786,6 +886,15 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
         "avg_submissions": 0,
         "avg_time_spent": 0,
         "group_id": "11",
+        "item_id": "310",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "11",
         "item_id": "311",
         "validation_rate": 0
       },
@@ -828,13 +937,31 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     ]
     """
 
-  Scenario: No visible items
+  Scenario: No visible child items
     Given I am the user with id "21"
     When I send a GET request to "/groups/1/group-progress?parent_item_ids=1010"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "17",
+        "item_id": "1010",
+        "validation_rate": 0
+      },
+      {
+        "average_score": 0,
+        "avg_hints_requested": 0,
+        "avg_submissions": 0,
+        "avg_time_spent": 0,
+        "group_id": "11",
+        "item_id": "1010",
+        "validation_rate": 0
+      }
     ]
     """
 

--- a/app/api/groups/get_participant_progress.feature
+++ b/app/api/groups/get_participant_progress.feature
@@ -300,7 +300,7 @@ Feature: Display the current progress of a participant on children of an item (g
       {
         "hints_requested": 1,
         "item_id": "212",
-        "no_score": false,
+        "no_score": true,
         "type": "Task",
         "string": {"language_tag": "", "title": null},
         "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
@@ -375,7 +375,7 @@ Feature: Display the current progress of a participant on children of an item (g
         "validated": false
       },
       {
-        "no_score": false,
+        "no_score": true,
         "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
         "string": {"language_tag": "", "title": null},
         "type": "Task",
@@ -452,7 +452,7 @@ Feature: Display the current progress of a participant on children of an item (g
         "validated": false
       },
       {
-        "no_score": false,
+        "no_score": true,
         "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
         "string": {"language_tag": "", "title": null},
         "type": "Task",

--- a/app/api/groups/get_participant_progress.feature
+++ b/app/api/groups/get_participant_progress.feature
@@ -72,50 +72,51 @@ Feature: Display the current progress of a participant on children of an item (g
       | 20              | 21             |
     And the groups ancestors are computed
     And the database has the following table 'items':
-      | id  | type    | default_language_tag | no_score |
-      | 200 | Chapter | fr                   | false    |
-      | 210 | Chapter | fr                   | false    |
-      | 211 | Task    | fr                   | false    |
-      | 212 | Task    | fr                   | true     |
-      | 213 | Task    | fr                   | false    |
-      | 214 | Task    | fr                   | false    |
-      | 215 | Task    | fr                   | false    |
-      | 216 | Task    | fr                   | false    |
-      | 217 | Task    | fr                   | false    |
-      | 218 | Task    | fr                   | false    |
-      | 219 | Task    | fr                   | false    |
-      | 220 | Chapter | fr                   | false    |
-      | 221 | Task    | fr                   | false    |
-      | 222 | Task    | fr                   | false    |
-      | 223 | Task    | fr                   | false    |
-      | 224 | Task    | fr                   | false    |
-      | 225 | Task    | fr                   | false    |
-      | 226 | Task    | fr                   | false    |
-      | 227 | Task    | fr                   | false    |
-      | 228 | Task    | fr                   | false    |
-      | 229 | Task    | fr                   | false    |
-      | 300 | Course  | fr                   | false    |
-      | 310 | Chapter | fr                   | false    |
-      | 311 | Task    | fr                   | false    |
-      | 312 | Task    | fr                   | false    |
-      | 313 | Task    | fr                   | false    |
-      | 314 | Task    | fr                   | false    |
-      | 315 | Task    | fr                   | false    |
-      | 316 | Task    | fr                   | false    |
-      | 317 | Task    | fr                   | false    |
-      | 318 | Task    | fr                   | false    |
-      | 319 | Task    | fr                   | false    |
-      | 400 | Chapter | fr                   | false    |
-      | 410 | Chapter | fr                   | false    |
-      | 411 | Task    | fr                   | false    |
-      | 412 | Task    | fr                   | false    |
-      | 413 | Task    | fr                   | false    |
-      | 414 | Task    | fr                   | false    |
-      | 415 | Task    | fr                   | false    |
-      | 416 | Task    | fr                   | false    |
-      | 417 | Task    | fr                   | false    |
-      | 418 | Task    | fr                   | false    |
-      | 419 | Task    | fr                   | false    |
+      | id   | type    | default_language_tag | no_score |
+      | 200  | Chapter | fr                   | false    |
+      | 210  | Chapter | fr                   | false    |
+      | 211  | Task    | fr                   | false    |
+      | 212  | Task    | fr                   | true     |
+      | 213  | Task    | fr                   | false    |
+      | 214  | Task    | fr                   | false    |
+      | 215  | Task    | fr                   | false    |
+      | 216  | Task    | fr                   | false    |
+      | 217  | Task    | fr                   | false    |
+      | 218  | Task    | fr                   | false    |
+      | 219  | Task    | fr                   | false    |
+      | 220  | Chapter | fr                   | false    |
+      | 221  | Task    | fr                   | false    |
+      | 222  | Task    | fr                   | false    |
+      | 223  | Task    | fr                   | false    |
+      | 224  | Task    | fr                   | false    |
+      | 225  | Task    | fr                   | false    |
+      | 226  | Task    | fr                   | false    |
+      | 227  | Task    | fr                   | false    |
+      | 228  | Task    | fr                   | false    |
+      | 229  | Task    | fr                   | false    |
+      | 300  | Course  | fr                   | false    |
+      | 310  | Chapter | fr                   | false    |
+      | 311  | Task    | fr                   | false    |
+      | 312  | Task    | fr                   | false    |
+      | 313  | Task    | fr                   | false    |
+      | 314  | Task    | fr                   | false    |
+      | 315  | Task    | fr                   | false    |
+      | 316  | Task    | fr                   | false    |
+      | 317  | Task    | fr                   | false    |
+      | 318  | Task    | fr                   | false    |
+      | 319  | Task    | fr                   | false    |
+      | 400  | Chapter | fr                   | false    |
+      | 410  | Chapter | fr                   | false    |
+      | 411  | Task    | fr                   | false    |
+      | 412  | Task    | fr                   | false    |
+      | 413  | Task    | fr                   | false    |
+      | 414  | Task    | fr                   | false    |
+      | 415  | Task    | fr                   | false    |
+      | 416  | Task    | fr                   | false    |
+      | 417  | Task    | fr                   | false    |
+      | 418  | Task    | fr                   | false    |
+      | 419  | Task    | fr                   | false    |
+      | 1010 | Chapter | fr                   | false    |
     And the database has the following table 'items_strings':
       | item_id | language_tag | title    |
       | 214     | fr           | Tâche 14 |
@@ -165,6 +166,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 410            | 419           | 8           |
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated       | can_watch_generated |
+      | 4        | 210     | content                  | none                |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
       | 20       | 212     | content                  | none                |
@@ -205,8 +207,13 @@ Feature: Display the current progress of a participant on children of an item (g
       | 20       | 417     | none                     | none                |
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
-      | 4        | 1010    | none                     | answer_with_grant   |
-      | 51       | 210     | none                     | result              |
+      | 14       | 210     | content_with_descendants | none                |
+      | 14       | 211     | info                     | none                |
+      | 14       | 212     | info                     | none                |
+      | 14       | 213     | info                     | none                |
+      | 14       | 215     | info                     | none                |
+      | 14       | 1010    | content                  | none                |
+      | 51       | 210     | content                  | result              |
       | 51       | 211     | info                     | none                |
       | 51       | 212     | content                  | none                |
       | 51       | 213     | content_with_descendants | none                |
@@ -424,19 +431,6 @@ Feature: Display the current progress of a participant on children of an item (g
         "submissions": 100,
         "time_spent": 86400,
         "validated": true
-      },
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "fr", "title": "Tâche 14"},
-        "type": "Task",
-        "hints_requested": 0,
-        "item_id": "214",
-        "latest_activity_at": null,
-        "score": 0,
-        "submissions": 0,
-        "time_spent": 0,
-        "validated": false
       },
       {
         "no_score": false,

--- a/app/api/groups/get_participant_progress.feature
+++ b/app/api/groups/get_participant_progress.feature
@@ -264,73 +264,84 @@ Feature: Display the current progress of a participant on children of an item (g
     Then the response code should be 200
     And the response body should be, in JSON:
     """
-    [
-      {
+    {
+      "item": {
         "hints_requested": 0,
-        "item_id": "215",
-        "no_score": false,
-        "type": "Task",
-        "string": {"language_tag": "en", "title": "Task 15"},
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "latest_activity_at": "2018-11-01T00:00:00Z",
-        "score": 0,
-        "submissions": 0,
-        "time_spent": 0,
-        "validated": false
-      },
-      {
-        "hints_requested": 10,
-        "item_id": "214",
-        "no_score": false,
-        "type": "Task",
-        "string": {"language_tag": "fr", "title": "Tâche 14"},
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "latest_activity_at": "2017-05-30T06:38:48Z",
-        "score": 15,
-        "submissions": 11,
-        "time_spent": 10,
-        "validated": true
-      },
-      {
-        "hints_requested": 0,
-        "item_id": "213",
-        "no_score": false,
-        "type": "Task",
-        "string": {"language_tag": "", "title": null},
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
-        "latest_activity_at": "2018-11-01T00:00:00Z",
-        "score": 0,
-        "submissions": 0,
-        "time_spent": 20895545,
-        "validated": false
-      },
-      {
-        "hints_requested": 1,
-        "item_id": "212",
-        "no_score": true,
-        "type": "Task",
-        "string": {"language_tag": "", "title": null},
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "latest_activity_at": "2019-07-01T00:00:00Z",
-        "score": 20,
-        "submissions": 2,
-        "time_spent": 18303545,
-        "validated": false
-      },
-      {
-        "item_id": "211",
-        "no_score": false,
-        "type": "Task",
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
+        "item_id": "210",
         "latest_activity_at": null,
         "score": 0,
-        "hints_requested": 0,
         "submissions": 0,
         "time_spent": 0,
         "validated": false
-      }
-    ]
+      },
+      "children": [
+        {
+          "hints_requested": 0,
+          "item_id": "215",
+          "no_score": false,
+          "type": "Task",
+          "string": {"language_tag": "en", "title": "Task 15"},
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "latest_activity_at": "2018-11-01T00:00:00Z",
+          "score": 0,
+          "submissions": 0,
+          "time_spent": 0,
+          "validated": false
+        },
+        {
+          "hints_requested": 10,
+          "item_id": "214",
+          "no_score": false,
+          "type": "Task",
+          "string": {"language_tag": "fr", "title": "Tâche 14"},
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
+          "latest_activity_at": "2017-05-30T06:38:48Z",
+          "score": 15,
+          "submissions": 11,
+          "time_spent": 10,
+          "validated": true
+        },
+        {
+          "hints_requested": 0,
+          "item_id": "213",
+          "no_score": false,
+          "type": "Task",
+          "string": {"language_tag": "", "title": null},
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
+          "latest_activity_at": "2018-11-01T00:00:00Z",
+          "score": 0,
+          "submissions": 0,
+          "time_spent": 20895545,
+          "validated": false
+        },
+        {
+          "hints_requested": 1,
+          "item_id": "212",
+          "no_score": true,
+          "type": "Task",
+          "string": {"language_tag": "", "title": null},
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "latest_activity_at": "2019-07-01T00:00:00Z",
+          "score": 20,
+          "submissions": 2,
+          "time_spent": 18303545,
+          "validated": false
+        },
+        {
+          "item_id": "211",
+          "no_score": false,
+          "type": "Task",
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "latest_activity_at": null,
+          "score": 0,
+          "hints_requested": 0,
+          "submissions": 0,
+          "time_spent": 0,
+          "validated": false
+        }
+      ]
+    }
     """
 
   Scenario: Get progress of a current user
@@ -341,73 +352,84 @@ Feature: Display the current progress of a participant on children of an item (g
     Then the response code should be 200
     And the response body should be, in JSON:
     """
-    [
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "fr", "title": "Tâche 15"},
-        "type": "Task",
-        "hints_requested": 100,
-        "item_id": "215",
-        "latest_activity_at": "2018-05-30T06:38:58Z",
-        "score": 0,
-        "submissions": 100,
-        "time_spent": 86400,
-        "validated": true
-      },
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "fr", "title": "Tâche 14"},
-        "type": "Task",
+    {
+      "item": {
         "hints_requested": 0,
-        "item_id": "214",
+        "item_id": "210",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
         "time_spent": 0,
         "validated": false
       },
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
-        "hints_requested": 0,
-        "item_id": "213",
-        "latest_activity_at": "2030-05-29T06:38:38Z",
-        "score": 0,
-        "submissions": 0,
-        "time_spent": 0,
-        "validated": false
-      },
-      {
-        "no_score": true,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
-        "hints_requested": 1,
-        "item_id": "212",
-        "latest_activity_at": "2018-05-30T06:38:58Z",
-        "score": 0,
-        "submissions": 2,
-        "time_spent": 65886027,
-        "validated": false
-      },
-      {
-        "item_id": "211",
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
-        "latest_activity_at": "2018-05-30T06:38:48Z",
-        "score": 50,
-        "hints_requested": 3,
-        "submissions": 4,
-        "time_spent": 20,
-        "validated": true
-      }
-    ]
+      "children": [
+        {
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "fr", "title": "Tâche 15"},
+          "type": "Task",
+          "hints_requested": 100,
+          "item_id": "215",
+          "latest_activity_at": "2018-05-30T06:38:58Z",
+          "score": 0,
+          "submissions": 100,
+          "time_spent": 86400,
+          "validated": true
+        },
+        {
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "fr", "title": "Tâche 14"},
+          "type": "Task",
+          "hints_requested": 0,
+          "item_id": "214",
+          "latest_activity_at": null,
+          "score": 0,
+          "submissions": 0,
+          "time_spent": 0,
+          "validated": false
+        },
+        {
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "hints_requested": 0,
+          "item_id": "213",
+          "latest_activity_at": "2030-05-29T06:38:38Z",
+          "score": 0,
+          "submissions": 0,
+          "time_spent": 0,
+          "validated": false
+        },
+        {
+          "no_score": true,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "hints_requested": 1,
+          "item_id": "212",
+          "latest_activity_at": "2018-05-30T06:38:58Z",
+          "score": 0,
+          "submissions": 2,
+          "time_spent": 65886027,
+          "validated": false
+        },
+        {
+          "item_id": "211",
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "latest_activity_at": "2018-05-30T06:38:48Z",
+          "score": 50,
+          "hints_requested": 3,
+          "submissions": 4,
+          "time_spent": 20,
+          "validated": true
+        }
+      ]
+    }
     """
 
   Scenario: Get progress of a current user's team
@@ -418,68 +440,89 @@ Feature: Display the current progress of a participant on children of an item (g
     Then the response code should be 200
     And the response body should be, in JSON:
     """
-    [
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "fr", "title": "Tâche 15"},
-        "type": "Task",
-        "hints_requested": 100,
-        "item_id": "215",
-        "latest_activity_at": "2018-05-30T06:38:58Z",
-        "score": 0,
-        "submissions": 100,
-        "time_spent": 86400,
-        "validated": true
-      },
-      {
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
+    {
+      "item": {
         "hints_requested": 0,
-        "item_id": "213",
-        "latest_activity_at": "2030-05-29T06:38:38Z",
+        "item_id": "210",
+        "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
         "time_spent": 0,
         "validated": false
       },
-      {
-        "no_score": true,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
-        "hints_requested": 1,
-        "item_id": "212",
-        "latest_activity_at": "2018-05-30T06:38:58Z",
-        "score": 0,
-        "submissions": 2,
-        "time_spent": 65886027,
-        "validated": false
-      },
-      {
-        "item_id": "211",
-        "no_score": false,
-        "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
-        "string": {"language_tag": "", "title": null},
-        "type": "Task",
-        "latest_activity_at": "2018-05-30T06:38:48Z",
-        "score": 50,
-        "hints_requested": 3,
-        "submissions": 4,
-        "time_spent": 20,
-        "validated": true
-      }
-    ]
+      "children": [
+        {
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "fr", "title": "Tâche 15"},
+          "type": "Task",
+          "hints_requested": 100,
+          "item_id": "215",
+          "latest_activity_at": "2018-05-30T06:38:58Z",
+          "score": 0,
+          "submissions": 100,
+          "time_spent": 86400,
+          "validated": true
+        },
+        {
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "hints_requested": 0,
+          "item_id": "213",
+          "latest_activity_at": "2030-05-29T06:38:38Z",
+          "score": 0,
+          "submissions": 0,
+          "time_spent": 0,
+          "validated": false
+        },
+        {
+          "no_score": true,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "hints_requested": 1,
+          "item_id": "212",
+          "latest_activity_at": "2018-05-30T06:38:58Z",
+          "score": 0,
+          "submissions": 2,
+          "time_spent": 65886027,
+          "validated": false
+        },
+        {
+          "item_id": "211",
+          "no_score": false,
+          "current_user_permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false},
+          "string": {"language_tag": "", "title": null},
+          "type": "Task",
+          "latest_activity_at": "2018-05-30T06:38:48Z",
+          "score": 50,
+          "hints_requested": 3,
+          "submissions": 4,
+          "time_spent": 20,
+          "validated": true
+        }
+      ]
+    }
     """
 
-  Scenario: No visible items
+  Scenario: No visible child items
     Given I am the user with id "51"
     When I send a GET request to "/items/1010/participant-progress?as_team_id=14"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
-    [
-    ]
+    {
+      "item": {
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      "children": []
+    }
     """

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -149,7 +149,7 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 	user := srv.GetUser(r)
 	itemIDQuery := srv.Store.ItemItems().
 		Select(`
-			items.id, items.type, child_order, default_language_tag,
+			items.id, items.type, items.no_score, child_order, default_language_tag,
 			can_view_generated_value, can_grant_view_generated_value, can_watch_generated_value,
 			can_edit_generated_value, is_owner_generated`).
 		Joins("JOIN items ON items.id = items_items.child_item_id").
@@ -159,7 +159,7 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 	var fieldVariables []interface{}
 	var participantProgressQuery *database.DB
 	fields := `
-		items.id, items.type, items.default_language_tag,
+		items.id, items.type, items.no_score, items.default_language_tag,
 		can_view_generated_value, can_grant_view_generated_value, can_watch_generated_value,
 		can_edit_generated_value, is_owner_generated`
 	if participantType == groupTypeUser {

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -11,20 +11,9 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/structures"
 )
 
-// swagger:model groupParticipantProgressResponseRow
-type groupParticipantProgressResponseRow struct {
+type groupParticipantProgressResponseCommon struct {
 	// required: true
 	ItemID int64 `json:"item_id,string"`
-	// required: true
-	NoScore bool `json:"no_score"`
-	// required: true
-	// enum: Chapter,Task,Course,Skill
-	Type string `json:"type"`
-
-	String structures.ItemString `json:"string"`
-
-	// required: true
-	CurrentUserPermissions *structures.ItemPermissions `json:"current_user_permissions"`
 
 	// The best score across all participant's or participant teams' results. If there are no results, the score is 0.
 	// required:true
@@ -56,7 +45,31 @@ type groupParticipantProgressResponseRow struct {
 	TimeSpent int32 `json:"time_spent"`
 }
 
-type rawParticipantProgressRow struct {
+type groupParticipantProgressResponseChild struct {
+	*groupParticipantProgressResponseCommon
+
+	// required: true
+	NoScore bool `json:"no_score"`
+	// required: true
+	// enum: Chapter,Task,Course,Skill
+	Type string `json:"type"`
+
+	// required: true
+	String structures.ItemString `json:"string"`
+
+	// required: true
+	CurrentUserPermissions *structures.ItemPermissions `json:"current_user_permissions"`
+}
+
+// swagger:model groupParticipantProgressResponse
+type groupParticipantProgressResponse struct {
+	// required: true
+	Item groupParticipantProgressResponseCommon `json:"item"`
+	// required: true
+	Children []groupParticipantProgressResponseChild `json:"children"`
+}
+
+type rawParticipantProgressRaw struct {
 	// items
 	ItemID  int64 `gorm:"column:id"`
 	Type    string
@@ -74,6 +87,8 @@ type rawParticipantProgressRow struct {
 	HintsRequested   int32
 	Submissions      int32
 	TimeSpent        int32
+
+	IsParent bool
 }
 
 // swagger:operation GET /items/{item_id}/participant-progress groups groupParticipantProgress
@@ -83,7 +98,7 @@ type rawParticipantProgressRow struct {
 //              Returns the current progress of a participant on a given item.
 //
 //
-//              For all visible children of `{item_id}`,
+//              For `{item_id}` and all its visible children,
 //              displays the results of the given participant
 //              (current user or `as_team_id` (if given) or `watched_group_id` (if given)).
 //              Only one of `as_team_id` and `watched_group_id` can be given.
@@ -100,7 +115,7 @@ type rawParticipantProgressRow struct {
 //              * The current user (or the team given in `as_team_id`) should have at least 'content' permissions on `{item_id}`,
 //                otherwise the 'forbidden' response is returned.
 //
-//              * If `as_team_id` is given, it should be a user's parent team group,
+//              * If `{as_team_id}` is given, it should be a user's parent team group,
 //                otherwise the "forbidden" error is returned.
 //
 //              * If `{watched_group_id}` is given, the user should be a manager of the group with the 'can_watch_members' permission,
@@ -129,9 +144,7 @@ type rawParticipantProgressRow struct {
 //   "200":
 //     description: OK. Success response with the participant's progress on item's children
 //     schema:
-//       type: array
-//       items:
-//         "$ref": "#/definitions/groupParticipantProgressResponseRow"
+//       "$ref": "#/definitions/groupParticipantProgressResponse"
 //   "400":
 //     "$ref": "#/responses/badRequestResponse"
 //   "401":
@@ -147,21 +160,24 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 	}
 
 	user := srv.GetUser(r)
-	itemIDQuery := srv.Store.ItemItems().
+	itemIDQuery := srv.Store.Items().
 		Select(`
-			items.id, items.type, items.no_score, child_order, default_language_tag,
+			items.id, items.type, items.no_score, MAX(child_order) AS child_order, default_language_tag,
 			IFNULL(user_permissions.can_view_generated_value, 1) AS can_view_generated_value,
 			IFNULL(user_permissions.can_grant_view_generated_value, 1) AS can_grant_view_generated_value,
 			IFNULL(user_permissions.can_watch_generated_value, 1) AS can_watch_generated_value,
 			IFNULL(user_permissions.can_edit_generated_value, 1) AS can_edit_generated_value,
-			IFNULL(user_permissions.is_owner_generated, 0) AS is_owner_generated`).
-		Joins("JOIN items ON items.id = items_items.child_item_id").
-		Where("parent_item_id = ?", itemID).
+			IFNULL(user_permissions.is_owner_generated, 0) AS is_owner_generated,
+			MAX(is_parent) AS is_parent`).
+		Joins("JOIN ? AS items_items ON items_items.child_item_id = items.id",
+			srv.Store.ItemItems().ChildrenOf(itemID).Select("child_item_id, child_order, 0 AS is_parent").
+				UnionAll(srv.Store.Raw("SELECT ?, NULL AS child_order, 1 AS is_parent", itemID).QueryExpr()).SubQuery()).
 		JoinsPermissionsForGroupToItemsWherePermissionAtLeast(checkPermissionsForGroupID, "view", "info").
 		Joins(
 			"LEFT JOIN LATERAL ? AS user_permissions ON user_permissions.item_id = items.id",
 			srv.Store.Permissions().AggregatedPermissionsForItems(user.GroupID).
-				Where("permissions.item_id = items.id").SubQuery())
+				Where("permissions.item_id = items.id").SubQuery()).
+		Group("items.id")
 
 	var fieldVariables []interface{}
 	var participantProgressQuery *database.DB
@@ -175,17 +191,17 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 			// nolint:gosec
 			joinUserProgressResults(
 				srv.Store.Raw(`
-					SELECT STRAIGHT_JOIN`+fields+", "+userProgressFields+`
+					SELECT STRAIGHT_JOIN`+fields+", MAX(items.is_parent) AS is_parent, "+userProgressFields+`
 					FROM visible_items AS items`, fieldVariables...), participantID).
 				Group("items.id").
-				Order("MAX(items.child_order)").
+				Order("MAX(items.is_parent) DESC, MAX(items.child_order)").
 				QueryExpr())
 	} else {
 		participantProgressQuery = srv.Store.Raw("WITH visible_items AS ? ?",
 			itemIDQuery.SubQuery(),
 			srv.Store.Table("visible_items AS items").
 				Select(
-					fields+", "+`
+					fields+", is_parent, "+`
 					IFNULL(result_with_best_score.score_computed, 0) AS score,
 					IFNULL(result_with_best_score.validated, 0) AS validated,
 					(SELECT MAX(latest_activity_at) FROM results WHERE participant_id = ? AND item_id = items.id) AS latest_activity_at,
@@ -210,38 +226,46 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 						ORDER BY participant_id, item_id, score_computed DESC, score_obtained_at
 						LIMIT 1
 					) AS result_with_best_score ON 1`, participantID).QueryExpr()).
-			Order("items.child_order")
+			Order("items.is_parent DESC, items.child_order")
 	}
 
-	var result []rawParticipantProgressRow
+	var rows []rawParticipantProgressRaw
 	service.MustNotBeError(srv.Store.Raw(`
 		SELECT items.*,
 			COALESCE(user_strings.language_tag, default_strings.language_tag) AS language_tag,
 			IF(user_strings.language_tag IS NULL, default_strings.title, user_strings.title) AS title
-		FROM (?) AS items`, participantProgressQuery.SubQuery()).
+		FROM ? AS items`, participantProgressQuery.SubQuery()).
 		JoinsUserAndDefaultItemStrings(user).
-		Scan(&result).Error())
+		Scan(&rows).Error())
 
-	converted := make([]groupParticipantProgressResponseRow, 0, len(result))
-	for i := range result {
-		converted = append(converted, groupParticipantProgressResponseRow{
-			ItemID:  result[i].ItemID,
-			NoScore: result[i].NoScore,
-			Type:    result[i].Type,
-			String: structures.ItemString{
-				Title:       result[i].StringTitle,
-				LanguageTag: result[i].StringLanguageTag,
-			},
-			CurrentUserPermissions: result[i].AsItemPermissions(srv.Store.PermissionsGranted()),
-			Score:                  result[i].Score,
-			Validated:              result[i].Validated,
-			LatestActivityAt:       result[i].LatestActivityAt,
-			HintsRequested:         result[i].HintsRequested,
-			Submissions:            result[i].Submissions,
-			TimeSpent:              result[i].TimeSpent,
-		})
+	result := &groupParticipantProgressResponse{}
+	result.Children = make([]groupParticipantProgressResponseChild, 0, len(rows)-1)
+	for i := range rows {
+		commonFields := groupParticipantProgressResponseCommon{
+			ItemID:           rows[i].ItemID,
+			Score:            rows[i].Score,
+			Validated:        rows[i].Validated,
+			LatestActivityAt: rows[i].LatestActivityAt,
+			HintsRequested:   rows[i].HintsRequested,
+			Submissions:      rows[i].Submissions,
+			TimeSpent:        rows[i].TimeSpent,
+		}
+		if rows[i].IsParent {
+			result.Item = commonFields
+		} else {
+			result.Children = append(result.Children, groupParticipantProgressResponseChild{
+				groupParticipantProgressResponseCommon: &commonFields,
+				NoScore:                                rows[i].NoScore,
+				Type:                                   rows[i].Type,
+				String: structures.ItemString{
+					Title:       rows[i].StringTitle,
+					LanguageTag: rows[i].StringLanguageTag,
+				},
+				CurrentUserPermissions: rows[i].AsItemPermissions(srv.Store.PermissionsGranted()),
+			})
+		}
 	}
-	render.Respond(w, r, converted)
+	render.Respond(w, r, result)
 	return service.NoError
 }
 

--- a/app/api/groups/get_participant_progress.robustness.feature
+++ b/app/api/groups/get_participant_progress.robustness.feature
@@ -24,9 +24,11 @@ Feature: Display the current progress of a participant on children of an item (g
       | 211 | Task    | fr                   |
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated       | can_watch_generated |
-      | 11       | 210     | info                     | result              |
+      | 11       | 210     | content                  | result              |
+      | 14       | 200     | info                     | answer              |
       | 20       | 210     | none                     | answer              |
-      | 21       | 210     | none                     | answer_with_grant   |
+      | 21       | 200     | content                  | answer              |
+      | 21       | 210     | content                  | answer_with_grant   |
       | 21       | 211     | info                     | none                |
     And the database has the following table 'items_items':
       | parent_item_id | child_item_id | child_order |
@@ -41,7 +43,7 @@ Feature: Display the current progress of a participant on children of an item (g
     And the response error message should contain "No rights to watch for watched_group_id"
 
   Scenario: watched_group_id is incorrect
-    Given I am the user with id "21"
+    Given I am the user with id "11"
     When I send a GET request to "/items/210/participant-progress?watched_group_id=abc"
     Then the response code should be 400
     And the response error message should contain "Wrong value for watched_group_id (should be int64)"
@@ -67,6 +69,18 @@ Feature: Display the current progress of a participant on children of an item (g
   Scenario: Not enough permissions to watch results on item_id
     Given I am the user with id "21"
     When I send a GET request to "/items/211/participant-progress?watched_group_id=14"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: can_view < content on item_id for a user
+    Given I am the user with id "21"
+    When I send a GET request to "/items/211/participant-progress"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: can_view < content on item_id for a team
+    Given I am the user with id "21"
+    When I send a GET request to "/items/200/participant-progress?as_team_id=14"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
 

--- a/app/api/groups/get_team_progress.feature
+++ b/app/api/groups/get_team_progress.feature
@@ -207,6 +207,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 5  | 14             | 2017-05-29 06:38:38 |
     And the database has the following table 'results':
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
+      | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                | 2018-05-30 06:38:38 |
       | 1          | 14             | 211     | 2017-05-29 06:38:38 | 40             | 2017-05-29 06:38:38 | 2            | 3           | null                | 2018-05-29 06:38:38 |
       | 2          | 14             | 211     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 3            | 4           | 2017-05-30 06:38:38 | 2018-05-28 06:38:38 | # hints_cached & submissions for 14,211 come from this line
@@ -229,6 +230,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
     And the response body should be, in JSON:
     """
     [
+      {
+        "group_id": "16",
+        "hints_requested": 0,
+        "item_id": "210",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
       {
         "group_id": "16",
         "item_id": "211",
@@ -282,6 +293,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       {
         "group_id": "16",
         "hints_requested": 0,
+        "item_id": "220",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "16",
+        "hints_requested": 0,
         "item_id": "221",
         "latest_activity_at": null,
         "score": 0,
@@ -323,6 +344,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
         "group_id": "16",
         "hints_requested": 0,
         "item_id": "225",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "16",
+        "hints_requested": 0,
+        "item_id": "310",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
@@ -383,6 +414,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
 
       {
         "group_id": "14",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
+        "validated": false
+      },
+      {
+        "group_id": "14",
         "item_id": "211",
         "latest_activity_at": "2018-05-30T06:38:38Z",
         "score": 50,
@@ -434,6 +475,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       {
         "group_id": "14",
         "hints_requested": 0,
+        "item_id": "220",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "14",
+        "hints_requested": 0,
         "item_id": "221",
         "latest_activity_at": null,
         "score": 0,
@@ -475,6 +526,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
         "group_id": "14",
         "hints_requested": 0,
         "item_id": "225",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "14",
+        "hints_requested": 0,
+        "item_id": "310",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
@@ -545,6 +606,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
     [
       {
         "group_id": "16",
+        "hints_requested": 0,
+        "item_id": "210",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "16",
         "item_id": "211",
         "latest_activity_at": null,
         "score": 0,
@@ -596,6 +667,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       {
         "group_id": "16",
         "hints_requested": 0,
+        "item_id": "220",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "16",
+        "hints_requested": 0,
         "item_id": "221",
         "latest_activity_at": null,
         "score": 0,
@@ -637,6 +718,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
         "group_id": "16",
         "hints_requested": 0,
         "item_id": "225",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "16",
+        "hints_requested": 0,
+        "item_id": "310",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
@@ -707,6 +798,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
     [
       {
         "group_id": "14",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
+        "validated": false
+      },
+      {
+        "group_id": "14",
         "item_id": "211",
         "latest_activity_at": "2018-05-30T06:38:38Z",
         "score": 50,
@@ -749,6 +850,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
         "group_id": "14",
         "hints_requested": 0,
         "item_id": "215",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "14",
+        "hints_requested": 0,
+        "item_id": "220",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
@@ -808,6 +919,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       {
         "group_id": "14",
         "hints_requested": 0,
+        "item_id": "310",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "14",
+        "hints_requested": 0,
         "item_id": "311",
         "latest_activity_at": null,
         "score": 0,
@@ -855,6 +976,16 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
         "time_spent": 0,
         "validated": false
       }
+    ]
+    """
+
+  Scenario: No parent item ids given
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/1/team-progress?parent_item_ids="
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
     ]
     """
 

--- a/app/api/groups/get_team_progress.go
+++ b/app/api/groups/get_team_progress.go
@@ -11,8 +11,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
-// swagger:model groupTeamProgressResponseRow
-type groupTeamProgressResponseRow struct {
+// swagger:model groupTeamProgressResponseTableCell
+type groupTeamProgressResponseTableCell struct {
 	// The team’s `group_id`
 	// required:true
 	GroupID int64 `json:"group_id,string"`
@@ -55,7 +55,7 @@ type groupTeamProgressResponseRow struct {
 //              Returns the current progress of teams on a subset of items.
 //
 //
-//              For all visible children of items from the `{parent_item_id}` list,
+//              For each item from `{parent_item_id}` and its visible children,
 //              displays the result of each team among the descendants of the group.
 //
 //
@@ -101,7 +101,7 @@ type groupTeamProgressResponseRow struct {
 //     schema:
 //       type: array
 //       items:
-//         "$ref": "#/definitions/groupTeamProgressResponseRow"
+//         "$ref": "#/definitions/groupTeamProgressResponseTableCell"
 //   "400":
 //     "$ref": "#/responses/badRequestResponse"
 //   "401":
@@ -126,6 +126,13 @@ func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) serv
 	if apiError != service.NoError {
 		return apiError
 	}
+	if len(itemParentIDs) == 0 {
+		render.Respond(w, r, []map[string]interface{}{})
+		return service.NoError
+	}
+
+	// Preselect item IDs since we need them to build the results table (there shouldn't be many)
+	orderedItemIDListWithDuplicates, itemIDs, itemsUnion := srv.preselectIDsOfVisibleItems(itemParentIDs, user)
 
 	// Preselect IDs of end member for that we will calculate the stats.
 	// There should not be too many of end members on one page.
@@ -151,14 +158,8 @@ func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) serv
 		return service.NoError
 	}
 
-	itemsQuery := srv.Store.Permissions().MatchingUserAncestors(user).
-		WherePermissionIsAtLeast("view", "info").
-		Joins("JOIN items_items ON items_items.child_item_id = permissions.item_id").
-		Where("items_items.parent_item_id IN (?)", itemParentIDs).
-		Select("DISTINCT items_items.child_item_id")
-
-	var result []groupTeamProgressResponseRow
-	service.MustNotBeError(srv.Store.Groups().
+	var result []*groupTeamProgressResponseTableCell
+	scanAndBuildProgressResults(srv.Store.Groups().
 		Select(`
 			items.id AS item_id,
 			groups.id AS group_id,
@@ -178,7 +179,7 @@ func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) serv
 					WHERE participant_id = groups.id AND item_id = items.id
 				)
 			) AS time_spent`).
-		Joins(`JOIN items ON items.id IN ?`, itemsQuery.SubQuery()).
+		Joins(`JOIN items ON items.id IN ?`, itemsUnion.SubQuery()).
 		Joins(`
 			LEFT JOIN LATERAL (
 				SELECT score_computed, validated, hints_cached, submissions, participant_id
@@ -190,9 +191,9 @@ func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) serv
 		Where("groups.id IN (?)", teamIDs).
 		Order(gorm.Expr(
 			"FIELD(groups.id"+strings.Repeat(", ?", len(teamIDs))+")",
-			teamIDs...)).
-		Order("items.id").
-		Scan(&result).Error())
+			teamIDs...)),
+		orderedItemIDListWithDuplicates, len(itemIDs), &result,
+	)
 
 	render.Respond(w, r, result)
 	return service.NoError

--- a/app/api/groups/get_user_progress.feature
+++ b/app/api/groups/get_user_progress.feature
@@ -216,6 +216,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 5  | 14             | 2017-05-29 06:38:38 |
     And the database has the following table 'results':
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
+      | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | 2017-05-30 06:38:38 | 2018-05-30 06:38:38 | # latest_activity_at for 51, 211 comes from this line (the last activity is made by a team)
       | 1          | 14             | 211     | 2017-05-29 06:38:38 | 40             | 2017-05-29 06:38:38 | 2            | 3           | 2017-05-29 06:38:58 | 2018-05-29 06:38:38 | # min(validated_at) for 51, 211 comes from this line (from a team)
       | 2          | 14             | 211     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 3            | 4           | 2017-05-31 06:58:38 | 2018-05-28 06:38:38 | # hints_cached & submissions for 51, 211 come from this line (the best attempt is made by a team)
@@ -242,6 +243,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     And the response body should be, in JSON:
     """
     [
+      {
+        "group_id": "67",
+        "hints_requested": 0,
+        "item_id": "210",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
       {
         "group_id": "67",
         "item_id": "211",
@@ -293,6 +304,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
         "validated": false
       },
 
+      {
+        "group_id": "51",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
+        "validated": false
+      },
       {
         "group_id": "51",
         "item_id": "211",
@@ -358,6 +379,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     [
       {
         "group_id": "63",
+        "hints_requested": 0,
+        "item_id": "210",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "63",
         "item_id": "211",
         "latest_activity_at": null,
         "score": 0,
@@ -409,6 +440,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       {
         "group_id": "63",
         "hints_requested": 0,
+        "item_id": "220",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "63",
+        "hints_requested": 0,
         "item_id": "221",
         "latest_activity_at": null,
         "score": 0,
@@ -450,6 +491,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
         "group_id": "63",
         "hints_requested": 0,
         "item_id": "225",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "63",
+        "hints_requested": 0,
+        "item_id": "310",
         "latest_activity_at": null,
         "score": 0,
         "submissions": 0,
@@ -519,13 +570,83 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     ]
     """
 
-  Scenario: No visible items
+  Scenario: No visible child items
     Given I am the user with id "21"
     When I send a GET request to "/groups/1/user-progress?parent_item_ids=1010"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
+      {
+        "group_id": "63",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "65",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "67",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "51",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "53",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "55",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "59",
+        "hints_requested": 0,
+        "item_id": "1010",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      }
     ]
     """
 
@@ -541,6 +662,8 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
 
   Scenario: The input group_id is a team
     Given I am the user with id "21"
+    # here we fixate time_spent even if it depends on NOW()
+    And the DB time now is "2019-06-30 20:19:05"
     When I send a GET request to "/groups/14/user-progress?parent_item_ids=210"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -548,6 +671,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     [
       {
         "group_id": "51",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
+        "validated": false
+      },
+      {
+        "group_id": "51",
         "hints_requested": 3,
         "item_id": "211",
         "latest_activity_at": "2018-05-30T06:38:38Z",
@@ -596,6 +729,17 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
         "time_spent": 0,
         "validated": false
       },
+
+      {
+        "group_id": "53",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
+        "validated": false
+      },
       {
         "group_id": "53",
         "hints_requested": 3,
@@ -644,6 +788,17 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
         "score": 0,
         "submissions": 0,
         "time_spent": 0,
+        "validated": false
+      },
+
+      {
+        "group_id": "55",
+        "hints_requested": 115,
+        "item_id": "210",
+        "latest_activity_at": "2019-05-29T06:38:38Z",
+        "score": 50,
+        "submissions": 127,
+        "time_spent": 65889627,
         "validated": false
       },
       {
@@ -708,6 +863,16 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     [
       {
         "group_id": "69",
+        "hints_requested": 0,
+        "item_id": "210",
+        "latest_activity_at": null,
+        "score": 0,
+        "submissions": 0,
+        "time_spent": 0,
+        "validated": false
+      },
+      {
+        "group_id": "69",
         "item_id": "211",
         "latest_activity_at": null,
         "score": 0,
@@ -756,5 +921,15 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
         "time_spent": 0,
         "validated": false
       }
+    ]
+    """
+
+  Scenario: No parent item ids given
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/1/user-progress?parent_item_ids="
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
     ]
     """

--- a/app/database/permission_generated_store.go
+++ b/app/database/permission_generated_store.go
@@ -29,6 +29,13 @@ func (s *PermissionGeneratedStore) AggregatedPermissionsForItemsOnWhichGroupHasV
 // for all the items on that the given group has 'permissionKind' >= `neededPermission`.
 func (s *PermissionGeneratedStore) AggregatedPermissionsForItemsOnWhichGroupHasPermission(
 	groupID int64, permissionKind, neededPermission string) *DB {
+	return s.AggregatedPermissionsForItems(groupID).
+		HavingMaxPermissionAtLeast(permissionKind, neededPermission)
+}
+
+// AggregatedPermissionsForItems returns a composable query for getting access rights of the given group
+// (as *_generated_value) and item ids (as item_id) for all items.
+func (s *PermissionGeneratedStore) AggregatedPermissionsForItems(groupID int64) *DB {
 	return s.
 		Select(`
 			permissions.item_id,
@@ -39,7 +46,6 @@ func (s *PermissionGeneratedStore) AggregatedPermissionsForItemsOnWhichGroupHasP
 			MAX(is_owner_generated) AS is_owner_generated`).
 		Joins("JOIN groups_ancestors_active AS ancestors ON ancestors.ancestor_group_id = permissions.group_id").
 		Where("ancestors.child_group_id = ?", groupID).
-		HavingMaxPermissionAtLeast(permissionKind, neededPermission).
 		Group("permissions.item_id")
 }
 


### PR DESCRIPTION
Fixes #780

Additionally, some bugs were fixed here:
1) CircleCI builds breakage caused by release of Debian 11,
2) no_score was not returned correctly in groupParticipantProgress,
3) groupParticipantProgress didn't check view permissions on the parent item,
4) Visibility of child items always was always checked for the current user (even if as_team_id was given) in groupParticipantProgress.

Also the main SQL query of groupUserProgress was noticeably simplified.
