### PR TITLE
Fix permissions checking in permissionsView & updatePermissions

### DIFF
--- a/app/api/answers/list_answers_with_author_id.feature
+++ b/app/api/answers/list_answers_with_author_id.feature
@@ -212,7 +212,7 @@ Background:
 
   Scenario: Start from the second row
     Given I am the user with id "21"
-    When I send a GET request to "/items/200/answers?author_id=11&from.created_at=2017-05-29T06:38:38Z&from.id=2"
+    When I send a GET request to "/items/200/answers?author_id=11&from.id=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/contests/get_administered_list.feature
+++ b/app/api/contests/get_administered_list.feature
@@ -152,7 +152,7 @@ Feature: Get the contests that the user has administration rights on (contestAdm
 
   Scenario: User's default language is English  (parents are visible), start from the second row, limit=1
     Given I am the user with id "51"
-    When I send a GET request to "/contests/administered?from.title&from.id=50&limit=1"
+    When I send a GET request to "/contests/administered?from.id=50&limit=1"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/contests/get_members_additional_times.feature
+++ b/app/api/contests/get_members_additional_times.feature
@@ -192,7 +192,7 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
 
   Scenario: Team-only contest (start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/contests/60/groups/11/members/additional-times?from.name=Group%20B&from.id=13"
+    When I send a GET request to "/contests/60/groups/11/members/additional-times?from.id=13"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/contests/get_members_additional_times.go
+++ b/app/api/contests/get_members_additional_times.go
@@ -44,14 +44,8 @@ import (
 //   in: path
 //   type: integer
 //   required: true
-// - name: from.name
-//   description: Start the page from the group next to the group with `name` = `from.name` and `id` = `from.id`
-//                (`from.id` is required when `from.name` is present)
-//   in: query
-//   type: string
 // - name: from.id
-//   description: Start the page from the group next to the group with `name` = `from.name` and `id`=`from.id`
-//                (`from.name` is required when from.id is present)
+//   description: Start the page from the group next to the group with `id`=`{from.id}`
 //   in: query
 //   type: integer
 // - name: sort
@@ -141,11 +135,16 @@ func (srv *Service) getMembersAdditionalTimes(w http.ResponseWriter, r *http.Req
 			srv.Store.PermissionsGranted().ViewIndexByName("info"))
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"name": {ColumnName: "found_group.name", FieldType: "string"},
-			"id":   {ColumnName: "found_group.id", FieldType: "int64"}},
-		"name,id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"name": {ColumnName: "found_group.name"},
+				"id":   {ColumnName: "found_group.id"},
+			},
+			DefaultRules: "name,id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -116,6 +116,29 @@ Feature: Get group invitations for the current user
     ]
     """
 
+  Scenario: Request the second row
+    Given I am the user with id "21"
+    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[4][at]"))}}"
+    When I send a GET request to "/current-user/group-invitations?limit=1&from.group_id=4&from.at={{from_at}}"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group_id": "3",
+        "inviting_user": null,
+        "group": {
+          "id": "3",
+          "name": "Our Club",
+          "description": "Our club group",
+          "type": "Club"
+        },
+        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "action": "join_request_created"
+      }
+    ]
+    """
+
   Scenario: Filter out old invitations
     Given I am the user with id "21"
     When I send a GET request to "/current-user/group-invitations?within_weeks=1"

--- a/app/api/currentuser/get_group_memberships.feature
+++ b/app/api/currentuser/get_group_memberships.feature
@@ -138,3 +138,23 @@ Feature: Get group memberships for the current user
     ]
     """
 
+  Scenario: Request the second row
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/group-memberships?limit=1&from.id=6"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {
+          "id": "5",
+          "name": "Other people",
+          "description": "Group for other people",
+          "type": "Other"
+        },
+        "member_since": "2017-06-29T06:38:38Z",
+        "action": "invitation_accepted",
+        "is_membership_locked": false
+      }
+    ]
+    """

--- a/app/api/currentuser/get_group_memberships_history.go
+++ b/app/api/currentuser/get_group_memberships_history.go
@@ -23,15 +23,15 @@ import (
 //     type: string
 //     enum: [at,-at,group_id,-group_id]
 // - name: from.at
-//   description: Start the page from the invitation/request next to one with `at` = `from.at`
-//                and `group_membership_changes.group_id` = `from.group_id`
-//                (`from.group_id` is required when `from.at` is present)
+//   description: Start the page from the invitation/request next to one with `at` = `{from.at}`
+//                and `group_membership_changes.group_id` = `{from.group_id}`
+//                (`{from.group_id}` is required when `{from.at}` is present)
 //   in: query
 //   type: string
 // - name: from.group_id
-//   description: Start the page from the invitation/request next to one with `at`=`from.at`
-//                and `group_membership_changes.group_id`=`from.group_id`
-//                (`from.at` is required when from.group_id is present)
+//   description: Start the page from the invitation/request next to one with `at`=`{from.at}`
+//                and `group_membership_changes.group_id`=`{from.group_id}`
+//                (`{from.at}` is required when `{from.group_id}` is present)
 //   in: query
 //   type: integer
 // - name: limit
@@ -72,11 +72,19 @@ func (srv *Service) getGroupMembershipsHistory(w http.ResponseWriter, r *http.Re
 	}
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"at":       {ColumnName: "group_membership_changes.at", FieldType: "time"},
-			"group_id": {ColumnName: "group_membership_changes.group_id", FieldType: "int64"}},
-		"-at,group_id", []string{"group_id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"at":       {ColumnName: "group_membership_changes.at"},
+				"group_id": {ColumnName: "group_membership_changes.group_id"},
+			},
+			DefaultRules: "-at,group_id",
+			TieBreakers: service.SortingAndPagingTieBreakers{
+				"group_id": service.FieldTypeInt64,
+				"at":       service.FieldTypeTime,
+			},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_managed_groups.feature
+++ b/app/api/currentuser/get_managed_groups.feature
@@ -121,7 +121,7 @@ Feature: List groups managed by the current user
 
   Scenario: Start from the second row
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/managed-groups?from.type=Class&from.name=Our%20Class&from.id=13"
+    When I send a GET request to "/current-user/managed-groups?from.id=13"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/currentuser/get_managed_groups.go
+++ b/app/api/currentuser/get_managed_groups.go
@@ -45,19 +45,8 @@ type managedGroupsGetResponseRow struct {
 //   items:
 //     type: string
 //     enum: [type,-type,name,-name,id,-id]
-// - name: from.type
-//   description: Start the page from the group next to one with `type` = `{from.type}`
-//                (depending on the `sort` parameter, some other `{from.*}` parameters may be required)
-//   in: query
-//   type: string
-// - name: from.name
-//   description: Start the page from the group next to one with `name` = `{from.name}`
-//                (depending on the `sort` parameter, some other `{from.*}` parameters may be required)
-//   in: query
-//   type: string
 // - name: from.id
 //   description: Start the page from the group next to one with `id`=`{from.id}`
-//                (depending on the `sort` parameter, some other `{from.*}` parameters may be required)
 //   in: query
 //   type: integer
 //   format: int64
@@ -97,12 +86,17 @@ func (srv *Service) getManagedGroups(w http.ResponseWriter, r *http.Request) ser
 		Group("groups.id")
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"type": {ColumnName: "groups.type", FieldType: "string"},
-			"name": {ColumnName: "groups.name", FieldType: "string"},
-			"id":   {ColumnName: "groups.id", FieldType: "int64"}},
-		"type,name,id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"type": {ColumnName: "groups.type"},
+				"name": {ColumnName: "groups.name"},
+				"id":   {ColumnName: "groups.id"},
+			},
+			DefaultRules: "type,name,id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/currentuser/get_managed_groups.robustness.feature
+++ b/app/api/currentuser/get_managed_groups.robustness.feature
@@ -13,8 +13,8 @@ Feature: List groups managed by the current user - robustness
     Then the response code should be 400
     And the response error message should contain "Unallowed field in sorting parameters: "description""
 
-  Scenario: Missing from
+  Scenario: Wrong from
     Given I am the user with id "21"
     When I send a GET request to "/current-user/managed-groups?from.type=Class"
     Then the response code should be 400
-    And the response error message should contain "All 'from' parameters (from.type, from.name, from.id) or none of them must be present"
+    And the response error message should contain "Unallowed paging parameters (from.type)"

--- a/app/api/currentuser/search_for_available_groups.feature
+++ b/app/api/currentuser/search_for_available_groups.feature
@@ -64,6 +64,34 @@ Feature: Search for groups available to the current user
     ]
     """
 
+  Scenario: Search for groups with "the", start from the second row
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/available-groups?search=the&from.id=2"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "4",
+        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "description": "Group for our friends",
+        "type": "Friends"
+      },
+      {
+        "id": "7",
+        "name": "Another %%%Team",
+        "description": "Another team group",
+        "type": "Team"
+      },
+      {
+        "id": "8",
+        "name": "Another %%%Club",
+        "description": "Another club group",
+        "type": "Club"
+      }
+    ]
+    """
+
   Scenario: Search for groups with "the" (limit=2)
     Given I am the user with id "21"
     When I send a GET request to "/current-user/available-groups?search=the&limit=2"

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -41,7 +41,7 @@ const minSearchStringLength = 3
 //     type: string
 //     enum: [id,-id]
 // - name: from.id
-//   description: Start the page from the group next to one with `groups.id`=`from.id`
+//   description: Start the page from the group next to one with `groups.id`=`{from.id}`
 //   in: query
 //   type: integer
 // - name: limit
@@ -120,10 +120,13 @@ func (srv *Service) searchForAvailableGroups(w http.ResponseWriter, r *http.Requ
 		Where("groups.name LIKE CONCAT('%', ?, '%') ESCAPE '|'", escapedSearchString)
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"id": {ColumnName: "groups.id", FieldType: "int64"}},
-		"id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields:       service.SortingAndPagingFields{"id": {ColumnName: "groups.id"}},
+			DefaultRules: "id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -261,7 +261,7 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is a manager of the parent group, paging applied, User is skipped
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/children?from.name=Our%20Team&from.id=25&types_exclude=User"
+    When I send a GET request to "/groups/13/children?from.id=25&types_exclude=User"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -323,7 +323,7 @@ Feature: Get group children (groupChildrenView)
 
   Scenario: User is a member of some descendant groups (start from the second row)
     Given I am the user with id "53"
