### PR TITLE
Service get best answer

### DIFF
--- a/app/api/answers/answers.go
+++ b/app/api/answers/answers.go
@@ -28,6 +28,7 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Use(render.SetContentType(render.ContentTypeJSON))
 	router.Use(auth.UserMiddleware(srv.Base))
 	router.Get("/items/{item_id}/answers", service.AppHandler(srv.listAnswers).ServeHTTP)
+	router.Get("/items/{item_id}/best-answer", service.AppHandler(srv.getBestAnswer).ServeHTTP)
 	router.Get("/answers/{answer_id}", service.AppHandler(srv.getAnswer).ServeHTTP)
 	router.Post("/answers", service.AppHandler(srv.submit).ServeHTTP)
 

--- a/app/api/answers/get_best.feature
+++ b/app/api/answers/get_best.feature
@@ -1,0 +1,99 @@
+Feature: Get a current answer
+Background:
+  Given the database has the following table 'groups':
+    | id | name    | type  |
+    | 11 | jdoe    | User  |
+    | 13 | Team    | Team  |
+    | 14 | Group B | Class |
+    | 21 | manager | User  |
+    | 23 | Group C | Class |
+  And the database has the following table 'users':
+    | login   | group_id | first_name | last_name |
+    | jdoe    | 11       | John       | Doe       |
+    | manager | 21       | Man        | Ager      |
+  And the database has the following table 'groups_groups':
+    | parent_group_id | child_group_id |
+    | 14              | 11             |
+    | 13              | 21             |
+    | 23              | 21             |
+  And the groups ancestors are computed
+  And the database has the following table 'group_managers':
+    | group_id | manager_id | can_watch_members |
+    | 13       | 21         | true              |
+  And the groups ancestors are computed
+  And the database has the following table 'items':
+    | id  | default_language_tag |
+    | 200 | fr                   |
+    | 210 | fr                   |
+  And the database has the following table 'permissions_generated':
+    | group_id | item_id | can_view_generated       | can_watch_generated |
+    | 13       | 200     | content                  | answer              |
+    | 14       | 200     | content                  | none                |
+    | 23       | 210     | content_with_descendants | answer                |
+  And the database has the following table 'results':
+    | attempt_id | participant_id | item_id |
+    | 1          | 11             | 200     |
+    | 2          | 11             | 200     |
+    | 3          | 11             | 200     |
+    | 1          | 13             | 210     |
+    | 1          | 11             | 210     |
+  And the database has the following table 'answers':
+    | id  | author_id | participant_id | attempt_id | item_id | type       | state   | answer   | created_at          |
+    | 101 | 11        | 11             | 1          | 200     | Submission | Current | print(1) | 2017-05-29 06:38:38 |
+    | 102 | 11        | 11             | 2          | 200     | Submission | Current | print(2) | 2017-05-29 07:38:38 |
+    | 103 | 11        | 11             | 3          | 200     | Submission | Current | print(3) | 2017-05-29 08:38:38 |
+    | 104 | 11        | 13             | 1          | 210     | Submission | Current | print(4) | 2017-05-29 09:38:38 |
+    | 105 | 11        | 13             | 1          | 210     | Submission | Current | print(5) | 2017-05-29 10:38:38 |
+    | 106 | 11        | 13             | 1          | 210     | Submission | Current | print(6) | 2017-05-29 11:38:38 |
+    | 107 | 11        | 11             | 1          | 210     | Submission | Current | print(7) | 2017-05-29 08:38:38 |
+  And the database has the following table 'gradings':
+    | answer_id | score | graded_at           |
+    | 101       | 91    | 2018-05-29 06:38:31 |
+    | 102       | 97    | 2019-05-29 06:38:32 |
+    | 103       | 97    | 2018-05-29 06:38:33 |
+    | 104       | 96    | 2019-05-29 06:38:34 |
+    | 105       | 96    | 2018-05-29 06:38:35 |
+    | 106       | 95    | 2019-05-29 06:38:36 |
+    | 107       | 98    | 2019-05-29 06:38:38 |
+
+  Scenario: User has access to the item and retrieves his best answer
+    Given I am the user with id "11"
+    When I send a GET request to "/items/200/best-answer"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "id": "103",
+      "attempt_id": "3",
+      "participant_id": "11",
+      "score": 97.0,
+      "answer": "print(3)",
+      "state": "Current",
+      "created_at": "2017-05-29T08:38:38Z",
+      "type": "Submission",
+      "item_id": "200",
+      "author_id": "11",
+      "graded_at": "2018-05-29T06:38:33Z"
+    }
+    """
+
+  Scenario: User has access to the item and retrieves the best answer given by watched_group_id
+    Given I am the user with id "21"
+    When I send a GET request to "/items/210/best-answer?watched_group_id=13"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "id": "105",
+      "attempt_id": "1",
+      "participant_id": "13",
+      "score": 96.0,
+      "answer": "print(5)",
+      "state": "Current",
+      "created_at": "2017-05-29T10:38:38Z",
+      "type": "Submission",
+      "item_id": "210",
+      "author_id": "11",
+      "graded_at": "2018-05-29T06:38:35Z"
+    }
+    """

