### PR TITLE
Fix before_update_items trigger and fix the corresponding test

### DIFF
--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -1063,7 +1063,7 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 		updateMap      map[string]interface{}
 		wantPlatformID *int64
 	}{
-		{name: "url is unchanged", updateMap: map[string]interface{}{"type": "Chapter"}, wantPlatformID: ptrInt64(4)},
+		{name: "url is unchanged", updateMap: map[string]interface{}{"type": "Chapter"}, wantPlatformID: ptrInt64(1)},
 		{name: "new url is null", updateMap: map[string]interface{}{"url": nil}, wantPlatformID: nil},
 		{name: "chooses a platform with higher priority", updateMap: map[string]interface{}{"url": ptrString("12345")},
 			wantPlatformID: ptrInt64(2)},
@@ -1074,18 +1074,18 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
-					- {id: 3, regexp: "^1.*", priority: 1}
-					- {id: 4, regexp: "^2.*", priority: 2}
-					- {id: 2, regexp: "^1.*", priority: 3}
 					- {id: 1, regexp: "^4.*", priority: 4}
+					- {id: 2, regexp: "^1.*", priority: 3}
+					- {id: 4, regexp: "^2.*", priority: 2}
+					- {id: 3, regexp: "^1.*", priority: 1}
 				languages: [{tag: fr}]
 				items:
-					- {id: 1, platform_id: 4, url: 1234, default_language_tag: fr}`)
+					- {id: 1, platform_id: 1, url: 444, default_language_tag: fr}`)
 			defer func() { _ = db.Close() }()
 
 			itemStore := database.NewDataStore(db).Items()
-			assert.NoError(t, itemStore.ByID(1).UpdateColumn("platform_id", 4).Error())
 			assert.NoError(t, itemStore.UpdateColumn(test.updateMap).Error())
+
 			var platformID *int64
 			assert.NoError(t, itemStore.ByID(1).PluckFirst("platform_id", &platformID).Error())
 			if test.wantPlatformID == nil {

--- a/db/migrations/2303281630_fix_before_update_items_trigger.sql
+++ b/db/migrations/2303281630_fix_before_update_items_trigger.sql
@@ -1,0 +1,38 @@
+-- +migrate Up
+
+DROP TRIGGER `before_update_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_items` BEFORE UPDATE ON `items` FOR EACH ROW
+BEGIN
+  IF NOT OLD.url <=> NEW.url THEN
+    IF NEW.url IS NOT NULL THEN
+      SET @platformID = (SELECT platforms.id FROM platforms WHERE NEW.url REGEXP platforms.regexp ORDER BY platforms.priority DESC LIMIT 1);
+
+      SET NEW.platform_id=@platformID;
+    ELSE
+      SET NEW.platform_id = NULL;
+    END IF;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+
+-- +migrate Down
+
+DROP TRIGGER `before_update_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_items` BEFORE UPDATE ON `items` FOR EACH ROW
+BEGIN
+  IF NOT OLD.url <=> NEW.url THEN
+    IF NEW.url IS NOT NULL THEN
+      SELECT platforms.id INTO @platformID FROM platforms
+      WHERE NEW.url REGEXP platforms.regexp
+      ORDER BY platforms.priority DESC LIMIT 1;
+
+      SET NEW.platform_id=@platformID;
+    ELSE
+      SET NEW.platform_id = NULL;
+    END IF;
+  END IF;
+END;
+-- +migrate StatementEnd


### PR DESCRIPTION
When an item's url was updated to something that didn't match any platform regex, the platform_id wasn't set to NULL.

The corresponding test was written in a weird way that made the test pass:
- The initial data was inconsistent: it's not possible to have an url "1234" with a platform_id 4 where the regex states `don't start with a "4"`.
- There is no reason to update the platform_id to 4 prior to the tests. Or is it to test something else that I'm missing? In this case we should make a separate test. 

After the update to go1.20, the test doesn't pass anymore. I checked the trigger directly into mysql and noticed that it wasn't working in this case. I'm still not sure why the test used to pass prior to the update.