-    When I send a GET request to "/groups/13/children?from.name=Our%20Friends&from.id=27"
+    When I send a GET request to "/groups/13/children?from.id=27"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_granted_permissions.feature
+++ b/app/api/groups/get_granted_permissions.feature
@@ -1,0 +1,392 @@
+Feature: Get permissions granted to group
+  Background:
+    Given the database has the following table 'groups':
+      | id | name        | type  |
+      | 8  | Club        | Club  |
+      | 9  | Class       | Class |
+      | 10 | Other       | Other |
+      | 21 | owner       | User  |
+      | 23 | user        | User  |
+      | 25 | some class  | Class |
+      | 26 | other class | Class |
+      | 27 | third class | Class |
+      | 31 | jane        | User  |
+    And the database has the following table 'users':
+      | login | group_id | first_name  | last_name | default_language |
+      | owner | 21       | Jean-Michel | Blanquer  | fr               |
+      | user  | 23       | John        | Doe       | en               |
+      | jane  | 31       | Jane        | Doe       | en               |
+    And the database has the following table 'group_managers':
+      | group_id | manager_id | can_grant_group_access |
+      | 25       | 8          | 1                      |
+      | 26       | 8          | 1                      |
+      | 10       | 21         | 0                      |
+      | 31       | 21         | 0                      |
+    And the database has the following table 'groups_groups':
+      | parent_group_id | child_group_id |
+      | 8               | 21             |
+      | 9               | 10             |
+      | 10              | 25             |
+      | 25              | 23             |
+      | 25              | 31             |
+      | 25              | 27             |
+      | 26              | 25             |
+    And the groups ancestors are computed
+    And the database has the following table 'items':
+      | id  | default_language_tag | requires_explicit_entry |
+      | 100 | fr                   | true                    |
+      | 101 | en                   | false                   |
+      | 102 | fr                   | true                    |
+      | 103 | fr                   | false                   |
+      | 104 | fr                   | false                   |
+    And the database has the following table 'items_strings':
+      | item_id  | language_tag | title      |
+      | 101      | en           | Chapter A  |
+      | 102      | en           | Chapter B  |
+      | 102      | fr           | Chapitre B |
+      | 104      | fr           | Chapitre C |
+    And the database table 'permissions_granted' has also the following rows:
+      | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
+      | 31       | 102     | 10              | group_membership | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | item_unlocking   | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | self             | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | other            | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 102     | 25              | group_membership | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 26              | group_membership | none     | enter          | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 104     | 26              | group_membership | none     | none           | result    | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 101     | 25              | group_membership | none     | none           | none      | children | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 25              | group_membership | none     | none           | none      | none     | true     | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 101     | 26              | group_membership | none     | none           | none      | none     | false    | true                      | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 26              | group_membership | none     | none           | none      | none     | false    | false                     | 2999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 9        | 101     | 25              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 23       | 102     | 23              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 23       | 102     | 25              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 25       | 101     | 10              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 25       | 103     | 25              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 31       | 101     | 27              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+    And the database table 'permissions_generated' has also the following rows:
+      | group_id | item_id | can_grant_view_generated | can_watch_generated | can_edit_generated |
+      | 8        | 101     | enter                    | none                | none               |
+      | 21       | 102     | none                     | answer_with_grant   | none               |
+      | 21       | 103     | none                     | answer              | all                |
+      | 21       | 104     | none                     | none                | all_with_grant     |
+
+  Scenario: can_grant_group_access=1 for the group
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/granted_permissions"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "2999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": true
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "info", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "104", "language_tag": "fr", "requires_explicit_entry": false, "title": "Chapitre C"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "result",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": true, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "enter", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "9", "name": "Class"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "3999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "children", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      }
+    ]
+    """
+
+  Scenario: can_grant_group_access=1 for a ancestor group
+    Given I am the user with id "21"
+    And the database table 'group_managers' has also the following rows:
+      | group_id | manager_id | can_grant_group_access |
+      | 9        | 8          | 1                      |
+    When I send a GET request to "/groups/25/granted_permissions"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "2999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": true
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "info", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "104", "language_tag": "fr", "requires_explicit_entry": false, "title": "Chapitre C"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "result",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "3999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "10", "name": "Other"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": true, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "enter", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "26", "name": "other class"}
+      },
+      {
+        "group": {"id": "9", "name": "Class"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "3999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "children", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      }
+    ]
+    """
+
+  Scenario: Get only the second row
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/granted_permissions?from.source_group.id=26&from.group.id=10&from.item.id=102&limit=1"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "10", "name": "Other"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
+          "is_owner": true
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      }
+    ]
+    """
+
+  Scenario: Get only the third row
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/granted_permissions?from.source_group.id=25&from.group.id=10&from.item.id=102&limit=1"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "25", "name": "some class"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "info", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      }
+    ]
+    """
+
+  Scenario: can_grant_group_access=1 for the group's ancestor, descendants=1
+    Given I am the user with id "21"
+    And the database table 'group_managers' has also the following rows:
+      | group_id | manager_id | can_grant_group_access |
+      | 9        | 8          | 1                      |
+    When I send a GET request to "/groups/25/granted_permissions?descendants=1"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "31", "name": "jane"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "info", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "10", "name": "Other"}
+      },
+      {
+        "group": {"id": "23", "name": "user"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "3999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "content", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      },
+      {
+        "group": {"id": "31", "name": "jane"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "content", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "27", "name": "third class"}
+      }
+    ]
+    """
+
+  Scenario: can_grant_group_access=1 for the group's ancestor, descendants=1, order by group.name, source_group.name, item.title
+    Given I am the user with id "21"
+    And the database table 'group_managers' has also the following rows:
+      | group_id | manager_id | can_grant_group_access |
+      | 9        | 8          | 1                      |
+    When I send a GET request to "/groups/25/granted_permissions?descendants=1&sort=group.name,source_group.name,item.title"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {"id": "31", "name": "jane"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "info", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "10", "name": "Other"}
+      },
+      {
+        "group": {"id": "31", "name": "jane"},
+        "item": {"id": "101", "language_tag": "en", "requires_explicit_entry": false, "title": "Chapter A"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "content", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "27", "name": "third class"}
+      },
+      {
+        "group": {"id": "23", "name": "user"},
+        "item": {"id": "102", "language_tag": "fr", "requires_explicit_entry": true, "title": "Chapitre B"},
+        "permissions": {
+          "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "3999-12-31T23:59:59Z",
+          "can_grant_view": "none", "can_make_session_official": false, "can_view": "content", "can_watch": "none",
+          "is_owner": false
+        },
+        "source_group": {"id": "25", "name": "some class"}
+      }
+    ]
+    """

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -1,0 +1,247 @@
+package groups
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/service"
+	"github.com/France-ioi/AlgoreaBackend/app/structures"
+)
+
+type grantedPermissionsViewResultRowGroup struct {
+	// required: true
+	ID int64 `json:"id,string"`
+	// required: true
+	Name string `json:"name"`
+}
+
+type grantedPermissionsViewResultPermissions struct {
+	structures.ItemPermissions
+	// required: true
+	CanMakeSessionOfficial bool `json:"can_make_session_official"`
+	// required: true
+	CanEnterFrom database.Time `json:"can_enter_from"`
+	// required: true
+	CanEnterUntil database.Time `json:"can_enter_until"`
+}
+
+// swagger:model grantedPermissionsViewResultRow
+type grantedPermissionsViewResultRow struct {
+	// required: true
+	SourceGroup grantedPermissionsViewResultRowGroup `json:"source_group" gorm:"embedded;embedded_prefix:source_group__"`
+	// required: true
+	Group grantedPermissionsViewResultRowGroup `json:"group" gorm:"embedded;embedded_prefix:group__"`
+	// required: true
+	Item struct {
+		// required: true
+		ID int64 `json:"id,string"`
+		// Nullable
+		// required: true
+		Title *string `json:"title"`
+		// required: true
+		LanguageTag string `json:"language_tag"`
+		// required: true
+		RequiresExplicitEntry bool `json:"requires_explicit_entry"`
+	} `json:"item" gorm:"embedded;embedded_prefix:item__"`
+	// required: true
+	Permissions grantedPermissionsViewResultPermissions `json:"permissions" gorm:"embedded;embedded_prefix:permissions__"`
+}
+
+// swagger:operation GET /groups/{group_id}/granted_permissions groups grantedPermissionsView
+// ---
+// summary: View granted permissions
+// description:
+//   List all permissions granted to a group and its ancestors or to its descendants.
+//   Only permissions granted on items for which the current user has
+//   `can_grant_view` > 'none' or `can_watch` = 'answer_with_grant' or `can_edit` = 'all_with_grant' are displayed.
+//
+//
+//   When `{descendants}` is 0, source groups of permissions are ancestors of the `group_id` group (including the group itself)
+//   managed by the current user with `can_grant_group_access` permission.
+//
+//   When `{descendants}` is 1, source groups of permissions are ancestors of the `group_id` group (including the group itself)
+//   or descendants of the `group_id` group managed by the current user with `can_grant_group_access` permission.
+//
+//   * The current user must be a manager (with `can_grant_group_access` permission) of `{group_id}`.
+// parameters:
+// - name: group_id
+//   in: path
+//   required: true
+//   type: integer
+// - name: descendants
+//   description: If equal to 1, the results are permissions granted to the group's descendants (not including the group itself),
+//                otherwise the results are permissions granted to the group's ancestors (including the group itself).
+//   in: query
+//   type: integer
+//   enum: [0,1]
+//   default: 0
+// - name: sort
+//   in: query
+//   default: [item.title,source_group.name,group.name]
+//   type: array
+//   items:
+//     type: string
+//     enum: [source_group.name,-source_group.name,group.name,-group.name,
+//            item.title,-item.title,source_group.id,-source_group.id,group.id,-group.id,item.id,-item.id]
+// - name: from.source_group.id
+//   description: Start the page from permissions next to the permissions with `source_group_id`=`{from.source_group.id}`
+//                (`{from.item.id}` and `{from.group.id}` should be given too when `{from.source_group.id}` is given)
+//   in: query
+//   type: integer
+// - name: from.group.id
+//   description: Start the page from permissions next to the permissions with `group_id`=`{from.group.id}`
+//                (`{from.item.id}` and `{from.source_group.id}` should be given too when `{from.group.id}` is given)
+//   in: query
+//   type: integer
+// - name: from.item.id
+//   description: Start the page from permissions next to the permissions with `item_id`=`{from.item.id}`
+//                (`{from.group.id}` and `{from.source_group.id}` should be given too when `{from.item.id}` is given)
+//   in: query
+//   type: integer
+// - name: limit
+//   description: Display the first N permissions
+//   in: query
+//   type: integer
+//   maximum: 1000
+//   default: 500
+// responses:
+//   "200":
+//     description: OK. Granted permissions
+//     schema:
+//       type: array
+//       items:
+//         "$ref": "#/definitions/grantedPermissionsViewResultRow"
+//   "400":
+//     "$ref": "#/responses/badRequestResponse"
+//   "401":
+//     "$ref": "#/responses/unauthorizedResponse"
+//   "403":
+//     "$ref": "#/responses/forbiddenResponse"
+//   "500":
+//     "$ref": "#/responses/internalErrorResponse"
+func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request) service.APIError {
+	groupID, err := service.ResolveURLQueryPathInt64Field(r, "group_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	var forDescendants bool
+	if len(r.URL.Query()["descendants"]) > 0 {
+		forDescendants, err = service.ResolveURLQueryGetBoolField(r, "descendants")
+		if err != nil {
+			return service.ErrInvalidRequest(err)
+		}
+	}
+
+	user := srv.GetUser(r)
+
+	found, err := srv.Store.Groups().ManagedBy(user).Where("groups.id = ?", groupID).
+		Where("groups.type != 'User'").Where("can_grant_group_access").HasRows()
+	service.MustNotBeError(err)
+	if !found {
+		return service.InsufficientAccessRightsError
+	}
+
+	itemsQuery := srv.Store.Permissions().MatchingUserAncestors(user).
+		WherePermissionIsAtLeast("grant_view", "enter").
+		Or("can_watch_generated = 'answer_with_grant'").
+		Or("can_edit_generated = 'all_with_grant'").
+		Select("DISTINCT item_id AS id")
+
+	managedGroupsQuery := srv.Store.ActiveGroupAncestors().ManagedByUser(user).
+		Group("groups_ancestors_active.child_group_id").
+		Having("MAX(can_grant_group_access)").
+		Select("groups_ancestors_active.child_group_id AS id")
+
+	var sourceGroupsQuery, groupsQuery *database.DB
+	if forDescendants {
+		ancestorsAndDescendantsQuery := srv.Store.ActiveGroupAncestors().
+			Select("ancestor_group_id AS id").
+			Where("child_group_id = ?", groupID).
+			Union(
+				srv.Store.ActiveGroupAncestors().
+					Select("child_group_id AS id").
+					Where("ancestor_group_id = ?", groupID).SubQuery())
+
+		sourceGroupsQuery = srv.Store.Groups().
+			Where("groups.type != 'User'").
+			Where("id IN ?", managedGroupsQuery.SubQuery()).
+			Where("id IN ?", ancestorsAndDescendantsQuery.SubQuery()).
+			Select("groups.id, groups.name")
+
+		groupsQuery = srv.Store.Groups().
+			Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups.id").
+			Where("ancestor_group_id = ?", groupID).
+			Where("NOT is_self").
+			Select("groups.id, groups.name")
+	} else {
+		sourceGroupsQuery = srv.Store.ActiveGroupAncestors().
+			Where("child_group_id = ?", groupID).
+			Where("ancestor_group_id IN ?", managedGroupsQuery.SubQuery()).
+			Joins("JOIN `groups` ON groups.id = ancestor_group_id").
+			Where("groups.type != 'User'").
+			Select("groups.id, groups.name")
+
+		groupsQuery = srv.Store.Groups().
+			Joins("JOIN groups_ancestors_active ON groups_ancestors_active.ancestor_group_id = groups.id").
+			Where("child_group_id = ?", groupID).
+			Select("groups.id, groups.name")
+	}
+
+	var permissions []grantedPermissionsViewResultRow
+	query := srv.Store.PermissionsGranted().
+		Joins("JOIN ? AS source_group ON source_group.id = source_group_id", sourceGroupsQuery.SubQuery()).
+		Joins("JOIN ? AS target_group ON target_group.id = group_id", groupsQuery.SubQuery()).
+		Joins("JOIN items ON items.id = item_id").
+		Where("items.id IN (?)", itemsQuery.SubQuery()).
+		Where("origin = 'group_membership'").
+		JoinsUserAndDefaultItemStrings(user).
+		Where(`
+			can_view != 'none' OR can_grant_view != 'none' OR can_watch != 'none' OR can_edit != 'none' OR
+			can_make_session_official OR is_owner OR
+			can_enter_from != '9999-12-31 23:59:59' OR can_enter_until != '9999-12-31 23:59:59'`).
+		Select(`
+			target_group.id AS group__id, target_group.name AS group__name,
+			source_group.id AS source_group__id, source_group.name AS source_group__name,
+			items.id AS item__id,
+			IF(user_strings.language_tag IS NULL, default_strings.title, user_strings.title) AS item__title,
+			COALESCE(user_strings.language_tag, default_strings.language_tag) AS item__language_tag,
+			items.requires_explicit_entry AS item__requires_explicit_entry,
+			can_view AS permissions__can_view, can_grant_view AS permissions__can_grant_view,
+			can_watch AS permissions__can_watch, can_edit AS permissions__can_edit,
+			can_make_session_official AS permissions__can_make_session_official,
+			is_owner AS permissions__is_owner, can_enter_from AS permissions__can_enter_from,
+			can_enter_until AS permissions__can_enter_until`)
+
+	query = service.NewQueryLimiter().Apply(r, query)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"source_group.name": {ColumnName: "source_group.name"},
+				"group.name":        {ColumnName: "target_group.name"},
+				"item.title": {
+					ColumnName: "IF(user_strings.language_tag IS NULL, default_strings.title, user_strings.title)",
+					Nullable:   true,
+				},
+				"source_group.id": {ColumnName: "permissions_granted.source_group_id"},
+				"group.id":        {ColumnName: "permissions_granted.group_id"},
+				"item.id":         {ColumnName: "permissions_granted.item_id"},
+			},
+			DefaultRules: "item.title,source_group.name,group.name",
+			TieBreakers: service.SortingAndPagingTieBreakers{
+				"source_group.id": service.FieldTypeInt64,
+				"group.id":        service.FieldTypeInt64,
+				"item.id":         service.FieldTypeInt64,
+			},
+		})
+	if apiError != service.NoError {
+		return apiError
+	}
+
+	service.MustNotBeError(query.Scan(&permissions).Error())
+	render.Respond(w, r, permissions)
+	return service.NoError
+}

--- a/app/api/groups/get_granted_permissions.robustness.feature
+++ b/app/api/groups/get_granted_permissions.robustness.feature
@@ -1,0 +1,64 @@
+Feature: Get permissions granted to group - robustness
+  Background:
+    Given the database has the following table 'groups':
+      | id | name          | type  |
+      | 21 | owner         | User  |
+      | 23 | user          | User  |
+      | 25 | some class    | Class |
+      | 26 | another class | Class |
+      | 27 | third class   | Class |
+      | 31 | admin         | User  |
+    And the database has the following table 'users':
+      | login | group_id | first_name  | last_name |
+      | owner | 21       | Jean-Michel | Blanquer  |
+      | user  | 23       | John        | Doe       |
+      | admin | 31       | Allie       | Grater    |
+    And the database has the following table 'group_managers':
+      | group_id | manager_id | can_grant_group_access |
+      | 23       | 21         | 1                      |
+      | 25       | 21         | 0                      |
+      | 25       | 31         | 1                      |
+      | 26       | 21         | 1                      |
+      | 26       | 31         | 1                      |
+    And the database has the following table 'groups_groups':
+      | parent_group_id | child_group_id |
+      | 25              | 23             |
+      | 25              | 31             |
+      | 26              | 23             |
+    And the groups ancestors are computed
+
+  Scenario: Invalid group_id
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/111111111111111111111111111111111/granted_permissions"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for group_id (should be int64)"
+
+  Scenario: Invalid descendants
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/granted_permissions?descendants=abc"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for descendants (should have a boolean value (0 or 1))"
+
+  Scenario: The user is not a manager of the group_id
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/27/granted_permissions"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: The user is a manager of the group_id, but he doesn't have 'can_grant_group_access' permission on its ancestors
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/granted_permissions"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: The user is a manager of the group_id with 'can_grant_group_access' permission, but the group_id group is a user
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/23/granted_permissions"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: sort is incorrect
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/26/granted_permissions?sort=name"
+    Then the response code should be 400
+    And the response error message should contain "Unallowed field in sorting parameters: "name""

--- a/app/api/groups/get_group_progress.feature
+++ b/app/api/groups/get_group_progress.feature
@@ -767,7 +767,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
     Given I am the user with id "21"
     # here we fixate avg_time_spent even if it depends on NOW()
     And the DB time now is "2019-05-30 20:19:05"
