### PR TITLE
Fixes for MySQL 8.0.26

### DIFF
--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -155,7 +155,7 @@ func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request
 
 	// Used to be a subquery, but it failed with MySQL-8.0.26 due to obscure bugs introduced in this version.
 	// It works when doing the query first and using the result in the second query.
-	// See commit 1abc337a81f83462d4361b9876abee2a82c0e23a
+	// See commit 5a25fbded8134c93c72dc853f72071943a1bd24c
 	managedGroupsWithCanGrantGroupAccessIds := user.GetManagedGroupsWithCanGrantGroupAccessIds(store)
 
 	var sourceGroupsQuery, groupsQuery *database.DB

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -116,7 +116,7 @@ func constructItemListWithoutResultsQuery(dataStore *database.DataStore, groupID
 
 		// Used to be made with a WITH(), but it failed with MySQL-8.0.26 due to obscure bugs introduced in this version.
 		// It works when we get the groups directly with joins.
-		// See commit 1abc337a81f83462d4361b9876abee2a82c0e23a
+		// See commit 5a25fbded8134c93c72dc853f72071943a1bd24c
 		watchedGroupAvgScoreQuery = dataStore.Raw(
 			"SELECT IFNULL(AVG(score), 0) AS avg_score, COUNT(*) > 0 AND COUNT(*) = SUM(validated) AS all_validated FROM ? AS stats",
 			dataStore.Table("groups_ancestors_active").

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -40,3 +40,17 @@ func (u *User) CanWatchGroupMembers(store *DataStore, groupID int64) bool {
 
 	return found
 }
+
+// GetManagedGroupsWithCanGrantGroupAccessIds retrieve all group ids that the user manager and for which
+// he can_grant_group_access.
+func (u *User) GetManagedGroupsWithCanGrantGroupAccessIds(store *DataStore) []int64 {
+	var managedGroupsWithCanGrantGroupAccessIds []int64
+
+	store.ActiveGroupAncestors().ManagedByUser(u).
+		Group("groups_ancestors_active.child_group_id").
+		Having("MAX(group_managers.can_grant_group_access)").
+		Select("groups_ancestors_active.child_group_id AS id").
+		Pluck("id", &managedGroupsWithCanGrantGroupAccessIds)
+
+	return managedGroupsWithCanGrantGroupAccessIds
+}

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -41,7 +41,7 @@ func (u *User) CanWatchGroupMembers(store *DataStore, groupID int64) bool {
 	return found
 }
 
-// GetManagedGroupsWithCanGrantGroupAccessIds retrieve all group ids that the user manager and for which
+// GetManagedGroupsWithCanGrantGroupAccessIds retrieves all group ids that the user manages and for which
 // he can_grant_group_access.
 func (u *User) GetManagedGroupsWithCanGrantGroupAccessIds(store *DataStore) []int64 {
 	var managedGroupsWithCanGrantGroupAccessIds []int64


### PR DESCRIPTION
Some SQL adaptations to fix the bugs introduced by MySQL 8.0.26

-> One is the replacement of a subquery by doing the subquery first and using the results as parameters
-> The other one is the replacement of a WITH (...) by standard joins

Both problems are fixed in Mysql 8.0.28, though I couldn't find the source of the issues in the changelog https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html

It could be related to, but isn't exaclty:
A query using aggregation on a [BIT](https://dev.mysql.com/doc/refman/8.0/en/bit-type.html) type could return different results depending on the indexes or join type employed. This was due to the fact that a DML statement using such an aggregation caches the BIT values using an integer type, and later looks up and converts to a string format for output. The current issue arose because this lookup treated the BIT value as an integer, resulting in an incorrect string value.

The only thing I could do was to use both mysql version side-by-side and see the differences returned by the requests.

Note: Uses PR https://github.com/France-ioi/AlgoreaBackend/pull/918