### PR TITLE
Add references in Gherkin definitions

### DIFF
--- a/app/api/currentuser/refresh.feature
+++ b/app/api/currentuser/refresh.feature
@@ -79,7 +79,6 @@ Feature: Update the local user info cache
     | profile_with_all_fields_set | janedoe@gmail.com | Jane       | Doe       | 456789012  | gb           | 2001-08-03 | 2021            | 0     | I'm Jane Doe | http://jane.freepages.com | Female | true           | Europe/London | true        | true           | true              |
     | profile_with_null_fields    | null              | null       | null      | null       |              | null       | 0               | null  | null         | null                      | null   | false          | null          | false       | false          | false             |
 
-
   Scenario: Update an existing user with badges
     Given the time now is "2019-07-16T22:02:29Z"
     And the DB time now is "2019-07-16 22:02:28"

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -74,26 +74,26 @@ Feature: Update thread - robustness
       | item_id | participant_id | status | helper_group_id | latest_update_at |
 
   Scenario: Should be logged in
-    When I send a PUT request to "/items/10/participant/1/thread"
+    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
 
   Scenario: The item_id parameter should be an int64
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/aaa/participant/1/thread"
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/aaa/participant/@RichardFeynman/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for item_id (should be int64)"
 
   Scenario: The participant_id parameter should be an int64
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/10/participant/aaa/thread"
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@SomeItem/participant/aaa/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for participant_id (should be int64)"
 
   Scenario: Either status, helper_group_id, message_count or message_count_increment must be given
-    Given I am the user with id "1"
-    And there is a thread with "item_id=10,participant_id=1"
-    When I send a PUT request to "/items/10/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=@SomeItem,participant_id=@RichardFeynman"
+    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread" with the following body:
       """
       {}
       """
@@ -101,8 +101,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Either status, helper_group_id, message_count or message_count_increment must be given"
 
   Scenario: The item should exist
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/404/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@NonExistentItem/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "message_count": 42
@@ -112,12 +112,12 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: The participant should exist
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/5/participant/404/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@SomeItem/participant/@NonExistentParticipant/thread" with the following body:
       """
       {
         "status": "waiting_for_trainer",
-        "helper_group_id": 10
+        "helper_group_id": @SomeItem
       }
       """
     Then the response code should be 400
@@ -199,7 +199,7 @@ Feature: Update thread - robustness
   Scenario: >
   Should return access error when the status is not set and
   "can write to thread" condition (3) is not met: user is not part of the help group
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I have validated the item with id "40"
     And I can watch answer on item with id "40"
     And there is a thread with "item_id=40,participant_id=3"
@@ -227,8 +227,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: message_count should be positive
-    Given I am the user with id "1"
-    And there is a thread with "item_id=60,participant_id=1"
+    Given I am RichardFeynman
+    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
     When I send a PUT request to "/items/60/participant/3/thread" with the following body:
       """
       {
@@ -249,9 +249,9 @@ Feature: Update thread - robustness
     """
 
   Scenario: Should not contain both message_count and message_count_increment
-    Given I am the user with id "1"
-    And there is a thread with "item_id=60,participant_id=1"
-    When I send a PUT request to "/items/60/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
+    When I send a PUT request to "/items/60/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "message_count": 1,
@@ -406,7 +406,7 @@ Feature: Update thread - robustness
       | 140     | answer_with_grant | waiting_for_participant |
 
   Scenario: Cannot switch between open status if only can_watch>answer but not a part of the helper group, and cannot watch participant
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I can watch answer on item with id "150"
     And there is a thread with "item_id=150,participant_id=3,status=waiting_for_participant"
     When I send a PUT request to "/items/150/participant/3/thread" with the following body:
@@ -419,7 +419,7 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: Cannot switch between open status if only item validated but not a part of the helper group, and cannot watch participant
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I have validated the item with id "160"
     And there is a thread with "item_id=160,participant_id=3,status=waiting_for_trainer"
     When I send a PUT request to "/items/160/participant/3/thread" with the following body:
@@ -432,9 +432,9 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread exists
-    Given I am the user with id "1"
-    And there is a thread with "item_id=<item_id>,participant_id=1,status=closed"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=<item_id>,participant_id=@RichardFeynman,status=closed"
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -458,8 +458,8 @@ Feature: Update thread - robustness
       | 210     | waiting_for_participant |
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread doesn't exists
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -485,7 +485,7 @@ Feature: Update thread - robustness
   Scenario Outline: If status is already "closed" and not changing status OR if switching to status "closed": helper_group_id must not be given when thread exists
     Given I am the user with id "1"
     And there is a thread with "item_id=<item_id>,participant_id=1,status=<old_status>"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>",
