### PR TITLE
Introduce the app's own random numbers generator (package app/rand), make random numbers less predictable and fix golangci-lint installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ $(TEST_REPORT_DIR):
 $(GODOG):
 	$(GOGET) -u github.com/cucumber/godog/cmd/godog@v0.9.0
 $(GOLANGCILINT):
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(LOCAL_BIN_DIR) v1.18.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCAL_BIN_DIR) v1.18.0
 $(MYSQL_CONNECTOR_JAVA):
 	curl -sfL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.16.tar.gz | tar -xzf - mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar
 	mv mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar $(MYSQL_CONNECTOR_JAVA)

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/auth"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,9 +1,9 @@
 package app
 
 import (
+	crand "crypto/rand"
+	"encoding/binary"
 	"fmt"
-	"math/rand"
-	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -15,6 +15,7 @@ import (
 	_ "github.com/France-ioi/AlgoreaBackend/app/doc" // for doc generation
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 )
 
 // Application is the core state of the app
@@ -31,8 +32,13 @@ func New() (*Application, error) {
 	config := LoadConfig()
 	application := &Application{}
 
-	// Init the PRNG with current time
-	rand.Seed(time.Now().UTC().UnixNano())
+	var b [8]byte
+	_, err := crand.Read(b[:])
+	if err != nil {
+		panic("cannot seed the randomizer")
+	}
+	// Init the PRNG with a random value
+	rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
 
 	if err := application.Reset(config); err != nil {
 		return nil, err

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	crand "crypto/rand"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -77,6 +78,16 @@ func TestNew_DBErr(t *testing.T) {
 	assert.Equal(logrus.ErrorLevel, logMsg.Level)
 	assert.Equal("db opening error", logMsg.Message)
 	assert.Equal("database", logMsg.Data["module"])
+}
+
+func TestNew_RandSeedingFailed(t *testing.T) {
+	assert := assertlib.New(t)
+	expectedError := errors.New("some error")
+	patch := monkey.Patch(crand.Read, func([]byte) (int, error) {
+		return 1, expectedError
+	})
+	defer patch.Unpatch()
+	assert.PanicsWithValue("cannot seed the randomizer", func() { _, _ = New() })
 }
 
 func TestNew_DBConfigError(t *testing.T) {

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -1,8 +1,9 @@
 package database
 
 import (
-	"math/rand"
 	"time"
+
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 )
 
 // DataStore gather all stores for database operations on business data

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"runtime"
 	"sort"
@@ -18,6 +17,7 @@ import (
 	"github.com/luna-duclos/instrumentedsql"
 
 	log "github.com/France-ioi/AlgoreaBackend/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 )
 
 // DB contains information for current db connection (wraps *gorm.DB)

--- a/app/rand/rand.go
+++ b/app/rand/rand.go
@@ -1,0 +1,37 @@
+package rand
+
+import (
+	mr "math/rand"
+	"sync"
+)
+
+var globalRand = mr.New(mr.NewSource(1))
+var globalLock sync.Mutex
+
+// Seed uses the provided seed value to initialize the generator to a deterministic state.
+func Seed(s int64) {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	globalRand.Seed(s)
+}
+
+// Int31n returns, as an int32, a non-negative pseudo-random number in [0,n). It panics if n <= 0.
+func Int31n(n int32) int32 {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	return globalRand.Int31n(n)
+}
+
+// Int63 returns a non-negative pseudo-random 63-bit integer as an int64.
+func Int63() int64 {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	return globalRand.Int63()
+}
+
+// Float64 returns, as a float64, a pseudo-random number in [0.0,1.0).
+func Float64() float64 {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	return globalRand.Float64()
+}

--- a/app/rand/rand_test.go
+++ b/app/rand/rand_test.go
@@ -1,0 +1,43 @@
+package rand
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFloat64(t *testing.T) {
+	Seed(1)
+	assert.Equal(t, 0.6046602879796196, Float64())
+	assert.Equal(t, 0.9405090880450124, Float64())
+	Seed(2)
+	assert.Equal(t, 0.16729663442585624, Float64())
+	assert.Equal(t, 0.2650543054337802, Float64())
+	Seed(1)
+	assert.Equal(t, 0.6046602879796196, Float64())
+}
+
+func TestInt31n(t *testing.T) {
+	Seed(1)
+	assert.Equal(t, int32(1298498081), Int31n(math.MaxInt32))
+	assert.Equal(t, int32(2019727887), Int31n(math.MaxInt32))
+	Seed(2)
+	assert.Equal(t, int32(359266786), Int31n(math.MaxInt32))
+	assert.Equal(t, int32(569199786), Int31n(math.MaxInt32))
+	Seed(1)
+	assert.Equal(t, int32(1298498081), Int31n(math.MaxInt32))
+	Seed(1)
+	assert.Equal(t, int32(939984059), Int31n(1298498081))
+}
+
+func TestInt63(t *testing.T) {
+	Seed(1)
+	assert.Equal(t, int64(5577006791947779410), Int63())
+	assert.Equal(t, int64(8674665223082153551), Int63())
+	Seed(2)
+	assert.Equal(t, int64(1543039099823358511), Int63())
+	assert.Equal(t, int64(2444694468985893231), Int63())
+	Seed(1)
+	assert.Equal(t, int64(5577006791947779410), Int63())
+}

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app"
 	log "github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/loggingtest"
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 )
 
 type dbquery struct {


### PR DESCRIPTION
1. Introduce the app's own random numbers generator (package app/rand) which substitutes math/rand in the app to make random numbers in tests fixed even when external libraries call math/rand methods.
2. Seed the random generator with a value read by crypto.rand/Read() instead of time.UnixNano() to make random numbers less predictable.
3. Fix golangci-lint installation in Makefile