### PR TITLE
groupUserRequestsView: mark user.grade as required and nullable in swagger docs

### DIFF
--- a/app/api/groups/get_user_requests.go
+++ b/app/api/groups/get_user_requests.go
@@ -40,6 +40,8 @@ type groupUserRequestsViewResponseRow struct {
 		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 
+		// Nullable
+		// required: true
 		Grade *int32 `json:"grade"`
 	} `json:"user" gorm:"embedded;embedded_prefix:user__"`
 }


### PR DESCRIPTION
Fixes #799 