--- a/app/api/answers/get_best.go
+++ b/app/api/answers/get_best.go
@@ -1,0 +1,105 @@
+package answers
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/service"
+)
+
+// swagger:operation GET /items/{item_id}/best-answer answers bestAnswerGet
+// ---
+// summary: Get the best answer
+// description: Returns the best answer of the user on the given `{item_id}` among all attempts. The best answer is
+//              defined as the one which gives the highest score. If there are several, it is the most recent one
+//							by `created_at`.
+//
+//   * if `watched_group_id` is given, the current user must be allowed to watch "answer" of the item identified by `item_id`
+//   * if `watched_group_id` is given, it must be a participant (= team or user)
+//   * if `watched_group_id` is given, the current user must be allowed to watch the participant
+//
+//
+//   If any of the preconditions fails, the 'forbidden' error is returned.
+// parameters:
+// - name: item_id
+//   in: path
+//   type: integer
+//   format: int64
+//   required: true
+// - name: watched_group_id
+//   in: query
+//   type: integer
+//   description: A participant (`team_id` or user). If given, get the best answer of the participant instead
+//				  		  of the one of the user.
+// responses:
+//   "200":
+//     "$ref": "#/responses/itemAnswerGetResponse"
+//   "400":
+//     "$ref": "#/responses/badRequestResponse"
+//   "401":
+//     "$ref": "#/responses/unauthorizedResponse"
+//   "403":
+//     "$ref": "#/responses/forbiddenResponse"
+//   "500":
+//     "$ref": "#/responses/internalErrorResponse"
+func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request) service.APIError {
+	itemID, err := service.ResolveURLQueryPathInt64Field(httpReq, "item_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(httpReq)
+	if apiError != service.NoError {
+		return apiError
+	}
+
+	user := srv.GetUser(httpReq)
+	store := srv.GetStore(httpReq)
+	var result []map[string]interface{}
+
+	var bestAnswerQuery *database.DB
+	if watchedGroupID != 0 && watchedGroupIDSet {
+		// check 'can_watch'>='answer' permission on the answers.item_id
+		itemPerms := store.Permissions().MatchingUserAncestors(user).
+			WherePermissionIsAtLeast("watch", "answer").
+			Where("permissions.item_id = answers.item_id").
+			Select("1").
+			Limit(1)
+
+		// check if able to watch the participant
+		participantPerms := store.ActiveGroupAncestors().ManagedByUser(user).
+			Joins("JOIN `groups` ON groups.id = groups_ancestors_active.child_group_id").
+			Where("groups_ancestors_active.child_group_id = answers.participant_id").
+			Where("can_watch_members").
+			Select("1").
+			Limit(1)
+
+		bestAnswerQuery = store.Answers().
+			Where(`?`, itemPerms.SubQuery()).
+			Where(`?`, participantPerms.SubQuery()).
+			Where("participant_id = ?", watchedGroupID)
+	} else {
+		bestAnswerQuery = store.Answers().
+			Visible(user).
+			Where("author_id = ?", user.GroupID)
+	}
+
+	err = withGradings(bestAnswerQuery).
+		Where("item_id = ?", itemID).
+		Where("`type` = 'Submission'").
+		Where("graded_at IS NOT NULL").
+		Order("gradings.score DESC").
+		Order("answers.created_at DESC").
+		Limit(1).
+		ScanIntoSliceOfMaps(&result).Error()
+	service.MustNotBeError(err)
+	if len(result) == 0 {
+		return service.InsufficientAccessRightsError
+	}
+	convertedResult := service.ConvertSliceOfMapsFromDBToJSON(result)[0]
+
+	render.Respond(rw, httpReq, convertedResult)
+	return service.NoError
+}

--- a/app/api/answers/get_best.robustness.feature
+++ b/app/api/answers/get_best.robustness.feature
@@ -1,0 +1,94 @@
+Feature: Get the best answer - robustness
+  Background:
+    Given the database has the following table 'groups':
+      | id | name    | type |
+      | 11 | jdoe    | User |
+      | 12 | manager | User |
+      | 13 | team    | Team |
+    And the database has the following table 'users':
+      | login   | group_id |
+      | jdoe    | 11       |
+      | manager | 12       |
+    And the database has the following table 'items':
+      | id  | entry_participant_type | default_language_tag |
+      | 200 | User                   | fr                   |
+      | 210 | Team                   | fr                   |
+    And the database has the following table 'groups_groups':
+      | parent_group_id | child_group_id |
+      | 13              | 11             |
+      | 13              | 12             |
+    And the groups ancestors are computed
+    And the database has the following table 'group_managers':
+      | group_id | manager_id | can_watch_members |
+      | 13       | 11         | false             |
+      | 13       | 12         | true              |
+    And the database has the following table 'permissions_generated':
+      | item_id | group_id | can_view_generated | can_watch_generated |
+      | 200     | 11       | info               | none                |
+      | 210     | 11       | content            | answer              |
+      | 210     | 12       | content            | result              |
+      | 210     | 13       | content            | answer              |
+    And the database has the following table 'attempts':
+      | id | participant_id |
+      | 1  | 11             |
+      | 2  | 13             |
+    And the database has the following table 'results':
+      | attempt_id | participant_id | item_id |
+      | 1          | 11             | 200     |
+      | 2          | 13             | 210     |
+    And the database has the following table 'answers':
+      | id  | author_id | participant_id | attempt_id | item_id | type          | state   | answer   | created_at          |
+      | 101 | 11        | 11             | 1          | 200     | Submission    | Current | print(1) | 2017-05-29 06:38:38 |
+      | 102 | 13        | 13             | 2          | 210     | Submission    | Current | print(3) | 2017-05-29 06:38:38 |
+    And the database has the following table 'gradings':
+      | answer_id | score | graded_at           |
+      | 101       | 100   | 2018-05-29 06:38:38 |
+      | 102       | 100   | 2019-05-29 06:38:38 |
+
+  Scenario: Invalid item_id
+    Given I am the user with id "11"
+    When I send a GET request to "/items/1111111111111111111111111111/best-answer"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for item_id (should be int64)"
+
+  Scenario: Non-existent item_id
+    Given I am the user with id "11"
+    When I send a GET request to "/items/404/best-answer"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Invalid watched_group_id
+    Given I am the user with id "11"
+    When I send a GET request to "/items/200/best-answer?watched_group_id=abc"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for watched_group_id (should be int64)"
+
+  Scenario: Non-existent watched_group_id
+    Given I am the user with id "11"
+    When I send a GET request to "/items/200/best-answer?watched_group_id=404"
+    Then the response code should be 403
+    And the response error message should contain "No rights to watch for watched_group_id"
+
+  Scenario: User doesn't have sufficient access rights to the item
+    Given I am the user with id "11"
+    When I send a GET request to "/items/200/best-answer"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: No answer for the item
+    Given I am the user with id "11"
+    When I send a GET request to "/items/210/best-answer"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: The user is not allowed to watch the participant
+    Given I am the user with id "11"
+    When I send a GET request to "/items/210/best-answer?watched_group_id=13"
+    Then the response code should be 403
+    And the response error message should contain "No rights to watch for watched_group_id"
+
+  Scenario: The user is not allowed to watch "answer" of the item
+    Given I am the user with id "12"
+    When I send a GET request to "/items/210/best-answer?watched_group_id=13"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"


### PR DESCRIPTION
Fixes #874

Notes:
- If there is no answer, the service returns 403 instead of 404. This is the same behavior as the other "answers" services. Returning a 404 instead would require checking the permission and existance separately.
- I'm not sure about the permissions checks when `watched_group_id` is used.  I used the same permissions checks as the get_current service, but in the query there is only mention of  `can_view_generated_value` , and nothing about `can_watch_generated_value`:

`
JOIN (
	SELECT DISTINCT item_id FROM permissions_generated AS permissions
	JOIN groups_ancestors_active AS ancestors
	ON ancestors.child_group_id = 21 AND ancestors.ancestor_group_id = permissions.group_id
	WHERE (IFNULL(can_view_generated_value, 1) >= 3)
) AS permissions USING(item_id)
`