-    When I send a GET request to "/groups/1/group-progress?parent_item_ids=210,220,310&from.name=A%20custom%20group&from.id=17"
+    When I send a GET request to "/groups/1/group-progress?parent_item_ids=210,220,310&from.id=17"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_managers.feature
+++ b/app/api/groups/get_managers.feature
@@ -142,6 +142,20 @@ Feature: Get managers of group_id
     ]
     """
 
+  Scenario: Request the second row
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/13/managers?from.id=51&limit=1"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "91", "name": "lp", "login": "lp", "first_name": null, "last_name": null,
+        "can_manage": "none", "can_grant_group_access": true, "can_watch_members": false
+      }
+    ]
+    """
+
   Scenario: Default sort (by name) including managers of ancestor groups
     Given I am the user with id "21"
     When I send a GET request to "/groups/13/managers?include_managers_of_ancestor_groups=1"

--- a/app/api/groups/get_managers.go
+++ b/app/api/groups/get_managers.go
@@ -85,14 +85,8 @@ type groupManagersViewResponseRow struct {
 //   items:
 //     type: string
 //     enum: [name,-name,id,-id]
-// - name: from.name
-//   description: Start the page from the manager next to the manager with `groups.name` = `from.name`
-//                and `groups.id`=`from.id` (`from.id` is required when `from.name` is present)
-//   in: query
-//   type: string
 // - name: from.id
-//   description: Start the page from the manager next to the manager with `groups.id`=`from.id`
-//                (depending on `sort`, `from.name` may be required when `from.id` is present)
+//   description: Start the page from the manager next to the manager with `groups.id`=`{from.id}`
 //   in: query
 //   type: integer
 // - name: limit
@@ -164,11 +158,16 @@ func (srv *Service) getManagers(w http.ResponseWriter, r *http.Request) service.
 	}
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"name": {ColumnName: "groups.name"},
-			"id":   {ColumnName: "groups.id", FieldType: "int64"}},
-		"name,id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"name": {ColumnName: "groups.name"},
+				"id":   {ColumnName: "groups.id"},
+			},
+			DefaultRules: "name,id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 
 	if apiError != service.NoError {
 		return apiError

--- a/app/api/groups/get_members.feature
+++ b/app/api/groups/get_members.feature
@@ -248,6 +248,28 @@ Feature: Get members of group_id
     ]
     """
 
+  Scenario: User is a manager of the group; request the second row
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/13/members?limit=1&from.id=51"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "61",
+        "user": {
+          "first_name": "Mark",
+          "group_id": "61",
+          "last_name": "Zuckerberg",
+          "login": "zuck",
+          "grade": 9
+        },
+        "member_since": "2017-06-29T06:38:38Z",
+        "action": "join_request_accepted"
+      }
+    ]
+    """
+
   Scenario: The member is not a user
     Given I am the user with id "21"
     When I send a GET request to "/groups/22/members?limit=1"

--- a/app/api/groups/get_permissions.feature
+++ b/app/api/groups/get_permissions.feature
@@ -859,3 +859,16 @@ Feature: Get permissions for a group
         }
       }
     """
+
+  Scenario Outline: Access rights for the current user
+    Given I am the user with id "21"
+    And the database table 'permissions_generated' has also the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated   | can_watch_generated   | can_edit_generated   | is_owner_generated |
+      | 21       | 102     | none               | <can_grant_view_generated> | <can_watch_generated> | <can_edit_generated> | false              |
+    When I send a GET request to "/groups/25/permissions/23/102"
+    Then the response code should be 200
+  Examples:
+    | can_grant_view_generated | can_watch_generated | can_edit_generated |
+    | enter                    | none                | none               |
+    | none                     | answer_with_grant   | none               |
+    | none                     | none                | all_with_grant     |

--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -73,9 +73,10 @@ type permissionsViewResponse struct {
 // description: Lets a manager of a group view permissions on an item for the group.
 //
 //   * The current user must be a manager (with `can_grant_group_access` permission)
-//     of `{source_group_id}` which should be a parent of the `{group_id}`.
+//     of `{source_group_id}` which should be an ancestor of the `{group_id}`.
 //
-//   * The current user must have `permissions_generated.can_grant_view` > 'none' on `{item_id}`.
+//   * The current user must have `can_grant_view` > 'none' or
+//     `can_watch` = 'answer_with_grant' or `can_edit` = 'all_with_grant' on `{item_id}` on the item.
 // parameters:
 // - name: group_id
 //   in: path
@@ -120,12 +121,15 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 
 	user := srv.GetUser(r)
 
-	apiErr := checkIfUserIsManagerAllowedToGrantPermissions(srv.Store, user, sourceGroupID, groupID)
+	apiErr := checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(srv.Store, user, sourceGroupID, groupID)
 	if apiErr != service.NoError {
 		return apiErr
 	}
 
-	found, err := srv.Store.Permissions().MatchingUserAncestors(user).WherePermissionIsAtLeast("grant_view", enter).
+	found, err := srv.Store.Permissions().MatchingUserAncestors(user).
+		WherePermissionIsAtLeast("grant_view", enter).
+		Or("can_watch_generated = 'answer_with_grant'").
+		Or("can_edit_generated = 'all_with_grant'").
 		Where("item_id = ?", itemID).HasRows()
 	service.MustNotBeError(err)
 	if !found {

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -290,7 +290,8 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by joining user's login, start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.joining_user.login=jane&from.member_id=31"
+    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[3][at]"))}}"
+    When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.member_id=31&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -335,7 +336,8 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by action, start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/13/requests?sort=action&from.action=invitation_created&from.member_id=21"
+    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[1][at]"))}}"
+    When I send a GET request to "/groups/13/requests?sort=action&from.at={{from_at}}&from.member_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_team_descendants.feature
+++ b/app/api/groups/get_team_descendants.feature
@@ -183,7 +183,7 @@ Feature: List team descendants of the group (groupTeamDescendantView)
 
   Scenario: Get teams skipping the first one
     Given I am the user with id "21"
-    When I send a GET request to "/groups/1/team-descendants?from.name=First%20Team&from.id=16"
+    When I send a GET request to "/groups/1/team-descendants?from.id=16"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_team_descendants.go
+++ b/app/api/groups/get_team_descendants.go
@@ -25,14 +25,8 @@ import (
 //   in: path
 //   required: true
 //   type: integer
-// - name: from.name
-//   description: Start the page from the team next to the team with `name` = `from.name` and `id` = `from.id`
-//                (`from.id` is required when `from.name` is present)
-//   in: query
-//   type: string
 // - name: from.id
-//   description: Start the page from the team next to the team with `name`=`from.name` and `id`=`from.id`
-//                (`from.name` is required when from.id is present)
+//   description: Start the page from the team next to the team with `id`=`{from.id}`
 //   in: query
 //   type: integer
 // - name: sort
@@ -83,11 +77,16 @@ func (srv *Service) getTeamDescendants(w http.ResponseWriter, r *http.Request) s
 				groups_ancestors_active.ancestor_group_id = ?`, groupID).
 		Where("groups.type = 'Team'")
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"name": {ColumnName: "groups.name", FieldType: "string"},
-			"id":   {ColumnName: "groups.id", FieldType: "int64"}},
-		"name,id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"name": {ColumnName: "groups.name"},
+				"id":   {ColumnName: "groups.id"},
+			},
+			DefaultRules: "name,id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/get_team_progress.feature
+++ b/app/api/groups/get_team_progress.feature
@@ -791,7 +791,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
     Given I am the user with id "21"
     # here we fixate time_spent even if it depends on NOW()
     And the DB time now is "2019-06-30 20:19:05"
-    When I send a GET request to "/groups/1/team-progress?parent_item_ids=210,220,310&from.name=First%20Team&from.id=16"
+    When I send a GET request to "/groups/1/team-progress?parent_item_ids=210,220,310&from.id=16"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_user_batch_prefixes.go
+++ b/app/api/groups/get_user_batch_prefixes.go
@@ -46,7 +46,7 @@ type userBatchPrefix struct {
 //     type: string
 //     enum: [group_prefix,-group_prefix]
 // - name: from.group_prefix
-//   description: Start the page from the prefix next to the prefix with `user_batch_prefixes.group_prefix` = `from.group_prefix`
+//   description: Start the page from the prefix next to the prefix with `user_batch_prefixes.group_prefix` = `{from.group_prefix}`
 //   in: query
 //   type: string
 // - name: limit
@@ -98,9 +98,15 @@ func (srv *Service) getUserBatchPrefixes(w http.ResponseWriter, r *http.Request)
 			(SELECT COUNT(*) FROM user_batches
 			 WHERE user_batches.group_prefix = user_batch_prefixes.group_prefix) AS total_size`)
 
-	query, apiErr := service.ApplySortingAndPaging(r, query, map[string]*service.FieldSortingParams{
-		"group_prefix": {ColumnName: "group_prefix", FieldType: "string", Unique: true},
-	}, "group_prefix", []string{"group_prefix"}, false)
+	query, apiErr := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"group_prefix": {ColumnName: "group_prefix"},
+			},
+			DefaultRules: "group_prefix",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"group_prefix": service.FieldTypeString},
+		})
 	if apiErr != service.NoError {
 		return apiErr
 	}

--- a/app/api/groups/get_user_batches.feature
+++ b/app/api/groups/get_user_batches.feature
@@ -93,26 +93,26 @@ Feature: List user batches (userBatchesView)
     [
       {"creator_id": null, "custom_prefix": "custom", "group_prefix": "test", "size": 100},
       {"creator_id": "13", "custom_prefix": "custom1", "group_prefix": "test", "size": 200},
-      {"creator_id": "21", "custom_prefix": "cust", "group_prefix": "test1", "size": 300},
       {"creator_id": "21", "custom_prefix": "cus", "group_prefix": "test2", "size": 300},
-      {"creator_id": null, "custom_prefix": "cust1", "group_prefix": "test1", "size": 400},
+      {"creator_id": "21", "custom_prefix": "cust", "group_prefix": "test1", "size": 300},
       {"creator_id": null, "custom_prefix": "cus1", "group_prefix": "test2", "size": 400},
+      {"creator_id": null, "custom_prefix": "cust1", "group_prefix": "test1", "size": 400},
       {"creator_id": null, "custom_prefix": "pref", "group_prefix": "test3", "size": 500}
     ]
     """
 
   Scenario: List user batches (sorted by size, start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/user-batches/by-group/21?sort=size&from.size=200&from.group_prefix=test&from.custom_prefix=custom"
+    When I send a GET request to "/user-batches/by-group/21?sort=size&from.group_prefix=test&from.custom_prefix=custom"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {"creator_id": "13", "custom_prefix": "custom1", "group_prefix": "test", "size": 200},
-      {"creator_id": "21", "custom_prefix": "cust", "group_prefix": "test1", "size": 300},
       {"creator_id": "21", "custom_prefix": "cus", "group_prefix": "test2", "size": 300},
-      {"creator_id": null, "custom_prefix": "cust1", "group_prefix": "test1", "size": 400},
+      {"creator_id": "21", "custom_prefix": "cust", "group_prefix": "test1", "size": 300},
       {"creator_id": null, "custom_prefix": "cus1", "group_prefix": "test2", "size": 400},
+      {"creator_id": null, "custom_prefix": "cust1", "group_prefix": "test1", "size": 400},
       {"creator_id": null, "custom_prefix": "pref", "group_prefix": "test3", "size": 500}
     ]
     """

--- a/app/api/groups/get_user_batches.robustness.feature
+++ b/app/api/groups/get_user_batches.robustness.feature
@@ -31,6 +31,6 @@ Feature: List user batches (userBatchesView) - robustness
 
   Scenario: A tie-breaker field is missing
     Given I am the user with id "21"
-    When I send a GET request to "/user-batches/by-group/13?sort=size&from.size=200"
+    When I send a GET request to "/user-batches/by-group/13?sort=size&from.group_prefix=abc"
     Then the response code should be 400
-    And the response error message should contain "All 'from' parameters (from.size, from.group_prefix, from.custom_prefix) or none of them must be present"
+    And the response error message should contain "All 'from' parameters (from.custom_prefix, from.group_prefix) or none of them must be present"

--- a/app/api/groups/get_user_descendants.feature
+++ b/app/api/groups/get_user_descendants.feature
@@ -110,7 +110,7 @@ Feature: List user descendants of the group (groupUserDescendantView)
       }
     ]
     """
-    When I send a GET request to "/groups/1/user-descendants?from.name=johna&from.id=51"
+    When I send a GET request to "/groups/1/user-descendants?from.id=51"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_user_progress.feature
+++ b/app/api/groups/get_user_progress.feature
@@ -238,7 +238,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
     Given I am the user with id "21"
     # here we fixate time_spent even if it depends on NOW()
     And the DB time now is "2019-06-30 20:19:05"
-    When I send a GET request to "/groups/1/user-progress?parent_item_ids=210&from.name=janec&from.id=65&limit=2"
+    When I send a GET request to "/groups/1/user-progress?parent_item_ids=210&from.id=65&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -328,7 +328,7 @@ Feature: Get pending requests for managed groups
 
   Scenario: group_id is given, include descendant groups (sort by group name desc & login, start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/user-requests?group_id=1&include_descendant_groups=1&sort=-group.name,user.login&from.group.name=Friends&from.user.login=owner&from.group.id=14&from.user.group_id=21"
+    When I send a GET request to "/groups/user-requests?group_id=1&include_descendant_groups=1&sort=-group.name,user.login&from.group.id=14&from.user.group_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -423,7 +423,7 @@ Feature: Get pending requests for managed groups
 
   Scenario: group_id is not given (sort by group name desc & login, start from the second row)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/user-requests?sort=-group.name,user.login&from.group.name=Friends&from.user.login=owner&from.group.id=14&from.user.group_id=21"
+    When I send a GET request to "/groups/user-requests?sort=-group.name,user.login&from.group.id=14&from.user.group_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -29,6 +29,8 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Delete("/groups/{group_id}", service.AppHandler(srv.deleteGroup).ServeHTTP)
 	router.Get("/groups/{source_group_id}/permissions/{group_id}/{item_id}",
 		service.AppHandler(srv.getPermissions).ServeHTTP)
+	router.Get("/groups/{group_id}/granted_permissions",
+		service.AppHandler(srv.getGrantedPermissions).ServeHTTP)
 	router.Put("/groups/{source_group_id}/permissions/{group_id}/{item_id}",
 		service.AppHandler(srv.updatePermissions).ServeHTTP)
 

--- a/app/api/groups/search_for_possible_subgroups.feature
+++ b/app/api/groups/search_for_possible_subgroups.feature
@@ -96,6 +96,22 @@ Feature: Search for possible subgroups
     ]
     """
 
+  Scenario: Search for groups with "the", get the third row
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/possible-subgroups?search=the&limit=1&from.id=2"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "4",
+        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "description": "Group for our friends",
+        "type": "Friends"
+      }
+    ]
+    """
+
   Scenario: Search for groups with percent signs ("%%%")
     Given I am the user with id "21"
     When I send a GET request to "/groups/possible-subgroups?search=%25%25%25"