@@ -558,7 +558,7 @@ Feature: Update thread - robustness
     """
 
   Scenario: helper_group_id is visible to participant but not to current-user
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And there is a thread with "item_id=310,participant_id=3"
     When I send a PUT request to "/items/310/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -73,8 +73,10 @@ Feature: Update thread - robustness
     And the database has the following table 'threads':
       | item_id | participant_id | status | helper_group_id | latest_update_at |
 
-  Scenario: Should be logged in
-    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread"
+  Scenario: Should be logged
+    Given there is a user RichardFeynman
+    And there is an item Exercice
+    When I send a PUT request to "/items/@Exercice/participant/@RichardFeynman/thread"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
 
@@ -86,14 +88,16 @@ Feature: Update thread - robustness
 
   Scenario: The participant_id parameter should be an int64
     Given I am RichardFeynman
-    When I send a PUT request to "/items/@SomeItem/participant/aaa/thread"
+    And there is an item Exercice
+    When I send a PUT request to "/items/@Exercice/participant/aaa/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for participant_id (should be int64)"
 
   Scenario: Either status, helper_group_id, message_count or message_count_increment must be given
     Given I am RichardFeynman
-    And there is a thread with "item_id=@SomeItem,participant_id=@RichardFeynman"
-    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread" with the following body:
+    And there is an item Exercice
+    And there is a thread with "item_id=@Exercice,participant_id=@RichardFeynman"
+    When I send a PUT request to "/items/@Exercice/participant/@RichardFeynman/thread" with the following body:
       """
       {}
       """
@@ -102,7 +106,7 @@ Feature: Update thread - robustness
 
   Scenario: The item should exist
     Given I am RichardFeynman
-    When I send a PUT request to "/items/@NonExistentItem/participant/@RichardFeynman/thread" with the following body:
+    When I send a PUT request to "/items/404/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "message_count": 42
@@ -113,7 +117,8 @@ Feature: Update thread - robustness
 
   Scenario: The participant should exist
     Given I am RichardFeynman
-    When I send a PUT request to "/items/@SomeItem/participant/@NonExistentParticipant/thread" with the following body:
+    And there is an item Exercice
+    When I send a PUT request to "/items/@Exercice/participant/404/thread" with the following body:
       """
       {
         "status": "waiting_for_trainer",

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -39,8 +39,11 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
+	s.Step(`^there is an item (\w+)$`, ctx.ThereIsAnItem)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
+	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
+		ctx.ICanViewOnItemWithID)
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
 	s.Step(`^there is a thread with "([^"]*)"$`, ctx.ThereIsAThreadWith)
 	s.Step(`^there is no thread with "([^"]*)"$`, ctx.ThereIsNoThreadWith)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -20,7 +20,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 
 	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
-	s.Step(`^I am ([^ ]*)$`, ctx.IAm)
+	s.Step(`^I am (\w+)$`, ctx.IAm)
+	s.Step(`^there is a user (\w+)$`, ctx.ThereIsAUser)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
 	s.Step(`^the generated group code is "([^"]*)"$`, ctx.TheGeneratedGroupCodeIs)
@@ -37,6 +38,7 @@ func FeatureContext(s *godog.Suite) {
 		ctx.ICanViewOnItemWithID)
 	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
+	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -4,7 +4,6 @@ package testhelpers
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -40,23 +39,6 @@ func getParametersString(parameters map[string]string) string {
 	}
 
 	return str
-}
-
-// getReferenceFor gets the ID from a reference, or set it if it doesn't exist.
-func (ctx *TestContext) getReferenceFor(name string) int64 {
-	if _, ok := ctx.identifierReferences[name]; !ok {
-		ctx.identifierReferences[name] = rand.Int63()
-	}
-
-	return ctx.identifierReferences[name]
-}
-
-// replaceReferencesByIDs changes the references (@ref) in a string by the referenced identifiers (ID).
-func (ctx *TestContext) replaceReferencesByIDs(str string) string {
-	regex := regexp.MustCompile(`(@\w+)`)
-	return regex.ReplaceAllStringFunc(str, func(reference string) string {
-		return strconv.FormatInt(ctx.getReferenceFor(reference[1:]), 10)
-	})
 }
 
 // populateDatabase populate the database with all the initialized data

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -294,6 +294,20 @@ func (ctx *TestContext) ICanViewOnItemWithID(watchValue string, itemID int64) er
 	return ctx.ICanOnItemWithID("view", watchValue, itemID)
 }
 
