### PR TITLE
Option to filter run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ GOBUILD_VERSION_INJECTION=-ldflags="-X main.version=$(shell $(VERSION_FETCHING_C
 ifdef FILTER
 	TEST_FILTER=-run $(FILTER)
 endif
-ifndef TEST_DIR
+ifdef DIRECTORY
+	TEST_DIR=$(DIRECTORY)
+else
 	TEST_DIR=./app/...
 endif
 
@@ -77,12 +79,13 @@ db-recompute: $(BIN_PATH)
 
 test: $(TEST_REPORT_DIR)
 	$(Q)# TODO: the tests using the db do not currently support parallelism
-	$(Q)# add TEST_DIR=./app/api/item to only test a certain directory. Must start with ".".
+	$(Q)# add DIRECTORY=./app/api/item to only test a certain directory. Must start with ".".
+	$(Q)# Warning: DIRECTORY must be a directory, it will fail if it is a file
 	$(Q)# add FILTER=functionToTest to only test a certain function. functionToTest is a Regex.
 
 	$(Q)$(GOTEST) -gcflags=all=-l -race -coverprofile=$(TEST_REPORT_DIR)/coverage.txt -covermode=atomic -v $(TEST_DIR) -p 1 -parallel 1 $(TEST_FILTER)
 test-unit:
-	$(GOTEST) -gcflags=all=-l -race -cover -v ./app/... -tags=unit
+	$(GOTEST) -gcflags=all=-l -race -cover -v -tags=unit $(TEST_DIR) $(TEST_FILTER)
 test-bdd: $(GODOG)
 	# to pass args: make ARGS="--tags=wip" test-bdd
 	$(GODOG) --format=progress $(ARGS) .

--- a/README.md
+++ b/README.md
@@ -85,25 +85,33 @@ in order to recompute DB caches.
 
 ## Testing
 
-Run all tests (unit and bdd):
+Run all tests (unit, and bdd):
 ```
 make test
 ```
-Only unit:
+You can filter with a certain directory and the name of the test function you want to run:
+```
+make DIRECTORY=./app/database FILTER=TestItemStore_TriggerBeforeInsert_SetsPlatformID test
+```
+Only unit tests who are marked with the "unit" tag. For unit tests not marked, use `make test`:
 ```
 make test-unit
 ```
-Only bdd (cucumber using `godog`), using the database connection:
+You can also use the filters:
+```
+make DIRECTORY=./app/database FILTER=TestItemStore_TriggerBeforeInsert_SetsPlatformID test-unit
+```
+Only Gherkin tests defined in *.feature files (cucumber using `godog`), using the database connection:
 ```
 make test-bdd
 ```
-or if you want only to run bdd tests with a specific tag:
+or if you want only to run the tests with a specific tag
 ```
 make ARGS="--tags=wip" test-bdd
 ```
 To add a tag to a test, just precede it by @wip on the line above it in the *.feature file. This is useful to only execute appropriate tests.
 
-you may have to specify the godog directory:
+you may also have to specify the godog directory:
 ```
 make BIN_DIR=~/go/bin ARGS="--tags=wip" test-bdd
 ```


### PR DESCRIPTION
make test-bdd can now be run with a filter on directory and function name to make development easier