--- a/app/api/groups/search_for_possible_subgroups.go
+++ b/app/api/groups/search_for_possible_subgroups.go
@@ -35,7 +35,7 @@ const minSearchStringLength = 3
 //     type: string
 //     enum: [id,-id]
 // - name: from.id
-//   description: Start the page from the group next to one with `groups.id`=`from.id`
+//   description: Start the page from the group next to one with `groups.id`=`{from.id}`
 //   in: query
 //   type: integer
 // - name: limit
@@ -102,10 +102,13 @@ func (srv *Service) searchForPossibleSubgroups(w http.ResponseWriter, r *http.Re
 		Where("groups.name LIKE CONCAT('%', ?, '%') ESCAPE '|'", escapedSearchString)
 
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError := service.ApplySortingAndPaging(r, query,
-		map[string]*service.FieldSortingParams{
-			"id": {ColumnName: "groups.id", FieldType: "int64"}},
-		"id", []string{"id"}, false)
+	query, apiError := service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields:       service.SortingAndPagingFields{"id": {ColumnName: "groups.id"}},
+			DefaultRules: "id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/groups/update_permissions.robustness.feature
+++ b/app/api/groups/update_permissions.robustness.feature
@@ -6,6 +6,7 @@ Feature: Change item access rights for a group - robustness
       | 23 | user          | User  |
       | 25 | some class    | Class |
       | 26 | another class | Class |
+      | 27 | third class   | Class |
       | 31 | admin         | User  |
     And the database has the following table 'users':
       | login | group_id | first_name  | last_name |
@@ -190,7 +191,7 @@ Feature: Change item access rights for a group - robustness
 
   Scenario: The user is not a manager of the source_group_id
     Given I am the user with id "21"
-    When I send a PUT request to "/groups/21/permissions/21/102" with the following body:
+    When I send a PUT request to "/groups/27/permissions/27/102" with the following body:
     """
     {
       "can_view": "solution"
@@ -214,9 +215,22 @@ Feature: Change item access rights for a group - robustness
     And the table "permissions_granted" should stay unchanged
     And the table "permissions_generated" should stay unchanged
 
-  Scenario: source_group_id is not a parent of group_id
-    Given I am the user with id "21"
-    When I send a PUT request to "/groups/25/permissions/21/102" with the following body:
+  Scenario: source_group_id is not an ancestor of group_id
+    Given I am the user with id "31"
+    When I send a PUT request to "/groups/25/permissions/26/102" with the following body:
+    """
+    {
+      "can_view": "solution"
+    }
+    """
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    And the table "permissions_granted" should stay unchanged
+    And the table "permissions_generated" should stay unchanged
+
+  Scenario: source_group_id is a user group
+    Given I am the user with id "31"
+    When I send a PUT request to "/groups/31/permissions/31/102" with the following body:
     """
     {
       "can_view": "solution"

--- a/app/api/items/get_activity_log.feature
+++ b/app/api/items/get_activity_log.feature
@@ -321,7 +321,7 @@ Feature: Get activity log
   Scenario Outline: User is a manager of the group and there are visible descendants of the item; request the second and the third rows
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
-    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_validated&from.at=2017-05-30T12:00:00Z&from.participant_id=11&from.attempt_id=1&from.item_id=200&from.answer_id=-1&limit=2"
+    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_validated&from.participant_id=11&from.attempt_id=1&from.item_id=200&from.answer_id=-1&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -356,7 +356,7 @@ Feature: Get activity log
   Scenario Outline: User is a manager of the group and there are visible descendants of the item; request the sixth and the seventh rows
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
-    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=submission&from.at=2017-05-29T06:38:38Z&from.participant_id=11&from.attempt_id=1&from.item_id=200&from.answer_id=16&limit=2"
+    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=submission&from.participant_id=11&from.attempt_id=1&from.item_id=200&from.answer_id=16&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -390,7 +390,7 @@ Feature: Get activity log
   Scenario Outline: User is a manager of the group and there are visible descendants of the item; request the eleventh row
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
-    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_started&from.at=2017-05-29T06:38:38Z&from.participant_id=11&from.attempt_id=0&from.item_id=200&from.answer_id=17&limit=1"
+    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_started&from.participant_id=11&from.attempt_id=0&from.item_id=200&from.answer_id=17&limit=1"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -414,7 +414,7 @@ Feature: Get activity log
   Scenario Outline: User is a manager of the group and there are visible descendants of the item; request the last rows
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
-    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_started&from.at=2017-05-29T06:38:00Z&from.participant_id=11&from.attempt_id=0&from.item_id=201&from.answer_id=7"
+    When I send a GET request to "/items/200/log?watched_group_id=13&from.activity_type=result_started&from.participant_id=11&from.attempt_id=0&from.item_id=201&from.answer_id=7"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -819,7 +819,7 @@ Feature: Get activity log
   Scenario Outline: Get activity of the current user for all visible items (start from the second row)
     Given I am the user with id "31"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
-    When I send a GET request to "/items/log?from.activity_type=result_validated&from.at=2017-05-30T12:00:00Z&from.participant_id=31&from.attempt_id=1&from.item_id=200&from.answer_id=-1"
+    When I send a GET request to "/items/log?from.activity_type=result_validated&from.participant_id=31&from.attempt_id=1&from.item_id=200&from.answer_id=-1"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -3,6 +3,7 @@ package items
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/go-chi/render"
@@ -64,7 +65,7 @@ type itemActivityLogResponseRow struct {
 	} `json:"item" gorm:"embedded;embedded_prefix:item__"`
 }
 
-// swagger:operation GET /items/{item_id}/log items itemActivityLogForItem
+// swagger:operation GET /items/{ancestor_item_id}/log items itemActivityLogForItem
 // ---
 // summary: Activity log on an item
 // description: >
@@ -82,14 +83,15 @@ type itemActivityLogResponseRow struct {
 //
 //
 //   If `{watched_group_id}` is given, all rows of the result are related to descendant groups of `{watched_group_id}`
-//   and items that are descendants of `{item_id}` (+ `{item_id}` itself) and visible to the current user
+//   and items that are descendants of `{ancestor_item_id}` (+ `{ancestor_item_id}` itself) and visible to the current user
 //   (at least 'info' access with `can_watch` >= 'result').
 //
 //
 //   If `{watched_group_id}` is not given, all rows of the result are related to the participant group (the current user or `{as_team_id}`)
-//   and items that are descendants of `{item_id}` (+ `{item_id}` itself) and visible to the current user (at least 'info' access).
+//   and items that are descendants of `{ancestor_item_id}` (+ `{ancestor_item_id}` itself) and
+//   visible to the current user (at least 'info' access).
 // parameters:
-// - name: item_id
+// - name: ancestor_item_id
 //   in: path
 //   type: integer
 //   required: true
@@ -101,34 +103,29 @@ type itemActivityLogResponseRow struct {
 //                otherwise the 'forbidden' error is returned
 //   in: query
 //   type: integer
-// - name: from.at
-//   description: Start the page from the row next to the row with `at` = `{from.at}`
-//                (all other `from.*` parameters are required when `from.at` is present)
-//   in: query
-//   type: string
 // - name: from.item_id
 //   description: Start the page from the row next to the row with `item_id`=`{from.item_id}`
-//                (all other `from.*` parameters are required when `from.item_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.item_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.participant_id
 //   description: Start the page from the row next to the row with `participant_id`=`{from.participant_id}`
-//                (all other `from.*` parameters are required when `from.participant_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.participant_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.attempt_id
 //   description: Start the page from the row next to the row with `attempt_id`=`{from.attempt_id}`
-//                (all other `from.*` parameters are required when `from.attempt_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.attempt_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.answer_id
 //   description: Start the page from the row next to the row with `from_answer_id`=`{from.answer_id}`
-//                (all other `from.*` parameters are required when `from.answer_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.answer_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.activity_type
 //   description: Start the page from the row next to the row with `activity_type`=`{from.activity_type}`
-//                (all other `from.*` parameters are required when `from.activity_type` is present)
+//                (all other `{from.*}` parameters are required when `{from.activity_type}` is present)
 //   in: query
 //   type: string
 //   enum: [result_started,submission,result_validated]
@@ -154,7 +151,7 @@ type itemActivityLogResponseRow struct {
 //   "500":
 //     "$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getActivityLogForItem(w http.ResponseWriter, r *http.Request) service.APIError {
-	itemID, err := service.ResolveURLQueryPathInt64Field(r, "item_id")
+	itemID, err := service.ResolveURLQueryPathInt64Field(r, "ancestor_item_id")
 	if err != nil {
 		return service.ErrInvalidRequest(err)
 	}
@@ -194,34 +191,29 @@ func (srv *Service) getActivityLogForItem(w http.ResponseWriter, r *http.Request
 //                otherwise the 'forbidden' error is returned
 //   in: query
 //   type: integer
-// - name: from.at
-//   description: Start the page from the row next to the row with `at` = `{from.at}`
-//                (all other `from.*` parameters are required when `from.at` is present)
-//   in: query
-//   type: string
 // - name: from.item_id
 //   description: Start the page from the row next to the row with `item_id`=`{from.item_id}`
-//                (all other `from.*` parameters are required when `from.item_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.item_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.participant_id
 //   description: Start the page from the row next to the row with `participant_id`=`{from.participant_id}`
-//                (all other `from.*` parameters are required when `from.participant_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.participant_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.attempt_id
 //   description: Start the page from the row next to the row with `attempt_id`=`{from.attempt_id}`
-//                (all other `from.*` parameters are required when `from.attempt_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.attempt_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.answer_id
 //   description: Start the page from the row next to the row with `from_answer_id`=`{from.answer_id}`
-//                (all other `from.*` parameters are required when `from.answer_id` is present)
+//                (all other `{from.*}` parameters are required when `{from.answer_id}` is present)
 //   in: query
 //   type: integer
 // - name: from.activity_type
 //   description: Start the page from the row next to the row with `activity_type`=`{from.activity_type}`
-//                (all other `from.*` parameters are required when `from.activity_type` is present)
+//                (all other `{from.*}` parameters are required when `{from.activity_type}` is present)
 //   in: query
 //   type: string
 //   enum: [result_started,submission,result_validated]
@@ -267,7 +259,19 @@ func (srv *Service) getActivityLog(w http.ResponseWriter, r *http.Request, itemI
 		r.URL.RawQuery = urlParams.Encode()
 	}
 
-	query, apiError := srv.constructActivityLogQuery(r, itemID, user)
+	fromValues, err := service.ParsePagingParameters(
+		r, service.SortingAndPagingTieBreakers{
+			"activity_type":  service.FieldTypeInt64,
+			"participant_id": service.FieldTypeInt64,
+			"attempt_id":     service.FieldTypeInt64,
+			"item_id":        service.FieldTypeInt64,
+			"answer_id":      service.FieldTypeInt64,
+		})
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	query, apiError := srv.constructActivityLogQuery(r, itemID, user, fromValues)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -299,7 +303,8 @@ func (srv *Service) getActivityLog(w http.ResponseWriter, r *http.Request, itemI
 	return service.NoError
 }
 
-func (srv *Service) constructActivityLogQuery(r *http.Request, itemID *int64, user *database.User) (*database.DB, service.APIError) {
+func (srv *Service) constructActivityLogQuery(
+	r *http.Request, itemID *int64, user *database.User, fromValues map[string]interface{}) (*database.DB, service.APIError) {
 	participantID := service.ParticipantIDFromContext(r.Context())
 	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
@@ -368,104 +373,117 @@ func (srv *Service) constructActivityLogQuery(r *http.Request, itemID *int64, us
 	}
 	answersQuery = answersQuery.Select(answersQuerySelect)
 
-	answersQuery = service.NewQueryLimiter().Apply(r, answersQuery)
-	answersQuery, apiError = service.ApplySortingAndPaging(r, answersQuery,
-		map[string]*service.FieldSortingParams{
-			"at":             {ColumnName: "answers.created_at", FieldType: "time"},
-			"item_id":        {ColumnName: "answers.item_id", FieldType: "int64"},
-			"participant_id": {ColumnName: "answers.participant_id", FieldType: "int64"},
-			"attempt_id":     {ColumnName: "answers.attempt_id", FieldType: "int64"},
-			"answer_id":      {ColumnName: "answers.id", FieldType: "int64"},
-			"activity_type":  {FieldType: "int64", Ignore: true},
-		},
-		"-at,item_id,participant_id,-attempt_id,-activity_type,answer_id", []string{"answer_id"}, true)
-	if apiError != service.NoError {
-		return nil, apiError
-	}
-
-	answersQuery = srv.Store.Raw("SELECT limited_answers.*, gradings.score FROM ? AS limited_answers", answersQuery.SubQuery()).
-		Joins("LEFT JOIN gradings ON gradings.answer_id = limited_answers.answer_id")
-
 	startedResultsQuery := srv.Store.Table("results AS started_results").
 		Select(`
 			STRAIGHT_JOIN /* tell the optimizer we don't want to convert IN(...) into JOIN */
 			'result_started' AS activity_type,
 			started_at AS at,
 			-1 AS answer_id,
-			attempt_id, participant_id, item_id, participant_id AS user_id,
+			started_results.attempt_id, started_results.participant_id, started_results.item_id, started_results.participant_id AS user_id,
 			NULL AS score`).
-		Where("item_id <= (SELECT MAX(id) FROM items_to_show)").
-		Where("item_id >= (SELECT MIN(id) FROM items_to_show)").
-		Where("item_id IN (SELECT id FROM items_to_show)").
-		Where("started_at <= NOW()").
-		Where("participant_id <= (SELECT MAX(id) FROM participants)").
-		Where("participant_id >= (SELECT MIN(id) FROM participants)").
-		Where("participant_id IN (SELECT id FROM participants)")
+		Where("started_results.item_id <= (SELECT MAX(id) FROM items_to_show)").
+		Where("started_results.item_id >= (SELECT MIN(id) FROM items_to_show)").
+		Where("started_results.item_id IN (SELECT id FROM items_to_show)").
+		Where("started_results.started_at <= NOW()").
+		Where("started_results.participant_id <= (SELECT MAX(id) FROM participants)").
+		Where("started_results.participant_id >= (SELECT MIN(id) FROM participants)").
+		Where("started_results.participant_id IN (SELECT id FROM participants)")
 
-	startedResultsQuery = service.NewQueryLimiter().Apply(r, startedResultsQuery)
-	startedResultsQuery, _ = service.ApplySortingAndPaging(r, startedResultsQuery,
-		map[string]*service.FieldSortingParams{
-			"at":             {ColumnName: "started_at", FieldType: "time"},
-			"item_id":        {ColumnName: "item_id", FieldType: "int64"},
-			"participant_id": {ColumnName: "participant_id", FieldType: "int64"},
-			"attempt_id":     {ColumnName: "attempt_id", FieldType: "int64"},
-			"activity_type":  {ColumnName: "1", FieldType: "int64"},
-			"answer_id":      {FieldType: "int64", Ignore: true},
-		},
-		"-at,item_id,participant_id,-attempt_id,-activity_type,answer_id", []string{"participant_id", "attempt_id", "item_id"}, true)
-
-	validatedResultsQuery := srv.Store.Results().
+	validatedResultsQuery := srv.Store.Table("results AS validated_results").
 		Select(`
 			STRAIGHT_JOIN /* tell the optimizer we don't want to convert IN(...) into JOIN */
 			'result_validated' AS activity_type,
-			results.validated_at AS at,
+			validated_results.validated_at AS at,
 			-1 AS answer_id,
-			results.attempt_id, results.participant_id,
-			item_id, participant_id AS user_id,
+			validated_results.attempt_id, validated_results.participant_id,
+			validated_results.item_id, validated_results.participant_id AS user_id,
 			NULL AS score`).
-		Where("results.item_id IN (SELECT id FROM items_to_show)").
-		Where("results.validated_at <= NOW()").
-		Where("results.participant_id IN (SELECT id FROM participants)")
+		Where("validated_results.item_id IN (SELECT id FROM items_to_show)").
+		Where("validated_results.validated_at <= NOW()").
+		Where("validated_results.participant_id IN (SELECT id FROM participants)")
+
+	startFromRowSubQuery, startFromRowCTESubQuery := srv.generateSubQueriesForPagination(
+		r.URL.Query().Get("from.activity_type"), startedResultsQuery, validatedResultsQuery, answersQuery, fromValues)
+
+	answersQuery = service.NewQueryLimiter().Apply(r, answersQuery)
+	// we have already checked for possible errors in constructActivityLogQuery()
+	answersQuery, _ = service.ApplySortingAndPaging(
+		fakeRequestParametersForPagination(r, []string{"from.answer_id"}),
+		answersQuery,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"at":             {ColumnName: "answers.created_at"},
+				"item_id":        {ColumnName: "answers.item_id"},
+				"participant_id": {ColumnName: "answers.participant_id"},
+				"attempt_id":     {ColumnName: "answers.attempt_id"},
+				"answer_id":      {ColumnName: "answers.id"},
+			},
+			DefaultRules:         "-at,item_id,participant_id,-attempt_id,answer_id",
+			IgnoreSortParameter:  true,
+			StartFromRowSubQuery: startFromRowSubQuery,
+		})
+
+	answersQuery = srv.Store.Raw("SELECT limited_answers.*, gradings.score FROM ? AS limited_answers", answersQuery.SubQuery()).
+		Joins("LEFT JOIN gradings ON gradings.answer_id = limited_answers.answer_id")
+
+	startedResultsQuery = service.NewQueryLimiter().Apply(r, startedResultsQuery)
+	// we have already checked for possible errors in constructActivityLogQuery()
+	startedResultsQuery, _ = service.ApplySortingAndPaging(
+		fakeRequestParametersForPagination(r, []string{"from.participant_id", "from.attempt_id", "from.item_id"}),
+		startedResultsQuery,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"at":             {ColumnName: "started_results.started_at"},
+				"item_id":        {ColumnName: "started_results.item_id"},
+				"participant_id": {ColumnName: "started_results.participant_id"},
+				"attempt_id":     {ColumnName: "started_results.attempt_id"},
+			},
+			DefaultRules:         "-at,item_id,participant_id,-attempt_id",
+			IgnoreSortParameter:  true,
+			StartFromRowSubQuery: startFromRowSubQuery,
+		})
 
 	validatedResultsQuery = service.NewQueryLimiter().Apply(r, validatedResultsQuery)
-	validatedResultsQuery, _ = service.ApplySortingAndPaging(r, validatedResultsQuery,
-		map[string]*service.FieldSortingParams{
-			"at":             {ColumnName: "validated_at", FieldType: "time"},
-			"item_id":        {ColumnName: "item_id", FieldType: "int64"},
-			"participant_id": {ColumnName: "participant_id", FieldType: "int64"},
-			"attempt_id":     {ColumnName: "attempt_id", FieldType: "int64"},
-			"activity_type":  {ColumnName: "3", FieldType: "int64"},
-			"answer_id":      {FieldType: "int64", Ignore: true},
-		},
-		"-at,item_id,participant_id,-attempt_id,-activity_type,answer_id", []string{"participant_id", "attempt_id", "item_id"}, true)
-
-	// There is a bug in Gorm. They assume that queries constructed with Raw() already contain WHERE.
-	// It is easier to add a workaround here than to patch Gorm because many programs depend on this behavior.
-	unionQueryString := "SELECT * FROM (? UNION ALL ? UNION ALL ?) AS un"
-	if len(r.URL.Query()["from.answer_id"]) > 0 {
-		unionQueryString += " WHERE "
-	}
-
-	unionQuery := srv.Store.Raw(unionQueryString,
-		answersQuery.SubQuery(), startedResultsQuery.SubQuery(), validatedResultsQuery.SubQuery())
-	unionQuery = service.NewQueryLimiter().Apply(r, unionQuery)
-	unionQuery, _ = service.ApplySortingAndPaging(r, unionQuery,
-		map[string]*service.FieldSortingParams{
-			"at":             {ColumnName: "at", FieldType: "time"},
-			"participant_id": {ColumnName: "participant_id", FieldType: "int64"},
-			"attempt_id":     {ColumnName: "attempt_id", FieldType: "int64"},
-			"item_id":        {ColumnName: "item_id", FieldType: "int64"},
-			"activity_type": {
-				ColumnName: "CASE activity_type WHEN 'result_started' THEN 1 WHEN 'submission' THEN 2 WHEN 'result_validated' THEN 3 END",
-				FieldType:  "int64",
+	// we have already checked for possible errors in constructActivityLogQuery()
+	validatedResultsQuery, _ = service.ApplySortingAndPaging(
+		fakeRequestParametersForPagination(r, []string{"from.participant_id", "from.attempt_id", "from.item_id"}),
+		validatedResultsQuery,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"at":             {ColumnName: "validated_results.validated_at"},
+				"item_id":        {ColumnName: "validated_results.item_id"},
+				"participant_id": {ColumnName: "validated_results.participant_id"},
+				"attempt_id":     {ColumnName: "validated_results.attempt_id"},
 			},
-			"answer_id": {ColumnName: "answer_id", FieldType: "int64"},
-		},
-		"-at,item_id,participant_id,-attempt_id,-activity_type,answer_id",
-		[]string{"participant_id", "attempt_id", "item_id", "activity_type", "answer_id"}, true)
+			DefaultRules:         "-at,item_id,participant_id,-attempt_id",
+			IgnoreSortParameter:  true,
+			StartFromRowSubQuery: startFromRowSubQuery,
+		})
+
+	unionCTEQuery := srv.Store.Raw("SELECT * FROM (? UNION ALL ? UNION ALL ?) AS un",
+		answersQuery.SubQuery(), startedResultsQuery.SubQuery(), validatedResultsQuery.SubQuery())
+	unionQuery := srv.Store.Table("un")
+	unionQuery = service.NewQueryLimiter().Apply(r, unionQuery)
+	unionQuery, _ = service.ApplySortingAndPaging(
+		r, unionQuery,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"at":             {ColumnName: "un.at"},
+				"participant_id": {ColumnName: "un.participant_id"},
+				"attempt_id":     {ColumnName: "un.attempt_id"},
+				"item_id":        {ColumnName: "un.item_id"},
+				"activity_type": {
+					ColumnName: "CASE un.activity_type WHEN 'result_started' THEN 1 WHEN 'submission' THEN 2 WHEN 'result_validated' THEN 3 END",
+				},
+				"answer_id": {ColumnName: "un.answer_id"},
+			},
+			DefaultRules:         "-at,item_id,participant_id,-attempt_id,-activity_type,answer_id",
+			IgnoreSortParameter:  true,
+			StartFromRowSubQuery: startFromRowSubQuery,
+		})
 
 	query := srv.Store.Raw(`
-		WITH items_to_show AS ?, participants AS ?
+		WITH items_to_show AS ?, participants AS ?, start_from_row AS ?, un AS ?
 		SELECT STRAIGHT_JOIN activity_type, at, answer_id, attempt_id, participant_id, score,
 			items.id AS item__id, items.type AS item__type,
 			groups.id AS participant__id,
@@ -477,7 +495,8 @@ func (srv *Service) constructActivityLogQuery(r *http.Request, itemID *int64, us
 			IF(users.group_id = ? OR personal_info_view_approvals.approved, users.first_name, NULL) AS user__first_name,
 			IF(users.group_id = ? OR personal_info_view_approvals.approved, users.last_name, NULL) AS user__last_name,
 			IF(user_strings.language_tag IS NULL, default_strings.title, user_strings.title) AS item__string__title
-		FROM ? AS activities`, visibleItemDescendantsSubQuery, participantsQuerySubQuery, user.GroupID, user.GroupID, user.GroupID,
+		FROM ? AS activities`, visibleItemDescendantsSubQuery, participantsQuerySubQuery,
+		startFromRowCTESubQuery, unionCTEQuery.SubQuery(), user.GroupID, user.GroupID, user.GroupID,
 		unionQuery.SubQuery()).
 		Joins("JOIN items ON items.id = item_id").
 		Joins("JOIN `groups` ON groups.id = participant_id").
@@ -485,4 +504,42 @@ func (srv *Service) constructActivityLogQuery(r *http.Request, itemID *int64, us
 		WithPersonalInfoViewApprovals(user).
 		JoinsUserAndDefaultItemStrings(user)
 	return query, service.NoError
+}
+
+func (srv *Service) generateSubQueriesForPagination(
+	activityTypeIndex string, startedResultsQuery, validatedResultsQuery, answersQuery *database.DB, fromValues map[string]interface{}) (
+	startFromRowSubQuery, startFromRowCTESubQuery interface{}) {
+	startFromRowSubQuery = srv.Store.Table("start_from_row").SubQuery()
+	var startFromRowQuery *database.DB
+	switch activityTypeIndex {
+	case "1": // result_started
+		startFromRowQuery = startedResultsQuery.
+			Where("started_results.participant_id = ?", fromValues["participant_id"]).
+			Where("started_results.attempt_id = ?", fromValues["attempt_id"]).
+			Where("started_results.item_id = ?", fromValues["item_id"])
+	case "2": // submission
+		startFromRowQuery = answersQuery.Where("answers.id = ?", fromValues["answer_id"])
+	case "3": // result_validated
+		startFromRowQuery = validatedResultsQuery.
+			Where("validated_results.participant_id = ?", fromValues["participant_id"]).
+			Where("validated_results.attempt_id = ?", fromValues["attempt_id"]).
+			Where("validated_results.item_id = ?", fromValues["item_id"])
+	default:
+		startFromRowQuery = srv.Store.Raw("SELECT 1")
+		startFromRowSubQuery = service.FromFirstRow
+	}
+	return startFromRowSubQuery, startFromRowQuery.Limit(1).SubQuery()
+}
+
+func fakeRequestParametersForPagination(r *http.Request, fieldsToCopy []string) *http.Request {
+	cleanRequest := &http.Request{URL: &url.URL{}}
+	query := r.URL.Query()
+	newQuery := url.Values(make(map[string][]string, len(fieldsToCopy)))
+	for _, key := range fieldsToCopy {
+		if value, ok := query[key]; ok {
+			newQuery[key] = value
+		}
+	}
+	cleanRequest.URL.RawQuery = newQuery.Encode()
+	return cleanRequest
 }

--- a/app/api/items/get_activity_log.robustness.feature
+++ b/app/api/items/get_activity_log.robustness.feature
@@ -62,11 +62,11 @@ Feature: Get activity log - robustness
     Then the response code should be 400
     And the response error message should contain "Only one of as_team_id and watched_group_id can be given"
 
-  Scenario: Wrong item
+  Scenario: Wrong ancestor item
     Given I am the user with id "23"
     When I send a GET request to "/items/abc/log?watched_group_id=13"
     Then the response code should be 400
-    And the response error message should contain "Wrong value for item_id (should be int64)"
+    And the response error message should contain "Wrong value for ancestor_item_id (should be int64)"
 
   Scenario: Should fail when user cannot watch group members of watched_group_id
     Given I am the user with id "21"
@@ -93,7 +93,7 @@ Feature: Get activity log - robustness
     Given I am the user with id "23"
     When I send a GET request to "/items/200/log?watched_group_id=13&from.answer_id=1"
     Then the response code should be 400
-    And the response error message should contain "All 'from' parameters (from.at, from.item_id, from.participant_id, from.attempt_id, from.activity_type, from.answer_id) or none of them must be present"
+    And the response error message should contain "All 'from' parameters (from.activity_type, from.answer_id, from.attempt_id, from.item_id, from.participant_id) or none of them must be present"
 
   Scenario: Should fail when some of from.activity_type is invalid
     Given I am the user with id "23"
@@ -144,7 +144,7 @@ Feature: Get activity log - robustness
     Given I am the user with id "23"
     When I send a GET request to "/items/log?watched_group_id=13&from.answer_id=1"
     Then the response code should be 400
-    And the response error message should contain "All 'from' parameters (from.at, from.item_id, from.participant_id, from.attempt_id, from.activity_type, from.answer_id) or none of them must be present"
+    And the response error message should contain "All 'from' parameters (from.activity_type, from.answer_id, from.attempt_id, from.item_id, from.participant_id) or none of them must be present"
 
   Scenario: Should fail when some of from.activity_type is invalid (without item_id)
     Given I am the user with id "23"

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -55,7 +55,7 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	routerWithParticipant.Post("/items/{item_id}/attempts/{attempt_id}/publish", service.AppHandler(srv.publishResult).ServeHTTP)
 	routerWithParticipant.Get("/items/{item_id}/attempts", service.AppHandler(srv.listAttempts).ServeHTTP)
 	routerWithParticipant.Post("/items/{ids:(\\d+/)+}attempts", service.AppHandler(srv.createAttempt).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/log", service.AppHandler(srv.getActivityLogForItem).ServeHTTP)
+	routerWithParticipant.Get("/items/{ancestor_item_id}/log", service.AppHandler(srv.getActivityLogForItem).ServeHTTP)
 	routerWithParticipant.Get("/items/log", service.AppHandler(srv.getActivityLogForAllItems).ServeHTTP)
 	router.Get("/items/{item_id}/official-sessions", service.AppHandler(srv.listOfficialSessions).ServeHTTP)
 	router.Put("/items/{item_id}/strings/{language_tag}", service.AppHandler(srv.updateItemString).ServeHTTP)

--- a/app/api/items/list_attempts.go
+++ b/app/api/items/list_attempts.go
@@ -88,7 +88,7 @@ type attemptsListResponseRow struct {
 //     type: string
 //     enum: [id,-id]
 // - name: from.id
-//   description: Start the page from the attempt next to the attempt with `results.attempt_id` = `from.id`
+//   description: Start the page from the attempt next to the attempt with `results.attempt_id` = `{from.id}`
 //   in: query
 //   type: integer
 //   format: int64
@@ -135,9 +135,15 @@ func (srv *Service) listAttempts(w http.ResponseWriter, r *http.Request) service
 			IF(users.group_id = ? OR personal_info_view_approvals.approved, users.last_name, NULL) AS user_creator__last_name,
 			users.group_id AS user_creator__group_id`, user.GroupID, user.GroupID, user.GroupID)
 	query = service.NewQueryLimiter().Apply(r, query)