+// ThereIsAnItemWithID adds an item with a specific id.
+func (ctx *TestContext) ThereIsAnItemWithID(id string) error {
+	ctx.addItem(id, "en", "Task")
+
+	return nil
+}
+
+// ThereIsAnItem adds an item.
+func (ctx *TestContext) ThereIsAnItem(name string) error {
+	itemID := ctx.getReferenceFor(name)
+
+	return ctx.ThereIsAnItemWithID(strconv.FormatInt(itemID, 10))
+}
+
 // ICanWatchOnItemWithID gives the user a "watch" permission on an item.
 func (ctx *TestContext) ICanWatchOnItemWithID(watchValue string, itemID int64) error {
 	return ctx.ICanOnItemWithID("watch", watchValue, itemID)
@@ -319,7 +333,10 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 	thread := ctx.getParametersMap(parameters)
 
 	// add item
-	ctx.addItem(thread["item_id"], "en", "Task")
+	err := ctx.ThereIsAnItemWithID(thread["item_id"])
+	if err != nil {
+		return err
+	}
 
 	// add helper_group_id
 	if _, ok := thread["helper_group_id"]; !ok {

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -22,6 +22,7 @@ import (
 var dbPathRegexp = regexp.MustCompile(`^\s*(\w+)\[(\d+)]\[(\w+)]\s*$`)
 
 func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
+	jsonBody = ctx.replaceReferencesByIDs(jsonBody)
 	tmpl, err := ctx.templateSet.Parse("template", jsonBody)
 
 	if err != nil {

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -43,9 +43,9 @@ func (ctx *TestContext) replaceReferencesByIDs(str string) string {
 
 		if capture[0] == '@' {
 			return strconv.FormatInt(ctx.getReferenceFor(capture[1:]), 10)
-		} else {
-			return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
 		}
+		
+		return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
 	})
 }
 

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -32,19 +32,20 @@ type dbquery struct {
 // TestContext implements context for tests
 type TestContext struct {
 	// nolint
-	application      *app.Application // do NOT call it directly, use `app()`
-	userID           int64            // userID that will be used for the next requests
-	featureQueries   []dbquery
-	lastResponse     *http.Response
-	lastResponseBody string
-	logsHook         *loggingtest.Hook
-	logsRestoreFunc  func()
-	inScenario       bool
-	dbTableData      map[string]*messages.PickleStepArgument_PickleTable
-	templateSet      *jet.Set
-	requestHeaders   map[string][]string
-	dbTables         map[string]map[string]map[string]interface{}
-	currentThreadKey string
+	application          *app.Application // do NOT call it directly, use `app()`
+	userID               int64            // userID that will be used for the next requests
+	featureQueries       []dbquery
+	lastResponse         *http.Response
+	lastResponseBody     string
+	logsHook             *loggingtest.Hook
+	logsRestoreFunc      func()
+	inScenario           bool
+	dbTableData          map[string]*messages.PickleStepArgument_PickleTable
+	templateSet          *jet.Set
+	requestHeaders       map[string][]string
+	identifierReferences map[string]int64
+	dbTables             map[string]map[string]map[string]interface{}
+	currentThreadKey     string
 }
 
 var db *sql.DB
@@ -66,6 +67,7 @@ func (ctx *TestContext) SetupTestContext(pickle *messages.Pickle) { // nolint
 	ctx.requestHeaders = map[string][]string{}
 	ctx.dbTableData = make(map[string]*messages.PickleStepArgument_PickleTable)
 	ctx.templateSet = ctx.constructTemplateSet()
+	ctx.identifierReferences = make(map[string]int64)
 	ctx.dbTables = make(map[string]map[string]map[string]interface{})
 
 	// reset the seed to get predictable results on PRNG for tests


### PR DESCRIPTION
It is now possible to use references in Gherkin definition with the @ReferenceName notation.

This allows the use of meaningful names instead of writing ids everywhere. It also makes it possible to combine definitions with names and the use of their id.

    Given I am RichardFeynman
    When I send a PUT request to "/items/aaa/participant/@RichardFeynman/thread"`