-	query, apiError = service.ApplySortingAndPaging(r, query, map[string]*service.FieldSortingParams{
-		"id": {ColumnName: "results.attempt_id", FieldType: "int64"},
-	}, "id", []string{"id"}, false)
+	query, apiError = service.ApplySortingAndPaging(
+		r, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"id": {ColumnName: "results.attempt_id"},
+			},
+			DefaultRules: "id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
 	if apiError != service.NoError {
 		return apiError
 	}

--- a/app/api/items/list_official_sessions.feature
+++ b/app/api/items/list_official_sessions.feature
@@ -201,7 +201,7 @@ Feature: List official sessions for item_id
 
   Scenario: User has access to the item (default sort, start from the second row)
     Given I am the user with id "11"
-    When I send a GET request to "/items/200/official-sessions?from.expected_start=2019-05-30T12:00:00Z&from.name=Session%20200.3&from.group_id=53"
+    When I send a GET request to "/items/200/official-sessions?from.group_id=53"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -236,7 +236,7 @@ Feature: List official sessions for item_id
 
   Scenario: User has access to the item (sort=expected_start, start from the second row)
     Given I am the user with id "11"
-    When I send a GET request to "/items/200/official-sessions?sort=expected_start&from.expected_start=[NULL]&from.group_id=50"
+    When I send a GET request to "/items/200/official-sessions?sort=expected_start&from.group_id=50"
     Then the response code should be 200
     And the response body should be, in JSON:
     """

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -3,27 +3,31 @@ package service
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 )
 
+// FieldType represents a type of tie-breaker field's value
+type FieldType string
+
+// Value type of 'from.*' field in HTTP requests
+const (
+	FieldTypeInt64  FieldType = "int64"
+	FieldTypeBool   FieldType = "bool"
+	FieldTypeString FieldType = "string"
+	FieldTypeTime   FieldType = "time"
+)
+
 // FieldSortingParams represents sorting parameters for one field
 type FieldSortingParams struct {
-	// ColumnName is a DB column name (may contain a table name as a prefix, e.g. "groups.id")
+	// ColumnName is a DB column name (should contain a table name as a prefix, e.g. "groups.id")
 	ColumnName string
-	// ColumnNameForOrdering is a DB column name (may contain a table name as a prefix, e.g. "groups.id")
-	// used (if set) in ORDER BY clause instead of 'ColumnName'
-	ColumnNameForOrdering string
-	// FieldType is one of "int64", "bool", "string", "time"
-	FieldType string
 	// Nullable means that the field can be null
 	Nullable bool
-	// Unique means that sorting rules containing this parameter will not be augmented with a tie-breaker field
-	Unique bool
-	// Ignore means that the field doesn't participate in conditions and sorting while it is still allowed in sorting rules
-	Ignore bool
 }
 
 type sortingDirection int
@@ -67,45 +71,66 @@ func (t sortingType) conditionSign() string {
 	return "<"
 }
 
-// ApplySortingAndPaging applies ordering and paging according to given accepted fields and sorting types
-// taking into the account the URL parameters 'from.*'.
-// When the `skipSortParameter` is true, the 'sort' request parameter is ignored.
-func ApplySortingAndPaging(r *http.Request, query *database.DB, acceptedFields map[string]*FieldSortingParams,
-	defaultRules string, tieBreakerFieldNames []string, skipSortParameter bool) (*database.DB, APIError) {
-	sortingRules := prepareSortingRulesAndAcceptedFields(r, defaultRules, skipSortParameter)
+// FromFirstRow is a special value of SortingAndPagingParameters.StartFromRowSubQuery
+// needed to bypass pagination completely and ignore 'from.*' parameters of the HTTP request.
+const FromFirstRow = iota
 
-	usedFields, fieldsSortingTypes, err := parseSortingRules(sortingRules, acceptedFields, tieBreakerFieldNames)
+// SortingAndPagingFields is a type of SortingAndPagingParameters.Fields (field_name -> params)
+type SortingAndPagingFields map[string]*FieldSortingParams
+
+// SortingAndPagingTieBreakers is a type of SortingAndPagingParameters.TieBreakers (field_name -> type)
+type SortingAndPagingTieBreakers map[string]FieldType
+
+// SortingAndPagingParameters represents sorting and paging parameters to apply
+type SortingAndPagingParameters struct {
+	Fields       SortingAndPagingFields
+	DefaultRules string
+	TieBreakers  SortingAndPagingTieBreakers
+
+	// If IgnoreSortParameter is true, the 'sort' parameter of the HTTP request is ignored
+	IgnoreSortParameter bool
+
+	// If StartFromRowSubQuery is not nil, 'from.*' parameters of the HTTP request are not analyzed,
+	// the sub-query should provide tie-breaker fields instead.
+	//
+	// If StartFromRowSubQuery is FromFirstRow, pagination gets skipped.
+	StartFromRowSubQuery interface{}
+}
+
+// ApplySortingAndPaging applies ordering and paging according to the given parameters
+// taking into the account the URL parameters 'from.*' if needed.
+//
+// When `parameters.IgnoreSortParameter` is true, the 'sort' request parameter is ignored.
+//
+// When `parameters.StartFromRowSubQuery` is set, the 'from.*' request parameters are ignored.
+func ApplySortingAndPaging(r *http.Request, query *database.DB, parameters *SortingAndPagingParameters) (*database.DB, APIError) {
+	mustHaveValidTieBreakerFieldsList(parameters.Fields, parameters.TieBreakers)
+	sortingRules := chooseSortingRules(r, parameters.DefaultRules, parameters.IgnoreSortParameter)
+
+	usedFields, fieldsSortingTypes, err := parseSortingRules(sortingRules, parameters.Fields, parameters.TieBreakers)
 	if err != nil {
 		return nil, ErrInvalidRequest(err)
 	}
 
-	fromValues, err := parsePagingParameters(r, usedFields, acceptedFields, fieldsSortingTypes)
-	if err != nil {
-		return nil, ErrInvalidRequest(err)
-	}
+	query = applyOrder(query, usedFields, parameters.Fields, fieldsSortingTypes)
 
-	filteredUsedFields := make([]string, 0, len(usedFields))
-	filteredFromValues := make([]interface{}, 0, len(fromValues))
-	for index, field := range usedFields {
-		if !acceptedFields[field].Ignore {
-			filteredUsedFields = append(filteredUsedFields, field)
-			if len(fromValues) > 0 {
-				filteredFromValues = append(filteredFromValues, fromValues[index])
-			}
+	var fromValues map[string]interface{}
+	if parameters.StartFromRowSubQuery == nil {
+		fromValues, err = ParsePagingParameters(r, parameters.TieBreakers)
+		if err != nil {
+			return nil, ErrInvalidRequest(err)
 		}
 	}
-	usedFields = filteredUsedFields
-	fromValues = filteredFromValues
-	query = applyOrder(query, usedFields, acceptedFields, fieldsSortingTypes)
-	query = applyPagingConditions(query, usedFields, fieldsSortingTypes, acceptedFields, fromValues)
+
+	query = applyPagingConditions(query, usedFields, fieldsSortingTypes, parameters.Fields, fromValues, parameters.StartFromRowSubQuery)
 	return query, NoError
 }
 
-// prepareSortingRulesAndAcceptedFields builds sorting rules and a map of accepted fields.
+// chooseSortingRules chooses which sorting rules to use.
 // If urlQuery["sort"] is not present, the default sorting rules are used.
-func prepareSortingRulesAndAcceptedFields(r *http.Request, defaultRules string, skipSortParameter bool) (sortingRules string) {
+func chooseSortingRules(r *http.Request, defaultRules string, ignoreSortParameter bool) (sortingRules string) {
 	urlQuery := r.URL.Query()
-	if !skipSortParameter && len(urlQuery["sort"]) > 0 {
+	if !ignoreSortParameter && len(urlQuery["sort"]) > 0 {
 		sortingRules = urlQuery["sort"][0]
 	} else {
 		sortingRules = defaultRules
@@ -115,47 +140,63 @@ func prepareSortingRulesAndAcceptedFields(r *http.Request, defaultRules string, 
 
 // parseSortingRules returns a slice with used fields and a map fieldName -> sortingType
 // It also checks that there are no unallowed fields in the rules.
-func parseSortingRules(sortingRules string, acceptedFields map[string]*FieldSortingParams, tieBreakerFieldNames []string) (
+func parseSortingRules(sortingRules string, configuredFields map[string]*FieldSortingParams, tieBreakerFields map[string]FieldType) (
 	usedFields []string, fieldsSortingTypes map[string]sortingType, err error) {
 	sortStatements := strings.Split(sortingRules, ",")
 	usedFields = make([]string, 0, len(sortStatements)+1)
 	fieldsSortingTypes = make(map[string]sortingType, len(sortStatements)+1)
-	includesUniqueField := false
 	for _, sortStatement := range sortStatements {
 		fieldName, sorting := getFieldNameAndSortingTypeFromSortStatement(sortStatement)
-		err = validateSortingField(fieldsSortingTypes, fieldName, acceptedFields, sorting)
+		err = validateSortingField(fieldsSortingTypes, fieldName, configuredFields, sorting)
 		if err != nil {
 			return nil, nil, err
 		}
-		if acceptedFields[fieldName].Nullable && sorting.nullPlacement == 0 {
+		if configuredFields[fieldName].Nullable && sorting.nullPlacement == 0 {
 			sorting.nullPlacement = first
 		}
 		fieldsSortingTypes[fieldName] = sorting
 		usedFields = append(usedFields, fieldName)
-		if acceptedFields[fieldName].Unique {
-			includesUniqueField = true
+	}
+	tieBreakerFieldsToAdd := make([]string, 0, len(tieBreakerFields))
+	for tieBreakerFieldName := range tieBreakerFields {
+		if fieldsSortingTypes[tieBreakerFieldName].sortingDirection == 0 {
+			fieldsSortingTypes[tieBreakerFieldName] = sortingType{sortingDirection: 1}
+			tieBreakerFieldsToAdd = append(tieBreakerFieldsToAdd, tieBreakerFieldName)
 		}
 	}
-	if !includesUniqueField {
-		for _, tieBreakerFieldName := range tieBreakerFieldNames {
-			if fieldsSortingTypes[tieBreakerFieldName].sortingDirection == 0 {
-				fieldsSortingTypes[tieBreakerFieldName] = sortingType{sortingDirection: 1}
-				usedFields = append(usedFields, tieBreakerFieldName)
-			}
-		}
-	}
+	sort.Strings(tieBreakerFieldsToAdd)
+	usedFields = append(usedFields, tieBreakerFieldsToAdd...)
 	return usedFields, fieldsSortingTypes, err
 }
 
+func mustHaveValidTieBreakerFieldsList(configuredFields map[string]*FieldSortingParams, tieBreakerFields map[string]FieldType) {
+	for fieldName, fieldType := range tieBreakerFields {
+		if !map[FieldType]bool{
+			FieldTypeString: true,
+			FieldTypeInt64:  true,
+			FieldTypeBool:   true,
+			FieldTypeTime:   true,
+		}[fieldType] {
+			panic(fmt.Errorf("unsupported type %q for field %q", fieldType, fieldName))
+		}
+		if configuredFields[fieldName] == nil {
+			panic(fmt.Errorf("no such field %q, cannot use it as a tie-breaker field", fieldName))
+		}
+		if configuredFields[fieldName].Nullable {
+			panic(fmt.Errorf("a nullable field %q cannot be a tie-breaker field", fieldName))
+		}
+	}
+}
+
 func validateSortingField(
-	fieldsSortingTypes map[string]sortingType, fieldName string, acceptedFields map[string]*FieldSortingParams, sorting sortingType) error {
+	fieldsSortingTypes map[string]sortingType, fieldName string, configuredFields map[string]*FieldSortingParams, sorting sortingType) error {
 	if _, ok := fieldsSortingTypes[fieldName]; ok {
 		return fmt.Errorf("a field cannot be a sorting parameter more than once: %q", fieldName)
 	}
-	if _, ok := acceptedFields[fieldName]; !ok {
+	if _, ok := configuredFields[fieldName]; !ok {
 		return fmt.Errorf("unallowed field in sorting parameters: %q", fieldName)
 	}
-	if !acceptedFields[fieldName].Nullable && sorting.nullPlacement != 0 {
+	if !configuredFields[fieldName].Nullable && sorting.nullPlacement != 0 {
 		return fmt.Errorf("'null last' sorting cannot be applied to a non-nullable field: %q", fieldName)
 	}
 	return nil
@@ -184,19 +225,13 @@ func getFieldNameAndSortingTypeFromSortStatement(sortStatement string) (string, 
 }
 
 // applyOrder appends the "ORDER BY" statement to given query according to the given list of used fields,
-// the fields configuration (acceptedFields) and sorting types
-func applyOrder(query *database.DB, usedFields []string, acceptedFields map[string]*FieldSortingParams,
+// the fields configuration (configuredFields) and sorting types
+func applyOrder(query *database.DB, usedFields []string, configuredFields map[string]*FieldSortingParams,
 	fieldsSortingTypes map[string]sortingType) *database.DB {
 	usedFieldsNumber := len(usedFields)
 	orderStrings := make([]string, 0, usedFieldsNumber)
 	for _, field := range usedFields {
-		var columnName string
-		if acceptedFields[field].ColumnNameForOrdering != "" {
-			columnName = acceptedFields[field].ColumnNameForOrdering
-		} else {
-			columnName = acceptedFields[field].ColumnName
-		}
-		orderStrings = append(orderStrings, fieldsSortingTypes[field].asSQL(columnName))
+		orderStrings = append(orderStrings, fieldsSortingTypes[field].asSQL(configuredFields[field].ColumnName))
 	}
 	if len(orderStrings) > 0 {
 		query = query.Order(strings.Join(orderStrings, ", "))
@@ -204,40 +239,18 @@ func applyOrder(query *database.DB, usedFields []string, acceptedFields map[stri
 	return query
 }
 
-// parsePagingParameters returns a slice of values provided for paging in a request URL (none or all should be present)
-// The values are in the order of the 'usedFields' and converted according to 'FieldType' of 'acceptedFields'
-func parsePagingParameters(r *http.Request, usedFields []string,
-	acceptedFields map[string]*FieldSortingParams, fieldsSortingTypes map[string]sortingType) ([]interface{}, error) {
-	fromValueSkipped := false
+// ParsePagingParameters returns a map with values provided for paging in a request URL (none or all should be present)
+func ParsePagingParameters(r *http.Request, expectedFromFields map[string]FieldType) (map[string]interface{}, error) {
+	fromValueIsMissing := false
 	fromValueAccepted := false
-	fromValues := make([]interface{}, 0, len(usedFields))
-	const fromPrefix = "from."
-	for _, fieldName := range usedFields {
-		var value interface{}
-		fromFieldName := fromPrefix + fieldName
-		if len(r.URL.Query()[fromFieldName]) > 0 {
-			var err error
-			value, err = getFromValueForField(r, fieldName, acceptedFields)
-			if err != nil {
-				return nil, err
-			}
-			fromValueAccepted = true
-		} else {
-			fromValueSkipped = true
-			continue
-		}
-		fromValues = append(fromValues, value)
-	}
-	if fromValueAccepted && fromValueSkipped {
-		fromParameters := strings.Join(usedFields, ", from.")
-		return nil, fmt.Errorf("all 'from' parameters (from.%s) or none of them must be present", fromParameters)
-	}
+	fromValues := make(map[string]interface{}, len(expectedFromFields))
 
+	const fromPrefix = "from."
+	urlQuery := r.URL.Query()
 	var unknownFromFields []string
-	for fieldName := range r.URL.Query() {
+	for fieldName := range urlQuery {
 		if strings.HasPrefix(fieldName, fromPrefix) {
-			fieldNameSuffix := fieldName[len(fromPrefix):]
-			if _, ok := fieldsSortingTypes[fieldNameSuffix]; !ok {
+			if _, ok := expectedFromFields[fieldName[len(fromPrefix):]]; !ok {
 				unknownFromFields = append(unknownFromFields, fieldName)
 			}
 		}
@@ -247,73 +260,141 @@ func parsePagingParameters(r *http.Request, usedFields []string,
 		return nil, fmt.Errorf("unallowed paging parameters (%s)", strings.Join(unknownFromFields, ", "))
 	}
 
+	expectedFromFieldNames := make([]string, 0, len(expectedFromFields))
+	for fieldName, fieldType := range expectedFromFields {
+		expectedFromFieldNames = append(expectedFromFieldNames, fieldName)
+		var value interface{}
+		fromFieldName := fromPrefix + fieldName
+		if len(r.URL.Query()[fromFieldName]) > 0 {
+			var err error
+			value, err = getFromValueForField(r, fieldName, fieldType)
+			if err != nil {
+				return nil, err
+			}
+			fromValueAccepted = true
+		} else {
+			fromValueIsMissing = true
+			continue
+		}
+		fromValues[fieldName] = value
+	}
+	if fromValueAccepted && fromValueIsMissing {
+		sort.Strings(expectedFromFieldNames)
+		fromParameters := strings.Join(expectedFromFieldNames, ", from.")
+		return nil, fmt.Errorf("all 'from' parameters (from.%s) or none of them must be present", fromParameters)
+	}
+
 	return fromValues, nil
 }
 
 // getFromValueForField returns a 'from' value (a paging parameter) for a given field.
-// The value is converted according to 'FieldType' of 'acceptedFields[fieldName]'
-func getFromValueForField(r *http.Request, fieldName string,
-	acceptedFields map[string]*FieldSortingParams) (interface{}, error) {
+// The value is converted according to fieldType.
+func getFromValueForField(r *http.Request, fieldName string, fieldType FieldType) (result interface{}, err error) {
 	fromFieldName := "from." + fieldName
-	if acceptedFields[fieldName].Nullable && r.URL.Query()[fromFieldName][0] == "[NULL]" {
-		return nil, nil
+	switch fieldType {
+	case FieldTypeString:
+		result, err = r.URL.Query()[fromFieldName][0], nil
+	case FieldTypeInt64:
+		result, err = ResolveURLQueryGetInt64Field(r, fromFieldName)
+	case FieldTypeBool:
+		result, err = ResolveURLQueryGetBoolField(r, fromFieldName)
+	case FieldTypeTime:
+		var timeResult time.Time
+		timeResult, err = ResolveURLQueryGetTimeField(r, fromFieldName)
+		result = (*database.Time)(&timeResult)
 	}
-	switch acceptedFields[fieldName].FieldType {
-	case "string":
-		return r.URL.Query()[fromFieldName][0], nil
-	case "int64":
-		return ResolveURLQueryGetInt64Field(r, fromFieldName)
-	case "bool":
-		return ResolveURLQueryGetBoolField(r, fromFieldName)
-	case "time":
-		return ResolveURLQueryGetTimeField(r, fromFieldName)
-	default:
-		panic(fmt.Errorf("unsupported type %q for field %q", acceptedFields[fieldName].FieldType, fieldName))
-	}
+	return result, err
 }
+
+var safeColumnNameRegexp = regexp.MustCompile("[^a-zA-Z_0-9]")
 
 // applyPagingConditions adds filtering on paging values into the query
 func applyPagingConditions(query *database.DB, usedFields []string, fieldsSortingTypes map[string]sortingType,
-	acceptedFields map[string]*FieldSortingParams, fromValues []interface{}) *database.DB {
-	if len(fromValues) == 0 {
+	configuredFields map[string]*FieldSortingParams, fromValues map[string]interface{}, startFromRowSubQuery interface{}) *database.DB {
+	if startFromRowSubQuery == nil && len(fromValues) == 0 || startFromRowSubQuery == FromFirstRow {
 		return query
 	}
+
+	// Note: Since all the tie-breaker columns are always used and usedFields cannot contain duplicates,
+	// having the same number of elements in usedFields and fromValues mean we have all the needed data
+	// for paging. At the same time, fromValues are empty (unknown) when startFromRowSubQuery is given,
+	// meaning the sub-query is needed in this case.
+	subQueryNeeded := len(usedFields) != len(fromValues) || startFromRowSubQuery != nil
+
+	conditions, queryValues, safeColumnNames := constructPagingConditions(
+		usedFields, configuredFields, subQueryNeeded, fieldsSortingTypes, fromValues)
+	if len(conditions) > 0 {
+		if subQueryNeeded {
+			query = joinSubQueryForPaging(query, usedFields, configuredFields, startFromRowSubQuery, safeColumnNames, fromValues, conditions)
+		} else {
+			query = query.Where(strings.Join(conditions, " OR "), queryValues...)
+		}
+	}
+	return query
+}
+
+func constructPagingConditions(usedFields []string, configuredFields map[string]*FieldSortingParams,
+	subQueryNeeded bool, fieldsSortingTypes map[string]sortingType, fromValues map[string]interface{}) (
+	conditions []string, queryValues []interface{}, safeColumnNames []string) {
 	usedFieldsNumber := len(usedFields)
-	conditions := make([]string, 0, usedFieldsNumber)
-	queryValues := make([]interface{}, 0, (usedFieldsNumber+1)*usedFieldsNumber/2)
+	safeColumnNames = make([]string, usedFieldsNumber)
+	conditions = make([]string, 0, usedFieldsNumber)
 	queryValuesPart := make([]interface{}, 0, usedFieldsNumber)
-	conditionPrefix := ""
+	queryValues = make([]interface{}, 0, (usedFieldsNumber+1)*usedFieldsNumber/2)
+	var conditionPrefix string
 
 	// Here we're constructing an expression like this one:
 	// (col1 > val1) OR (col1 = val1 AND col2 > val2) OR (col1 = val1 AND col2 = val2 AND col3 > val3) OR ...
 	for index, fieldName := range usedFields {
+		safeColumnName := safeColumnNameRegexp.ReplaceAllLiteralString(fieldName, "_")
+		safeColumnNames[index] = safeColumnName
+
 		if len(conditionPrefix) > 0 {
 			conditionPrefix += " AND "
 		}
-		columnName := acceptedFields[fieldName].ColumnName
-		if fromValues[index] == nil {
+		columnName := configuredFields[fieldName].ColumnName
+		if subQueryNeeded {
+			condition := fmt.Sprintf("%s %s from_page.%s", columnName, fieldsSortingTypes[fieldName].conditionSign(), safeColumnName)
 			if fieldsSortingTypes[fieldName].nullPlacement == first {
-				conditions = append(conditions,
-					fmt.Sprintf("(%s%s IS NOT NULL)", conditionPrefix, columnName))
-			} else if index == len(usedFields)-1 {
-				conditions = append(conditions,
-					fmt.Sprintf("(%s%s IS NULL)", conditionPrefix, columnName))
+				condition = fmt.Sprintf("IF(from_page.%s IS NULL, %s IS NOT NULL, %s)", safeColumnName, columnName, condition)
+			} else if fieldsSortingTypes[fieldName].nullPlacement == last {
+				condition = fmt.Sprintf("IF(from_page.%s IS NULL, FALSE, %s IS NULL OR %s)", safeColumnName, columnName, condition)
 			}
-			conditionPrefix = fmt.Sprintf("%s%s IS NULL", conditionPrefix, columnName)
+			conditions = append(conditions, fmt.Sprintf("(%s%s)", conditionPrefix, condition))
+			conditionPrefix = fmt.Sprintf("%s%s <=> from_page.%s", conditionPrefix, columnName, safeColumnName)
 		} else {
+			// As here we deal with primary key columns which cannot be nullable,
+			// we can omit tricks related to null placement.
 			condition := fmt.Sprintf("%s %s ?", columnName, fieldsSortingTypes[fieldName].conditionSign())
-			if fieldsSortingTypes[fieldName].nullPlacement == last {
-				condition = fmt.Sprintf("(%s OR %s IS NULL)", condition, columnName)
-			}
 			conditions = append(conditions, fmt.Sprintf("(%s%s)", conditionPrefix, condition))
 			conditionPrefix = fmt.Sprintf("%s%s = ?", conditionPrefix, columnName)
 
-			queryValuesPart = append(queryValuesPart, fromValues[index])
+			fromValue := fromValues[fieldName]
+			queryValuesPart = append(queryValuesPart, fromValue)
 			queryValues = append(queryValues, queryValuesPart...)
 		}
 	}
-	if len(conditions) > 0 {
-		query = query.Where(strings.Join(conditions, " OR "), queryValues...)
+	return conditions, queryValues, safeColumnNames
+}
+
+func joinSubQueryForPaging(query *database.DB, usedFields []string, configuredFields map[string]*FieldSortingParams,
+	startFromRowSubQuery interface{}, safeColumnNames []string, fromValues map[string]interface{}, conditions []string) *database.DB {
+	if startFromRowSubQuery == nil {
+		startFromRowQuery := query
+		fieldsToSelect := make([]string, 0, len(fromValues))
+		for index, fieldName := range usedFields {
+			fieldsToSelect = append(fieldsToSelect,
+				fmt.Sprintf("%s AS %s", configuredFields[fieldName].ColumnName, safeColumnNames[index]))
+		}
+		for fieldName := range fromValues {
+			startFromRowQuery = startFromRowQuery.
+				Where(fmt.Sprintf("%s <=> ?", configuredFields[fieldName].ColumnName), fromValues[fieldName])
+		}
+		startFromRowQuery = startFromRowQuery.Select(strings.Join(fieldsToSelect, ", "))
+		startFromRowSubQuery = startFromRowQuery.Limit(1).SubQuery()
 	}
+	query = query.
+		Joins("JOIN ? AS from_page", startFromRowSubQuery).
+		Where(strings.Join(conditions, " OR "))
 	return query
 }

--- a/app/service/sorting_test.go
+++ b/app/service/sorting_test.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
@@ -17,11 +17,8 @@ import (
 
 func TestApplySorting(t *testing.T) {
 	type args struct {
-		urlParameters        string
-		acceptedFields       map[string]*FieldSortingParams
-		defaultRules         string
-		tieBreakerFieldNames []string
-		skipSortParameters   bool
+		urlParameters              string
+		sortingAndPagingParameters *SortingAndPagingParameters
 	}
 	tests := []struct {
 		name             string
@@ -34,125 +31,121 @@ func TestApplySorting(t *testing.T) {
 		{name: "sorting (default rules)",
 			args: args{
 				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name DESC, id ASC",
 			wantAPIError: NoError},
 		{name: "sorting (request rules)",
 			args: args{
 				urlParameters: "?sort=name,-id",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					TieBreakers: SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name ASC, id DESC",
 			wantAPIError: NoError},
 		{name: "sorting (request rules are skipped)",
 			args: args{
 				urlParameters: "?sort=name,-id",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					TieBreakers:         SortingAndPagingTieBreakers{"id": FieldTypeInt64},
+					IgnoreSortParameter: true,
+					DefaultRules:        "id",
 				},
-				tieBreakerFieldNames: []string{"id"},
-				skipSortParameters:   true,
-				defaultRules:         "id",
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY id ASC",
-			wantAPIError: NoError},
-		{name: "sorting (custom column name for ordering)",
-			args: args{
-				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", ColumnNameForOrdering: "LOWER(name)"},
-					"id":   {ColumnName: "id", FieldType: "int64", ColumnNameForOrdering: "-id"},
-				},
-				tieBreakerFieldNames: []string{"id"},
-				defaultRules:         "-name,id",
-			},
-			wantSQL:      "SELECT id FROM `users` ORDER BY LOWER(name) DESC, -id ASC",
 			wantAPIError: NoError},
 		{name: "repeated field",
 			args: args{
 				urlParameters: "?sort=name,name",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`a field cannot be a sorting parameter more than once: "name"`))},
 		{name: "unallowed field",
 			args: args{
 				urlParameters: "?sort=class",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`unallowed field in sorting parameters: "class"`))},
-		{name: "allows ignored field in sort",
-			args: args{
-				urlParameters: "?sort=name",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {Ignore: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-				},
-				defaultRules: "-name,id",
-			},
-		},
 		{name: "'null last' for a non-nullable field",
 			args: args{
 				urlParameters: "?sort=name$",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`'null last' sorting cannot be applied to a non-nullable field: "name"`))},
 		{name: "applies default null sorting for nullable fields",
 			args: args{
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name IS NOT NULL, name DESC, id ASC",
 			wantAPIError: NoError},
 		{name: "'null last'",
 			args: args{
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "id,-name$",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "id,-name$",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY id ASC, name IS NULL, name DESC",
 			wantAPIError: NoError},
 		{name: "add a tie-breaker field",
 			args: args{
 				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, id ASC",
 			wantSQLArguments: nil,
@@ -160,13 +153,15 @@ func TestApplySorting(t *testing.T) {
 		{name: "add multiple tie-breaker fields",
 			args: args{
 				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name":     {ColumnName: "name", FieldType: "string"},
-					"group_id": {ColumnName: "group_id", FieldType: "int64"},
-					"item_id":  {ColumnName: "item_id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name":     {ColumnName: "name"},
+						"group_id": {ColumnName: "group_id"},
+						"item_id":  {ColumnName: "item_id"},
+					},
+					DefaultRules: "-name",
+					TieBreakers:  SortingAndPagingTieBreakers{"group_id": FieldTypeInt64, "item_id": FieldTypeInt64},
 				},
-				defaultRules:         "-name",
-				tieBreakerFieldNames: []string{"group_id", "item_id"},
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, group_id ASC, item_id ASC",
 			wantSQLArguments: nil,
@@ -174,218 +169,238 @@ func TestApplySorting(t *testing.T) {
 		{name: "add some of tie-breaker fields",
 			args: args{
 				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name":     {ColumnName: "name", FieldType: "string"},
-					"group_id": {ColumnName: "group_id", FieldType: "int64"},
-					"item_id":  {ColumnName: "item_id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name":     {ColumnName: "name"},
+						"group_id": {ColumnName: "group_id"},
+						"item_id":  {ColumnName: "item_id"},
+					},
+					DefaultRules: "-name,item_id",
+					TieBreakers:  SortingAndPagingTieBreakers{"group_id": FieldTypeInt64, "item_id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,item_id",
-				tieBreakerFieldNames: []string{"group_id", "item_id"},
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, item_id ASC, group_id ASC",
-			wantSQLArguments: nil,
-			wantAPIError:     NoError},
-		{name: "do not add a tie-breaker field if a sorting field is unique",
-			args: args{
-				urlParameters: "",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Unique: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-				},
-				defaultRules:         "-name",
-				tieBreakerFieldNames: []string{"id"},
-			},
-			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC",
 			wantSQLArguments: nil,
 			wantAPIError:     NoError},
 		{name: "sorting + paging",
 			args: args{
 				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules: "-name,id,flag",
+					TieBreakers: SortingAndPagingTieBreakers{
+						"id":   FieldTypeInt64,
+						"name": FieldTypeString,
+						"flag": FieldTypeBool,
+					},
 				},
-				defaultRules:         "-name,id,flag",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users` " +
 				"WHERE ((name < ?) OR (name = ? AND id > ?) OR (name = ? AND id = ? AND bFlag > ?)) " +
 				"ORDER BY name DESC, id ASC, bFlag ASC",
 			wantSQLArguments: []driver.Value{"Joe", "Joe", 1, "Joe", 1, true},
 			wantAPIError:     NoError},
-		{name: "sorting + paging (ignored fields are skipped)",
+		{name: "sorting + paging with a nullable field",
 			args: args{
-				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Ignore: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool", Ignore: true},
+				urlParameters: "?from.id=1",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules: "-name,id,flag",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id,flag",
-				tieBreakerFieldNames: []string{"id"},
 			},
-			wantSQL:          "SELECT id FROM `users` WHERE ((id > ?)) ORDER BY id ASC",
+			wantSQL: "SELECT id FROM `users` " +
+				"JOIN (SELECT name AS name, id AS id, bFlag AS flag FROM `users` WHERE (id <=> ?) " +
+				"  ORDER BY name IS NOT NULL, name DESC, id ASC, bFlag ASC LIMIT 1) AS from_page " +
+				"WHERE ((IF(from_page.name IS NULL, name IS NOT NULL, name < from_page.name)) OR " +
+				"  (name <=> from_page.name AND id > from_page.id) OR " +
+				"  (name <=> from_page.name AND id <=> from_page.id AND bFlag > from_page.flag)) " +
+				"ORDER BY name IS NOT NULL, name DESC, id ASC, bFlag ASC",
 			wantSQLArguments: []driver.Value{1},
 			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field",
+		{name: "sorting + paging with a nullable field (null last)",
 			args: args{
-				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
+				urlParameters: "?from.id=1",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules: "-name$,id,flag",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id,flag",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users` " +
-				"WHERE ((name < ?) OR (name = ? AND id > ?) OR (name = ? AND id = ? AND bFlag > ?)) " +
-				"ORDER BY name IS NOT NULL, name DESC, id ASC, bFlag ASC",
-			wantSQLArguments: []driver.Value{"Joe", "Joe", 1, "Joe", 1, true},
-			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field (null last)",
-			args: args{
-				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
-				},
-				defaultRules:         "-name$,id,flag",
-				tieBreakerFieldNames: []string{"id"},
-			},
-			wantSQL: "SELECT id FROM `users` " +
-				"WHERE (((name < ? OR name IS NULL)) OR (name = ? AND id > ?) OR (name = ? AND id = ? AND bFlag > ?)) " +
+				"JOIN (SELECT name AS name, id AS id, bFlag AS flag FROM `users` WHERE (id <=> ?) " +
+				"  ORDER BY name IS NULL, name DESC, id ASC, bFlag ASC LIMIT 1) AS from_page " +
+				"WHERE ((IF(from_page.name IS NULL, FALSE, name IS NULL OR name < from_page.name)) OR " +
+				"  (name <=> from_page.name AND id > from_page.id) OR " +
+				"  (name <=> from_page.name AND id <=> from_page.id AND bFlag > from_page.flag)) " +
 				"ORDER BY name IS NULL, name DESC, id ASC, bFlag ASC",
-			wantSQLArguments: []driver.Value{"Joe", "Joe", 1, "Joe", 1, true},
+			wantSQLArguments: []driver.Value{1},
 			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field (null last, nullable field is in the middle)",
+		{name: "sorting + paging with a nullable field (null last, nullable field is in the middle)",
 			args: args{
-				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
+				urlParameters: "?from.id=1",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules: "flag,-name$,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "flag,-name$,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users` " +
-				"WHERE ((bFlag > ?) OR (bFlag = ? AND (name < ? OR name IS NULL)) OR (bFlag = ? AND name = ? AND id > ?)) " +
+				"JOIN (SELECT bFlag AS flag, name AS name, id AS id FROM `users` WHERE (id <=> ?) " +
+				"  ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC LIMIT 1) AS from_page " +
+				"WHERE ((bFlag > from_page.flag) OR " +
+				"  (bFlag <=> from_page.flag AND IF(from_page.name IS NULL, FALSE, name IS NULL OR name < from_page.name)) OR " +
+				"  (bFlag <=> from_page.flag AND name <=> from_page.name AND id > from_page.id)) " +
 				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
-			wantSQLArguments: []driver.Value{true, true, "Joe", true, "Joe", 1},
+			wantSQLArguments: []driver.Value{1},
 			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field (from value is null, null first)",
+		{name: "does not do paging when StartFromRowQuery = FromFirstRow",
 			args: args{
-				urlParameters: "?from.id=1&from.name=[NULL]&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
+				urlParameters: "?from.id=1",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules:         "flag,-name$,id",
+					TieBreakers:          SortingAndPagingTieBreakers{"id": FieldTypeInt64},
+					StartFromRowSubQuery: FromFirstRow,
 				},
-				defaultRules:         "-name,id,flag",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users` " +
-				"WHERE ((name IS NOT NULL) OR (name IS NULL AND id > ?) OR (name IS NULL AND id = ? AND bFlag > ?)) " +
-				"ORDER BY name IS NOT NULL, name DESC, id ASC, bFlag ASC",
-			wantSQLArguments: []driver.Value{1, 1, true},
-			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field (from value is null, null last)",
+				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
+			wantAPIError: NoError},
+		{name: "uses a custom sub-query for the first row if StartFromRowQuery is given",
 			args: args{
-				urlParameters: "?from.id=1&from.name=[NULL]&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
+				urlParameters: "?from.id=1",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name", Nullable: true},
+						"id":   {ColumnName: "id"},
+						"flag": {ColumnName: "bFlag"},
+					},
+					DefaultRules:         "flag,-name$,id",
+					TieBreakers:          SortingAndPagingTieBreakers{"id": FieldTypeInt64},
+					StartFromRowSubQuery: gorm.Expr("(SELECT '1' AS name, 2 AS id, 3 AS flag)"),
 				},
-				defaultRules:         "-name$,id,flag",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users` " +
-				"WHERE ((name IS NULL AND id > ?) OR (name IS NULL AND id = ? AND bFlag > ?)) " +
-				"ORDER BY name IS NULL, name DESC, id ASC, bFlag ASC",
-			wantSQLArguments: []driver.Value{1, 1, true},
-			wantAPIError:     NoError},
-		{name: "sorting + paging by a nullable field (from value is null, null last, nullable field is the last field)",
-			args: args{
-				urlParameters: "?from.id=1&from.name=[NULL]&from.flag=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string", Nullable: true},
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"flag": {ColumnName: "bFlag", FieldType: "bool"},
-				},
-				defaultRules:         "id,flag,name$",
-				tieBreakerFieldNames: []string{"id"},
-			},
-			wantSQL: "SELECT id FROM `users` " +
-				"WHERE ((id > ?) OR (id = ? AND bFlag > ?) OR (id = ? AND bFlag = ? AND name IS NULL)) " +
-				"ORDER BY id ASC, bFlag ASC, name IS NULL, name ASC",
-			wantSQLArguments: []driver.Value{1, 1, true},
-			wantAPIError:     NoError},
+				"JOIN (SELECT '1' AS name, 2 AS id, 3 AS flag) AS from_page " +
+				"WHERE ((bFlag > from_page.flag) OR " +
+				"  (bFlag <=> from_page.flag AND IF(from_page.name IS NULL, FALSE, name IS NULL OR name < from_page.name)) OR " +
+				"  (bFlag <=> from_page.flag AND name <=> from_page.name AND id > from_page.id)) " +
+				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
+			wantAPIError: NoError},
 		{name: "wrong value in from.id field",
 			args: args{
-				urlParameters: "?from.id=abc&from.name=Joe",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				urlParameters: "?from.id=abc",
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`wrong value for from.id (should be int64)`))},
-		{name: "one of the from. fields is skipped",
+		{name: "one of the 'from.*' fields is skipped",
 			args: args{
 				urlParameters: "?from.id=2",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "string"},
-					"type": {ColumnName: "type", FieldType: "string"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"type": {ColumnName: "type"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64, "name": FieldTypeString},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`all 'from' parameters (from.name, from.id) or none of them must be present`))},
+			wantAPIError: ErrInvalidRequest(errors.New(`all 'from' parameters (from.id, from.name) or none of them must be present`))},
 		{name: "unsupported field type",
 			args: args{
 				urlParameters: "?from.name=Joe&from.id=2",
-				acceptedFields: map[string]*FieldSortingParams{
-					"name": {ColumnName: "name", FieldType: "interface{}"},
-					"id":   {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": "interface{}"},
 				},
-				defaultRules:         "-name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
-			shouldPanic: errors.New(`unsupported type "interface{}" for field "name"`)},
+			shouldPanic: errors.New(`unsupported type "interface{}" for field "id"`)},
+		{name: "unknown tie-breaker field",
+			args: args{
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id"},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"flag": FieldTypeInt64},
+				},
+			},
+			shouldPanic: errors.New(`no such field "flag", cannot use it as a tie-breaker field`)},
+		{name: "nullable field as a tie-breaker field",
+			args: args{
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"name": {ColumnName: "name"},
+						"id":   {ColumnName: "id", Nullable: true},
+					},
+					DefaultRules: "-name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
+				},
+			},
+			shouldPanic: errors.New(`a nullable field "id" cannot be a tie-breaker field`)},
 		{name: "unallowed from fields",
 			args: args{
 				urlParameters: "?from.field=Joe&from.version=2&from.name=Jane&from.id=1234",
-				acceptedFields: map[string]*FieldSortingParams{
-					"id":   {ColumnName: "id", FieldType: "int64"},
-					"name": {ColumnName: "name", FieldType: "string", Ignore: true},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"id":   {ColumnName: "id"},
+						"name": {ColumnName: "name"},
+					},
+					DefaultRules: "name,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64, "name": FieldTypeString},
 				},
-				defaultRules:         "name,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantAPIError: ErrInvalidRequest(errors.New(`unallowed paging parameters (from.field, from.version)`))},
 		{name: "paging by time",
 			args: args{
 				urlParameters: "?from.submitted_at=" + url.QueryEscape("2006-01-02T15:04:05+03:00") + "&from.id=1",
-				acceptedFields: map[string]*FieldSortingParams{
-					"submitted_at": {ColumnName: "submitted_at", FieldType: "time"},
-					"id":           {ColumnName: "id", FieldType: "int64"},
+				sortingAndPagingParameters: &SortingAndPagingParameters{
+					Fields: map[string]*FieldSortingParams{
+						"submitted_at": {ColumnName: "submitted_at"},
+						"id":           {ColumnName: "id"},
+					},
+					DefaultRules: "submitted_at,id",
+					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64, "submitted_at": FieldTypeTime},
 				},
-				defaultRules:         "submitted_at,id",
-				tieBreakerFieldNames: []string{"id"},
 			},
 			wantSQL: "SELECT id FROM `users`  WHERE ((submitted_at > ?) OR (submitted_at = ? AND id > ?)) " +
 				"ORDER BY submitted_at ASC, id ASC",
-			wantSQLArguments: []driver.Value{
-				sqlMockTime{time.Date(2006, 1, 2, 15, 4, 5, 0, time.FixedZone("MSK", 3*3600))},
-				sqlMockTime{time.Date(2006, 1, 2, 15, 4, 5, 0, time.FixedZone("MSK", 3*3600))},
-				1},
-			wantAPIError: NoError},
+			wantSQLArguments: []driver.Value{"2006-01-02 12:04:05", "2006-01-02 12:04:05", 1},
+			wantAPIError:     NoError},
 	}
 
 	for _, tt := range tests {
@@ -412,8 +427,7 @@ func TestApplySorting(t *testing.T) {
 			request, _ := http.NewRequest("GET", "/"+tt.args.urlParameters, nil)
 			query := db.Table("users").Select("id")
 
-			query, gotAPIError := ApplySortingAndPaging(request, query, tt.args.acceptedFields, tt.args.defaultRules,
-				tt.args.tieBreakerFieldNames, tt.args.skipSortParameters)
+			query, gotAPIError := ApplySortingAndPaging(request, query, tt.args.sortingAndPagingParameters)
 			assert.Equal(t, tt.wantAPIError, gotAPIError)
 
 			if gotAPIError == NoError {
@@ -424,22 +438,4 @@ func TestApplySorting(t *testing.T) {
 			assert.NoError(t, dbMock.ExpectationsWereMet())
 		})
 	}
-}
-
-type sqlMockTime struct {
-	time.Time
-}
-
-// Match satisfies sqlmock.Argument interface
-func (a sqlMockTime) Match(v driver.Value) bool {
-	var secondValue time.Time
-	switch value := v.(type) {
-	case sqlMockTime:
-		secondValue = value.Time
-	case time.Time:
-		secondValue = value
-	default:
-		return false
-	}
-	return a.Time.Equal(secondValue)
 }


### PR DESCRIPTION
Allow source_group_id to be an ancestor of any level for group_id in permissionsView & updatePermissions;
Allow current user not to have 'can_grant_view' permission if he has 'can_watch' = 'answer_with_grant' or 'can_edit' = 'all_with_grant' on the item in permissionsView.

Fixes #794 