### PR TITLE
Latest lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,40 @@ linters:
     - gomnd # flags all "magic numbers" in the code. requires many changes
     - goerr113 # don't allow dynamic errors, requires wrapped static errors. requires many changes
     - nestif # Doesn't allow too long nested if. requires complex changes
+    - forbidigo # For update to go1.20
+    - gci # For update to go1.20
+    - gochecknoinits # For update to go1.20
+    - revive # For update to go1.20
+    - asasalint # For update to go1.20
+    - containedctx # For update to go1.20
+    - contextcheck # For update to go1.20
+    - cyclop # For update to go1.20
+    - dupword # For update to go1.20
+    - revive # For update to go1.20
+    - errchkjson # For update to go1.20
+    - errorlint # For update to go1.20
+    - errname # For update to go1.20
+    - execinquery # For update to go1.20
+    - exhaustive # For update to go1.20
+    - exhaustivestruct # For update to go1.20
+    - forcetypeassert # For update to go1.20
+    - ifshort # For update to go1.20
+    - ireturn # For update to go1.20
+    - ineffassign # For update to go1.20
+    - maintidx # For update to go1.20
+    - musttag # For update to go1.20
+    - nilnil # For update to go1.20
+    - nlreturn # For update to go1.20
+    - noctx # For update to go1.20
+    - nonamedreturns # For update to go1.20
+    - paralleltest # For update to go1.20
+    - sqlclosecheck # For update to go1.20
+    - tagliatelle # For update to go1.20
+    - tenv # For update to go1.20
+    - thelper # For update to go1.20
+    - usestdlibvars # For update to go1.20
+    - varnamelen # For update to go1.20
+    - wrapcheck # For update to go1.20
 
 run:
   skip-dirs:
@@ -92,4 +126,4 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.27.0 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.2 # use the fixed version to not introduce new linters unexpectedly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters-settings:
       - experimental
     disabled-checks:
       - wrapperFunc
-      - whyNoLint # requires an explanation for each nolint. requires many changes
+      - whyNoLint # Requires an explanation for each nolint. requires many changes
 
 linters:
   enable-all: true
@@ -54,46 +54,57 @@ linters:
     - maligned
     - prealloc
     - gochecknoglobals
-    - testpackage # requires that go test files are in a different package, but current tests are on private functions
-    - wsl # requires whitelines between blocks. requires many changes, enable it later
-    - nolintlint # requires explanation for each "nolint" directive. requires many changes
-    - gomnd # flags all "magic numbers" in the code. requires many changes
-    - goerr113 # don't allow dynamic errors, requires wrapped static errors. requires many changes
-    - nestif # Doesn't allow too long nested if. requires complex changes
-    - forbidigo # For update to go1.20
-    - gci # For update to go1.20
-    - gochecknoinits # For update to go1.20
-    - revive # For update to go1.20
-    - asasalint # For update to go1.20
-    - containedctx # For update to go1.20
-    - contextcheck # For update to go1.20
-    - cyclop # For update to go1.20
-    - dupword # For update to go1.20
-    - revive # For update to go1.20
-    - errchkjson # For update to go1.20
-    - errorlint # For update to go1.20
-    - errname # For update to go1.20
-    - execinquery # For update to go1.20
-    - exhaustive # For update to go1.20
+    - varcheck         # Deprecated.
+    - golint           # Deprecated.
+    - structcheck      # Deprecated.
+    - deadcode         # Deprecated.
+    - scopelint        # Deprecated.
+    - nosnakecase      # Deprecated.
+    - interfacer       # Deprecated.
+    - testpackage      # Requires that go tests files are in a different package, but current tests are on private functions
+    - wsl              # Requires whitelines between blocks. requires many changes, enable it later
+    - nolintlint       # Requires explanation for each "nolint" directive. requires many changes
+    - gomnd            # Flags all "magic numbers" in the code. requires many changes
+    - goerr113         # Don't allow dynamic errors, requires wrapped static errors. requires many changes
+    - nestif           # Doesn't allow too long nested if. requires complex changes
+    - forbidigo        # For update to go1.20
+    - gci              # For update to go1.20
+    - gochecknoinits   # For update to go1.20
+    - revive           # For update to go1.20
+    - asasalint        # For update to go1.20
+    - containedctx     # For update to go1.20
+    - contextcheck     # For update to go1.20
+    - cyclop           # For update to go1.20
+    - dupword          # For update to go1.20
+    - revive           # For update to go1.20
+    - errchkjson       # For update to go1.20
+    - errorlint        # For update to go1.20
+    - errname          # For update to go1.20
+    - execinquery      # For update to go1.20
+    - exhaustive       # For update to go1.20
     - exhaustivestruct # For update to go1.20
-    - forcetypeassert # For update to go1.20
-    - ifshort # For update to go1.20
-    - ireturn # For update to go1.20
-    - ineffassign # For update to go1.20
-    - maintidx # For update to go1.20
-    - musttag # For update to go1.20
-    - nilnil # For update to go1.20
-    - nlreturn # For update to go1.20
-    - noctx # For update to go1.20
-    - nonamedreturns # For update to go1.20
-    - paralleltest # For update to go1.20
-    - sqlclosecheck # For update to go1.20
-    - tagliatelle # For update to go1.20
-    - tenv # For update to go1.20
-    - thelper # For update to go1.20
-    - usestdlibvars # For update to go1.20
-    - varnamelen # For update to go1.20
-    - wrapcheck # For update to go1.20
+    - forcetypeassert  # For update to go1.20
+    - ifshort          # For update to go1.20
+    - ireturn          # For update to go1.20
+    - ineffassign      # For update to go1.20
+    - maintidx         # For update to go1.20
+    - musttag          # For update to go1.20
+    - nilnil           # For update to go1.20
+    - nlreturn         # For update to go1.20
+    - noctx            # For update to go1.20
+    - nonamedreturns   # For update to go1.20
+    - paralleltest     # For update to go1.20
+    - sqlclosecheck    # For update to go1.20
+    - tagliatelle      # For update to go1.20
+    - tenv             # For update to go1.20
+    - thelper          # For update to go1.20
+    - usestdlibvars    # For update to go1.20
+    - varnamelen       # For update to go1.20
+    - wrapcheck        # For update to go1.20
+    - exhaustruct      # For update to go1.20
+    - gomoddirectives  # For update to go1.20
+    - typecheck        # For update to go1.20
+    - dupl             # For update to go1.20
 
 run:
   skip-dirs:
@@ -106,6 +117,11 @@ run:
 issues:
   exclude-use-default: false
   exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gosec
+        - gocognit
     - text: "weak cryptographic primitive"
       linters:
         - gosec
@@ -118,10 +134,46 @@ issues:
     - text: "has too many statements"
       linters:
         - funlen
+    - text: "unknown JSON option" # requires update of package "mapstructure"
+      linters:
+        - staticcheck
+    - text: "function has more than 5 results, consider to simplify the function"
+      linters:
+        - gocritic
+    - text: "to be of non-pointer type"
+      linters:
+        - gocritic
+    - text: "SA1019:" # io/util has been deprecated since Go 1.19
+      linters:
+        - staticcheck
+    - text: "SA1029:" # should not use built'in type string as key for value; define your own type to avoid collisions
+      linters:
+        - staticcheck
+    - text: "ptrToRefParam:"
+      linters:
+        - gocritic
+    - text: "G404:" # Use of weak random number generator (math/rang instead of crypto/rand)
+      linters:
+        - gosec
+    - text: "deferInLoop:" # Possible resource leak, 'defer' is called in the 'for' loop.
+      linters:
+        - gocritic
+    - text: "type .answerSubmitResponse. is unused"
+      linters:
+        - unused
+    - text: "uncheckedInlineErr: err error is unchecked, maybe intended to check it instead of conn.db.AddError.err."
+      linters:
+        - gocritic
+    - text: "timeCmpSimplify:"
+      linters:
+        - gocritic
 
   exclude:
     - "not declared by package utf8"
     - "unicode/utf8/utf8.go"
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  #fix: true # Enable to try auto fix.
 
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ $(TEST_REPORT_DIR):
 $(GODOG):
 	$(GOGET) -u github.com/cucumber/godog/cmd/godog@v0.9.0
 $(GOLANGCILINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCAL_BIN_DIR) v1.27.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCAL_BIN_DIR) v1.52.2
 $(MYSQL_CONNECTOR_JAVA):
 	curl -sfL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.16.tar.gz | tar -xzf - mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar
 	mv mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar $(MYSQL_CONNECTOR_JAVA)

--- a/app/api/answers/bdd_test.go
+++ b/app/api/answers/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package answers_test
 

--- a/app/api/answers/list_answers.go
+++ b/app/api/answers/list_answers.go
@@ -208,7 +208,8 @@ func (srv *Service) convertDBDataToResponse(rawData []rawAnswersData) (response 
 }
 
 func (srv *Service) checkAccessRightsForGetAnswersByAttemptID(
-	store *database.DataStore, attemptID int64, user *database.User) service.APIError {
+	store *database.DataStore, attemptID int64, user *database.User,
+) service.APIError {
 	var count int64
 	groupsManagedByUser := store.GroupAncestors().ManagedByUser(user).Select("groups_ancestors.child_group_id")
 	groupsWhereUserIsMember := store.GroupGroups().WhereUserIsMember(user).Select("parent_group_id")
@@ -226,7 +227,8 @@ func (srv *Service) checkAccessRightsForGetAnswersByAttemptID(
 }
 
 func (srv *Service) checkAccessRightsForGetAnswersByAuthorID(
-	store *database.DataStore, authorID int64, user *database.User) service.APIError {
+	store *database.DataStore, authorID int64, user *database.User,
+) service.APIError {
 	if authorID != user.GroupID {
 		found, err := store.GroupAncestors().ManagedByUser(user).
 			Where("groups_ancestors.child_group_id=?", authorID).HasRows()

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -185,13 +185,11 @@ func (requestData *SubmitRequest) Bind(r *http.Request) error {
 	return nil
 }
 
-var (
-	_ render.Binder = (*SubmitRequest)(nil)
-)
+var _ render.Binder = (*SubmitRequest)(nil)
 
 // Created. Success response with answer_token
 // swagger:model answerSubmitResponse
-type answerSubmitResponse struct { //nolint:deadcode Used for documentation.
+type answerSubmitResponse struct {
 	// description
 	// swagger:allOf
 	doc.CreatedResponse

--- a/app/api/api.go
+++ b/app/api/api.go
@@ -26,7 +26,8 @@ type Ctx struct {
 
 // Router provides routes for the whole API.
 func Router(db *database.DB, serverConfig, authConfig *viper.Viper, domainConfig []domain.ConfigItem,
-	tokenConfig *token.Config) (*Ctx, *chi.Mux) {
+	tokenConfig *token.Config,
+) (*Ctx, *chi.Mux) {
 	r := chi.NewRouter()
 
 	srv := &service.Base{

--- a/app/api/auth/bdd_test.go
+++ b/app/api/auth/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package auth_test
 

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -189,7 +189,8 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) se
 
 func (srv *Service) respondWithNewAccessToken(r *http.Request, w http.ResponseWriter,
 	rendererGenerator func(interface{}) render.Renderer, token string, expiresIn time.Time,
-	cookieAttributes *auth.SessionCookieAttributes) {
+	cookieAttributes *auth.SessionCookieAttributes,
+) {
 	secondsUntilExpiry := int32(time.Until(expiresIn).Round(time.Second) / time.Second)
 	response := map[string]interface{}{
 		"expires_in": secondsUntilExpiry,
@@ -211,7 +212,8 @@ func (srv *Service) respondWithNewAccessToken(r *http.Request, w http.ResponseWr
 }
 
 func (srv *Service) resolveCookieAttributes(r *http.Request, requestData map[string]interface{}) (
-	cookieAttributes *auth.SessionCookieAttributes, apiError service.APIError) {
+	cookieAttributes *auth.SessionCookieAttributes, apiError service.APIError,
+) {
 	cookieAttributes = &auth.SessionCookieAttributes{}
 	if value, ok := requestData["use_cookie"]; ok && value.(bool) {
 		cookieAttributes.UseCookie = true

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -78,7 +78,8 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 }
 
 func (srv *Service) refreshTokens(ctx context.Context, store *database.DataStore, user *database.User, oldAccessToken string) (
-	newToken string, expiresIn int32, apiError service.APIError) {
+	newToken string, expiresIn int32, apiError service.APIError,
+) {
 	var refreshToken string
 	err := store.RefreshTokens().Where("user_id = ?", user.GroupID).
 		PluckFirst("refresh_token", &refreshToken).Error()

--- a/app/api/bdd_test.go
+++ b/app/api/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package api_test
 

--- a/app/api/contests/bdd_test.go
+++ b/app/api/contests/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package contests_test
 

--- a/app/api/contests/contests.go
+++ b/app/api/contests/contests.go
@@ -48,7 +48,8 @@ type contestInfo struct {
 const team = "Team"
 
 func getParticipantTypeForContestManagedByUser(
-	store *database.DataStore, itemID int64, user *database.User) (string, error) {
+	store *database.DataStore, itemID int64, user *database.User,
+) (string, error) {
 	var participantType string
 	err := store.Items().ContestManagedByUser(itemID, user).
 		PluckFirst("items.entry_participant_type", &participantType).Error()

--- a/app/api/contests/get_administered_list.go
+++ b/app/api/contests/get_administered_list.go
@@ -139,11 +139,10 @@ func (srv *Service) getAdministeredList(w http.ResponseWriter, r *http.Request) 
 			if _, ok := parentTitlesMap[parents[index].ChildID]; !ok {
 				parentTitlesMap[parents[index].ChildID] = make([]parentTitle, 0, 1)
 			}
-			parentTitlesMap[parents[index].ChildID] =
-				append(parentTitlesMap[parents[index].ChildID], parentTitle{
-					Title:       parents[index].ParentTitle,
-					LanguageTag: parents[index].ParentLanguageTag,
-				})
+			parentTitlesMap[parents[index].ChildID] = append(parentTitlesMap[parents[index].ChildID], parentTitle{
+				Title:       parents[index].ParentTitle,
+				LanguageTag: parents[index].ParentLanguageTag,
+			})
 		}
 		for index := range rows {
 			rows[index].Parents = parentTitlesMap[rows[index].ItemID]

--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -136,7 +136,8 @@ func (srv *Service) getParametersForSetAdditionalTime(r *http.Request) (itemID, 
 }
 
 func setAdditionalTimeForGroupInContest(
-	store *database.DataStore, groupID, itemID, participantsGroupID, durationInSeconds, additionalTimeInSeconds int64) {
+	store *database.DataStore, groupID, itemID, participantsGroupID, durationInSeconds, additionalTimeInSeconds int64,
+) {
 	groupContestItemStore := store.GroupContestItems()
 	scope := groupContestItemStore.Where("group_id = ?", groupID).Where("item_id = ?", itemID)
 	found, err := scope.WithWriteLock().HasRows()

--- a/app/api/currentuser/bdd_test.go
+++ b/app/api/currentuser/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package currentuser_test
 

--- a/app/api/currentuser/current_user.go
+++ b/app/api/currentuser/current_user.go
@@ -147,7 +147,8 @@ func (srv *Service) performGroupRelationAction(w http.ResponseWriter, r *http.Re
 }
 
 func performUserGroupRelationAction(action userGroupRelationAction, store *database.DataStore, user *database.User,
-	groupID int64, approvals database.GroupApprovals) (service.APIError, database.GroupGroupTransitionResult, database.GroupApprovals) {
+	groupID int64, approvals database.GroupApprovals,
+) (service.APIError, database.GroupGroupTransitionResult, database.GroupApprovals) {
 	var err error
 	apiError := service.NoError
 
@@ -198,7 +199,8 @@ func performUserGroupRelationAction(action userGroupRelationAction, store *datab
 }
 
 func checkPreconditionsForGroupRequests(store *database.DataStore, user *database.User,
-	groupID int64, action userGroupRelationAction) service.APIError {
+	groupID int64, action userGroupRelationAction,
+) service.APIError {
 	// The group should exist (and optionally should have `is_public` = 1)
 	query := store.Groups().ByID(groupID).
 		Where("type != 'User'").Select("type, frozen_membership").WithWriteLock()

--- a/app/api/currentuser/current_user_export_test.go
+++ b/app/api/currentuser/current_user_export_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func CheckPreconditionsForGroupRequests(store *database.DataStore, user *database.User,
-	groupID int64, action userGroupRelationAction) service.APIError {
+	groupID int64, action userGroupRelationAction,
+) service.APIError {
 	return checkPreconditionsForGroupRequests(store, user, groupID, action)
 }

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package currentuser_test
 

--- a/app/api/currentuser/get_group_activities.go
+++ b/app/api/currentuser/get_group_activities.go
@@ -156,7 +156,8 @@ func (srv *Service) getRootItems(w http.ResponseWriter, r *http.Request, getActi
 }
 
 func generateRootItemListFromRawData(
-	store *database.DataStore, rawData []rawRootItem, getActivities bool) ([]activitiesViewResponseRow, []skillsViewResponseRow) {
+	store *database.DataStore, rawData []rawRootItem, getActivities bool,
+) ([]activitiesViewResponseRow, []skillsViewResponseRow) {
 	var activitiesResult []activitiesViewResponseRow
 	var skillsResult []skillsViewResponseRow
 	if getActivities {
@@ -229,7 +230,8 @@ func generateRootItemInfoFromRawData(store *database.DataStore, rawData *rawRoot
 
 func getRootItemsFromDB(
 	store *database.DataStore, watcherID, watchedGroupID int64, watchedGroupIDSet bool,
-	user *database.User, selectActivities bool) []rawRootItem {
+	user *database.User, selectActivities bool,
+) []rawRootItem {
 	hasVisibleChildrenQuery := store.Permissions().
 		MatchingGroupAncestors(watcherID).
 		WherePermissionIsAtLeast("view", "info").

--- a/app/api/currentuser/get_info_test.go
+++ b/app/api/currentuser/get_info_test.go
@@ -23,7 +23,7 @@ func TestService_getInfo_Returns403WhenUserNotFound(t *testing.T) {
 		return &database.User{GroupID: 123}
 	})
 	defer patch.Unpatch()
-	request, _ := http.NewRequest("GET", "", nil)
+	request, _ := http.NewRequest("GET", "", http.NoBody)
 	result := srv.getInfo(nil, request)
 	assert.Equal(t, service.InsufficientAccessRightsError, result)
 

--- a/app/api/currentuser/render_group_group_transition_result.go
+++ b/app/api/currentuser/render_group_group_transition_result.go
@@ -12,7 +12,8 @@ import (
 
 // RenderGroupGroupTransitionResult renders database.GroupGroupTransitionResult as a response or returns an APIError.
 func RenderGroupGroupTransitionResult(w http.ResponseWriter, r *http.Request, result database.GroupGroupTransitionResult,
-	approvalsToRequest database.GroupApprovals, action userGroupRelationAction) service.APIError {
+	approvalsToRequest database.GroupApprovals, action userGroupRelationAction,
+) service.APIError {
 	isCreateAction := map[userGroupRelationAction]bool{
 		createGroupJoinRequestAction:         true,
 		joinGroupByCodeAction:                true,

--- a/app/api/currentuser/render_group_group_transition_result_test.go
+++ b/app/api/currentuser/render_group_group_transition_result_test.go
@@ -120,7 +120,7 @@ func TestRenderGroupGroupTransitionResult(t *testing.T) {
 					return RenderGroupGroupTransitionResult(respW, req, tt.result, tt.approvalsToRequest, action)
 				}
 				handler := http.HandlerFunc(fn.ServeHTTP)
-				req, _ := http.NewRequest("GET", "/dummy", nil)
+				req, _ := http.NewRequest("GET", "/dummy", http.NoBody)
 				recorder := httptest.NewRecorder()
 				handler.ServeHTTP(recorder, req)
 

--- a/app/api/groups/bdd_test.go
+++ b/app/api/groups/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package groups_test
 

--- a/app/api/groups/check_code.go
+++ b/app/api/groups/check_code.go
@@ -143,7 +143,8 @@ const (
 )
 
 func checkGroupCodeForUser(store *database.DataStore, userIDToCheck int64, code string) (
-	valid bool, reason groupCodeFailReason, groupID int64) {
+	valid bool, reason groupCodeFailReason, groupID int64,
+) {
 	info, err := store.GetGroupJoiningByCodeInfoByCode(code, false)
 	service.MustNotBeError(err)
 	if info == nil {

--- a/app/api/groups/create_code_test.go
+++ b/app/api/groups/create_code_test.go
@@ -63,7 +63,8 @@ func TestService_changeCode_RetriesOnDuplicateEntryError(t *testing.T) {
 }
 
 func assertMockedChangeCodeRequest(t *testing.T,
-	setMockExpectationsFunc func(sqlmock.Sqlmock)) (*http.Response, sqlmock.Sqlmock, string, error) {
+	setMockExpectationsFunc func(sqlmock.Sqlmock),
+) (*http.Response, sqlmock.Sqlmock, string, error) {
 	response, mock, logs, err := servicetest.GetResponseForRouteWithMockedDBAndUser(
 		"POST", "/groups/1/code", ``, &database.User{GroupID: 2},
 		setMockExpectationsFunc,

--- a/app/api/groups/create_invitations.go
+++ b/app/api/groups/create_invitations.go
@@ -176,7 +176,8 @@ func (srv *Service) createGroupInvitations(w http.ResponseWriter, r *http.Reques
 }
 
 func filterOtherTeamsMembersOutForLogins(store *database.DataStore, parentGroupID int64, groupsToCheck []int64,
-	results map[string]string, groupIDToLoginMap map[int64]string) []int64 {
+	results map[string]string, groupIDToLoginMap map[int64]string,
+) []int64 {
 	groupsToCheckMap := make(map[int64]bool, len(groupsToCheck))
 	for _, id := range groupsToCheck {
 		groupsToCheckMap[id] = true

--- a/app/api/groups/create_invitations_export_test.go
+++ b/app/api/groups/create_invitations_export_test.go
@@ -3,6 +3,7 @@ package groups
 import "github.com/France-ioi/AlgoreaBackend/app/database"
 
 func FilterOtherTeamsMembersOutForLogins(store *database.DataStore, parentGroupID int64, groupsToInvite []int64,
-	results map[string]string, groupIDToLoginMap map[int64]string) []int64 {
+	results map[string]string, groupIDToLoginMap map[int64]string,
+) []int64 {
 	return filterOtherTeamsMembersOutForLogins(store, parentGroupID, groupsToInvite, results, groupIDToLoginMap)
 }

--- a/app/api/groups/create_invitations_integration_test.go
+++ b/app/api/groups/create_invitations_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package groups_test
 

--- a/app/api/groups/create_user_batch.go
+++ b/app/api/groups/create_user_batch.go
@@ -183,7 +183,8 @@ func (srv *Service) createUserBatch(w http.ResponseWriter, r *http.Request) serv
 }
 
 func checkCreateUserBatchRequestParameters(store *database.DataStore, user *database.User, input createUserBatchRequest) (
-	numberOfUsersToBeCreated int, subgroupsApprovals []subgroupApproval, apiError service.APIError) {
+	numberOfUsersToBeCreated int, subgroupsApprovals []subgroupApproval, apiError service.APIError,
+) {
 	var prefixInfo struct {
 		GroupID  int64
 		MaxUsers int
@@ -253,7 +254,8 @@ type resultRow struct {
 }
 
 func createBatchUsersInDB(store *database.DataStore, input createUserBatchRequest, r *http.Request, numberOfUsersToBeCreated int,
-	createdUsers []loginmodule.CreateUsersResponseDataRow, subgroupsApprovals []subgroupApproval, user *database.User) []*resultRow {
+	createdUsers []loginmodule.CreateUsersResponseDataRow, subgroupsApprovals []subgroupApproval, user *database.User,
+) []*resultRow {
 	result := make([]*resultRow, 0, len(subgroupsApprovals))
 
 	service.MustNotBeError(store.InTransaction(func(store *database.DataStore) error {
@@ -305,13 +307,15 @@ func createBatchUsersInDB(store *database.DataStore, input createUserBatchReques
 				map[string]interface{}{
 					"parent_group_id":                domainConfig.AllUsersGroupID,
 					"child_group_id":                 userGroupID,
-					"personal_info_view_approved_at": nil, "lock_membership_approved_at": nil, "watch_approved_at": nil},
+					"personal_info_view_approved_at": nil, "lock_membership_approved_at": nil, "watch_approved_at": nil,
+				},
 				map[string]interface{}{
 					"parent_group_id":                input.Subgroups[currentSubgroupIndex].GroupID,
 					"child_group_id":                 userGroupID,
 					"personal_info_view_approved_at": personalInfoApprovedAt,
 					"lock_membership_approved_at":    lockMembershipApprovedAt,
-					"watch_approved_at":              watchApprovedAt},
+					"watch_approved_at":              watchApprovedAt,
+				},
 			)
 
 			usersToCreate = append(usersToCreate, map[string]interface{}{

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -185,8 +185,8 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 			result[index].ManagerPermissionsPart = nil
 			result[index].UserCountPart = nil
 		} else {
-			result[index].ManagerPermissionsPart.CurrentUserCanManage =
-				groupManagerStore.CanManageNameByIndex(result[index].CurrentUserCanManageValue)
+			result[index].ManagerPermissionsPart.CurrentUserCanManage = groupManagerStore.
+				CanManageNameByIndex(result[index].CurrentUserCanManageValue)
 		}
 	}
 

--- a/app/api/groups/get_group.go
+++ b/app/api/groups/get_group.go
@@ -192,8 +192,7 @@ func (srv *Service) getGroup(w http.ResponseWriter, r *http.Request) service.API
 		result.GroupGetResponseCodePart = nil
 		result.ManagerPermissionsPart = nil
 	} else {
-		result.ManagerPermissionsPart.CurrentUserCanManage =
-			store.GroupManagers().CanManageNameByIndex(result.CurrentUserCanManageValue)
+		result.ManagerPermissionsPart.CurrentUserCanManage = store.GroupManagers().CanManageNameByIndex(result.CurrentUserCanManageValue)
 	}
 
 	if result.CurrentUserMembership != "none" {

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -241,7 +241,8 @@ func (srv *Service) getGroupProgress(w http.ResponseWriter, r *http.Request) ser
 }
 
 func preselectIDsOfVisibleItems(store *database.DataStore, itemParentIDs []int64, user *database.User) (
-	orderedItemIDListWithDuplicates []interface{}, uniqueItemIDs []string, itemOrder []int, itemsSubQuery interface{}) {
+	orderedItemIDListWithDuplicates []interface{}, uniqueItemIDs []string, itemOrder []int, itemsSubQuery interface{},
+) {
 	itemParentIDsAsIntSlice := make([]interface{}, len(itemParentIDs))
 	for i, parentID := range itemParentIDs {
 		itemParentIDsAsIntSlice[i] = parentID
@@ -322,7 +323,8 @@ func appendTableRowToResult(orderedItemIDListWithDuplicates []interface{}, reflR
 
 // resultPtr should be a pointer to a slice of pointers to table cells.
 func scanAndBuildProgressResults(
-	query *database.DB, orderedItemIDListWithDuplicates []interface{}, uniqueItemsCount int, resultPtr interface{}) {
+	query *database.DB, orderedItemIDListWithDuplicates []interface{}, uniqueItemsCount int, resultPtr interface{},
+) {
 	// resultPtr is *[]*tableCellType
 	reflTableCellType := reflect.TypeOf(resultPtr).Elem().Elem().Elem()
 	reflDecodedTableCell := reflect.New(reflTableCellType).Elem()

--- a/app/api/groups/get_group_progress_csv.go
+++ b/app/api/groups/get_group_progress_csv.go
@@ -186,7 +186,8 @@ func (srv *Service) getGroupProgressCSV(w http.ResponseWriter, r *http.Request) 
 }
 
 func generateGroupNameAndWriteEmptyRowsForSkippedGroups(
-	groupNumber *int, groups []idName, numberOfItems int, csvWriter *csv.Writer) func(groupID int64) []string {
+	groupNumber *int, groups []idName, numberOfItems int, csvWriter *csv.Writer,
+) func(groupID int64) []string {
 	return func(groupID int64) []string {
 		for ; groups[*groupNumber].ID != groupID; *groupNumber++ {
 			writeEmptyGroupProgressResultRow(csvWriter, groups[*groupNumber].Name, numberOfItems)

--- a/app/api/groups/get_managers.go
+++ b/app/api/groups/get_managers.go
@@ -186,8 +186,9 @@ func (srv *Service) getManagers(w http.ResponseWriter, r *http.Request) service.
 		if !includeManagersOfAncestorGroups {
 			result[index].GroupManagersViewResponseRowThroughAncestorGroups = nil
 		} else {
-			result[index].CanManageThroughAncestorGroups =
-				store.GroupManagers().CanManageNameByIndex(result[index].CanManageThroughAncestorGroupsValue)
+			result[index].CanManageThroughAncestorGroups = store.
+				GroupManagers().
+				CanManageNameByIndex(result[index].CanManageThroughAncestorGroupsValue)
 		}
 	}
 

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -157,8 +157,7 @@ type rawParticipantProgressRaw struct {
 func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Request) service.APIError {
 	user := srv.GetUser(r)
 	store := srv.GetStore(r)
-	itemID, participantID, checkPermissionsForGroupID, participantType, apiError :=
-		srv.parseParticipantProgressParameters(r, store, user)
+	itemID, participantID, checkPermissionsForGroupID, participantType, apiError := srv.parseParticipantProgressParameters(r, store, user)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -273,7 +272,8 @@ func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Reques
 }
 
 func (srv *Service) parseParticipantProgressParameters(r *http.Request, store *database.DataStore, user *database.User) (
-	itemID, participantID, checkPermissionsForGroupID int64, participantType string, apiError service.APIError) {
+	itemID, participantID, checkPermissionsForGroupID int64, participantType string, apiError service.APIError,
+) {
 	itemID, err := service.ResolveURLQueryPathInt64Field(r, "item_id")
 	if err != nil {
 		return 0, 0, 0, "", service.ErrInvalidRequest(err)

--- a/app/api/groups/get_roots.go
+++ b/app/api/groups/get_roots.go
@@ -77,7 +77,8 @@ func (srv *Service) getRoots(w http.ResponseWriter, r *http.Request) service.API
 }
 
 func selectGroupsDataForMenu(store *database.DataStore, db *database.DB, user *database.User,
-	otherColumns string, otherColumnValues ...interface{}) *database.DB {
+	otherColumns string, otherColumnValues ...interface{},
+) *database.DB {
 	usersAncestorsQuery := store.ActiveGroupAncestors().
 		Where("child_group_id = ?", user.GroupID).Select("ancestor_group_id")
 

--- a/app/api/groups/get_user_progress_csv.go
+++ b/app/api/groups/get_user_progress_csv.go
@@ -178,7 +178,8 @@ func (srv *Service) getUserProgressCSV(w http.ResponseWriter, r *http.Request) s
 
 func printTableHeader(
 	store *database.DataStore, user *database.User, uniqueItemIDs []string, orderedItemIDListWithDuplicates []interface{},
-	itemOrder []int, csvWriter *csv.Writer, firstColumns []string) {
+	itemOrder []int, csvWriter *csv.Writer, firstColumns []string,
+) {
 	var items []struct {
 		ID           int64  `json:"id"`
 		ParentItemID int64  `json:"parent_item_id"`
@@ -210,7 +211,8 @@ func processCSVResultRow(
 	uniqueItemsCount int,
 	groupNumber *int,
 	generateGroupNamesFunc func(groupID int64) []string,
-	csvWriter *csv.Writer) func(m map[string]interface{}) error {
+	csvWriter *csv.Writer,
+) func(m map[string]interface{}) error {
 	var rowArray []string
 	var cellsMap map[int64]string
 	currentRowNumber := 0

--- a/app/api/groups/get_user_requests.go
+++ b/app/api/groups/get_user_requests.go
@@ -200,7 +200,8 @@ func (srv *Service) getUserRequests(w http.ResponseWriter, r *http.Request) serv
 }
 
 func (srv *Service) resolveParametersForGetUserRequests(store *database.DataStore, r *http.Request) (
-	groupID int64, groupIDSet, includeDescendantGroups bool, types []string, apiError service.APIError) {
+	groupID int64, groupIDSet, includeDescendantGroups bool, types []string, apiError service.APIError,
+) {
 	user := srv.GetUser(r)
 
 	var err error

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -120,7 +120,8 @@ const (
 
 func checkThatUserHasRightsForDirectRelation(
 	store *database.DataStore, user *database.User,
-	parentGroupID, childGroupID int64, createOrDelete createOrDeleteRelation) service.APIError {
+	parentGroupID, childGroupID int64, createOrDelete createOrDeleteRelation,
+) service.APIError {
 	groupStore := store.Groups()
 
 	var groupData []struct {
@@ -167,12 +168,15 @@ const (
 	withdrawInvitationsAction bulkMembershipAction = "withdrawInvitations"
 )
 
-const inAnotherTeam = "in_another_team"
-const notFound = "not_found"
-const team = "Team"
+const (
+	inAnotherTeam = "in_another_team"
+	notFound      = "not_found"
+	team          = "Team"
+)
 
 func (srv *Service) performBulkMembershipAction(w http.ResponseWriter, r *http.Request,
-	action bulkMembershipAction) service.APIError {
+	action bulkMembershipAction,
+) service.APIError {
 	parentGroupID, err := service.ResolveURLQueryPathInt64Field(r, "parent_group_id")
 	if err != nil {
 		return service.ErrInvalidRequest(err)
@@ -209,7 +213,8 @@ func (srv *Service) performBulkMembershipAction(w http.ResponseWriter, r *http.R
 }
 
 func performBulkMembershipActionTransition(store *database.DataStore, action bulkMembershipAction, parentGroupID int64,
-	groupIDs []int64, groupType string, user *database.User) (database.GroupGroupTransitionResults, error) {
+	groupIDs []int64, groupType string, user *database.User,
+) (database.GroupGroupTransitionResults, error) {
 	groupID := groupIDs[0]
 	if groupType == team {
 		if action == acceptJoinRequestsAction && isOtherTeamMember(store, parentGroupID, groupID) {
@@ -238,7 +243,8 @@ func performBulkMembershipActionTransition(store *database.DataStore, action bul
 }
 
 func checkPreconditionsForBulkMembershipAction(action bulkMembershipAction, user *database.User, store *database.DataStore,
-	parentGroupID int64, groupIDs []int64) (groupType string, apiError service.APIError) {
+	parentGroupID int64, groupIDs []int64,
+) (groupType string, apiError service.APIError) {
 	if apiError = checkThatUserCanManageTheGroupMemberships(store, user, parentGroupID); apiError != service.NoError {
 		return "", apiError
 	}

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -35,7 +35,7 @@ func Test_validateUpdateGroupInput(t *testing.T) {
 			defer func() { _ = db.Close() }()
 			database.ClearAllDBEnums()
 			database.MockDBEnumQueries(mock)
-			defer func() { database.ClearAllDBEnums() }()
+			defer database.ClearAllDBEnums()
 			store := database.NewDataStore(db)
 			r, _ := http.NewRequest("PUT", "/", strings.NewReader(tt.json))
 			_, err := validateUpdateGroupInput(r, &groupUpdateInput{

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -4,10 +4,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/France-ioi/validator"
 	"github.com/go-chi/render"
 	"github.com/jinzhu/gorm"
-
-	"github.com/France-ioi/validator"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
@@ -26,7 +25,7 @@ type updatePermissionsInput struct {
 	// (or 'info' if the new value is 'enter', or 'solution' if the new value is 'solution_with_grant') and
 	// the current user should have `permissions_generated.can_grant_view_generated` = 'solution_with_grant'
 	// in order to increase level of this permission. Only owners can increase it to 'solution_with_grant'.
-	CanGrantView string `json:"can_grant_view" validate:"oneof=none enter content content_with_descendants solution solution_with_grant,can_grant_view"` // nolint:lll
+	CanGrantView string `json:"can_grant_view" validate:"oneof=none enter content content_with_descendants solution solution_with_grant,can_grant_view"` //nolint:lll
 	// The granted `can_view` should be >= 'content' and
 	// the current user should have `permissions_generated.can_watch_generated` = 'answer_with_grant'
 	// in order to increase level of this permission. Only owners can increase it to 'answer_with_grant'.
@@ -196,7 +195,8 @@ func registerOptionalValidator(data *formdata.FormData, tag string, validatorFun
 
 func parsePermissionsInputData(s *database.DataStore, managerPermissions *managerGeneratedPermissions,
 	currentPermissions *userPermissions, r *http.Request) (
-	dataMap map[string]interface{}, modified bool, apiError service.APIError) {
+	dataMap map[string]interface{}, modified bool, apiError service.APIError,
+) {
 	data := formdata.NewFormData(&updatePermissionsInput{})
 	modifiedPtr := registerPermissionsValidators(s, managerPermissions, currentPermissions, data)
 
@@ -209,7 +209,8 @@ func parsePermissionsInputData(s *database.DataStore, managerPermissions *manage
 
 func registerPermissionsValidators(
 	s *database.DataStore, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	data *formdata.FormData) *bool {
+	data *formdata.FormData,
+) *bool {
 	var modified bool
 	registerIsOwnerValidator(data, managerPermissions, currentPermissions, &modified)
 	registerCanViewValidator(data, managerPermissions, currentPermissions, &modified, s)
@@ -223,7 +224,8 @@ func registerPermissionsValidators(
 }
 
 func registerIsOwnerValidator(data *formdata.FormData, managerPermissions *managerGeneratedPermissions,
-	currentPermissions *userPermissions, modified *bool) {
+	currentPermissions *userPermissions, modified *bool,
+) {
 	registerOptionalValidator(data, "is_owner", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().Bool()
 		if newValue && newValue != currentPermissions.IsOwner && !managerPermissions.IsOwnerGenerated {
@@ -237,7 +239,8 @@ func registerIsOwnerValidator(data *formdata.FormData, managerPermissions *manag
 }
 
 func registerCanViewValidator(data *formdata.FormData, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	modified *bool, s *database.DataStore) {
+	modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_view", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().String()
 		if !checkIfPossibleToModifyCanView(newValue, currentPermissions, managerPermissions, s) {
@@ -254,7 +257,8 @@ func registerCanViewValidator(data *formdata.FormData, managerPermissions *manag
 
 func registerCanGrantViewValidator(
 	data *formdata.FormData, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	modified *bool, s *database.DataStore) {
+	modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_grant_view", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().String()
 		if !checkIfPossibleToModifyCanGrantView(newValue, currentPermissions, managerPermissions, s) {
@@ -271,7 +275,8 @@ func registerCanGrantViewValidator(
 
 func registerCanWatchValidator(
 	data *formdata.FormData, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	modified *bool, s *database.DataStore) {
+	modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_watch", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().String()
 		if !checkIfPossibleToModifyCanWatch(newValue, currentPermissions, managerPermissions, s) {
@@ -288,7 +293,8 @@ func registerCanWatchValidator(
 
 func registerCanEditValidator(
 	data *formdata.FormData, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	modified *bool, s *database.DataStore) {
+	modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_edit", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().String()
 		if !checkIfPossibleToModifyCanEdit(newValue, currentPermissions, managerPermissions, s) {
@@ -304,7 +310,8 @@ func registerCanEditValidator(
 }
 
 func registerCanMakeSessionOfficialValidator(data *formdata.FormData, managerPermissions *managerGeneratedPermissions,
-	currentPermissions *userPermissions, modified *bool, s *database.DataStore) {
+	currentPermissions *userPermissions, modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_make_session_official", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().Bool()
 		if !checkIfPossibleToModifyCanMakeSessionOfficial(newValue, currentPermissions, managerPermissions, s) {
@@ -319,7 +326,8 @@ func registerCanMakeSessionOfficialValidator(data *formdata.FormData, managerPer
 }
 
 func registerCanEnterFromValidator(data *formdata.FormData, managerPermissions *managerGeneratedPermissions,
-	currentPermissions *userPermissions, modified *bool, s *database.DataStore) {
+	currentPermissions *userPermissions, modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_enter_from", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().Interface().(time.Time)
 		if !checkIfPossibleToModifyCanEnterFrom(newValue, currentPermissions, managerPermissions, s) {
@@ -334,7 +342,8 @@ func registerCanEnterFromValidator(data *formdata.FormData, managerPermissions *
 
 func registerCanEnterUntilValidator(
 	data *formdata.FormData, managerPermissions *managerGeneratedPermissions, currentPermissions *userPermissions,
-	modified *bool, s *database.DataStore) {
+	modified *bool, s *database.DataStore,
+) {
 	registerOptionalValidator(data, "can_enter_until", func(fl validator.FieldLevel) bool {
 		newValue := fl.Field().Interface().(time.Time)
 		if !checkIfPossibleToModifyCanEnterUntil(newValue, currentPermissions, managerPermissions, s) {
@@ -354,13 +363,14 @@ const (
 	content           = "content"
 	solution          = "solution"
 	solutionWithGrant = "solution_with_grant"
-	answer            = "answer" // nolint:deadcode,varcheck,unused
+	answer            = "answer" //nolint:unused
 	answerWithGrant   = "answer_with_grant"
 	allWithGrant      = "all_with_grant"
 )
 
 func checkIfUserIsManagerAllowedToGrantPermissionsOnItem(s *database.DataStore, user *database.User,
-	sourceGroupID, groupID, itemID int64) service.APIError {
+	sourceGroupID, groupID, itemID int64,
+) service.APIError {
 	apiError := checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(s, user, sourceGroupID, groupID)
 	if apiError != service.NoError {
 		return apiError
@@ -370,7 +380,8 @@ func checkIfUserIsManagerAllowedToGrantPermissionsOnItem(s *database.DataStore, 
 }
 
 func checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(
-	s *database.DataStore, user *database.User, sourceGroupID, groupID int64) service.APIError {
+	s *database.DataStore, user *database.User, sourceGroupID, groupID int64,
+) service.APIError {
 	// the authorized user should be a manager of the sourceGroupID with `can_grant_group_access' permission and
 	// the 'sourceGroupID' should be an ancestor of 'groupID'
 	found, err := s.Groups().ManagedBy(user).Where("groups.id = ?", sourceGroupID).
@@ -416,7 +427,8 @@ func checkIfItemOrOneOfItsParentsIsVisibleToGroupOrItemIsRoot(s *database.DataSt
 }
 
 func checkIfPossibleToModifyCanView(viewPermissionToSet string, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	permissionGrantedStore := store.PermissionsGranted()
 	if permissionGrantedStore.ViewIndexByName(viewPermissionToSet) <= currentPermissions.CanViewValue {
 		return true
@@ -432,7 +444,8 @@ func checkIfPossibleToModifyCanView(viewPermissionToSet string, currentPermissio
 }
 
 func checkIfPossibleToModifyCanGrantView(grantViewPermissionToSet string, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	permissionGrantedStore := store.PermissionsGranted()
 	if permissionGrantedStore.GrantViewIndexByName(grantViewPermissionToSet) <= currentPermissions.CanGrantViewValue {
 		return true
@@ -459,7 +472,8 @@ func checkIfPossibleToModifyCanGrantView(grantViewPermissionToSet string, curren
 }
 
 func checkIfPossibleToModifyCanWatch(watchPermissionToSet string, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	permissionGrantedStore := store.PermissionsGranted()
 	if permissionGrantedStore.WatchIndexByName(watchPermissionToSet) <= currentPermissions.CanWatchValue {
 		return true
@@ -477,7 +491,8 @@ func checkIfPossibleToModifyCanWatch(watchPermissionToSet string, currentPermiss
 }
 
 func checkIfPossibleToModifyCanEdit(editPermissionToSet string, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	permissionGrantedStore := store.PermissionsGranted()
 	if permissionGrantedStore.EditIndexByName(editPermissionToSet) <= currentPermissions.CanEditValue {
 		return true
@@ -495,7 +510,8 @@ func checkIfPossibleToModifyCanEdit(editPermissionToSet string, currentPermissio
 }
 
 func checkIfPossibleToModifyCanMakeSessionOfficial(canMakeSessionOfficalToSet bool, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	if !canMakeSessionOfficalToSet || canMakeSessionOfficalToSet == currentPermissions.CanMakeSessionOfficial {
 		return true
 	}
@@ -508,7 +524,8 @@ func checkIfPossibleToModifyCanMakeSessionOfficial(canMakeSessionOfficalToSet bo
 }
 
 func checkIfPossibleToModifyCanEnterFrom(canEnterFromToSet time.Time, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	if !time.Time(currentPermissions.CanEnterFrom).After(canEnterFromToSet) {
 		return true
 	}
@@ -517,7 +534,8 @@ func checkIfPossibleToModifyCanEnterFrom(canEnterFromToSet time.Time, currentPer
 }
 
 func checkIfPossibleToModifyCanEnterUntil(canEnterUntilToSet time.Time, currentPermissions *userPermissions,
-	managerPermissions *managerGeneratedPermissions, store *database.DataStore) bool {
+	managerPermissions *managerGeneratedPermissions, store *database.DataStore,
+) bool {
 	if !time.Time(currentPermissions.CanEnterUntil).Before(canEnterUntilToSet) {
 		return true
 	}

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -95,7 +95,8 @@ func (srv *Service) askHint(w http.ResponseWriter, r *http.Request) service.APIE
 	}
 
 	user := srv.GetUser(r)
-	apiError := service.NoError
+
+	var apiError service.APIError
 	if apiError = checkHintOrScoreTokenRequiredFields(user, requestData.TaskToken, "hint_requested",
 		requestData.HintToken.Converted.UserID, requestData.HintToken.LocalItemID,
 		requestData.HintToken.ItemURL, requestData.HintToken.AttemptID); apiError != service.NoError {
@@ -169,7 +170,8 @@ func (srv *Service) askHint(w http.ResponseWriter, r *http.Request) service.APIE
 }
 
 func queryAndParsePreviouslyRequestedHints(taskToken *token.Task, store *database.DataStore,
-	r *http.Request) ([]formdata.Anything, error) {
+	r *http.Request,
+) ([]formdata.Anything, error) {
 	hintsInfo, err := store.Results().
 		GetHintsInfoForActiveAttempt(taskToken.Converted.ParticipantID, taskToken.Converted.AttemptID, taskToken.Converted.LocalItemID)
 	var hintsRequestedParsed []formdata.Anything

--- a/app/api/items/ask_hint_test.go
+++ b/app/api/items/ask_hint_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/tokentest"
 )
 
-func TestAskHintRequest_UnmarshalJSON(t *testing.T) { //nolint:gocognit Should be refactored.
+func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
 	expectedTaskToken := token.Task{}
 	_ = payloads.ParseMap(payloadstest.TaskPayloadFromAlgoreaPlatform, &expectedTaskToken)
 	expectedTaskToken.Converted.UserID = 556371821693219925

--- a/app/api/items/bdd_test.go
+++ b/app/api/items/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package items_test
 

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -7,10 +7,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/France-ioi/validator"
 	"github.com/go-chi/render"
 	"github.com/jinzhu/gorm"
-
-	"github.com/France-ioi/validator"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
@@ -69,7 +68,7 @@ type Item struct {
 
 // ItemWithRequiredType represents common item fields plus the required type field.
 type ItemWithRequiredType struct {
-	Item `json:"item,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	Item `json:"item,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 	// Can be equal to 'Skill' only if the parent's type is 'Skill'
 	// required: true
 	// enum: Chapter,Task,Skill
@@ -101,7 +100,7 @@ type itemParent struct {
 	ContentViewPropagation string `json:"content_view_propagation" validate:"oneof=none as_info as_content"`
 	// default: as_is
 	// enum: use_content_view_propagation,as_content_with_descendants,as_is
-	UpperViewLevelsPropagation string `json:"upper_view_levels_propagation" validate:"oneof=use_content_view_propagation as_content_with_descendants as_is"` // nolint:lll
+	UpperViewLevelsPropagation string `json:"upper_view_levels_propagation" validate:"oneof=use_content_view_propagation as_content_with_descendants as_is"` //nolint:lll
 	// default: true
 	GrantViewPropagation bool `json:"grant_view_propagation"`
 	// default: true
@@ -116,13 +115,13 @@ type NewItemRequest struct {
 	// `default_language_tag` of the item
 	// required: true
 	LanguageTag   string                 `json:"language_tag" validate:"set,language_tag"`
-	newItemString `json:"string,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	newItemString `json:"string,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 
 	Parent          itemParent `json:"parent"`
 	AsRootOfGroupID int64      `json:"as_root_of_group_id,string" validate:"as_root_of_group_id"`
 
 	// Nullable fields are of pointer types
-	ItemWithRequiredType `json:"item,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	ItemWithRequiredType `json:"item,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 
 	Children []itemChild `json:"children" validate:"children,children_allowed,dive,child_type_non_skill"`
 }
@@ -285,7 +284,8 @@ func setNewItemAsRootActivityOrSkill(store *database.DataStore, formData *formda
 // constructParentItemIDValidator constructs a validator for the Parent.ItemID field.
 // The validator checks that the user has rights to manage the parent item's children (can_view >= content & can_edit >= children).
 func constructParentItemIDValidator(
-	store *database.DataStore, user *database.User, parentInfo *parentItemInfo) validator.Func {
+	store *database.DataStore, user *database.User, parentInfo *parentItemInfo,
+) validator.Func {
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		err := store.Items().
 			JoinsPermissionsForGroupToItemsWherePermissionAtLeast(user.GroupID, "view", "content").
@@ -303,7 +303,8 @@ func constructParentItemIDValidator(
 // constructAsRootOfGroupIDValidator constructs a validator for the AsRootOfGroupID field.
 // The validator checks that the user has rights to manage the group (can_manage = memberships_and_group).
 func constructAsRootOfGroupIDValidator(
-	store *database.DataStore, user *database.User, formData *formdata.FormData) validator.Func {
+	store *database.DataStore, user *database.User, formData *formdata.FormData,
+) validator.Func {
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		if !formData.IsSet("as_root_of_group_id") {
 			return true
@@ -371,7 +372,8 @@ func constructItemOptionsValidator() validator.Func {
 // all the children items are visible to the user (can_view != 'none').
 func constructChildrenValidator(store *database.DataStore, user *database.User,
 	childrenInfoMap *map[int64]permissionAndType, oldPropagationLevelsMap *map[int64]*itemsRelationData, // nolint:gocritic
-	itemID *int64) validator.Func {
+	itemID *int64,
+) validator.Func {
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		children := fl.Field().Interface().([]itemChild)
 
@@ -454,7 +456,8 @@ func generateChildrenInfoMap(store *database.DataStore, user *database.User, ids
 
 // constructChildrenAllowedValidator constructs a validator checking that the new item can have children (is not a Task).
 func constructChildrenAllowedValidator(
-	defaultItemType string, childrenInfoMap *map[int64]permissionAndType) validator.Func { // nolint:gocritic
+	defaultItemType string, childrenInfoMap *map[int64]permissionAndType,
+) validator.Func { // nolint:gocritic
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		if len(*childrenInfoMap) == 0 {
 			return true
@@ -471,7 +474,7 @@ func constructChildrenAllowedValidator(
 }
 
 // constructChildTypeNonSkillValidator constructs a validator for the Children field that check
-// if a child's type is not 'Skill' when the items's type is not 'Skill'.
+// if a child's type is not 'Skill' when the item's type is not 'Skill'.
 func constructChildTypeNonSkillValidator(childrenInfoMap *map[int64]permissionAndType) validator.Func { // nolint:gocritic
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		child := fl.Field().Interface().(itemChild)
@@ -489,7 +492,8 @@ type parentItemInfo struct {
 }
 
 func registerAddItemValidators(formData *formdata.FormData, store *database.DataStore, user *database.User,
-	parentInfo *parentItemInfo, childrenInfoMap *map[int64]permissionAndType) { // nolint:gocritic
+	parentInfo *parentItemInfo, childrenInfoMap *map[int64]permissionAndType,
+) { // nolint:gocritic
 	formData.RegisterValidation("parent_item_id",
 		formData.ValidatorSkippingUnsetFields(constructParentItemIDValidator(store, user, parentInfo)))
 	formData.RegisterTranslation("parent_item_id",
@@ -521,7 +525,8 @@ func registerLanguageTagValidator(formData *formdata.FormData, store *database.D
 
 func registerChildrenValidator(formData *formdata.FormData, store *database.DataStore, user *database.User,
 	itemType string, childrenInfoMap *map[int64]permissionAndType, oldPropagationLevelsMap *map[int64]*itemsRelationData, // nolint:gocritic
-	itemID *int64) {
+	itemID *int64,
+) {
 	formData.RegisterValidation("children", constructChildrenValidator(store, user, childrenInfoMap, oldPropagationLevelsMap, itemID))
 	formData.RegisterTranslation("children",
 		"children IDs should be unique and each should be visible to the user")
@@ -531,7 +536,8 @@ func registerChildrenValidator(formData *formdata.FormData, store *database.Data
 }
 
 func (srv *Service) insertItem(store *database.DataStore, user *database.User, formData *formdata.FormData,
-	newItemRequest *NewItemRequest) (itemID int64, apiError service.APIError) {
+	newItemRequest *NewItemRequest,
+) (itemID int64, apiError service.APIError) {
 	itemMap := formData.ConstructPartialMapForDB("ItemWithRequiredType")
 	stringMap := formData.ConstructPartialMapForDB("newItemString")
 

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -308,7 +308,8 @@ func (srv *Service) getActivityLog(w http.ResponseWriter, r *http.Request, itemI
 }
 
 func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http.Request, itemID *int64,
-	user *database.User, fromValues map[string]interface{}) (*database.DB, service.APIError) {
+	user *database.User, fromValues map[string]interface{},
+) (*database.DB, service.APIError) {
 	participantID := service.ParticipantIDFromContext(r.Context())
 	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
@@ -527,7 +528,8 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 func (srv *Service) generateSubQueriesForPagination(
 	store *database.DataStore, activityTypeIndex string, startedResultsQuery, validatedResultsQuery,
 	answersQuery *database.DB, fromValues map[string]interface{}) (
-	startFromRowSubQuery, startFromRowCTESubQuery interface{}) {
+	startFromRowSubQuery, startFromRowCTESubQuery interface{},
+) {
 	startFromRowSubQuery = store.Table("start_from_row").SubQuery()
 	var startFromRowQuery *database.DB
 	switch activityTypeIndex {

--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -28,7 +28,7 @@ import (
 //	    * `as_team_id` (if given) should be the current user's team,
 //	    * the participant should have at least 'content' access on each listed item except the last one through that path,
 //	      and at least 'info' access on the last item,
-//	    * all the results within the ancestry of `attempt_id`/`parent_attempt_id` on the items path
+//	    * all the results within the ancestry of `attempt_id`/`parent_attempt_id` on the items' path
 //	      (except for the last item if `parent_attempt_id` is given) should be started (`started_at` is not null),
 //
 //	    otherwise the 'forbidden' error is returned.
@@ -140,7 +140,8 @@ func (srv *Service) getBreadcrumbs(w http.ResponseWriter, r *http.Request) servi
 }
 
 func (srv *Service) parametersForGetBreadcrumbs(r *http.Request) (
-	ids []int64, participantID, attemptID, parentAttemptID int64, attemptIDSet bool, user *database.User, apiError service.APIError) {
+	ids []int64, participantID, attemptID, parentAttemptID int64, attemptIDSet bool, user *database.User, apiError service.APIError,
+) {
 	var err error
 	ids, err = idsFromRequest(r)
 	if err != nil {
@@ -158,7 +159,8 @@ func (srv *Service) parametersForGetBreadcrumbs(r *http.Request) (
 }
 
 func attemptIDOrParentAttemptID(r *http.Request) (
-	attemptID, parentAttemptID int64, attemptIDSet bool, apiError service.APIError) {
+	attemptID, parentAttemptID int64, attemptIDSet bool, apiError service.APIError,
+) {
 	var err error
 	attemptIDSet = len(r.URL.Query()["attempt_id"]) != 0
 	parentAttemptIDSet := len(r.URL.Query()["parent_attempt_id"]) != 0

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -211,8 +211,9 @@ type rawListChildItem struct {
 //			"500":
 //				"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemChildren(rw http.ResponseWriter, httpReq *http.Request) service.APIError {
-	itemID, attemptID, participantID, user, watchedGroupID, watchedGroupIDSet, apiError :=
-		srv.resolveGetParentsOrChildrenServiceParams(httpReq)
+	itemID, attemptID, participantID, user, watchedGroupID, watchedGroupIDSet, apiError := srv.resolveGetParentsOrChildrenServiceParams(
+		httpReq,
+	)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -276,7 +277,8 @@ func (srv *Service) getItemChildren(rw http.ResponseWriter, httpReq *http.Reques
 
 func constructItemChildrenQuery(dataStore *database.DataStore, parentItemID, groupID int64, requiredViewPermissionOnItems string,
 	attemptID int64, watchedGroupIDSet bool, watchedGroupID int64, columnList string, columnListValues []interface{},
-	externalColumnList string) *database.DB {
+	externalColumnList string,
+) *database.DB {
 	return constructItemListQuery(
 		dataStore, groupID, requiredViewPermissionOnItems, watchedGroupIDSet, watchedGroupID, columnList, columnListValues,
 		externalColumnList,
@@ -296,7 +298,8 @@ func constructItemChildrenQuery(dataStore *database.DataStore, parentItemID, gro
 }
 
 func childItemsFromRawData(
-	rawData []rawListChildItem, watchedGroupIDSet bool, permissionGrantedStore *database.PermissionGrantedStore) []childItem {
+	rawData []rawListChildItem, watchedGroupIDSet bool, permissionGrantedStore *database.PermissionGrantedStore,
+) []childItem {
 	result := make([]childItem, 0, len(rawData))
 	var currentChild *childItem
 	for index := range rawData {

--- a/app/api/items/get_entry_state.go
+++ b/app/api/items/get_entry_state.go
@@ -161,7 +161,8 @@ func (srv *Service) getEntryState(w http.ResponseWriter, r *http.Request) servic
 }
 
 func getItemInfoAndEntryState(itemID, groupID int64, user *database.User, store *database.DataStore, lock bool) (
-	*itemGetEntryStateResponse, service.APIError) {
+	*itemGetEntryStateResponse, service.APIError,
+) {
 	var itemInfo struct {
 		IsTeamItem                   bool
 		AllowsMultipleAttempts       bool
@@ -213,8 +214,9 @@ func getItemInfoAndEntryState(itemID, groupID int64, user *database.User, store 
 		Scan(&participationInfo).Error()
 	service.MustNotBeError(err)
 
-	membersCount, otherMembers, teamCanEnter, currentUserCanEnter, admittedMembersCount, attemptsViolationsFound :=
-		getEntryStateInfo(groupID, itemID, user, store, lock)
+	membersCount, otherMembers, teamCanEnter, currentUserCanEnter, admittedMembersCount, attemptsViolationsFound := getEntryStateInfo(
+		groupID, itemID, user, store, lock,
+	)
 	state := computeEntryState(
 		participationInfo.IsStarted, participationInfo.IsActive, itemInfo.AllowsMultipleAttempts, itemInfo.IsTeamItem,
 		itemInfo.EntryMaxTeamSize, itemInfo.EntryMinAdmittedMembersRatio, membersCount, admittedMembersCount, attemptsViolationsFound,
@@ -238,7 +240,8 @@ func getItemInfoAndEntryState(itemID, groupID int64, user *database.User, store 
 
 func computeEntryState(hasAlreadyStarted, isActive, allowsMultipleAttempts, isTeamContest bool,
 	maxTeamSize int32, entryMinAdmittedMembersRatio string, membersCount, admittedMembersCount int32,
-	attemptsViolationsFound, currentTeamIsFrozen, frozenTeamsRequired, teamCanEnter bool) entryState {
+	attemptsViolationsFound, currentTeamIsFrozen, frozenTeamsRequired, teamCanEnter bool,
+) entryState {
 	if hasAlreadyStarted && isActive {
 		return alreadyStarted
 	}
@@ -261,7 +264,8 @@ func isEntryMinAdmittedMembersRatioSatisfied(entryMinAdmittedMembersRatio string
 
 func isReadyToEnter(hasAlreadyStarted, allowsMultipleAttempts, isTeamContest bool,
 	maxTeamSize int32, entryMinAdmittedMembersRatio string, membersCount, admittedMembersCount int32,
-	attemptsViolationsFound, currentTeamIsFrozen, frozenTeamsRequired, teamCanEnter bool) bool {
+	attemptsViolationsFound, currentTeamIsFrozen, frozenTeamsRequired, teamCanEnter bool,
+) bool {
 	if isTeamContest && (!teamCanEnter && maxTeamSize < membersCount || frozenTeamsRequired && !currentTeamIsFrozen) ||
 		!teamCanEnter && !isEntryMinAdmittedMembersRatioSatisfied(entryMinAdmittedMembersRatio, membersCount, admittedMembersCount) {
 		return false
@@ -272,7 +276,8 @@ func isReadyToEnter(hasAlreadyStarted, allowsMultipleAttempts, isTeamContest boo
 
 func getEntryStateInfo(groupID, itemID int64, user *database.User, store *database.DataStore, lock bool) (
 	membersCount int32, otherMembers []itemGetEntryStateOtherMember, teamCanEnter, currentUserCanEnter bool, admittedMembersCount int32,
-	attemptsViolationsFound bool) {
+	attemptsViolationsFound bool,
+) {
 	if groupID != user.GroupID {
 		teamCanEnter = discoverIfTeamCanEnter(groupID, itemID, store, lock)
 

--- a/app/api/items/get_navigation.go
+++ b/app/api/items/get_navigation.go
@@ -206,7 +206,8 @@ func resolveAttemptIDForNavigationData(store *database.DataStore, httpReq *http.
 }
 
 func fillNavigationWithChildren(
-	store *database.DataStore, rawData []rawNavigationItem, watchedGroupIDSet bool, target *[]navigationItemChild) {
+	store *database.DataStore, rawData []rawNavigationItem, watchedGroupIDSet bool, target *[]navigationItemChild,
+) {
 	*target = make([]navigationItemChild, 0, len(rawData)-1)
 	var currentChild *navigationItemChild
 	if len(rawData) > 0 && rawData[0].CanViewGeneratedValue == store.PermissionsGranted().ViewIndexByName("info") {

--- a/app/api/items/get_parents.go
+++ b/app/api/items/get_parents.go
@@ -88,8 +88,9 @@ type parentItem struct {
 //			"500":
 //				"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemParents(rw http.ResponseWriter, httpReq *http.Request) service.APIError {
-	itemID, attemptID, participantID, user, watchedGroupID, watchedGroupIDSet, apiError :=
-		srv.resolveGetParentsOrChildrenServiceParams(httpReq)
+	itemID, attemptID, participantID, user, watchedGroupID, watchedGroupIDSet, apiError := srv.resolveGetParentsOrChildrenServiceParams(
+		httpReq,
+	)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -117,7 +118,8 @@ func (srv *Service) getItemParents(rw http.ResponseWriter, httpReq *http.Request
 }
 
 func (srv *Service) resolveGetParentsOrChildrenServiceParams(httpReq *http.Request) (
-	itemID, attemptID, participantID int64, user *database.User, watchedGroupID int64, watchedGroupIDSet bool, apiError service.APIError) {
+	itemID, attemptID, participantID int64, user *database.User, watchedGroupID int64, watchedGroupIDSet bool, apiError service.APIError,
+) {
 	itemID, err := service.ResolveURLQueryPathInt64Field(httpReq, "item_id")
 	if err != nil {
 		return 0, 0, 0, nil, 0, false, service.ErrInvalidRequest(err)
@@ -136,7 +138,8 @@ func (srv *Service) resolveGetParentsOrChildrenServiceParams(httpReq *http.Reque
 }
 
 func constructItemParentsQuery(dataStore *database.DataStore, childItemID, groupID, attemptID int64,
-	watchedGroupIDSet bool, watchedGroupID int64) *database.DB {
+	watchedGroupIDSet bool, watchedGroupID int64,
+) *database.DB {
 	return constructItemListQuery(
 		dataStore, groupID, "info", watchedGroupIDSet, watchedGroupID,
 		`items.allows_multiple_attempts, category, items.id, items.type, items.default_language_tag,
@@ -169,7 +172,8 @@ func constructItemParentsQuery(dataStore *database.DataStore, childItemID, group
 }
 
 func parentItemsFromRawData(rawData []RawListItem, watchedGroupIDSet bool,
-	permissionGrantedStore *database.PermissionGrantedStore) []parentItem {
+	permissionGrantedStore *database.PermissionGrantedStore,
+) []parentItem {
 	result := make([]parentItem, 0, len(rawData))
 	for index := range rawData {
 		item := parentItem{

--- a/app/api/items/get_prerequisites.go
+++ b/app/api/items/get_prerequisites.go
@@ -101,7 +101,8 @@ func (srv *Service) getItemPrerequisites(rw http.ResponseWriter, httpReq *http.R
 
 func (srv *Service) getItemPrerequisitesOrDependencies(
 	rw http.ResponseWriter, httpReq *http.Request,
-	givenColumn, joinToColumn string) service.APIError {
+	givenColumn, joinToColumn string,
+) service.APIError {
 	itemID, err := service.ResolveURLQueryPathInt64Field(httpReq, "item_id")
 	if err != nil {
 		return service.ErrInvalidRequest(err)
@@ -163,7 +164,8 @@ func (srv *Service) getItemPrerequisitesOrDependencies(
 
 func prerequisiteOrDependencyItemsFromRawData(
 	rawData []rawPrerequisiteOrDependencyItem, watchedGroupIDSet bool,
-	permissionGrantedStore *database.PermissionGrantedStore) []prerequisiteOrDependencyItem {
+	permissionGrantedStore *database.PermissionGrantedStore,
+) []prerequisiteOrDependencyItem {
 	result := make([]prerequisiteOrDependencyItem, 0, len(rawData))
 	for index := range rawData {
 		item := prerequisiteOrDependencyItem{

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -20,9 +20,11 @@ type Service struct {
 	*service.Base
 }
 
-const undefined = "Undefined"
-const task = "Task"
-const skill = "Skill"
+const (
+	undefined = "Undefined"
+	task      = "Task"
+	skill     = "Skill"
+)
 
 // SetRoutes defines the routes for this package in a route group.
 func (srv *Service) SetRoutes(router chi.Router) {
@@ -74,7 +76,8 @@ func (srv *Service) SetRoutes(router chi.Router) {
 
 func checkHintOrScoreTokenRequiredFields(user *database.User, taskToken *token.Task, otherTokenFieldName string,
 	otherTokenConvertedUserID int64,
-	otherTokenLocalItemID, otherTokenItemURL, otherTokenAttemptID string) service.APIError {
+	otherTokenLocalItemID, otherTokenItemURL, otherTokenAttemptID string,
+) service.APIError {
 	if user.GroupID != taskToken.Converted.UserID {
 		return service.ErrInvalidRequest(fmt.Errorf(
 			"token in task_token doesn't correspond to user session: got idUser=%d, expected %d",
@@ -132,7 +135,7 @@ type itemChild struct {
 	// (if `can_grant_view` >= 'content_with_descendants') or 'use_content_view_propagation' (otherwise).
 	// It is always possible to set this field to the same or a lower value, `can_grant_view` doesn't matter in this case.
 	// enum: use_content_view_propagation,as_content_with_descendants,as_is
-	UpperViewLevelsPropagation string `json:"upper_view_levels_propagation" validate:"oneof=use_content_view_propagation as_content_with_descendants as_is"` // nolint:lll
+	UpperViewLevelsPropagation string `json:"upper_view_levels_propagation" validate:"oneof=use_content_view_propagation as_content_with_descendants as_is"` //nolint:lll
 	// Can be set to true if `can_grant_view` >= 'solution_with_grant'.
 	// Defaults to true  if `can_grant_view` >= 'solution_with_grant', false otherwise.
 	// It is always possible to set this field to the same or a lower value, `can_grant_view` doesn't matter in this case.
@@ -226,7 +229,8 @@ type itemsRelationData struct {
 }
 
 func validateChildrenFieldsAndApplyDefaults(childrenInfoMap map[int64]permissionAndType, children []itemChild,
-	formData *formdata.FormData, oldRelationsMap map[int64]*itemsRelationData, store *database.DataStore) service.APIError {
+	formData *formdata.FormData, oldRelationsMap map[int64]*itemsRelationData, store *database.DataStore,
+) service.APIError {
 	for index := range children {
 		childRelation := childrenInfoMap[children[index].ItemID]
 		oldChildRelation := oldRelationsMap[children[index].ItemID]
@@ -295,7 +299,8 @@ func applyScoreWeightDefaultValue(formData *formdata.FormData, prefix string, ch
 }
 
 func validateChildBooleanPropagationAndApplyDefaultValue(formData *formdata.FormData, fieldName, prefix string,
-	propagationValue, oldPropagationValue *bool, permissionValue, requiredPermissionValue int) service.APIError {
+	propagationValue, oldPropagationValue *bool, permissionValue, requiredPermissionValue int,
+) service.APIError {
 	switch {
 	case formData.IsSet(prefix + fieldName):
 		// allow setting the propagation to the same or a lower value
@@ -314,7 +319,8 @@ func validateChildBooleanPropagationAndApplyDefaultValue(formData *formdata.Form
 }
 
 func validateChildEditPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string, child *itemChild,
-	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	var oldPropagationValue *bool
 	if oldRelationData != nil {
 		oldPropagationValue = &oldRelationData.EditPropagation
@@ -325,7 +331,8 @@ func validateChildEditPropagationAndApplyDefaultValue(formData *formdata.FormDat
 }
 
 func validateChildRequestHelpPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string, child *itemChild,
-	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	var oldPropagationValue *bool
 	if oldRelationData != nil {
 		oldPropagationValue = &oldRelationData.RequestHelpPropagation
@@ -337,7 +344,8 @@ func validateChildRequestHelpPropagationAndApplyDefaultValue(formData *formdata.
 }
 
 func validateChildWatchPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string, child *itemChild,
-	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	var oldPropagationValue *bool
 	if oldRelationData != nil {
 		oldPropagationValue = &oldRelationData.WatchPropagation
@@ -348,7 +356,8 @@ func validateChildWatchPropagationAndApplyDefaultValue(formData *formdata.FormDa
 }
 
 func validateChildGrantViewPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string, child *itemChild,
-	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	var oldPropagationValue *bool
 	if oldRelationData != nil {
 		oldPropagationValue = &oldRelationData.GrantViewPropagation
@@ -358,9 +367,10 @@ func validateChildGrantViewPropagationAndApplyDefaultValue(formData *formdata.Fo
 		childPermissions.CanGrantViewGeneratedValue, store.PermissionsGranted().PermissionIndexByKindAndName("grant_view", "solution_with_grant"))
 }
 
-// nolint:dupl
+//nolint:dupl
 func validateChildUpperViewLevelsPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string,
-	child *itemChild, childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	child *itemChild, childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	switch {
 	case formData.IsSet(prefix + "upper_view_levels_propagation"):
 		if oldRelationData != nil &&
@@ -381,18 +391,19 @@ func validateChildUpperViewLevelsPropagationAndApplyDefaultValue(formData *formd
 			return service.ErrForbidden(errors.New("not enough permissions for setting upper_view_levels_propagation"))
 		}
 	case oldRelationData != nil:
-		child.UpperViewLevelsPropagation =
-			store.ItemItems().UpperViewLevelsPropagationNameByIndex(oldRelationData.UpperViewLevelsPropagationValue)
+		child.UpperViewLevelsPropagation = store.
+			ItemItems().
+			UpperViewLevelsPropagationNameByIndex(oldRelationData.UpperViewLevelsPropagationValue)
 	default:
-		child.UpperViewLevelsPropagation =
-			defaultUpperViewLevelsPropagationForNewItemItems(childPermissions.CanGrantViewGeneratedValue, store)
+		child.UpperViewLevelsPropagation = defaultUpperViewLevelsPropagationForNewItemItems(childPermissions.CanGrantViewGeneratedValue, store)
 	}
 	return service.NoError
 }
 
-// nolint:dupl
+//nolint:dupl
 func validateChildContentViewPropagationAndApplyDefaultValue(formData *formdata.FormData, prefix string,
-	child *itemChild, childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore) service.APIError {
+	child *itemChild, childPermissions *Permission, oldRelationData *itemsRelationData, store *database.DataStore,
+) service.APIError {
 	switch {
 	case formData.IsSet(prefix + "content_view_propagation"):
 		if oldRelationData != nil &&
@@ -402,8 +413,7 @@ func validateChildContentViewPropagationAndApplyDefaultValue(formData *formdata.
 		var failed bool
 		switch child.ContentViewPropagation {
 		case asInfo:
-			failed =
-				childPermissions.CanGrantViewGeneratedValue == store.PermissionsGranted().PermissionIndexByKindAndName("grant_view", "none")
+			failed = childPermissions.CanGrantViewGeneratedValue == store.PermissionsGranted().PermissionIndexByKindAndName("grant_view", "none")
 		case asContent:
 			failed = childPermissions.CanGrantViewGeneratedValue < store.PermissionsGranted().PermissionIndexByKindAndName("grant_view", "content")
 		}
@@ -413,8 +423,7 @@ func validateChildContentViewPropagationAndApplyDefaultValue(formData *formdata.
 	case oldRelationData != nil:
 		child.ContentViewPropagation = store.ItemItems().ContentViewPropagationNameByIndex(oldRelationData.ContentViewPropagationValue)
 	default:
-		child.ContentViewPropagation =
-			defaultContentViewPropagationForNewItemItems(childPermissions.CanGrantViewGeneratedValue, store)
+		child.ContentViewPropagation = defaultContentViewPropagationForNewItemItems(childPermissions.CanGrantViewGeneratedValue, store)
 	}
 	return service.NoError
 }
@@ -444,8 +453,10 @@ func insertItemItems(store *database.DataStore, spec []*insertItemItemsSpec) {
 	}
 
 	service.MustNotBeError(store.ItemItems().InsertOrUpdateMaps(values,
-		[]string{"child_order", "category", "score_weight", "content_view_propagation", "upper_view_levels_propagation",
-			"grant_view_propagation", "watch_propagation", "edit_propagation", "request_help_propagation"}))
+		[]string{
+			"child_order", "category", "score_weight", "content_view_propagation", "upper_view_levels_propagation",
+			"grant_view_propagation", "watch_propagation", "edit_propagation", "request_help_propagation",
+		}))
 }
 
 // createContestParticipantsGroup creates a new contest participants group for the given item and

--- a/app/api/items/list_attempts.go
+++ b/app/api/items/list_attempts.go
@@ -167,7 +167,8 @@ func (srv *Service) listAttempts(w http.ResponseWriter, r *http.Request) service
 }
 
 func (srv *Service) resolveParametersForListAttempts(r *http.Request) (
-	itemID, participantID, parentAttemptID int64, apiError service.APIError) {
+	itemID, participantID, parentAttemptID int64, apiError service.APIError,
+) {
 	itemID, err := service.ResolveURLQueryPathInt64Field(r, "item_id")
 	if err != nil {
 		return 0, 0, 0, service.ErrInvalidRequest(err)

--- a/app/api/items/list_official_sessions.go
+++ b/app/api/items/list_official_sessions.go
@@ -232,7 +232,8 @@ func (srv *Service) listOfficialSessions(w http.ResponseWriter, r *http.Request)
 }
 
 func (srv *Service) fillOfficialSessionsWithParents(
-	rawData []rawOfficialSession, target *[]officialSessionsListResponseRow) {
+	rawData []rawOfficialSession, target *[]officialSessionsListResponseRow,
+) {
 	*target = make([]officialSessionsListResponseRow, 0, len(rawData))
 	var currentRow *officialSessionsListResponseRow
 	for index := range rawData {

--- a/app/api/items/path_from_root_export_integration_test.go
+++ b/app/api/items/path_from_root_export_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package items
 

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package items_test
 

--- a/app/api/items/raw_watched_group_stat_fields.go
+++ b/app/api/items/raw_watched_group_stat_fields.go
@@ -13,7 +13,8 @@ type RawWatchedGroupStatFields struct {
 }
 
 func (stat *RawWatchedGroupStatFields) asItemWatchedGroupStat(
-	watchedGroupIDSet bool, permissionGrantedStore *database.PermissionGrantedStore) *itemWatchedGroupStat {
+	watchedGroupIDSet bool, permissionGrantedStore *database.PermissionGrantedStore,
+) *itemWatchedGroupStat {
 	if !watchedGroupIDSet {
 		return nil
 	}

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -134,7 +134,8 @@ func (srv *Service) saveGrade(w http.ResponseWriter, r *http.Request) service.AP
 }
 
 func saveGradingResultsIntoDB(store *database.DataStore, user *database.User,
-	requestData *saveGradeRequestParsed) (validated, ok bool) {
+	requestData *saveGradeRequestParsed,
+) (validated, ok bool) {
 	score := requestData.ScoreToken.Converted.Score
 
 	gotFullScore := score == 100
@@ -194,7 +195,8 @@ func saveGradingResultsIntoDB(store *database.DataStore, user *database.User,
 }
 
 func saveNewScoreIntoGradings(store *database.DataStore, user *database.User,
-	requestData *saveGradeRequestParsed, score float64) bool {
+	requestData *saveGradeRequestParsed, score float64,
+) bool {
 	answerID := requestData.ScoreToken.Converted.UserAnswerID
 	gradingStore := store.Gradings()
 

--- a/app/api/items/start_result_path_export_integration_test.go
+++ b/app/api/items/start_result_path_export_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package items
 

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package items_test
 
@@ -141,7 +141,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			`,
 			args: args{participantID: 100, ids: []int64{1, 2}},
 			want: []map[string]interface{}{
-				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)}},
+				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)},
+			},
 		},
 		{
 			name: "supports permissions given directly",
@@ -152,7 +153,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			`,
 			args: args{participantID: 100, ids: []int64{1, 2}},
 			want: []map[string]interface{}{
-				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)}},
+				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)},
+			},
 		},
 		{
 			name: "steps into child attempts for items requiring explicit entry",
@@ -176,8 +178,11 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			`,
 			args: args{participantID: 100, ids: []int64{1, 2, 22}},
 			want: []map[string]interface{}{
-				{"attempt_id0": int64(0), "attempt_id1": int64(0), "attempt_id2": int64(1),
-					"has_started_result0": int64(0), "has_started_result1": int64(1), "has_started_result2": int64(0)}},
+				{
+					"attempt_id0": int64(0), "attempt_id1": int64(0), "attempt_id2": int64(1),
+					"has_started_result0": int64(0), "has_started_result1": int64(1), "has_started_result2": int64(0),
+				},
+			},
 		},
 		{
 			name: "supports paths starting with an item requiring explicit entry",
@@ -193,7 +198,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			`,
 			args: args{participantID: 103, ids: []int64{22}},
 			want: []map[string]interface{}{
-				{"attempt_id0": int64(1), "has_started_result0": int64(0)}},
+				{"attempt_id0": int64(1), "has_started_result0": int64(0)},
+			},
 		},
 		{
 			name: "can find attempt chains without a result for the first item",
@@ -208,7 +214,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			`,
 			args: args{participantID: 101, ids: []int64{1, 2}},
 			want: []map[string]interface{}{
-				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)}},
+				{"attempt_id0": int64(0), "has_started_result0": int64(0), "attempt_id1": int64(0), "has_started_result1": int64(0)},
+			},
 		},
 		{
 			name: "prefers the last (by id) existing attempt chain with started results",
@@ -241,7 +248,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					"attempt_id0": int64(1), "has_started_result0": int64(1),
 					"attempt_id1": int64(1), "has_started_result1": int64(1),
 					"attempt_id2": int64(3), "has_started_result2": int64(1),
-				}},
+				},
+			},
 		},
 		{
 			name: "prefers the attempt chain with the highest score",
@@ -273,7 +281,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					"attempt_id0": int64(0), "has_started_result0": int64(1),
 					"attempt_id1": int64(0), "has_started_result1": int64(0),
 					"attempt_id2": int64(5), "has_started_result2": int64(1),
-				}},
+				},
+			},
 		},
 		{
 			name: "prefers the last (by id) attempt chain among all chains with started results for the same items",
@@ -305,7 +314,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					"attempt_id0": int64(1), "has_started_result0": int64(1),
 					"attempt_id1": int64(1), "has_started_result1": int64(0),
 					"attempt_id2": int64(3), "has_started_result2": int64(1),
-				}},
+				},
+			},
 		},
 		{
 			name: "ignores attempt chains with missing results for items requiring explicit entry",
@@ -377,7 +387,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					"attempt_id0": int64(1), "has_started_result0": int64(1),
 					"attempt_id1": int64(1), "has_started_result1": int64(1),
 					"attempt_id2": int64(2), "has_started_result2": int64(1),
-				}},
+				},
+			},
 		},
 		{
 			name: "ignores attempt chains with not started results for an attempt not allowing submissions",

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/France-ioi/validator"
 	"github.com/go-chi/render"
 	"github.com/jinzhu/gorm"
-
-	"github.com/France-ioi/validator"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
@@ -16,7 +15,7 @@ import (
 
 // ItemWithDefaultLanguageTag represents common item fields plus 'default_language_tag'.
 type ItemWithDefaultLanguageTag struct {
-	Item `json:"item,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	Item `json:"item,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 	// new `default_language_tag` of the item can only be set to a language
 	// for that an `items_strings` row exists
 	// minLength: 1
@@ -27,7 +26,7 @@ type ItemWithDefaultLanguageTag struct {
 // updateItemRequest is the expected input for item updating
 // swagger:model itemEditRequest
 type updateItemRequest struct {
-	ItemWithDefaultLanguageTag `json:"item,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	ItemWithDefaultLanguageTag `json:"item,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 	Children                   []itemChild          `json:"children" validate:"children,children_allowed,dive,child_type_non_skill"`
 
 	childrenIDsCache []int64
@@ -224,7 +223,8 @@ func updateItemInDB(itemData map[string]interface{}, participantsGroupID *int64,
 
 func updateChildrenAndRunListeners(formData *formdata.FormData, store *database.DataStore, itemID int64,
 	input *updateItemRequest, childrenPermissionMap map[int64]permissionAndType,
-	oldPropagationLevelsMap map[int64]*itemsRelationData) (apiError service.APIError, err error) {
+	oldPropagationLevelsMap map[int64]*itemsRelationData,
+) (apiError service.APIError, err error) {
 	if formData.IsSet("children") {
 		err = store.ItemItems().WithItemsRelationsLock(func(lockedStore *database.DataStore) error {
 			deleteStatement := lockedStore.ItemItems().DB
@@ -262,7 +262,8 @@ func updateChildrenAndRunListeners(formData *formdata.FormData, store *database.
 // constructUpdateItemChildTypeNonSkillValidator constructs a validator for the Children field that checks
 // if a child's type is not 'Skill' when the items's type is not 'Skill'.
 func constructUpdateItemChildTypeNonSkillValidator(itemType string,
-	childrenInfoMap *map[int64]permissionAndType) validator.Func { // nolint:gocritic
+	childrenInfoMap *map[int64]permissionAndType,
+) validator.Func { // nolint:gocritic
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		child := fl.Field().Interface().(itemChild)
 		if itemType == skill {
@@ -283,7 +284,8 @@ func constructUpdateItemCannotBeSetForSkillsValidator(itemType string) validator
 // The validator checks that when the duration is given and is not null or is not given while its previous value is not null,
 // the field is true.
 func constructUpdateItemDurationRequiresExplicitEntryValidator(
-	formData *formdata.FormData, duration *string, requiresExplicitEntry bool) validator.Func { // nolint:gocritic
+	formData *formdata.FormData, duration *string, requiresExplicitEntry bool,
+) validator.Func { // nolint:gocritic
 	return validator.Func(func(fl validator.FieldLevel) bool {
 		data := fl.Parent().Addr().Interface().(*Item)
 		var changed bool

--- a/app/api/threads/bdd_test.go
+++ b/app/api/threads/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package threads_test
 

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
-
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
@@ -19,9 +18,9 @@ import (
 type threadUpdateFields struct {
 	// Optional
 	// enum: waiting_for_participant,waiting_for_trainer,closed
-	Status string `json:"status" validate:"helper_group_id_set_if_non_open_to_open_status,oneof=waiting_for_participant waiting_for_trainer closed"` // nolint
+	Status string `json:"status" validate:"helper_group_id_set_if_non_open_to_open_status,oneof=waiting_for_participant waiting_for_trainer closed"` //nolint
 	// Optional
-	HelperGroupID *int64 `json:"helper_group_id" validate:"helper_group_id_not_set_when_set_or_keep_closed,group_visible_by=user_id,group_visible_by=participant_id,can_request_help_to_when_own_thread"` // nolint
+	HelperGroupID *int64 `json:"helper_group_id" validate:"helper_group_id_not_set_when_set_or_keep_closed,group_visible_by=user_id,group_visible_by=participant_id,can_request_help_to_when_own_thread"` //nolint
 	// Optional
 	MessageCount *int `json:"message_count" validate:"omitempty,gte=0,exclude_increment_if_message_count_set"`
 }
@@ -29,7 +28,7 @@ type threadUpdateFields struct {
 // updateThreadRequest is the expected input for thread updating
 // swagger:model threadEditRequest
 type updateThreadRequest struct {
-	threadUpdateFields `json:"thread,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+	threadUpdateFields `json:"thread,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 
 	ItemID        int64
 	ParticipantID int64
@@ -174,7 +173,8 @@ func (srv *Service) updateThread(w http.ResponseWriter, r *http.Request) service
 }
 
 func computeNewThreadData(formData *formdata.FormData, oldMessageCount int, oldHelperGroupID int64,
-	input updateThreadRequest) map[string]interface{} {
+	input updateThreadRequest,
+) map[string]interface{} {
 	threadData := formData.ConstructPartialMapForDB("threadUpdateFields")
 	if formData.IsSet("message_count_increment") && input.MessageCountIncrement != nil {
 		threadData["message_count"] = newMessageCountWithIncrement(oldMessageCount, *input.MessageCountIncrement)
@@ -197,7 +197,8 @@ func computeNewThreadData(formData *formdata.FormData, oldMessageCount int, oldH
 }
 
 func checkUpdateThreadPermissions(user *database.User, store *database.DataStore, oldThreadStatus string,
-	input updateThreadRequest) service.APIError {
+	input updateThreadRequest,
+) service.APIError {
 	if input.Status == "" {
 		if input.HelperGroupID == nil && input.MessageCount == nil && input.MessageCountIncrement == nil {
 			return service.ErrInvalidRequest(
@@ -226,7 +227,8 @@ func newMessageCountWithIncrement(oldMessageCount, increment int) int {
 }
 
 func constructValidateCanRequestHelpToWhenOwnThread(user *database.User, store *database.DataStore,
-	participantID, itemID int64) validator.Func {
+	participantID, itemID int64,
+) validator.Func {
 	return func(fl validator.FieldLevel) bool {
 		if user.GroupID != participantID {
 			return true

--- a/app/api/users/bdd_test.go
+++ b/app/api/users/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package users_test
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -142,7 +142,7 @@ func TestMiddlewares_OnPanic(t *testing.T) {
 	defer srv.Close()
 
 	nbLogsBeforeRequest := len(hook.AllEntries())
-	request, _ := http.NewRequest("GET", srv.URL+"/dummy", nil)
+	request, _ := http.NewRequest("GET", srv.URL+"/dummy", http.NoBody)
 	request.Header.Set("X-Forwarded-For", "1.1.1.1")
 	response, err := http.DefaultClient.Do(request)
 	assert.NoError(err)
@@ -185,7 +185,7 @@ func TestMiddlewares_OnSuccess(t *testing.T) {
 	defer srv.Close()
 
 	nbLogsBeforeRequest := len(hook.AllEntries())
-	request, _ := http.NewRequest("GET", srv.URL+"/dummy", nil)
+	request, _ := http.NewRequest("GET", srv.URL+"/dummy", http.NoBody)
 	request.Header.Set("X-Real-IP", "1.1.1.1")
 	request.Header.Set("Accept-Encoding", "gzip, deflate")
 	response, err := http.DefaultClient.Do(request)
@@ -222,7 +222,7 @@ func TestNew_MountsPprofInDev(t *testing.T) {
 	srv := httptest.NewServer(app.HTTPHandler)
 	defer srv.Close()
 
-	request, _ := http.NewRequest("GET", srv.URL+"/debug", nil)
+	request, _ := http.NewRequest("GET", srv.URL+"/debug", http.NoBody)
 	response, err := http.DefaultClient.Do(request)
 	assert.NoError(err)
 	if err != nil {
@@ -247,7 +247,7 @@ func TestNew_DoesNotMountPprofInEnvironmentsOtherThanDev(t *testing.T) {
 	srv := httptest.NewServer(app.HTTPHandler)
 	defer srv.Close()
 
-	request, _ := http.NewRequest("GET", srv.URL+"/debug", nil)
+	request, _ := http.NewRequest("GET", srv.URL+"/debug", http.NoBody)
 	response, err := http.DefaultClient.Do(request)
 	assert.NoError(err)
 	if err != nil {

--- a/app/appenv/environment.go
+++ b/app/appenv/environment.go
@@ -3,10 +3,12 @@ package appenv
 
 import "os"
 
-const envVarName = "ALGOREA_ENV"
-const productionEnv = "prod"
-const developmentEnv = "dev"
-const testEnv = "test"
+const (
+	envVarName     = "ALGOREA_ENV"
+	productionEnv  = "prod"
+	developmentEnv = "dev"
+	testEnv        = "test"
+)
 
 // Env returns the deployment environment set for this app ("prod", "dev", or "test"). Default to "dev".
 func Env() string {

--- a/app/appenv/environment_test.go
+++ b/app/appenv/environment_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/app/auth/middleware_test.go
+++ b/app/auth/middleware_test.go
@@ -236,7 +236,8 @@ func (sp *storeProvider) GetStore(*http.Request) *database.DataStore { return sp
 var _ GetStorer = &storeProvider{}
 
 func callAuthThroughMiddleware(expectedSessionID string, authorizationHeaders, cookieHeaders []string,
-	userID int64, dbError error) (bool, *http.Response, sqlmock.Sqlmock) {
+	userID int64, dbError error,
+) (bool, *http.Response, sqlmock.Sqlmock) {
 	dbmock, mock := database.NewDBMock()
 	defer func() { _ = dbmock.Close() }()
 	if expectedSessionID != "" {
@@ -251,8 +252,10 @@ func callAuthThroughMiddleware(expectedSessionID string, authorizationHeaders, c
 		if dbError != nil {
 			expectation.WillReturnError(dbError)
 		} else {
-			neededRows := mock.NewRows([]string{"group_id", "login", "login_id", "is_admin", "access_group_id", "temp_user",
-				"notifications_read_at", "default_language"})
+			neededRows := mock.NewRows([]string{
+				"group_id", "login", "login_id", "is_admin", "access_group_id", "temp_user",
+				"notifications_read_at", "default_language",
+			})
 			if userID != 0 {
 				neededRows = neededRows.AddRow(userID, "login", "12345", int64(1), int64(23456), int64(1),
 					[]byte("2019-05-30 11:00:00"), "fr")
@@ -279,7 +282,7 @@ func callAuthThroughMiddleware(expectedSessionID string, authorizationHeaders, c
 	defer mainSrv.Close()
 
 	// calling web server
-	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, nil)
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, http.NoBody)
 	for _, header := range authorizationHeaders {
 		mainRequest.Header.Add("Authorization", header)
 	}

--- a/app/auth/mocks_test.go
+++ b/app/auth/mocks_test.go
@@ -22,7 +22,7 @@ func TestMiddlewareMock(t *testing.T) {
 	})))
 	defer ts.Close()
 
-	request, _ := http.NewRequest("GET", ts.URL, nil)
+	request, _ := http.NewRequest("GET", ts.URL, http.NoBody)
 	response, err := http.DefaultClient.Do(request)
 	assert.NoError(err)
 	if err != nil {

--- a/app/auth/random_test.go
+++ b/app/auth/random_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/app/auth/session_cookie_attributes.go
+++ b/app/auth/session_cookie_attributes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // SessionCookieAttributes represents attributes of the session cookie.
@@ -59,7 +60,8 @@ func unmarshalSessionCookieValue(cookieValue string) (token string, attributes S
 	if len(parts) != 4 || len(parts[0]) != 1 {
 		return
 	}
-	kind := []rune(parts[0])[0] - '0'
+	r, _ := utf8.DecodeRuneInString(parts[0])
+	kind := r - '0'
 	attributes.UseCookie = true
 	// | secure | same_site | code |
 	// | 0      | 1         | 1    |

--- a/app/auth/temp_sessions.go
+++ b/app/auth/temp_sessions.go
@@ -12,7 +12,8 @@ const TemporaryUserSessionLifetimeInSeconds = int32(2 * time.Hour / time.Second)
 
 // CreateNewTempSession creates a new session for a temporary user.
 func CreateNewTempSession(s *database.SessionStore, userID int64) (
-	accessToken string, expiresIn int32, err error) {
+	accessToken string, expiresIn int32, err error,
+) {
 	expiresIn = TemporaryUserSessionLifetimeInSeconds
 
 	err = s.RetryOnDuplicatePrimaryKeyError(func(retryStore *database.DataStore) error {

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/token"
 )
 
-func init() { // nolint:gochecknoinits
+func init() { //nolint:gochecknoinits
 	appenv.SetDefaultEnvToTest()
 }
 
@@ -44,7 +44,7 @@ func TestLoadConfigFrom(t *testing.T) {
 	configName := fileName[:len(fileName)-5] // strip the ".yaml"
 
 	tmpTestFileName := tmpDir + "/" + configName + ".test.yaml"
-	err = ioutil.WriteFile(tmpTestFileName, []byte("server:\n  rootpath: '/test/'"), 0600)
+	err = ioutil.WriteFile(tmpTestFileName, []byte("server:\n  rootpath: '/test/'"), 0o600)
 	assert.NoError(err)
 	defer func() {
 		_ = os.Remove(tmpTestFileName)

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -132,6 +132,7 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 	for i := 0; i < len(recomputeQueries); i++ {
 		recomputeAncestors[i], err = s.db.CommonDB().Prepare(recomputeQueries[i])
 		mustNotBeError(err)
+
 		defer func(i int) { mustNotBeError(recomputeAncestors[i].Close()) }(i)
 	}
 

--- a/app/database/answer_store.go
+++ b/app/database/answer_store.go
@@ -51,10 +51,10 @@ func (s *AnswerStore) SubmitNewAnswer(authorID, participantID, attemptID, itemID
 
 // Visible returns a composable query for getting answers with the following access rights
 // restrictions:
-// 1) the user should have at least 'content' access rights to the answers.item_id item,
-// 2) the user is able to see answers related to his group's attempts, so
-//    the user should be a member of the answers.participant_id team or
-//    answers.participant_id should be equal to the user's self group
+//  1. the user should have at least 'content' access rights to the answers.item_id item,
+//  2. the user is able to see answers related to his group's attempts, so
+//     the user should be a member of the answers.participant_id team or
+//     answers.participant_id should be equal to the user's self group
 func (s *AnswerStore) Visible(user *User) *DB {
 	usersGroupsQuery := s.GroupGroups().WhereUserIsMember(user).Select("parent_group_id")
 

--- a/app/database/answer_store_integration_test.go
+++ b/app/database/answer_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/attempt_store_integration_test.go
+++ b/app/database/attempt_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/badges_integration_test.go
+++ b/app/database/badges_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -322,8 +322,11 @@ func TestGroupStore_StoreBadges(t *testing.T) {
 				expectedGroupManagers = append(expectedGroupManagers, tt.userID, groupID)
 			}
 
-			expectedGroupsGroups :=
-				make([]int64, 0, len(tt.existingGroupGroups)*2+len(tt.shouldMakeMemberOf)*2+len(tt.shouldCreateBadgeGroupRelations)*2)
+			expectedGroupsGroups := make(
+				[]int64,
+				0,
+				len(tt.existingGroupGroups)*2+len(tt.shouldMakeMemberOf)*2+len(tt.shouldCreateBadgeGroupRelations)*2,
+			)
 			for _, idsPair := range tt.existingGroupGroups {
 				parentGroupID, childGroupID := idsPair[0], idsPair[1]
 				expectedGroupsGroups = append(expectedGroupsGroups, parentGroupID, childGroupID)

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -52,8 +52,8 @@ func TestDataStore_StoreConstructorsSetTablesCorrectly(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
-			mock.ExpectQuery("SELECT \\* FROM " + tt.wantTable). // nolint:gosec
-										WithArgs().WillReturnRows(mock.NewRows([]string{"id"}))
+			mock.ExpectQuery("SELECT \\* FROM " + tt.wantTable).
+				WithArgs().WillReturnRows(mock.NewRows([]string{"id"}))
 
 			var result []interface{}
 			assert.NoError(t, tt.function(NewDataStore(db)).Scan(&result).Error())
@@ -282,7 +282,8 @@ func TestDataStore_WithNamedLock(t *testing.T) {
 }
 
 func assertNamedLockMethod(t *testing.T, expectedLockName string, expectedTimeout int, expectedTableName string,
-	funcToTestGenerator func(store *DataStore) func(func(store *DataStore) error) error) {
+	funcToTestGenerator func(store *DataStore) func(func(store *DataStore) error) error,
+) {
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/db_integration_test.go
+++ b/app/database/db_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/errors.go
+++ b/app/database/errors.go
@@ -11,8 +11,7 @@ func IsDuplicateEntryError(err error) bool {
 	return mysqldb.IsMysqlError(err, mysqldb.DuplicateEntryError)
 }
 
-// IsDuplicateEntryErrorForKey checks whether an error corresponds to a duplicate of primary keys on insertion
-//                             for a certain key.
+// IsDuplicateEntryErrorForKey checks whether an error corresponds to a duplicate of primary keys on insertion for a certain key.
 func IsDuplicateEntryErrorForKey(err error, key string) bool {
 	return IsDuplicateEntryError(err) && mysqldb.ErrorContains(err, fmt.Sprintf("for key '%s'", key))
 }

--- a/app/database/group_group_store_ancestors_integration_test.go
+++ b/app/database/group_group_store_ancestors_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -182,7 +182,8 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 }
 
 func assertGroupRelations(t *testing.T, dataStore *database.DataStore,
-	remainingGroupIDs []int64, remainingGroupsGroups, remainingGroupsAncestors []map[string]interface{}) {
+	remainingGroupIDs []int64, remainingGroupsGroups, remainingGroupsAncestors []map[string]interface{},
+) {
 	var rows []map[string]interface{}
 	var ids []int64
 
@@ -211,7 +212,8 @@ type grantedPermission struct {
 }
 
 func assertGroupLinkedObjects(t *testing.T, dataStore *database.DataStore, remainingGroupIDs []int64,
-	expectedGrantedPermissions []grantedPermission, expectedGeneratedPermissions []permissionsGeneratedResultRow) {
+	expectedGrantedPermissions []grantedPermission, expectedGeneratedPermissions []permissionsGeneratedResultRow,
+) {
 	var ids []int64
 	assert.NoError(t, dataStore.Table("filters").Order("group_id").
 		Pluck("group_id", &ids).Error())
@@ -250,8 +252,9 @@ func assertGroupLinkedObjects(t *testing.T, dataStore *database.DataStore, remai
 	assert.Zero(t, cnt)
 }
 
-const done = "done"
-const groupGroupMarksResultsAsChangedFixture = `
+const (
+	done                                   = "done"
+	groupGroupMarksResultsAsChangedFixture = `
 	items:
 		- {id: 1, default_language_tag: fr}
 		- {id: 2, default_language_tag: fr}
@@ -311,6 +314,7 @@ const groupGroupMarksResultsAsChangedFixture = `
 		- {attempt_id: 1, participant_id: 106, item_id: 3}
 		- {attempt_id: 1, participant_id: 107, item_id: 3}
 		- {attempt_id: 1, participant_id: 108, item_id: 3}`
+)
 
 func TestGroupGroupStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 	for _, test := range []struct {
@@ -326,8 +330,10 @@ func TestGroupGroupStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) 
 			childGroupID:  104,
 			expiresAt:     "9999-12-31 23:59:59",
 			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2}, {104, 1, 3},
-				{105, 1, 2}, {105, 1, 3},
+				{104, 1, 2},
+				{104, 1, 3},
+				{105, 1, 2},
+				{105, 1, 3},
 			},
 		},
 		{
@@ -394,8 +400,10 @@ func TestGroupGroupStore_TriggerAfterUpdate_MarksResultsAsChanged(t *testing.T) 
 			childGroupID:  104,
 			expiresAt:     "9999-12-31 23:59:59",
 			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2}, {104, 1, 3},
-				{105, 1, 2}, {105, 1, 3},
+				{104, 1, 2},
+				{104, 1, 3},
+				{105, 1, 2},
+				{105, 1, 3},
 			},
 		},
 		{

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -10,43 +10,43 @@ import (
 type GroupMembershipAction string
 
 const (
-	// InvitationCreated means a pending group admin's invitation for user to join a group was created
+	// InvitationCreated means a pending group admin's invitation for user to join a group was created.
 	InvitationCreated GroupMembershipAction = "invitation_created"
-	// JoinRequestCreated means a pending user's request to join a group was created
+	// JoinRequestCreated means a pending user's request to join a group was created.
 	JoinRequestCreated GroupMembershipAction = "join_request_created"
-	// InvitationAccepted means a user became a member of a group by accepting an invitation
+	// InvitationAccepted means a user became a member of a group by accepting an invitation.
 	InvitationAccepted GroupMembershipAction = "invitation_accepted"
-	// JoinRequestAccepted means a user became a member of a group since a group admin accepted his request
+	// JoinRequestAccepted means a user became a member of a group since a group admin accepted his request.
 	JoinRequestAccepted GroupMembershipAction = "join_request_accepted"
-	// LeaveRequestAccepted means a user left a group since a group admin accepted his leave request
+	// LeaveRequestAccepted means a user left a group since a group admin accepted his leave request.
 	LeaveRequestAccepted GroupMembershipAction = "leave_request_accepted"
-	// InvitationRefused means a user refused an invitation to join a group
+	// InvitationRefused means a user refused an invitation to join a group.
 	InvitationRefused GroupMembershipAction = "invitation_refused"
-	// InvitationWithdrawn means an admin withdrew his invitation to join a group
+	// InvitationWithdrawn means an admin withdrew his invitation to join a group.
 	InvitationWithdrawn GroupMembershipAction = "invitation_withdrawn"
-	// JoinedByBadge means a user has been added into a group because of a badge returned by the login module
+	// JoinedByBadge means a user has been added into a group because of a badge returned by the login module.
 	JoinedByBadge GroupMembershipAction = "joined_by_badge"
-	// JoinedByCode means a user joined a group by the group's code
+	// JoinedByCode means a user joined a group by the group's code.
 	JoinedByCode GroupMembershipAction = "joined_by_code"
-	// JoinRequestRefused means an admin refused a user's request to join a group
+	// JoinRequestRefused means an admin refused a user's request to join a group.
 	JoinRequestRefused GroupMembershipAction = "join_request_refused"
-	// JoinRequestWithdrawn means a user withdrew his request to join a group
+	// JoinRequestWithdrawn means a user withdrew his request to join a group.
 	JoinRequestWithdrawn GroupMembershipAction = "join_request_withdrawn"
-	// Removed means a user was removed from a group
+	// Removed means a user was removed from a group.
 	Removed GroupMembershipAction = "removed"
-	// Left means a user left a group
+	// Left means a user left a group.
 	Left GroupMembershipAction = "left"
-	// IsMember means a user is a member of a group
+	// IsMember means a user is a member of a group.
 	IsMember GroupMembershipAction = "is_member"
-	// LeaveRequestCreated means a pending user's request to leave a group was created
+	// LeaveRequestCreated means a pending user's request to leave a group was created.
 	LeaveRequestCreated GroupMembershipAction = "is_member,leave_request_created"
-	// LeaveRequestExpired means a pending user's leave request for an expired membership
+	// LeaveRequestExpired means a pending user's leave request for an expired membership.
 	LeaveRequestExpired GroupMembershipAction = "leave_request_created"
-	// LeaveRequestRefused means a manager refused a user's request to leave a group
+	// LeaveRequestRefused means a manager refused a user's request to leave a group.
 	LeaveRequestRefused GroupMembershipAction = "leave_request_refused"
-	// LeaveRequestWithdrawn means a user withdrew his request to leave a group
+	// LeaveRequestWithdrawn means a user withdrew his request to leave a group.
 	LeaveRequestWithdrawn GroupMembershipAction = "leave_request_withdrawn"
-	// NoRelation means there is no row for the group pair in the groups_groups/group_pending_requests tables
+	// NoRelation means there is no row for the group pair in the groups_groups/group_pending_requests tables.
 	NoRelation GroupMembershipAction = ""
 )
 
@@ -88,48 +88,48 @@ func (groupMembershipAction GroupMembershipAction) PendingType() string {
 type GroupGroupTransitionAction int
 
 const (
-	// AdminCreatesInvitation means a group admin invites new users to the group
+	// AdminCreatesInvitation means a group admin invites new users to the group.
 	AdminCreatesInvitation GroupGroupTransitionAction = iota
-	// UserCreatesJoinRequest means a user creates a request to become a group member
+	// UserCreatesJoinRequest means a user creates a request to become a group member.
 	UserCreatesJoinRequest
 	// UserCreatesAcceptedJoinRequest means a user adds himself into a group that he owns
-	// It doesn't check if the user owns the group / all needed approvals are given (a calling service should check that)
+	// It doesn't check if the user owns the group / all needed approvals are given (a calling service should check that).
 	UserCreatesAcceptedJoinRequest
-	// UserAcceptsInvitation means a user accepts a group invitation
+	// UserAcceptsInvitation means a user accepts a group invitation.
 	UserAcceptsInvitation
 	// AdminAcceptsJoinRequest means a group admin accepts a request to join a group.
 	// For this action we check that all the approvals required by the group are given in the join request
 	// and set groups_groups.*_approved_at to group_pending_requests.at for each.
 	AdminAcceptsJoinRequest
-	// AdminAcceptsLeaveRequest means a group admin accepts a request to leave a group
+	// AdminAcceptsLeaveRequest means a group admin accepts a request to leave a group.
 	AdminAcceptsLeaveRequest
-	// AdminRefusesLeaveRequest means a group admin refuses a request to leave a group
+	// AdminRefusesLeaveRequest means a group admin refuses a request to leave a group.
 	AdminRefusesLeaveRequest
-	// UserRefusesInvitation means a user refuses a group invitation
+	// UserRefusesInvitation means a user refuses a group invitation.
 	UserRefusesInvitation
-	// AdminRefusesJoinRequest means a group admin refuses a request to join the group
+	// AdminRefusesJoinRequest means a group admin refuses a request to join the group.
 	AdminRefusesJoinRequest
 	// AdminRemovesUser means a group admin removes a user from a group. It marks relations as "removed".
 	// It doesn't check if a child is a user or not.
 	AdminRemovesUser
-	// AdminWithdrawsInvitation means a group admin withdraws an invitation
+	// AdminWithdrawsInvitation means a group admin withdraws an invitation.
 	AdminWithdrawsInvitation
-	// UserLeavesGroup means a user leaves a group
+	// UserLeavesGroup means a user leaves a group.
 	UserLeavesGroup
 	// UserCreatesLeaveRequest means a user creates a request to leave a group
 	// We don't check that groups.require_lock_membership_approval_until & groups_groups.lock_membership_approved_at
-	// are not null (a calling service should check that by itself)
+	// are not null (a calling service should check that by itself).
 	UserCreatesLeaveRequest
-	// UserCancelsJoinRequest means a user cancels his request to join a group
+	// UserCancelsJoinRequest means a user cancels his request to join a group.
 	UserCancelsJoinRequest
-	// UserCancelsLeaveRequest means a user cancels his request to leave a group
+	// UserCancelsLeaveRequest means a user cancels his request to leave a group.
 	UserCancelsLeaveRequest
-	// AdminRemovesDirectRelation removes a direct relation
+	// AdminRemovesDirectRelation removes a direct relation.
 	AdminRemovesDirectRelation
-	// UserJoinsGroupByBadge means we add a user into a group because of his badge returned by the login module
+	// UserJoinsGroupByBadge means we add a user into a group because of his badge returned by the login module.
 	UserJoinsGroupByBadge
 	// UserJoinsGroupByCode means a user joins a group using a group's code
-	// We don't check the code here (a calling service should check the code by itself)
+	// We don't check the code here (a calling service should check the code by itself).
 	UserJoinsGroupByCode
 )
 
@@ -149,7 +149,7 @@ var groupGroupTransitionRules = map[GroupGroupTransitionAction]groupGroupTransit
 			JoinRequestCreated:  JoinRequestAccepted,
 			LeaveRequestExpired: InvitationCreated,
 		},
-		IfNotEnoughApprovalsDowngradeTo: InvitationCreated, // only JoinRequestAccepted requires approvals
+		IfNotEnoughApprovalsDowngradeTo: InvitationCreated, // only JoinRequestAccepted requires approvals.
 	},
 	UserCreatesJoinRequest: {
 		Transitions: map[GroupMembershipAction]GroupMembershipAction{
@@ -258,19 +258,19 @@ var groupGroupTransitionRules = map[GroupGroupTransitionAction]groupGroupTransit
 type GroupGroupTransitionResult string
 
 const (
-	// Cycle means that the transition wasn't performed because it would create a cycle in groups_groups graph
+	// Cycle means that the transition wasn't performed because it would create a cycle in groups_groups graph.
 	Cycle GroupGroupTransitionResult = "cycle"
-	// Invalid means that the transition is impossible
+	// Invalid means that the transition is impossible.
 	Invalid GroupGroupTransitionResult = "invalid"
-	// ApprovalsMissing means that one or more approvals required by the transition are missing
+	// ApprovalsMissing means that one or more approvals required by the transition are missing.
 	ApprovalsMissing GroupGroupTransitionResult = "approvals_missing"
 	// Full means that the parent group is full (in terms of `groups.max_participants`) when `enforce_max_participants` is true
 	// (The number of participants is computed as the number of non-expired users or teams which are direct children
-	//  of the group + invitations (join requests are not counted).)
+	//  of the group + invitations (join requests are not counted)).
 	Full GroupGroupTransitionResult = "full"
-	// Success means that the transition was performed successfully
+	// Success means that the transition was performed successfully.
 	Success GroupGroupTransitionResult = "success"
-	// Unchanged means that the transition has been already performed
+	// Unchanged means that the transition has been already performed.
 	Unchanged GroupGroupTransitionResult = "unchanged"
 )
 
@@ -334,7 +334,8 @@ type requiredApprovalsAndLimits struct {
 // Transition performs a groups_groups relation transition according to groupGroupTransitionRules.
 func (s *GroupGroupStore) Transition(action GroupGroupTransitionAction,
 	parentGroupID int64, childGroupIDs []int64, approvals map[int64]GroupApprovals,
-	performedByUserID int64) (results GroupGroupTransitionResults, approvalsToRequest map[int64]GroupApprovals, err error) {
+	performedByUserID int64,
+) (results GroupGroupTransitionResults, approvalsToRequest map[int64]GroupApprovals, err error) {
 	s.mustBeInTransaction()
 	defer recoverPanics(&err)
 
@@ -439,8 +440,9 @@ func (s *GroupGroupStore) Transition(action GroupGroupTransitionAction,
 			insertQuery += " ON DUPLICATE KEY UPDATE expires_at = '9999-12-31 23:59:59'"
 			values := make([]interface{}, 0, len(idsToInsertRelation)*6)
 			for id := range idsToInsertRelation {
-				personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt :=
-					resolveApprovalTimesForGroupsGroups(oldActionsMap, id, approvals)
+				personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt := resolveApprovalTimesForGroupsGroups(
+					oldActionsMap, id, approvals,
+				)
 				values = append(values, parentGroupID, id,
 					personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt)
 			}
@@ -464,7 +466,8 @@ func (s *GroupGroupStore) Transition(action GroupGroupTransitionAction,
 
 func enforceMaxSize(dataStore *DataStore, action GroupGroupTransitionAction, parentGroupID int64,
 	limits *requiredApprovalsAndLimits, results GroupGroupTransitionResults, idsToInsertPending map[int64]GroupMembershipAction,
-	idsToInsertRelation, idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction) {
+	idsToInsertRelation, idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction,
+) {
 	if !limits.EnforceMaxParticipants || !map[GroupGroupTransitionAction]bool{
 		UserJoinsGroupByBadge: true, UserJoinsGroupByCode: true, UserCreatesJoinRequest: true, UserCreatesAcceptedJoinRequest: true,
 		AdminCreatesInvitation: true, AdminAcceptsJoinRequest: true,
@@ -500,7 +503,8 @@ func enforceMaxSize(dataStore *DataStore, action GroupGroupTransitionAction, par
 }
 
 func resolveApprovalTimesForGroupsGroups(oldActionsMap map[int64]stateInfo, id int64, approvals map[int64]GroupApprovals) (
-	personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt interface{}) {
+	personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt interface{},
+) {
 	personalInfoViewApprovedAt = gorm.Expr("NULL")
 	lockMembershipApprovedAt = gorm.Expr("NULL")
 	watchApprovedAt = gorm.Expr("NULL")
@@ -523,7 +527,8 @@ func resolveApprovalTimesForGroupsGroups(oldActionsMap map[int64]stateInfo, id i
 }
 
 func insertGroupPendingRequests(dataStore *DataStore, idsToInsertPending map[int64]GroupMembershipAction,
-	parentGroupID int64, approvals map[int64]GroupApprovals) {
+	parentGroupID int64, approvals map[int64]GroupApprovals,
+) {
 	if len(idsToInsertPending) > 0 {
 		insertQuery := `
 			INSERT INTO group_pending_requests
@@ -544,7 +549,8 @@ func insertGroupPendingRequests(dataStore *DataStore, idsToInsertPending map[int
 }
 
 func insertGroupMembershipChanges(dataStore *DataStore, idsChanged map[int64]GroupMembershipAction,
-	parentGroupID, performedByUserID int64) {
+	parentGroupID, performedByUserID int64,
+) {
 	if len(idsChanged) > 0 {
 		insertQuery := "INSERT INTO group_membership_changes (group_id, member_id, action, at, initiator_id)"
 		valuesTemplate := "(?, ?, ?, NOW(3), ?)"
@@ -564,7 +570,8 @@ func insertGroupMembershipChanges(dataStore *DataStore, idsChanged map[int64]Gro
 
 func performCyclesChecking(s *DataStore, idsToCheckCycle map[int64]bool, parentGroupID int64,
 	results GroupGroupTransitionResults, idsToInsertPending map[int64]GroupMembershipAction, idsToInsertRelation,
-	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction) {
+	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction,
+) {
 	if len(idsToCheckCycle) > 0 {
 		idsToCheckCycleSlice := make([]int64, 0, len(idsToCheckCycle))
 		for id := range idsToCheckCycle {
@@ -583,7 +590,8 @@ func performCyclesChecking(s *DataStore, idsToCheckCycle map[int64]bool, parentG
 
 func deleteIDsFromTransitionPlan(ids []int64, status GroupGroupTransitionResult,
 	results GroupGroupTransitionResults, idsToInsertPending map[int64]GroupMembershipAction, idsToInsertRelation,
-	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction) {
+	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction,
+) {
 	for _, groupID := range ids {
 		results[groupID] = status
 		delete(idsToInsertRelation, groupID)
@@ -598,7 +606,8 @@ func buildTransitionsPlan(parentGroupID int64, childGroupIDs []int64, results Gr
 	oldActionsMap map[int64]stateInfo, groupRequiredApprovals *requiredApprovalsAndLimits,
 	approvals, approvalsToRequest map[int64]GroupApprovals, action GroupGroupTransitionAction,
 ) (idsToInsertPending map[int64]GroupMembershipAction, idsToInsertRelation, idsToCheckCycle,
-	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction) {
+	idsToDeletePending, idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction,
+) {
 	idsToCheckCycle = make(map[int64]bool, len(childGroupIDs))
 	idsToDeletePending = make(map[int64]bool, len(childGroupIDs))
 	idsToDeleteRelation = make(map[int64]bool, len(childGroupIDs))
@@ -638,7 +647,8 @@ func buildTransitionsPlan(parentGroupID int64, childGroupIDs []int64, results Gr
 func buildOneTransition(id int64, oldAction stateInfo, toAction GroupMembershipAction,
 	results GroupGroupTransitionResults,
 	idsToInsertPending map[int64]GroupMembershipAction, idsToInsertRelation, idsToCheckCycle, idsToDeletePending,
-	idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction) {
+	idsToDeleteRelation map[int64]bool, idsChanged map[int64]GroupMembershipAction,
+) {
 	if toAction != oldAction.Action {
 		if toAction != NoRelation {
 			idsChanged[id] = toAction
@@ -668,7 +678,8 @@ func buildOneTransition(id int64, oldAction stateInfo, toAction GroupMembershipA
 }
 
 func approvalsOK(oldAction *stateInfo, groupRequiredApprovals *requiredApprovalsAndLimits, approvals GroupApprovals) (
-	ok bool, approvalsToRequest GroupApprovals) {
+	ok bool, approvalsToRequest GroupApprovals,
+) {
 	var approvalsToCheck GroupApprovals
 	if oldAction.Action.hasApprovals() {
 		approvalsToCheck.PersonalInfoViewApproval = oldAction.PersonalInfoViewApprovedAt != nil
@@ -677,11 +688,10 @@ func approvalsOK(oldAction *stateInfo, groupRequiredApprovals *requiredApprovals
 	} else {
 		approvalsToCheck = approvals
 	}
-	approvalsToRequest.PersonalInfoViewApproval =
-		groupRequiredApprovals.RequirePersonalInfoAccessApproval && !approvalsToCheck.PersonalInfoViewApproval
-	approvalsToRequest.LockMembershipApproval =
-		groupRequiredApprovals.RequireLockMembershipApproval && !approvalsToCheck.LockMembershipApproval
-	approvalsToRequest.WatchApproval =
-		groupRequiredApprovals.RequireWatchApproval && !approvalsToCheck.WatchApproval
+	approvalsToRequest.PersonalInfoViewApproval = groupRequiredApprovals.RequirePersonalInfoAccessApproval &&
+		!approvalsToCheck.PersonalInfoViewApproval
+	approvalsToRequest.LockMembershipApproval = groupRequiredApprovals.RequireLockMembershipApproval &&
+		!approvalsToCheck.LockMembershipApproval
+	approvalsToRequest.WatchApproval = groupRequiredApprovals.RequireWatchApproval && !approvalsToCheck.WatchApproval
 	return approvalsToRequest == GroupApprovals{}, approvalsToRequest
 }

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -66,58 +66,60 @@ type transitionTest struct {
 	shouldRunListeners          bool
 }
 
-var allTheIDs = []int64{1, 2, 3, 4, 5, 6, 7, 10, 11, 20, 30}
-var allPossibleGroupsAncestors = []groupAncestor{
-	{AncestorGroupID: 1, ChildGroupID: 1, IsSelf: true},
-	{AncestorGroupID: 2, ChildGroupID: 2, IsSelf: true},
-	{AncestorGroupID: 3, ChildGroupID: 3, IsSelf: true},
-	{AncestorGroupID: 4, ChildGroupID: 4, IsSelf: true},
-	{AncestorGroupID: 5, ChildGroupID: 5, IsSelf: true},
-	{AncestorGroupID: 6, ChildGroupID: 6, IsSelf: true},
-	{AncestorGroupID: 7, ChildGroupID: 7, IsSelf: true},
-	{AncestorGroupID: 10, ChildGroupID: 10, IsSelf: true},
-	{AncestorGroupID: 11, ChildGroupID: 11, IsSelf: true},
-	{AncestorGroupID: 20, ChildGroupID: 1},
-	{AncestorGroupID: 20, ChildGroupID: 2},
-	{AncestorGroupID: 20, ChildGroupID: 3},
-	{AncestorGroupID: 20, ChildGroupID: 4},
-	{AncestorGroupID: 20, ChildGroupID: 5},
-	{AncestorGroupID: 20, ChildGroupID: 6},
-	{AncestorGroupID: 20, ChildGroupID: 7},
-	{AncestorGroupID: 20, ChildGroupID: 10},
-	{AncestorGroupID: 20, ChildGroupID: 11},
-	{AncestorGroupID: 20, ChildGroupID: 20, IsSelf: true},
-	{AncestorGroupID: 20, ChildGroupID: 50},
-	{AncestorGroupID: 20, ChildGroupID: 51},
-	{AncestorGroupID: 20, ChildGroupID: 52},
-	{AncestorGroupID: 20, ChildGroupID: 53},
-	{AncestorGroupID: 20, ChildGroupID: 54},
-	{AncestorGroupID: 20, ChildGroupID: 55},
-	{AncestorGroupID: 30, ChildGroupID: 1},
-	{AncestorGroupID: 30, ChildGroupID: 2},
-	{AncestorGroupID: 30, ChildGroupID: 3},
-	{AncestorGroupID: 30, ChildGroupID: 4},
-	{AncestorGroupID: 30, ChildGroupID: 5},
-	{AncestorGroupID: 30, ChildGroupID: 6},
-	{AncestorGroupID: 30, ChildGroupID: 7},
-	{AncestorGroupID: 30, ChildGroupID: 10},
-	{AncestorGroupID: 30, ChildGroupID: 11},
-	{AncestorGroupID: 30, ChildGroupID: 20},
-	{AncestorGroupID: 30, ChildGroupID: 30, IsSelf: true},
-	{AncestorGroupID: 30, ChildGroupID: 50},
-	{AncestorGroupID: 30, ChildGroupID: 51},
-	{AncestorGroupID: 30, ChildGroupID: 52},
-	{AncestorGroupID: 30, ChildGroupID: 53},
-	{AncestorGroupID: 30, ChildGroupID: 54},
-	{AncestorGroupID: 30, ChildGroupID: 55},
-	{AncestorGroupID: 50, ChildGroupID: 50, IsSelf: true},
-	{AncestorGroupID: 51, ChildGroupID: 51, IsSelf: true},
-	{AncestorGroupID: 52, ChildGroupID: 52, IsSelf: true},
-	{AncestorGroupID: 53, ChildGroupID: 53, IsSelf: true},
-	{AncestorGroupID: 54, ChildGroupID: 54, IsSelf: true},
-	{AncestorGroupID: 55, ChildGroupID: 55, IsSelf: true},
-	{AncestorGroupID: 111, ChildGroupID: 111, IsSelf: true},
-}
+var (
+	allTheIDs                  = []int64{1, 2, 3, 4, 5, 6, 7, 10, 11, 20, 30}
+	allPossibleGroupsAncestors = []groupAncestor{
+		{AncestorGroupID: 1, ChildGroupID: 1, IsSelf: true},
+		{AncestorGroupID: 2, ChildGroupID: 2, IsSelf: true},
+		{AncestorGroupID: 3, ChildGroupID: 3, IsSelf: true},
+		{AncestorGroupID: 4, ChildGroupID: 4, IsSelf: true},
+		{AncestorGroupID: 5, ChildGroupID: 5, IsSelf: true},
+		{AncestorGroupID: 6, ChildGroupID: 6, IsSelf: true},
+		{AncestorGroupID: 7, ChildGroupID: 7, IsSelf: true},
+		{AncestorGroupID: 10, ChildGroupID: 10, IsSelf: true},
+		{AncestorGroupID: 11, ChildGroupID: 11, IsSelf: true},
+		{AncestorGroupID: 20, ChildGroupID: 1},
+		{AncestorGroupID: 20, ChildGroupID: 2},
+		{AncestorGroupID: 20, ChildGroupID: 3},
+		{AncestorGroupID: 20, ChildGroupID: 4},
+		{AncestorGroupID: 20, ChildGroupID: 5},
+		{AncestorGroupID: 20, ChildGroupID: 6},
+		{AncestorGroupID: 20, ChildGroupID: 7},
+		{AncestorGroupID: 20, ChildGroupID: 10},
+		{AncestorGroupID: 20, ChildGroupID: 11},
+		{AncestorGroupID: 20, ChildGroupID: 20, IsSelf: true},
+		{AncestorGroupID: 20, ChildGroupID: 50},
+		{AncestorGroupID: 20, ChildGroupID: 51},
+		{AncestorGroupID: 20, ChildGroupID: 52},
+		{AncestorGroupID: 20, ChildGroupID: 53},
+		{AncestorGroupID: 20, ChildGroupID: 54},
+		{AncestorGroupID: 20, ChildGroupID: 55},
+		{AncestorGroupID: 30, ChildGroupID: 1},
+		{AncestorGroupID: 30, ChildGroupID: 2},
+		{AncestorGroupID: 30, ChildGroupID: 3},
+		{AncestorGroupID: 30, ChildGroupID: 4},
+		{AncestorGroupID: 30, ChildGroupID: 5},
+		{AncestorGroupID: 30, ChildGroupID: 6},
+		{AncestorGroupID: 30, ChildGroupID: 7},
+		{AncestorGroupID: 30, ChildGroupID: 10},
+		{AncestorGroupID: 30, ChildGroupID: 11},
+		{AncestorGroupID: 30, ChildGroupID: 20},
+		{AncestorGroupID: 30, ChildGroupID: 30, IsSelf: true},
+		{AncestorGroupID: 30, ChildGroupID: 50},
+		{AncestorGroupID: 30, ChildGroupID: 51},
+		{AncestorGroupID: 30, ChildGroupID: 52},
+		{AncestorGroupID: 30, ChildGroupID: 53},
+		{AncestorGroupID: 30, ChildGroupID: 54},
+		{AncestorGroupID: 30, ChildGroupID: 55},
+		{AncestorGroupID: 50, ChildGroupID: 50, IsSelf: true},
+		{AncestorGroupID: 51, ChildGroupID: 51, IsSelf: true},
+		{AncestorGroupID: 52, ChildGroupID: 52, IsSelf: true},
+		{AncestorGroupID: 53, ChildGroupID: 53, IsSelf: true},
+		{AncestorGroupID: 54, ChildGroupID: 54, IsSelf: true},
+		{AncestorGroupID: 55, ChildGroupID: 55, IsSelf: true},
+		{AncestorGroupID: 111, ChildGroupID: 111, IsSelf: true},
+	}
+)
 
 var groupAncestorsUnchanged = []groupAncestor{
 	{AncestorGroupID: 1, ChildGroupID: 1, IsSelf: true},
@@ -210,15 +212,18 @@ var generatedPermissionsUnchanged = []permissionsGeneratedResultRow{
 	{GroupID: 11, ItemID: 2, CanViewGenerated: "solution"},
 }
 
-var currentTimePtr = (*database.Time)(ptrTime(time.Now().UTC()))
-var userID = int64(111)
-var userIDPtr = &userID
+var (
+	currentTimePtr = (*database.Time)(ptrTime(time.Now().UTC()))
+	userID         = int64(111)
+	userIDPtr      = &userID
+)
 
 const maxDateTime = "9999-12-31 23:59:59"
 
 func testTransitionAcceptingNoRelationAndAnyPendingRequest(name string, action database.GroupGroupTransitionAction,
 	expectedGroupMembershipAction database.GroupMembershipAction,
-	doNotEnforceMaxParticipants bool, maxParticipants *int) transitionTest {
+	doNotEnforceMaxParticipants bool, maxParticipants *int,
+) transitionTest {
 	resultForDirectRelations := database.Invalid
 	return transitionTest{
 		name:                        name,
@@ -268,7 +273,8 @@ func testTransitionAcceptingNoRelationAndAnyPendingRequest(name string, action d
 }
 
 func testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipants(name string, action database.GroupGroupTransitionAction,
-	acceptDirectRelations bool) transitionTest {
+	acceptDirectRelations bool,
+) transitionTest {
 	resultForDirectRelations := database.Invalid
 	if acceptDirectRelations {
 		resultForDirectRelations = database.Unchanged
@@ -296,7 +302,8 @@ func testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipan
 
 func testTransitionAcceptingPendingRequest(name string, action database.GroupGroupTransitionAction,
 	acceptedID int64, pendingType, expectedGroupMembershipAction database.GroupMembershipAction,
-	doNotEnforceMaxParticipants bool, maxParticipants *int) transitionTest {
+	doNotEnforceMaxParticipants bool, maxParticipants *int,
+) transitionTest {
 	return transitionTest{
 		name:                        name,
 		action:                      action,
@@ -326,7 +333,8 @@ func testTransitionAcceptingPendingRequest(name string, action database.GroupGro
 }
 
 func testTransitionAcceptingPendingRequestEnforcingMaxParticipants(name string, action database.GroupGroupTransitionAction,
-	acceptedID int64, pendingType database.GroupMembershipAction) transitionTest {
+	acceptedID int64, pendingType database.GroupMembershipAction,
+) transitionTest {
 	return transitionTest{
 		name:                       name + " (enforcing max participants)",
 		action:                     action,
@@ -346,7 +354,8 @@ func testTransitionAcceptingPendingRequestEnforcingMaxParticipants(name string, 
 }
 
 func testTransitionRemovingUserFromGroup(name string, action database.GroupGroupTransitionAction,
-	expectedGroupMembershipAction database.GroupMembershipAction) transitionTest {
+	expectedGroupMembershipAction database.GroupMembershipAction,
+) transitionTest {
 	return transitionTest{
 		name:              name,
 		action:            action,
@@ -994,7 +1003,7 @@ func generateApprovalsTests(expectedTime *database.Time) []approvalsTest {
 }
 
 func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestsOnAcceptingJoinRequests(t *testing.T) {
-	var expectedTime = (*database.Time)(ptrTime(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC)))
+	expectedTime := (*database.Time)(ptrTime(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC)))
 	for _, tt := range generateApprovalsTests(expectedTime) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -1100,7 +1109,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestIfJoinRequestExi
 }
 
 func TestGroupGroupStore_Transition_ReplacesJoinRequestByInvitationWhenNotNotEnoughApprovalsInJoinRequestOnCreatingInvitation(
-	t *testing.T) {
+	t *testing.T,
+) {
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups:
 			- {id: 3}
@@ -1204,7 +1214,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsFromParametersOnAcceptingInvi
 }
 
 func patchGroupGroups(old []groupGroup, diff map[string]*groupGroup,
-	added []groupGroup) []groupGroup {
+	added []groupGroup,
+) []groupGroup {
 	result := make([]groupGroup, 0, len(old)+len(added))
 	for _, relation := range old {
 		if patch, ok := diff[fmt.Sprintf("%d_%d", relation.ParentGroupID, relation.ChildGroupID)]; ok {
@@ -1220,7 +1231,8 @@ func patchGroupGroups(old []groupGroup, diff map[string]*groupGroup,
 }
 
 func patchGroupPendingRequests(old []groupPendingRequest, cycleWithType string, diff map[string]*groupPendingRequest,
-	added []groupPendingRequest) []groupPendingRequest {
+	added []groupPendingRequest,
+) []groupPendingRequest {
 	result := make([]groupPendingRequest, 0, len(old)+len(added))
 	for _, relation := range old {
 		if patch, ok := diff[fmt.Sprintf("%d_%d", relation.GroupID, relation.MemberID)]; ok {
@@ -1277,7 +1289,8 @@ func patchGrantedPermissions(old []grantedPermission, deleteIDs []string) []gran
 }
 
 func patchGeneratedPermissions(
-	old []permissionsGeneratedResultRow, canViewGeneratedChangeMap map[string]string) []permissionsGeneratedResultRow {
+	old []permissionsGeneratedResultRow, canViewGeneratedChangeMap map[string]string,
+) []permissionsGeneratedResultRow {
 	result := make([]permissionsGeneratedResultRow, 0, len(old))
 	for _, permission := range old {
 		result = append(result, permission)
@@ -1336,7 +1349,8 @@ func assertGroupGroupsEqual(t *testing.T, groupGroupStore *database.GroupGroupSt
 }
 
 func assertGroupPendingRequestsEqual(t *testing.T, groupPendingRequestStore *database.GroupPendingRequestStore,
-	expected []groupPendingRequest) {
+	expected []groupPendingRequest,
+) {
 	var groupPendingRequests []groupPendingRequest
 	assert.NoError(t, groupPendingRequestStore.Select(`
 			group_id, member_id, `+"`type`"+`, personal_info_view_approved,
@@ -1365,7 +1379,8 @@ func assertGroupPendingRequestsEqual(t *testing.T, groupPendingRequestStore *dat
 }
 
 func assertGroupMembershipChangesEqual(
-	t *testing.T, groupMembershipChangeStore *database.GroupMembershipChangeStore, expected []groupMembershipChange) {
+	t *testing.T, groupMembershipChangeStore *database.GroupMembershipChangeStore, expected []groupMembershipChange,
+) {
 	var groupMembershipChanges []groupMembershipChange
 	assert.NoError(t, groupMembershipChangeStore.Select("group_id, member_id, initiator_id, action, at").
 		Order("group_id, member_id, at").Scan(&groupMembershipChanges).Error())
@@ -1399,7 +1414,8 @@ func assertGrantedPermissionsEqual(t *testing.T, grantedPermissionStore *databas
 }
 
 func assertGeneratedPermissionsEqual(
-	t *testing.T, permissionGeneratedStore *database.PermissionGeneratedStore, expected []permissionsGeneratedResultRow) {
+	t *testing.T, permissionGeneratedStore *database.PermissionGeneratedStore, expected []permissionsGeneratedResultRow,
+) {
 	if expected == nil {
 		expected = make([]permissionsGeneratedResultRow, 0)
 	}

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -27,8 +27,9 @@ func (s *GroupStore) ManagedBy(user *User) *DB {
 }
 
 // TeamGroupForTeamItemAndUser returns a composable query for getting a team that
-//  1) the given user is a member of
-//  2) has an unexpired attempt with root_item_id = `itemID`.
+//  1. the given user is a member of
+//  2. has an unexpired attempt with root_item_id = `itemID`.
+//
 // If more than one team is found (which should be impossible), the one with the smallest `groups.id` is returned.
 func (s *GroupStore) TeamGroupForTeamItemAndUser(itemID int64, user *User) *DB {
 	return s.
@@ -88,7 +89,8 @@ func (s *GroupStore) CreateNew(name, groupType string) (groupID int64, err error
 // (for more info see description of the itemGetEntryState service).
 // The isAdding parameter specifies if we are going to add or remove a user.
 func (s *GroupStore) CheckIfEntryConditionsStillSatisfiedForAllActiveParticipations(
-	teamGroupID, userID int64, isAdding, withLock bool) (bool, error) {
+	teamGroupID, userID int64, isAdding, withLock bool,
+) (bool, error) {
 	found, err := s.GenerateQueryCheckingIfActionBreaksEntryConditionsForActiveParticipations(
 		gorm.Expr("?", teamGroupID), userID, isAdding, withLock).HasRows()
 	return !found, err
@@ -104,7 +106,8 @@ func (s *GroupStore) CheckIfEntryConditionsStillSatisfiedForAllActiveParticipati
 // (for more info see description of the itemGetEntryState service).
 // The isAdding parameter specifies if we are going to add or remove a user.
 func (s *GroupStore) GenerateQueryCheckingIfActionBreaksEntryConditionsForActiveParticipations(
-	teamGroupIDExpr *gorm.SqlExpr, userID int64, isAdding, withLock bool) *DB {
+	teamGroupIDExpr *gorm.SqlExpr, userID int64, isAdding, withLock bool,
+) *DB {
 	activeTeamParticipationsQuery := s.Attempts().
 		Joins(`
 			JOIN results ON results.participant_id = attempts.participant_id AND results.attempt_id = attempts.id AND

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -64,8 +64,10 @@ func TestGroupStore_CreateNew(t *testing.T) {
 			var expectedAttempts []map[string]interface{}
 			if test.shouldCreateAttempts {
 				expectedAttempts = []map[string]interface{}{
-					{"participant_id": strconv.FormatInt(newID, 10), "id": "0", "creator_id": nil, "parent_attempt_id": nil,
-						"root_item_id": nil, "created_at_set": "1"},
+					{
+						"participant_id": strconv.FormatInt(newID, 10), "id": "0", "creator_id": nil, "parent_attempt_id": nil,
+						"root_item_id": nil, "created_at_set": "1",
+					},
 				}
 			}
 			assert.Equal(t, expectedAttempts, attempts)
@@ -330,9 +332,8 @@ func TestGroupStore_CheckIfEntryConditionsStillSatisfiedForAllActiveParticipatio
 			t.Run(tt.name+fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					store.GroupGroups().CreateNewAncestors()
-					got, err :=
-						store.Groups().CheckIfEntryConditionsStillSatisfiedForAllActiveParticipations(
-							tt.args.teamGroupID, tt.args.userID, tt.args.isAddition, withLock)
+					got, err := store.Groups().CheckIfEntryConditionsStillSatisfiedForAllActiveParticipations(
+						tt.args.teamGroupID, tt.args.userID, tt.args.isAddition, withLock)
 					if (err != nil) != tt.wantErr {
 						t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 						return nil

--- a/app/database/groups_integration_test.go
+++ b/app/database/groups_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -21,8 +21,13 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 	}))
 
 	assertResultsMarkedAsChanged(t, dataStore, []resultPrimaryKey{
-		{101, 1, 2}, {102, 1, 2}, {103, 1, 2},
-		{104, 1, 2}, {105, 1, 2}, {106, 1, 2},
-		{107, 1, 2}, {108, 1, 2},
+		{101, 1, 2},
+		{102, 1, 2},
+		{103, 1, 2},
+		{104, 1, 2},
+		{105, 1, 2},
+		{106, 1, 2},
+		{107, 1, 2},
+		{108, 1, 2},
 	})
 }

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -66,12 +66,18 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 		wantError     error
 	}{
 		{name: "normal", participantID: 10, attemptID: 1, itemID: 13, wantHasAccess: true, wantReason: nil, wantError: nil},
-		{name: "read-only", participantID: 10, attemptID: 2, itemID: 12, wantHasAccess: false,
-			wantReason: errors.New("item is read-only"), wantError: nil},
-		{name: "no access", participantID: 11, attemptID: 1, itemID: 10, wantHasAccess: false,
-			wantReason: errors.New("no access to the task item"), wantError: nil},
-		{name: "info access", participantID: 11, attemptID: 2, itemID: 10, wantHasAccess: false,
-			wantReason: errors.New("no access to the task item"), wantError: nil},
+		{
+			name: "read-only", participantID: 10, attemptID: 2, itemID: 12, wantHasAccess: false,
+			wantReason: errors.New("item is read-only"), wantError: nil,
+		},
+		{
+			name: "no access", participantID: 11, attemptID: 1, itemID: 10, wantHasAccess: false,
+			wantReason: errors.New("no access to the task item"), wantError: nil,
+		},
+		{
+			name: "info access", participantID: 11, attemptID: 2, itemID: 10, wantHasAccess: false,
+			wantReason: errors.New("no access to the task item"), wantError: nil,
+		},
 	}
 	for _, test := range tests {
 		test := test
@@ -106,10 +112,14 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 		wantError  error
 	}{
 		{name: "Should retrieve the corresponding item", textID: "id12", wantItemID: 12, wantError: nil},
-		{name: "Should return an error if textID is empty", textID: "", wantItemID: 0,
-			wantError: errors.New("record not found")},
-		{name: "Should return an error if no corresponding item", textID: "doesn't exist", wantItemID: 0,
-			wantError: errors.New("record not found")},
+		{
+			name: "Should return an error if textID is empty", textID: "", wantItemID: 0,
+			wantError: errors.New("record not found"),
+		},
+		{
+			name: "Should return an error if no corresponding item", textID: "doesn't exist", wantItemID: 0,
+			wantError: errors.New("record not found"),
+		},
 	}
 	for _, test := range tests {
 		test := test
@@ -573,7 +583,8 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 
 func assertBreadcrumbsHierarchy(t *testing.T,
 	wantAttemptIDMap, gotIDs map[int64]int64,
-	wantAttemptNumberMap, gotNumbers map[int64]int, err error) {
+	wantAttemptNumberMap, gotNumbers map[int64]int, err error,
+) {
 	assert.Equal(t, wantAttemptIDMap, gotIDs)
 	assert.Equal(t, wantAttemptNumberMap, gotNumbers)
 	assert.NoError(t, err)
@@ -845,7 +856,8 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 		wantAttemptNumberMap map[int64]int
 	}{
 		{name: "empty list of ids", args: args{ids: []int64{}, groupID: 100, attemptID: 0}},
-		{name: "one item",
+		{
+			name:                 "one item",
 			args:                 args{ids: []int64{2}, groupID: 100, attemptID: 200},
 			wantAttemptIDMap:     map[int64]int64{2: 200},
 			wantAttemptNumberMap: map[int64]int{},
@@ -1065,8 +1077,10 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 	}{
 		{name: "url is unchanged", updateMap: map[string]interface{}{"type": "Chapter"}, wantPlatformID: ptrInt64(4)},
 		{name: "new url is null", updateMap: map[string]interface{}{"url": nil}, wantPlatformID: nil},
-		{name: "chooses a platform with higher priority", updateMap: map[string]interface{}{"url": ptrString("12345")},
-			wantPlatformID: ptrInt64(2)},
+		{
+			name: "chooses a platform with higher priority", updateMap: map[string]interface{}{"url": ptrString("12345")},
+			wantPlatformID: ptrInt64(2),
+		},
 		{name: "new url doesn't match any regexp", updateMap: map[string]interface{}{"url": ptrString("34")}, wantPlatformID: nil},
 	}
 	for _, test := range tests {
@@ -1107,15 +1121,18 @@ func TestItemStore_PlatformsTriggerAfterInsert_SetsPlatformID(t *testing.T) {
 		priority        int
 		wantPlatformIDs []*int64
 	}{
-		{name: "recalculates items linked to platforms with lower priority or no platform",
+		{
+			name:   "recalculates items linked to platforms with lower priority or no platform",
 			regexp: "1", priority: 3,
 			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), ptrInt64(2)},
 		},
-		{name: "recalculates items linked to platforms with lower priority or no platform (higher priority)",
+		{
+			name:   "recalculates items linked to platforms with lower priority or no platform (higher priority)",
 			regexp: "1", priority: 6,
 			wantPlatformIDs: []*int64{ptrInt64(5), ptrInt64(4), ptrInt64(5), nil},
 		},
-		{name: "recalculates only item without a platform when the new platform has the lowest priority",
+		{
+			name:   "recalculates only item without a platform when the new platform has the lowest priority",
 			regexp: "1", priority: -1,
 			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), ptrInt64(2), ptrInt64(2)},
 		},
@@ -1158,23 +1175,28 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 		priority        int
 		wantPlatformIDs []*int64
 	}{
-		{name: "recalculates items linked to platforms with lower priority or no platform or the modified platform (only priority is changed)",
+		{
+			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (only priority is changed)",
 			regexp: "^1.*", priority: 3,
 			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), nil},
 		},
-		{name: "recalculates items linked to platforms with lower priority or no platform or the modified platform (only regexp is changed)",
+		{
+			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (only regexp is changed)",
 			regexp: "1", priority: 4,
 			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), nil},
 		},
-		{name: "recalculates items linked to platforms with lower priority or no platform or the modified platform (higher priority)",
+		{
+			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (higher priority)",
 			regexp: "1", priority: 6,
 			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(4), ptrInt64(2), nil},
 		},
-		{name: "recalculates only item without a platform when the new platform has the lowest priority",
+		{
+			name:   "recalculates only item without a platform when the new platform has the lowest priority",
 			regexp: "1", priority: -1,
 			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), ptrInt64(3), nil},
 		},
-		{name: "doesn't recalculate anything when regexp & priority stays unchanged",
+		{
+			name:   "doesn't recalculate anything when regexp & priority stays unchanged",
 			regexp: "^1.*", priority: 4,
 			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), nil, ptrInt64(2)},
 		},

--- a/app/database/mock_db.go
+++ b/app/database/mock_db.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package database
 

--- a/app/database/permission_generated_store.go
+++ b/app/database/permission_generated_store.go
@@ -28,7 +28,8 @@ func (s *PermissionGeneratedStore) AggregatedPermissionsForItemsOnWhichGroupHasV
 // (as *_generated_value) and item ids (as item_id)
 // for all the items on that the given group has 'permissionKind' >= `neededPermission`.
 func (s *PermissionGeneratedStore) AggregatedPermissionsForItemsOnWhichGroupHasPermission(
-	groupID int64, permissionKind, neededPermission string) *DB {
+	groupID int64, permissionKind, neededPermission string,
+) *DB {
 	return s.AggregatedPermissionsForItems(groupID).
 		HavingMaxPermissionAtLeast(permissionKind, neededPermission)
 }

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -70,8 +70,10 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 			itemID:  1,
 			canView: "info",
 			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2}, {104, 1, 3},
-				{105, 1, 2}, {105, 1, 3},
+				{104, 1, 2},
+				{104, 1, 3},
+				{105, 1, 2},
+				{105, 1, 3},
 			},
 		},
 		{
@@ -140,8 +142,10 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			itemID:  1,
 			canView: "info",
 			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2}, {104, 1, 3},
-				{105, 1, 2}, {105, 1, 3},
+				{104, 1, 2},
+				{104, 1, 3},
+				{105, 1, 2},
+				{105, 1, 3},
 			},
 		},
 		{
@@ -166,8 +170,10 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			canView:        "info",
 			updateExisting: true,
 			expectedChanged: []resultPrimaryKey{
-				{105, 1, 2}, {105, 1, 3},
-				{107, 1, 2}, {107, 1, 3},
+				{105, 1, 2},
+				{105, 1, 3},
+				{107, 1, 2},
+				{107, 1, 3},
 			},
 		},
 		{

--- a/app/database/permission_granted_store.go
+++ b/app/database/permission_granted_store.go
@@ -24,7 +24,7 @@ func (s *PermissionGrantedStore) PermissionIndexByKindAndName(kind, name string)
 
 // PermissionIsAtLeastSQLExpr returns a gorm.SqlExpr for filtering by `can_*_generated_value` >= indexOf(`permissionName`)
 // depending on the given permission kind.
-func (s *PermissionGrantedStore) PermissionIsAtLeastSQLExpr(permissionKind, permissionName string) *gorm.SqlExpr { // nolint:golint
+func (s *PermissionGrantedStore) PermissionIsAtLeastSQLExpr(permissionKind, permissionName string) *gorm.SqlExpr {
 	return gorm.Expr("IFNULL("+permissionColumnByKind(permissionKind)+", 1) >= ?",
 		s.PermissionIndexByKindAndName(permissionKind, permissionName))
 }

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -11,9 +11,8 @@ import "database/sql"
 // 3. Then the loop repeats from step 1 for all children (from items_items) of the processed permissions_generated.
 //
 // Notes:
-//  - The function may loop endlessly if items_items is a cyclic graph.
-//  - Processed group-item pairs are removed from permissions_propagate.
-//
+//   - The function may loop endlessly if items_items is a cyclic graph.
+//   - Processed group-item pairs are removed from permissions_propagate.
 func (s *PermissionGrantedStore) computeAllAccess() {
 	s.mustBeInTransaction()
 

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -252,46 +252,76 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 		upperViewLevelsPropagation string
 		expectedCanView            string
 	}{
-		{canView: "none", contentViewPropagation: "as_content",
+		{
+			canView: "none", contentViewPropagation: "as_content",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "none"},
-		{canView: "info", contentViewPropagation: "as_content",
+			expectedCanView:            "none",
+		},
+		{
+			canView: "info", contentViewPropagation: "as_content",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "none"},
-		{canView: "content", contentViewPropagation: "none",
+			expectedCanView:            "none",
+		},
+		{
+			canView: "content", contentViewPropagation: "none",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "none"},
-		{canView: "content", contentViewPropagation: "as_info",
+			expectedCanView:            "none",
+		},
+		{
+			canView: "content", contentViewPropagation: "as_info",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "info"},
-		{canView: "content", contentViewPropagation: "as_content",
+			expectedCanView:            "info",
+		},
+		{
+			canView: "content", contentViewPropagation: "as_content",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "content"},
-		{canView: "content_with_descendants", contentViewPropagation: "none",
+			expectedCanView:            "content",
+		},
+		{
+			canView: "content_with_descendants", contentViewPropagation: "none",
 			upperViewLevelsPropagation: "use_content_view_propagation",
-			expectedCanView:            "none"},
-		{canView: "content_with_descendants", contentViewPropagation: "as_info",
+			expectedCanView:            "none",
+		},
+		{
+			canView: "content_with_descendants", contentViewPropagation: "as_info",
 			upperViewLevelsPropagation: "use_content_view_propagation",
-			expectedCanView:            "info"},
-		{canView: "content_with_descendants", contentViewPropagation: "as_content",
+			expectedCanView:            "info",
+		},
+		{
+			canView: "content_with_descendants", contentViewPropagation: "as_content",
 			upperViewLevelsPropagation: "use_content_view_propagation",
-			expectedCanView:            "content"},
-		{canView: "content_with_descendants", contentViewPropagation: "none",
+			expectedCanView:            "content",
+		},
+		{
+			canView: "content_with_descendants", contentViewPropagation: "none",
 			upperViewLevelsPropagation: "as_content_with_descendants",
-			expectedCanView:            "content_with_descendants"},
-		{canView: "content_with_descendants", contentViewPropagation: "none",
+			expectedCanView:            "content_with_descendants",
+		},
+		{
+			canView: "content_with_descendants", contentViewPropagation: "none",
 			upperViewLevelsPropagation: "as_is",
-			expectedCanView:            "content_with_descendants"},
-		{canView: "solution", contentViewPropagation: "none",
-			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "none"},
-		{canView: "solution", contentViewPropagation: "as_info",
-			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "info"},
-		{canView: "solution", contentViewPropagation: "as_content",
-			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "content"},
-		{canView: "solution", contentViewPropagation: "none",
-			upperViewLevelsPropagation: "as_content_with_descendants", expectedCanView: "content_with_descendants"},
-		{canView: "solution", contentViewPropagation: "none",
-			upperViewLevelsPropagation: "as_is", expectedCanView: "solution"},
+			expectedCanView:            "content_with_descendants",
+		},
+		{
+			canView: "solution", contentViewPropagation: "none",
+			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "none",
+		},
+		{
+			canView: "solution", contentViewPropagation: "as_info",
+			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "info",
+		},
+		{
+			canView: "solution", contentViewPropagation: "as_content",
+			upperViewLevelsPropagation: "use_content_view_propagation", expectedCanView: "content",
+		},
+		{
+			canView: "solution", contentViewPropagation: "none",
+			upperViewLevelsPropagation: "as_content_with_descendants", expectedCanView: "content_with_descendants",
+		},
+		{
+			canView: "solution", contentViewPropagation: "none",
+			upperViewLevelsPropagation: "as_is", expectedCanView: "solution",
+		},
 	} {
 		testcase := testcase
 		t.Run(testcase.canView+" as "+testcase.expectedCanView, func(t *testing.T) {

--- a/app/database/permission_granted_store_compute_all_access_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -52,31 +52,41 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 		{
 			ids: []int64{1, 2, 3}, permissionKind: "view", neededPermission: "info",
 			expectedResult: []map[string]interface{}{
-				{"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
-					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0)},
-				{"id": int64(3), "item_id": int64(3), "can_view_generated_value": int64(3), "can_grant_view_generated_value": int64(1),
-					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(2), "is_owner_generated": int64(0)},
+				{
+					"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0),
+				},
+				{
+					"id": int64(3), "item_id": int64(3), "can_view_generated_value": int64(3), "can_grant_view_generated_value": int64(1),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(2), "is_owner_generated": int64(0),
+				},
 			},
 		},
 		{
 			ids: []int64{1, 2, 3}, permissionKind: "view", neededPermission: "solution",
 			expectedResult: []map[string]interface{}{
-				{"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
-					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0)},
+				{
+					"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0),
+				},
 			},
 		},
 		{
 			ids: []int64{1, 2, 3}, permissionKind: "edit", neededPermission: "all",
 			expectedResult: []map[string]interface{}{
-				{"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
-					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0)},
+				{
+					"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0),
+				},
 			},
 		},
 		{
 			ids: []int64{1, 4, 5}, permissionKind: "edit", neededPermission: "children",
 			expectedResult: []map[string]interface{}{
-				{"id": int64(4), "item_id": int64(4), "can_view_generated_value": int64(1), "can_grant_view_generated_value": int64(2),
-					"can_watch_generated_value": int64(1), "can_edit_generated_value": int64(2), "is_owner_generated": int64(1)},
+				{
+					"id": int64(4), "item_id": int64(4), "can_view_generated_value": int64(1), "can_grant_view_generated_value": int64(2),
+					"can_watch_generated_value": int64(1), "can_edit_generated_value": int64(2), "is_owner_generated": int64(1),
+				},
 			},
 		},
 	} {

--- a/app/database/raw_generated_permission_fields.go
+++ b/app/database/raw_generated_permission_fields.go
@@ -15,7 +15,8 @@ type RawGeneratedPermissionFields struct {
 
 // AsItemPermissions converts RawGeneratedPermissionFields into structures.ItemPermissions.
 func (raw *RawGeneratedPermissionFields) AsItemPermissions(
-	permissionGrantedStore *PermissionGrantedStore) *structures.ItemPermissions {
+	permissionGrantedStore *PermissionGrantedStore,
+) *structures.ItemPermissions {
 	return &structures.ItemPermissions{
 		CanView:      permissionGrantedStore.ViewNameByIndex(raw.CanViewGeneratedValue),
 		CanGrantView: permissionGrantedStore.GrantViewNameByIndex(raw.CanGrantViewGeneratedValue),

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -35,13 +35,17 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 		wantError     error
 	}{
 		{name: "empty info", participantID: 11, attemptID: 1, itemID: 12, wantHintsInfo: &database.HintsInfo{}},
-		{name: "with info", participantID: 11, attemptID: 2, itemID: 12,
+		{
+			name: "with info", participantID: 11, attemptID: 2, itemID: 12,
 			wantHintsInfo: &database.HintsInfo{
 				HintsRequested: ptrString(`[0,1,"hint",null]`),
 				HintsCached:    4,
-			}},
-		{name: "finished", participantID: 12, attemptID: 2, itemID: 14, wantHintsInfo: nil,
-			wantError: gorm.ErrRecordNotFound},
+			},
+		},
+		{
+			name: "finished", participantID: 12, attemptID: 2, itemID: 14, wantHintsInfo: nil,
+			wantError: gorm.ErrRecordNotFound,
+		},
 	}
 	for _, test := range tests {
 		test := test

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -5,22 +5,24 @@ import (
 	"time"
 )
 
-const propagateLockName = "listener_propagate"
-const propagateLockTimeout = 10 * time.Second
+const (
+	propagateLockName    = "listener_propagate"
+	propagateLockTimeout = 10 * time.Second
+)
 
 // propagate recomputes fields of results
 // For results marked as 'to_be_propagated'/'to_be_recomputed':
-// 1. We mark all their ancestors in results as 'to_be_recomputed'
-//  (we consider a row in results as an ancestor if
-//    a) it has the same value in group_id
-//    b) its item_id is an ancestor of the original row's item_id
-//    c) its attempt_id is equal to the original row's attempt_id for original rows with root_item_id != item_id or
-//       its attempt_id is equal to the original row's parent_attempt_id for original rows with root_item_id = item_id).
-// 2. We process all objects that are marked as 'to_be_recomputed' and that have no children marked as 'to_be_recomputed'.
-//  Then, if an object has children, we update
-//    latest_activity_at, tasks_tried, tasks_with_help, validated_at.
-//  This step is repeated until no records are updated.
-// 3. We insert new permissions_granted for each unlocked item according to corresponding item_dependencies.
+//  1. We mark all their ancestors in results as 'to_be_recomputed'
+//     (we consider a row in results as an ancestor if
+//     a) it has the same value in group_id
+//     b) its item_id is an ancestor of the original row's item_id
+//     c) its attempt_id is equal to the original row's attempt_id for original rows with root_item_id != item_id or
+//     its attempt_id is equal to the original row's parent_attempt_id for original rows with root_item_id = item_id).
+//  2. We process all objects that are marked as 'to_be_recomputed' and that have no children marked as 'to_be_recomputed'.
+//     Then, if an object has children, we update
+//     latest_activity_at, tasks_tried, tasks_with_help, validated_at.
+//     This step is repeated until no records are updated.
+//  3. We insert new permissions_granted for each unlocked item according to corresponding item_dependencies.
 func (s *ResultStore) propagate() (err error) {
 	s.mustBeInTransaction()
 	defer recoverPanics(&err)
@@ -264,7 +266,7 @@ func (s *ResultStore) propagate() (err error) {
 						target_propagate.state = 'to_be_propagated'`
 				updateStatement, err = s.db.CommonDB().Prepare(updateQuery)
 				mustNotBeError(err)
-				defer func() { mustNotBeError(updateStatement.Close()) }()
+				defer func() { mustNotBeError(updateStatement.Close()) }() //nolint:gocritic defer in for loop, possible resource leak.
 			}
 
 			result, err := updateStatement.Exec()

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -75,20 +75,32 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 			assert.NoError(t, err)
 
 			expected := []aggregatesResultRow{
-				{ParticipantID: 101, AttemptID: 1, ItemID: 1, LatestActivityAt: database.Time(oldDate), TasksTried: 1, TasksWithHelp: 2,
-					ScoreComputed: 10, State: "done"},
-				{ParticipantID: 101, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(currentDate), TasksTried: 1 + 5 + 9,
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 1, LatestActivityAt: database.Time(oldDate), TasksTried: 1, TasksWithHelp: 2,
+					ScoreComputed: 10, State: "done",
+				},
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(currentDate), TasksTried: 1 + 5 + 9,
 					TasksWithHelp: 2 + 6 + 10,
 					ScoreComputed: 23.3333, /* (10*1 + 20*2 + 30*3) / (1 + 2 + 3) */
-					State:         "done"}, // from 1, 3, 4
-				{ParticipantID: 101, AttemptID: 1, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
-					ScoreComputed: 20, State: "done"},
-				{ParticipantID: 101, AttemptID: 1, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
-					ScoreComputed: 30, State: "done"},
-				{ParticipantID: 101, AttemptID: 2, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
-					ScoreComputed: 20, State: "done"},
-				{ParticipantID: 101, AttemptID: 2, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
-					ScoreComputed: 30, State: "done"},
+					State:         "done",
+				}, // from 1, 3, 4
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
+					ScoreComputed: 20, State: "done",
+				},
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
+					ScoreComputed: 30, State: "done",
+				},
+				{
+					ParticipantID: 101, AttemptID: 2, ItemID: 3, LatestActivityAt: database.Time(currentDate), TasksTried: 5, TasksWithHelp: 6,
+					ScoreComputed: 20, State: "done",
+				},
+				{
+					ParticipantID: 101, AttemptID: 2, ItemID: 4, LatestActivityAt: database.Time(oldDate), TasksTried: 9, TasksWithHelp: 10,
+					ScoreComputed: 30, State: "done",
+				},
 				// another user
 				{ParticipantID: 102, AttemptID: 1, ItemID: 2, LatestActivityAt: database.Time(oldDate), State: "done"},
 			}
@@ -186,12 +198,18 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 			expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
 
 			expected := []aggregatesResultRow{
-				{ParticipantID: 101, AttemptID: 1, ItemID: 1, ScoreComputed: 10, State: "done",
-					LatestActivityAt: expectedLatestActivityAt1},
-				{ParticipantID: 101, AttemptID: 1, ItemID: 2, ScoreComputed: test.expectedComputedScore,
-					State: "done", LatestActivityAt: expectedLatestActivityAt1},
-				{ParticipantID: 102, AttemptID: 1, ItemID: 2, State: "done",
-					LatestActivityAt: expectedLatestActivityAt2},
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 1, ScoreComputed: 10, State: "done",
+					LatestActivityAt: expectedLatestActivityAt1,
+				},
+				{
+					ParticipantID: 101, AttemptID: 1, ItemID: 2, ScoreComputed: test.expectedComputedScore,
+					State: "done", LatestActivityAt: expectedLatestActivityAt1,
+				},
+				{
+					ParticipantID: 102, AttemptID: 1, ItemID: 2, State: "done",
+					LatestActivityAt: expectedLatestActivityAt2,
+				},
 			}
 			assertAggregatesEqual(t, resultStore, expected)
 		})

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/result_store_propagate_cyclic_graph_integration_test.go
+++ b/app/database/result_store_propagate_cyclic_graph_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -32,6 +32,7 @@ func constructExpectedResultsForValidatedAtTests(t11, t12, t13, t14, t23, t24 *t
 		{ParticipantID: 102, AttemptID: 1, ItemID: 2, ValidatedAt: nil, State: "done"},
 	}
 }
+
 func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValidatedAts(t *testing.T) {
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
@@ -71,8 +72,9 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 			&oldestForItem4AndWinner, &skippedInItem3, &skippedInItem4), result)
 }
 
-func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_NoSuitableChildren( // nolint:lll
-	t *testing.T) {
+func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_NoSuitableChildren(
+	t *testing.T,
+) {
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -102,7 +104,8 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 }
 
 func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategoriesAreNotValidated(
-	t *testing.T) {
+	t *testing.T,
+) {
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -134,7 +137,8 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 }
 
 func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithCategoryValidation_IfAllAreValidated(
-	t *testing.T) {
+	t *testing.T,
+) {
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -170,8 +174,9 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 		constructExpectedResultsForValidatedAtTests(&oldDate, &expectedDate, &oldDate, nil, nil, &expectedDate), result)
 }
 
-func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_IgnoresNoScoreItems( // nolint:lll
-	t *testing.T) {
+func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_IgnoresNoScoreItems(
+	t *testing.T,
+) {
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 
@@ -29,7 +29,8 @@ func (r validatedResultRow) LessThan(other validatedResultRow) bool {
 
 func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	validationType string,
-	prepareFunc func(*testing.T, *database.ResultStore), expectedResults []validatedResultRow) {
+	prepareFunc func(*testing.T, *database.ResultStore), expectedResults []validatedResultRow,
+) {
 	db := testhelpers.SetupDBWithFixture(fixtures...)
 	defer func() { _ = db.Close() }()
 
@@ -78,7 +79,8 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 }
 
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhenThereIsAtLeastOneValidatedChild(
-	t *testing.T) {
+	t *testing.T,
+) {
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
 		"One",
@@ -92,7 +94,8 @@ func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhe
 }
 
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneStaysNonValidatedWhenThereAreNoValidatedChildren(
-	t *testing.T) {
+	t *testing.T,
+) {
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
 		"One",

--- a/app/database/session_store_test.go
+++ b/app/database/session_store_test.go
@@ -18,11 +18,12 @@ func TestSessionStore_InsertNewOAuth(t *testing.T) {
 		{name: "success", issuer: "some issuer"},
 		{name: "error", dbError: errors.New("some error")},
 	}
+
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
 	for _, test := range tests {
 		test := test
-
-		db, mock := NewDBMock()
-		defer func() { _ = db.Close() }()
 
 		userID := int64(123456)
 		token := "accesstoken"

--- a/app/database/thread_store.go
+++ b/app/database/thread_store.go
@@ -27,9 +27,9 @@ func (s *ThreadStore) UpdateHelperGroupID(oldHelperGroupID, newHelperGroupID int
 
 // CanRetrieveThread checks whether a user can retrieve a thread.
 func (s *ThreadStore) CanRetrieveThread(user *User, participantID, itemID int64) bool {
-	// nolint TODO: Try to make the permission checks one query with OR instead of using subqueries.
+	//nolint TODO: Try to make the permission checks one query with OR instead of using subqueries.
 
-	// nolint TODO: We need to update GORM for this and use https://gorm.io/docs/advanced_query.html#Group-Conditions
+	//nolint TODO: We need to update GORM for this and use https://gorm.io/docs/advanced_query.html#Group-Conditions
 	// Update in progress by Dmitry: https://github.com/France-ioi/AlgoreaBackend/issues/769
 
 	// we check the permissions first without joining the threads because we need to distinguish between an

--- a/app/database/time_test.go
+++ b/app/database/time_test.go
@@ -14,29 +14,45 @@ func TestTime_ScanString(t *testing.T) {
 		wantErr  bool
 		wantTime time.Time
 	}{
-		{name: "normal datetime", str: "2019-05-30 11:30:12",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 0, time.UTC)},
+		{
+			name: "normal datetime", str: "2019-05-30 11:30:12",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 0, time.UTC),
+		},
 		{name: "zero datetime", str: "0000-00-00 00:00:00", wantTime: time.Time{}},
-		{name: "normal date", str: "2019-05-30",
-			wantTime: time.Date(2019, 5, 30, 0, 0, 0, 0, time.UTC)},
+		{
+			name: "normal date", str: "2019-05-30",
+			wantTime: time.Date(2019, 5, 30, 0, 0, 0, 0, time.UTC),
+		},
 		{name: "zero date", str: "0000-00-00", wantTime: time.Time{}},
-		{name: "normal datetime with ms (1 digit)", str: "2019-05-30 11:30:12.1",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 100000000, time.UTC)},
+		{
+			name: "normal datetime with ms (1 digit)", str: "2019-05-30 11:30:12.1",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 100000000, time.UTC),
+		},
 		{name: "zero datetime with ms (1 digit)", str: "0000-00-00 00:00:00.0", wantTime: time.Time{}},
-		{name: "normal datetime with ms 2", str: "2019-05-30 11:30:12.12",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 120000000, time.UTC)},
+		{
+			name: "normal datetime with ms 2", str: "2019-05-30 11:30:12.12",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 120000000, time.UTC),
+		},
 		{name: "zero datetime with ms (2 digits)", str: "0000-00-00 00:00:00.00", wantTime: time.Time{}},
-		{name: "normal datetime with ms (3 digits)", str: "2019-05-30 11:30:12.123",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123000000, time.UTC)},
+		{
+			name: "normal datetime with ms (3 digits)", str: "2019-05-30 11:30:12.123",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123000000, time.UTC),
+		},
 		{name: "zero datetime with ms  (3 digits)", str: "0000-00-00 00:00:00.000", wantTime: time.Time{}},
-		{name: "normal datetime with ms (4 digits)", str: "2019-05-30 11:30:12.1234",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123400000, time.UTC)},
+		{
+			name: "normal datetime with ms (4 digits)", str: "2019-05-30 11:30:12.1234",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123400000, time.UTC),
+		},
 		{name: "zero datetime with ms  (4 digits)", str: "0000-00-00 00:00:00.0000", wantTime: time.Time{}},
-		{name: "normal datetime with ms (5 digits)", str: "2019-05-30 11:30:12.12345",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123450000, time.UTC)},
+		{
+			name: "normal datetime with ms (5 digits)", str: "2019-05-30 11:30:12.12345",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123450000, time.UTC),
+		},
 		{name: "zero datetime with ms  (5 digits)", str: "0000-00-00 00:00:00.00000", wantTime: time.Time{}},
-		{name: "normal datetime with ms (6 digits)", str: "2019-05-30 11:30:12.123456",
-			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123456000, time.UTC)},
+		{
+			name: "normal datetime with ms (6 digits)", str: "2019-05-30 11:30:12.123456",
+			wantTime: time.Date(2019, 5, 30, 11, 30, 12, 123456000, time.UTC),
+		},
 		{name: "zero datetime with ms  (6 digits)", str: "0000-00-00 00:00:00.000000", wantTime: time.Time{}},
 		{name: "wrong datetime", str: "12345-67-89 25:60:70", wantErr: true, wantTime: time.Time{}},
 	}

--- a/app/database/user_store.go
+++ b/app/database/user_store.go
@@ -18,16 +18,16 @@ const deleteWithTrapsBatchSize = 1000
 
 // DeleteTemporaryWithTraps deletes temporary users who don't have active sessions.
 // It also removes linked rows in the tables:
-// 1. [`filters`, `sessions`, `refresh_tokens`]
-//    having `user_id` = `users.group_id`;
-// 2. `answers` having `author_id`/`participant_id` = `users.group_id`;
-// 3. [`permissions_granted`, `permissions_generated`, `attempts`]
-//    having `group_id` = `users.group_id`;
-// 4. [`attempts`, `results`]
-//    having `participant_id` = `users.group_id`;
-// 5. `groups_groups` having `parent_group_id` or `child_group_id` equal to `users.group_id`;
-// 6. `groups_ancestors` having `ancestor_group_id` or `child_group_id` equal to `users.group_id`;
-// 7. [`groups_propagate`, `groups`] having `id` equal to `users.group_id`.
+//  1. [`filters`, `sessions`, `refresh_tokens`]
+//     having `user_id` = `users.group_id`;
+//  2. `answers` having `author_id`/`participant_id` = `users.group_id`;
+//  3. [`permissions_granted`, `permissions_generated`, `attempts`]
+//     having `group_id` = `users.group_id`;
+//  4. [`attempts`, `results`]
+//     having `participant_id` = `users.group_id`;
+//  5. `groups_groups` having `parent_group_id` or `child_group_id` equal to `users.group_id`;
+//  6. `groups_ancestors` having `ancestor_group_id` or `child_group_id` equal to `users.group_id`;
+//  7. [`groups_propagate`, `groups`] having `id` equal to `users.group_id`.
 func (s *UserStore) DeleteTemporaryWithTraps() (err error) {
 	defer recoverPanics(&err)
 
@@ -109,5 +109,5 @@ func deleteOneBatchOfUsers(db *DB, userIDs []int64) {
 
 func executeDeleteQuery(s *DB, table, condition string, args ...interface{}) {
 	mustNotBeError(
-		s.Exec(fmt.Sprintf("DELETE %[1]s FROM %[1]s ", QuoteName(table))+condition, args...).Error()) //nolint:gosec
+		s.Exec(fmt.Sprintf("DELETE %[1]s FROM %[1]s ", QuoteName(table))+condition, args...).Error())
 }

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/database/user_test.go
+++ b/app/database/user_test.go
@@ -12,7 +12,8 @@ func TestUser_Clone(t *testing.T) {
 	ts := time.Now()
 	user := &User{
 		Login: "login", LoginID: ptrInt64(5), DefaultLanguage: "fr",
-		IsTempUser: true, IsAdmin: true, GroupID: 2, AccessGroupID: ptrInt64(4), NotificationsReadAt: (*Time)(&ts)}
+		IsTempUser: true, IsAdmin: true, GroupID: 2, AccessGroupID: ptrInt64(4), NotificationsReadAt: (*Time)(&ts),
+	}
 	userClone := user.Clone()
 	assert.False(t, userClone == user)
 	assert.False(t, user.NotificationsReadAt == userClone.NotificationsReadAt)

--- a/app/database/users.go
+++ b/app/database/users.go
@@ -10,7 +10,8 @@ func (conn *DB) WhereUsersAreDescendantsOfGroup(groupID int64) *DB {
 // CheckIfTeamParticipationsConflictWithExistingUserMemberships returns true if the given team
 // has at least one active participation conflicting with active participations of the given user's teams.
 func (s *DataStore) CheckIfTeamParticipationsConflictWithExistingUserMemberships(
-	teamID, userGroupID int64, withLock bool) (bool, error) {
+	teamID, userGroupID int64, withLock bool,
+) (bool, error) {
 	contestsQuery := s.Attempts().
 		Where("attempts.participant_id = ?", teamID).Where("root_item_id IS NOT NULL").
 		Group("root_item_id")

--- a/app/database/users_integration_test.go
+++ b/app/database/users_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package database_test
 

--- a/app/doc/api.go
+++ b/app/doc/api.go
@@ -2,17 +2,17 @@
 // AlgoreaBackend API.
 // API for the Algorea backend.
 //
-//     Schemes: http, https
-//     Host: localhost
-//     BasePath: /
-//     Version: 0.0.1
-//     License: MIT http://opensource.org/licenses/MIT
+//	Schemes: http, https
+//	Host: localhost
+//	BasePath: /
+//	Version: 0.0.1
+//	License: MIT http://opensource.org/licenses/MIT
 //
-//     Consumes:
-//     - application/json
+//	Consumes:
+//	- application/json
 //
-//     Produces:
-//     - application/json
+//	Produces:
+//	- application/json
 //
 // swagger:meta
 package doc

--- a/app/doc/error_responses.go
+++ b/app/doc/error_responses.go
@@ -11,14 +11,14 @@ package doc
 
 // BadRequest. There is an error in the input data which was provided (path or body) to this service.
 // swagger:response badRequestResponse
-type badRequestResponse struct { //nolint:deadcode Used for documentation.
+type badRequestResponse struct {
 	// in: body
 	Body struct{ badRequest }
 }
 
 // Unauthorized. The authorization token has not been provided or is invalid.
 // swagger:response unauthorizedResponse
-type unauthorizedResponse struct { //nolint:deadcode Used for documentation.
+type unauthorizedResponse struct {
 	// in: body
 	Body struct{ unauthorized }
 }
@@ -26,14 +26,14 @@ type unauthorizedResponse struct { //nolint:deadcode Used for documentation.
 // Forbidden. One of the permission requirements (cfr service description) is not met.
 // (note that some permission error may end up in not-found or bad-request errors)
 // swagger:response forbiddenResponse
-type forbiddenResponse struct { //nolint:deadcode Used for documentation.
+type forbiddenResponse struct {
 	// in: body
 	Body struct{ forbidden }
 }
 
 // Conflict. Wrong resource state is not allowing to perform the operation
 // swagger:response conflictResponse
-type conflictResponse struct { //nolint:deadcode Used for documentation.
+type conflictResponse struct {
 	// in: body
 	Body struct{ forbidden }
 }
@@ -41,7 +41,7 @@ type conflictResponse struct { //nolint:deadcode Used for documentation.
 // Not Found. The requested object (or its scope) is not found
 // (note that this error may be caused by insufficient access rights)
 // swagger:response notFoundResponse
-type notFoundResponse struct { //nolint:deadcode Used for documentation.
+type notFoundResponse struct {
 	// in: body
 	Body struct{ notFound }
 }
@@ -49,7 +49,7 @@ type notFoundResponse struct { //nolint:deadcode Used for documentation.
 // Unprocessable Entity. Returned by services performing groups relations transitions to indicate
 // that the transition is impossible.
 // swagger:response unprocessableEntityResponse
-type unprocessableEntityResponse struct { //nolint:deadcode Used for documentation.
+type unprocessableEntityResponse struct {
 	// in: body
 	Body struct{ unprocessableEntity }
 }
@@ -57,7 +57,7 @@ type unprocessableEntityResponse struct { //nolint:deadcode Used for documentati
 // Unprocessable Entity. Returned by services performing groups relations transitions to indicate
 // that the transition is impossible because of missing approvals.
 // swagger:response unprocessableEntityResponseWithMissingApprovals
-type unprocessableEntityResponseWithMissingApprovals struct { //nolint:deadcode Used for documentation.
+type unprocessableEntityResponseWithMissingApprovals struct {
 	// in:body
 	Body struct {
 		unprocessableEntityWithMissingApprovals
@@ -67,7 +67,7 @@ type unprocessableEntityResponseWithMissingApprovals struct { //nolint:deadcode 
 // Internal Error. An unexpected error has happened on the server (e.g., uncaught database error).
 // If the problem persists, it should be reported.
 // swagger:response internalErrorResponse
-type internalErrorResponse struct { //nolint:deadcode Used for documentation.
+type internalErrorResponse struct {
 	// in: body
 	Body struct{ internalError }
 }

--- a/app/doc/errors.go
+++ b/app/doc/errors.go
@@ -11,7 +11,7 @@ package doc
 //     schema:
 //       "$ref": "#/definitions/badRequest"
 
-type genericError struct { //nolint:deadcode Used for documentation.
+type genericError struct {
 	// false
 	// example: false
 	// required: true
@@ -23,7 +23,7 @@ type genericError struct { //nolint:deadcode Used for documentation.
 	ErrorText string `json:"error_text,omitempty"`
 }
 
-type badRequest struct { //nolint:deadcode Used for documentation.
+type badRequest struct {
 	genericError
 	// required: true
 	// enum: Bad Request
@@ -33,42 +33,42 @@ type badRequest struct { //nolint:deadcode Used for documentation.
 	Errors interface{} `json:"errors,omitempty"`
 }
 
-type unauthorized struct { //nolint:deadcode Used for documentation.
+type unauthorized struct {
 	genericError
 	// required: true
 	// enum: Unauthorized
 	Message string `json:"message"`
 }
 
-type forbidden struct { //nolint:deadcode Used for documentation.
+type forbidden struct {
 	genericError
 	// required: true
 	// enum: Forbidden
 	Message string `json:"message"`
 }
 
-type conflict struct { //nolint:deadcode Used for documentation.
+type conflict struct {
 	genericError
 	// required: true
 	// enum: Conflict
 	Message string `json:"message"`
 }
 
-type notFound struct { //nolint:deadcode Used for documentation.
+type notFound struct {
 	genericError
 	// required: true
 	// enum: Not Found
 	Message string `json:"message"`
 }
 
-type unprocessableEntity struct { //nolint:deadcode Used for documentation.
+type unprocessableEntity struct {
 	genericError
 	// required: true
 	// enum: Unprocessable Entity
 	Message string `json:"message"`
 }
 
-type unprocessableEntityWithMissingApprovals struct { //nolint:deadcode Used for documentation.
+type unprocessableEntityWithMissingApprovals struct {
 	genericError
 	// required: true
 	// enum: Unprocessable Entity
@@ -77,12 +77,12 @@ type unprocessableEntityWithMissingApprovals struct { //nolint:deadcode Used for
 }
 
 // Unprocessable Entity response with a list of missing approvals.
-type unprocessableEntityWithMissingApprovalsData struct { //nolint:deadcode Used for documentation.
+type unprocessableEntityWithMissingApprovalsData struct {
 	// items.enum: personal_info_view,lock_membership,watch
 	MissingApprovals []string `json:"missing_approvals"`
 }
 
-type internalError struct { //nolint:deadcode Used for documentation.
+type internalError struct {
 	genericError
 	// required: true
 	// enum: Internal Server Error

--- a/app/doc/models.go
+++ b/app/doc/models.go
@@ -3,7 +3,7 @@ package doc
 import "time"
 
 // swagger:model createdResponse
-type CreatedResponse struct { //nolint:deadcode Used for documentation.
+type CreatedResponse struct {
 	// "created"
 	// enum: created
 	// required: true
@@ -14,7 +14,7 @@ type CreatedResponse struct { //nolint:deadcode Used for documentation.
 }
 
 // swagger:model userCreateTmpResponse
-type userCreateTmpResponse struct { //nolint:deadcode Used for documentation.
+type userCreateTmpResponse struct {
 	// description
 	// swagger:allOf
 	CreatedResponse
@@ -30,7 +30,7 @@ type userCreateTmpResponse struct { //nolint:deadcode Used for documentation.
 }
 
 // swagger:model groupsMembershipHistoryResponseRow
-type groupsMembershipHistoryResponseRow struct { //nolint:deadcode Used for documentation.
+type groupsMembershipHistoryResponseRow struct {
 	// `group_membership_changes.at`
 	// required: true
 	At time.Time `json:"at"`
@@ -53,7 +53,7 @@ type groupsMembershipHistoryResponseRow struct { //nolint:deadcode Used for docu
 }
 
 // swagger:model invitationsViewResponseRow
-type invitationsViewResponseRow struct { //nolint:deadcode Used for documentation.
+type invitationsViewResponseRow struct {
 	// `group_membership_changes.group_id`
 	// required: true
 	GroupID int64 `json:"group_id"`

--- a/app/doc/responses.go
+++ b/app/doc/responses.go
@@ -10,7 +10,7 @@ import (
 
 // The request has successfully updated the object
 // swagger:response updatedResponse
-type updatedResponse struct { //nolint:deadcode Used for documentation.
+type updatedResponse struct {
 	// in: body
 	Body struct {
 		// "updated"
@@ -25,7 +25,7 @@ type updatedResponse struct { //nolint:deadcode Used for documentation.
 
 // The request has succeeded. The `data.changed` shows if the object has been updated.
 // swagger:response updatedOrUnchangedResponse
-type updatedOrUnchangedResponse struct { //nolint:deadcode Used for documentation.
+type updatedOrUnchangedResponse struct {
 	// in: body
 	Body struct {
 		// enum: updated,unchanged
@@ -44,7 +44,7 @@ type updatedOrUnchangedResponse struct { //nolint:deadcode Used for documentatio
 
 // Success
 // swagger:response successResponse
-type successResponse struct { //nolint:deadcode Used for documentation.
+type successResponse struct {
 	// in: body
 	Body struct {
 		// "success"
@@ -59,7 +59,7 @@ type successResponse struct { //nolint:deadcode Used for documentation.
 
 // Success or failure
 // swagger:response publishedOrFailedResponse
-type publishedOrFailedResponse struct { //nolint:deadcode Used for documentation.
+type publishedOrFailedResponse struct {
 	// in: body
 	Body struct {
 		// enum: published,failed
@@ -72,7 +72,7 @@ type publishedOrFailedResponse struct { //nolint:deadcode Used for documentation
 
 // The request has successfully deleted the object
 // swagger:response deletedResponse
-type deletedResponse struct { //nolint:deadcode Used for documentation.
+type deletedResponse struct {
 	// in: body
 	Body struct {
 		// "deleted"
@@ -87,7 +87,7 @@ type deletedResponse struct { //nolint:deadcode Used for documentation.
 
 // The request has succeeded. The `data.changed` shows if the object has been deleted.
 // swagger:response deletedOrUnchangedResponse
-type deletedOrUnchangedResponse struct { //nolint:deadcode Used for documentation.
+type deletedOrUnchangedResponse struct {
 	// in: body
 	Body struct {
 		// enum: deleted,unchanged
@@ -106,7 +106,7 @@ type deletedOrUnchangedResponse struct { //nolint:deadcode Used for documentatio
 
 // Created. Success response with the created object's id.
 // swagger:response createdWithIDResponse
-type createdWithIDResponse struct { //nolint:deadcode Used for documentation.
+type createdWithIDResponse struct {
 	// in: body
 	Body struct {
 		// enum: created
@@ -125,7 +125,7 @@ type createdWithIDResponse struct { //nolint:deadcode Used for documentation.
 
 // The request has succeeded. The `data.changed` shows if the object has been created.
 // swagger:response createdOrUnchangedResponse
-type createdOrUnchangedResponse struct { //nolint:deadcode Used for documentation.
+type createdOrUnchangedResponse struct {
 	// in: body
 	Body struct {
 		// enum: created,unchanged
@@ -144,7 +144,7 @@ type createdOrUnchangedResponse struct { //nolint:deadcode Used for documentatio
 
 // OK. Success response with the per-group update statuses
 // swagger:response
-type updatedGroupRelationsResponse struct { //nolint:deadcode Used for documentation.
+type updatedGroupRelationsResponse struct {
 	// in:body
 	Body struct {
 		// "updated"
@@ -161,11 +161,11 @@ type updatedGroupRelationsResponse struct { //nolint:deadcode Used for documenta
 }
 
 // enum: [cycle, invalid, success, unchanged, not_found]
-type loginTransitionResult string //nolint:deadcode Used for documentation.
+type loginTransitionResult string
 
 // Created. Success response with the per-login results
 // swagger:response createdLoginRelationsResponse
-type createdLoginRelationsResponse struct { //nolint:deadcode Used for documentation.
+type createdLoginRelationsResponse struct {
 	// in:body
 	Body struct {
 		// "created"
@@ -184,7 +184,7 @@ type createdLoginRelationsResponse struct { //nolint:deadcode Used for documenta
 
 // OK. Success response with the requested answer
 // swagger:response itemAnswerGetResponse
-type itemAnswerGetResponse struct { //nolint:deadcode Used for documentation.
+type itemAnswerGetResponse struct {
 	// description: The returned answer
 	// in:body
 	Body struct {
@@ -220,7 +220,7 @@ type itemAnswerGetResponse struct { //nolint:deadcode Used for documentation.
 
 // Created. The group has successfully entered the contest.
 // swagger:response itemEnterResponse
-type itemEnterResponse struct { //nolint:deadcode Used for documentation.
+type itemEnterResponse struct {
 	// in:body
 	Body struct {
 		// enum: created

--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -99,7 +99,8 @@ func TestMiddleware(t *testing.T) {
 }
 
 func assertMiddleware(t *testing.T, domains []ConfigItem, domainOverride string, shouldEnterService bool,
-	expectedStatusCode int, expectedBody string, expectedConfig *CtxConfig, expectedDomain string) {
+	expectedStatusCode int, expectedBody string, expectedConfig *CtxConfig, expectedDomain string,
+) {
 	// dummy server using the middleware
 	middleware := Middleware(domains, domainOverride)
 	enteredService := false // used to log if the service has been reached
@@ -115,7 +116,7 @@ func assertMiddleware(t *testing.T, domains []ConfigItem, domainOverride string,
 	defer mainSrv.Close()
 
 	// calling web server
-	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, nil)
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, http.NoBody)
 	client := &http.Client{}
 	response, err := client.Do(mainRequest)
 	var body string

--- a/app/formdata/anything.go
+++ b/app/formdata/anything.go
@@ -39,5 +39,7 @@ func (a Anything) MarshalJSON() ([]byte, error) {
 	return a.raw, nil
 }
 
-var _ = json.Unmarshaler(&Anything{})
-var _ = json.Marshaler(Anything{})
+var (
+	_ = json.Unmarshaler(&Anything{})
+	_ = json.Marshaler(Anything{})
+)

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -13,13 +13,12 @@ import (
 	"strings"
 	"time"
 
-	english "github.com/go-playground/locales/en"
-	ut "github.com/go-playground/universal-translator"
-	"github.com/jinzhu/gorm"
-
 	"github.com/France-ioi/mapstructure"
 	"github.com/France-ioi/validator"
 	"github.com/France-ioi/validator/translations/en"
+	english "github.com/go-playground/locales/en"
+	ut "github.com/go-playground/universal-translator"
+	"github.com/jinzhu/gorm"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 )
@@ -38,9 +37,11 @@ type FormData struct {
 	trans    ut.Translator
 }
 
-const set = "set"
-const null = "null"
-const squash = "squash"
+const (
+	set    = "set"
+	null   = "null"
+	squash = "squash"
+)
 
 // NewFormData creates a new FormData object for given definitions.
 func NewFormData(definitionStructure interface{}) *FormData {
@@ -48,8 +49,8 @@ func NewFormData(definitionStructure interface{}) *FormData {
 	validate := validator.New()
 
 	// Initialize go-playground/validator's default error messages in English
-	var eng = english.New()
-	var uni = ut.New(eng, eng)
+	eng := english.New()
+	uni := ut.New(eng, eng)
 	trans, _ := uni.GetTranslator("en")
 	_ = en.RegisterDefaultTranslations(validate, trans)
 
@@ -210,8 +211,10 @@ func (f *FormData) ValidatorSkippingUnchangedFields(nestedValidator validator.Fu
 	})
 }
 
-var mapstructTypeErrorRegexp = regexp.MustCompile(`^'([^']*)'\s+(.*)$`)
-var mapstructDecodingErrorRegexp = regexp.MustCompile(`^error decoding '([^']*)':\s+(.*)$`)
+var (
+	mapstructTypeErrorRegexp     = regexp.MustCompile(`^'([^']*)'\s+(.*)$`)
+	mapstructDecodingErrorRegexp = regexp.MustCompile(`^error decoding '([^']*)':\s+(.*)$`)
+)
 
 func (f *FormData) decodeRequestJSONDataIntoStruct(r *http.Request) error {
 	var rawData map[string]interface{}
@@ -245,7 +248,6 @@ func (f *FormData) decodeMapIntoStruct(m map[string]interface{}) {
 		ZeroFields:       true, // this marks keys with null values as used
 		WeaklyTypedInput: false,
 	})
-
 	if err != nil {
 		panic(err) // this error can only be caused by bugs in the code
 	}
@@ -365,7 +367,8 @@ func (f *FormData) addDBFieldsIntoMap(resultMap map[string]interface{}, reflValu
 }
 
 func traverseStructure(fn func(fieldValue reflect.Value, structField reflect.StructField, jsonName string) bool,
-	reflValue reflect.Value, prefix string) {
+	reflValue reflect.Value, prefix string,
+) {
 	for reflValue.Kind() == reflect.Ptr {
 		reflValue = reflValue.Elem()
 	}
@@ -449,7 +452,8 @@ func toAnythingHookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if t.Name() != "Anything" || t.PkgPath() != "github.com/France-ioi/AlgoreaBackend/app/formdata" {
 			return data, nil
 		}
@@ -468,7 +472,8 @@ func stringToInt64HookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if t.Kind() != reflect.Int64 || f.Kind() != reflect.String {
 			return data, nil
 		}
@@ -483,7 +488,8 @@ func stringToDatabaseTimeUTCHookFunc(layout string) mapstructure.DecodeHookFunc 
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if f.Kind() != reflect.String || t.Name() != "Time" || t.PkgPath() != "github.com/France-ioi/AlgoreaBackend/app/database" {
 			return data, nil
 		}

--- a/app/formdata/form_data_integration_test.go
+++ b/app/formdata/form_data_integration_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/France-ioi/mapstructure"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
 )
@@ -133,10 +132,10 @@ func TestFormData_ParseJSONRequestData(t *testing.T) {
 					Name        string `json:"name" validate:"set"`
 					OtherStruct struct {
 						Name *string `json:"name1" validate:"set"`
-					} `json:"other_struct,squash" validate:"set"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+					} `json:"other_struct,squash" validate:"set"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 					OtherStruct2 struct {
 						Name *string `json:"name2" validate:"set"`
-					} `json:"other_struct2,squash" validate:"set"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+					} `json:"other_struct2,squash" validate:"set"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 				} `json:"struct" validate:"set"`
 			}{},
 			`{"id":null, "struct":{"name1": "my name"}}`,
@@ -152,7 +151,7 @@ func TestFormData_ParseJSONRequestData(t *testing.T) {
 			&struct {
 				Struct struct {
 					Name string `json:"name" validate:"min=1"`
-				} `json:"struct,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+				} `json:"struct,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 			}{},
 			`{"name": ""}}`,
 			"invalid input data",
@@ -575,7 +574,7 @@ func TestFormData_ConstructMapForDB(t *testing.T) {
 		{
 			"skips unexported attributes",
 			&struct {
-				name string `json:"name" gorm:"column:name"` // nolint:govet
+				name string `json:"name" gorm:"column:name"` //nolint:govet
 			}{},
 			`{"name":"Test"}`,
 			map[string]interface{}{},
@@ -634,7 +633,7 @@ func TestFormData_ConstructMapForDB(t *testing.T) {
 					OtherStruct struct {
 						Name string `json:"name" validate:"set" sql:"column:structs.otherStructs.sName"`
 					} `json:"other_struct" validate:"set"`
-				} `json:"struct,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+				} `json:"struct,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 			}{},
 			`{"name":"John Doe", "other_struct": {"name": "Still John Doe"}}`,
 			map[string]interface{}{"structs.sName": "John Doe", "structs.otherStructs.sName": "Still John Doe"},
@@ -727,7 +726,7 @@ func TestFormData_ConstructPartialMapForDB(t *testing.T) {
 					OtherStruct struct {
 						Name string `json:"name" validate:"set" sql:"column:structs.otherStructs.sName"`
 					} `json:"other_struct" validate:"set"`
-				} `json:"struct,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+				} `json:"struct,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 			}{},
 			`{"name":"John Doe", "other_struct": {"name": "Still John Doe"}}`,
 			map[string]interface{}{"structs.sName": "John Doe", "structs.otherStructs.sName": "Still John Doe"},

--- a/app/formdata/form_data_test.go
+++ b/app/formdata/form_data_test.go
@@ -175,10 +175,10 @@ func TestFormData_fieldPathInValidator(t *testing.T) {
 		Field *string `json:"field" validate:"custom|custom1"`
 	}
 	type TestNestedStruct struct {
-		TestNestedNestedStruct `json:"nested_nested,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+		TestNestedNestedStruct `json:"nested_nested,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 	}
 	type testStruct struct {
-		TestNestedStruct `json:"nested,squash"` // nolint:staticcheck SA5008: unknown JSON option "squash"
+		TestNestedStruct `json:"nested,squash"` //nolint:staticcheck SA5008: unknown JSON option "squash"
 	}
 
 	var path, path1 string

--- a/app/formdata/validations.go
+++ b/app/formdata/validations.go
@@ -46,7 +46,7 @@ func validateHMSForDuration(hms []string) bool {
 	return hours >= 0 && hours <= 838 && minutes >= 0 && minutes <= 59 && seconds >= 0 && seconds <= 59
 }
 
-var dmyDateRegexp = regexp.MustCompile(`^[0-3][0-9]-[0-1][0-9]-[\d]{4}$`)
+var dmyDateRegexp = regexp.MustCompile(`^[0-3]\d-[01]\d-\d{4}$`)
 
 func validateDMYDate(fl validator.FieldLevel) bool {
 	field := fl.Field()

--- a/app/formdata/validations_test.go
+++ b/app/formdata/validations_test.go
@@ -104,6 +104,7 @@ func (fl *FieldLevel) Param() string           { return "" }
 func (fl *FieldLevel) ExtractType(reflect.Value) (reflect.Value, reflect.Kind, bool) {
 	return reflect.ValueOf(nil), reflect.Ptr, true
 }
+
 func (fl *FieldLevel) GetStructFieldOK() (reflect.Value, reflect.Kind, bool) {
 	return reflect.ValueOf(nil), reflect.Ptr, true
 }

--- a/app/logging/db_logger_test.go
+++ b/app/logging/db_logger_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewDBLogger_ErrorFallback(t *testing.T) {
 	assert := assertlib.New(t)
-	logger := new() // no config
+	logger := createLogger() // no config
 	dbLogger, logMode, rawLogMode := logger.NewDBLogger()
 	assert.IsType(gorm.Logger{}, dbLogger)
 	assert.False(logMode)
@@ -20,7 +20,7 @@ func TestNewDBLogger_ErrorFallback(t *testing.T) {
 
 func TestLoggerFromConfig_TextLog(t *testing.T) {
 	assert := assertlib.New(t)
-	logger := new()
+	logger := createLogger()
 	config := viper.New()
 	config.Set("Format", "text")
 	config.Set("Output", "file")
@@ -31,7 +31,7 @@ func TestLoggerFromConfig_TextLog(t *testing.T) {
 
 func TestLoggerFromConfig_JSONLog(t *testing.T) {
 	assert := assertlib.New(t)
-	logger := new()
+	logger := createLogger()
 	config := viper.New()
 	config.Set("Format", "json")
 	config.Set("Output", "file")
@@ -42,7 +42,7 @@ func TestLoggerFromConfig_JSONLog(t *testing.T) {
 
 func TestLoggerFromConfig_WrongFormat(t *testing.T) {
 	assert := assertlib.New(t)
-	logger := new()
+	logger := createLogger()
 	config := viper.New()
 	config.Set("Format", "yml")
 	config.Set("Output", "file")
@@ -70,7 +70,7 @@ func TestNewDBLogger_LogMode(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			assert := assertlib.New(t)
-			logger := new()
+			logger := createLogger()
 			config := viper.New()
 			config.Set("LogSQLQueries", test.logSQLQueries)
 			config.Set("LogRawSQLQueries", test.logRawSQLQueries)

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -17,18 +17,20 @@ type Logger struct {
 	config *viper.Viper
 }
 
-var (
-	// SharedLogger is the global scope logger
-	// It should not be used directly by other packages (except for testing) which should prefer shorthands functions
-	SharedLogger = new()
+// SharedLogger is the global scope logger
+// It should not be used directly by other packages (except for testing) which should prefer shorthands functions.
+var SharedLogger = createLogger()
+
+const (
+	formatJSON = "json"
+	formatText = "text"
 )
 
-const formatJSON = "json"
-const formatText = "text"
-
-const outputStdout = "stdout"
-const outputStderr = "stderr"
-const outputFile = "file"
+const (
+	outputStdout = "stdout"
+	outputStderr = "stderr"
+	outputFile   = "file"
+)
 
 // Configure applies the given logging configuration to the logger
 // (may panic if the configuration is invalid).
@@ -60,7 +62,7 @@ func (l *Logger) Configure(config *viper.Viper) {
 	case outputFile:
 		_, codeFilePath, _, _ := runtime.Caller(0)
 		codeDir := filepath.Dir(codeFilePath)
-		f, err := os.OpenFile(codeDir+"/../../log/all.log", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+		f, err := os.OpenFile(codeDir+"/../../log/all.log", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600) //nolint:gosec,gosec No user input.
 		if err != nil {
 			l.SetOutput(os.Stdout)
 			l.Errorf("Unable to open file for logs, fallback to stdout: %v\n", err)
@@ -83,9 +85,9 @@ func (l *Logger) Configure(config *viper.Viper) {
 
 // ResetShared reset the global logger to its default settings before its configuration.
 func ResetShared() {
-	SharedLogger = new()
+	SharedLogger = createLogger()
 }
 
-func new() *Logger {
+func createLogger() *Logger { //nolint:gosec
 	return &Logger{logrus.New(), nil}
 }

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -31,7 +31,7 @@ func TestConfigure_FormatText(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "text")
 	conf.Set("Output", "file")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.IsType(&logrus.TextFormatter{}, logger.Formatter)
 }
@@ -41,7 +41,7 @@ func TestConfigure_FormatJson(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "file")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.IsType(&logrus.JSONFormatter{}, logger.Formatter)
 }
@@ -51,7 +51,7 @@ func TestConfigure_FormatInvalid(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "yml")
 	conf.Set("Output", "file")
-	logger := new()
+	logger := createLogger()
 	assert.Panics(func() { logger.Configure(conf) })
 }
 
@@ -60,7 +60,7 @@ func TestConfigure_OutputStdout(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "stdout")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(os.Stdout, logger.Out)
 }
@@ -70,7 +70,7 @@ func TestConfigure_OutputStderr(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "stderr")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(os.Stderr, logger.Out)
 }
@@ -84,12 +84,12 @@ func TestConfigure_OutputFile(t *testing.T) {
 	// will append time to make sure not to match a prev exec of the test
 	timestamp := time.Now().UnixNano()
 
-	logger1 := new()
+	logger1 := createLogger()
 	logger1.Configure(conf)
 	logger1.Errorf("logexec1 %d", timestamp)
 
 	// redo another init to check it will not override
-	logger2 := new()
+	logger2 := createLogger()
 	logger2.Configure(conf)
 	logger2.Warnf("logexec2 %d", timestamp)
 
@@ -109,7 +109,7 @@ func TestConfigure_OutputFileError(t *testing.T) {
 	}
 	patch := monkey.Patch(os.OpenFile, fakeFunc)
 	defer patch.Unpatch()
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(os.Stdout, logger.Out)
 }
@@ -119,7 +119,7 @@ func TestConfigure_OutputInvalid(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "S3")
-	logger := new()
+	logger := createLogger()
 	assert.Panics(func() { logger.Configure(conf) })
 }
 
@@ -129,7 +129,7 @@ func TestConfigure_LevelDefault(t *testing.T) {
 	conf.Set("Format", "text")
 	conf.Set("Output", "file")
 	conf.Set("Level", "")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(logrus.InfoLevel, logger.Level)
 }
@@ -140,7 +140,7 @@ func TestConfigure_LevelParsed(t *testing.T) {
 	conf.Set("Format", "text")
 	conf.Set("Output", "file")
 	conf.Set("Level", "warn")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(logrus.WarnLevel, logger.Level)
 }
@@ -151,7 +151,7 @@ func TestConfigure_LevelInvalid(t *testing.T) {
 	conf.Set("Format", "text")
 	conf.Set("Output", "file")
 	conf.Set("Level", "invalid_level")
-	logger := new()
+	logger := createLogger()
 	logger.Configure(conf)
 	assert.Equal(logrus.InfoLevel, logger.Level)
 }

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -78,7 +78,7 @@ func doRequest(forcePanic bool) {
 	defer mainSrv.Close()
 
 	// calling web server
-	mainRequest, _ := http.NewRequest("GET", mainSrv.URL+"/a_path", nil)
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL+"/a_path", http.NoBody)
 	client := mainSrv.Client()
 	response, err := client.Do(mainRequest)
 	if err == nil {

--- a/app/logging/raw_db_logger_test.go
+++ b/app/logging/raw_db_logger_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"database/sql/driver"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestNewRawDBLogger_TextLog(t *testing.T) {
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
-	rawLogger.Log(nil, "some message", "err", nil) // nolint:staticcheck ignore SA1012 sql often uses nil context
+	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Contains(t, hook.GetAllStructuredLogs(), "some message map[err:<nil>]")
 }
 
@@ -31,7 +32,7 @@ func TestNewRawDBLogger_HonoursLogMode(t *testing.T) {
 	logger := &Logger{nulllogger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
-	rawLogger.Log(nil, "some message", "err", nil) // nolint:staticcheck SA1012 sql often uses nil context
+	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Empty(t, hook.GetAllStructuredLogs())
 }
 
@@ -43,7 +44,7 @@ func TestNewRawDBLogger_JSONLog(t *testing.T) {
 	logger := &Logger{nulllogger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
-	rawLogger.Log(nil, "some message", "err", nil) // nolint:staticcheck SA1012 sql often uses nil context
+	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Contains(t, hook.GetAllStructuredLogs(), `msg="some message"`)
 	assert.Contains(t, hook.GetAllStructuredLogs(), `err="<nil>"`)
 }
@@ -56,7 +57,7 @@ func TestRawDBLogger_ShouldSkipSkippedActions(t *testing.T) {
 	logger := &Logger{nulllogger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
-	rawLogger.Log(nil, "sql-stmt-exec", "err", driver.ErrSkip) // nolint:staticcheck SA1012 we check the nil context here
+	rawLogger.Log(context.TODO(), "sql-stmt-exec", "err", driver.ErrSkip)
 	assert.Empty(t, hook.GetAllStructuredLogs())
 }
 

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -58,7 +58,7 @@ func (l *StructuredDBLogger) Print(values ...interface{}) {
 	}
 }
 
-var spacesRegexp = regexp.MustCompile(`[\s\r\n]+`)
+var spacesRegexp = regexp.MustCompile(`\s+`)
 
 func fillSQLPlaceholders(query string, values []interface{}) string {
 	var sql string

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -17,7 +17,7 @@ func TestStructuredDBLogger_Print_SQL(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
-	defer func() { logging.ResetShared() }()
+	defer logging.ResetShared()
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "stdout")
@@ -47,7 +47,7 @@ func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
-	defer func() { logging.ResetShared() }()
+	defer logging.ResetShared()
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "stdout")
@@ -68,7 +68,7 @@ func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
-	defer func() { logging.ResetShared() }()
+	defer logging.ResetShared()
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "stdout")

--- a/app/loggingtest/loggingtest.go
+++ b/app/loggingtest/loggingtest.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 // Package loggingtest provides functions to test the content of the logs.
 package loggingtest

--- a/app/loginmodule/client.go
+++ b/app/loginmodule/client.go
@@ -35,7 +35,7 @@ func NewClient(loginModuleURL string) *Client {
 func (client *Client) GetUserProfile(ctx context.Context, accessToken string) (profile map[string]interface{}, err error) {
 	defer recoverPanics(&err)
 
-	request, err := http.NewRequest("GET", client.url+"/user_api/account", nil)
+	request, err := http.NewRequest("GET", client.url+"/user_api/account", http.NoBody)
 	mustNotBeError(err)
 	request.Header.Set("Authorization", "Bearer "+accessToken)
 	request = request.WithContext(ctx)
@@ -84,7 +84,8 @@ type CreateUsersResponseDataRow struct {
 
 // CreateUsers creates a batch of users in the login module.
 func (client *Client) CreateUsers(ctx context.Context, clientID, clientKey string,
-	params *CreateUsersParams) (bool, []CreateUsersResponseDataRow, error) {
+	params *CreateUsersParams,
+) (bool, []CreateUsersResponseDataRow, error) {
 	urlParams := map[string]string{
 		"prefix":          params.Prefix,
 		"amount":          strconv.Itoa(params.Amount),
@@ -141,7 +142,8 @@ func (client *Client) UnlinkClient(ctx context.Context, clientID, clientKey stri
 
 // SendLTIResult sends item score to LTI.
 func (client *Client) SendLTIResult(
-	ctx context.Context, clientID, clientKey string, userLoginID, itemID int64, score float32) (bool, error) {
+	ctx context.Context, clientID, clientKey string, userLoginID, itemID int64, score float32,
+) (bool, error) {
 	response, err := client.requestAccountsManagerAndDecode(ctx, "/platform_api/lti_result/send",
 		map[string]string{
 			"user_id":    strconv.FormatInt(userLoginID, 10),
@@ -161,7 +163,8 @@ type accountManagerResponse struct {
 }
 
 func (client *Client) requestAccountsManagerAndDecode(ctx context.Context, urlPath string, requestParams map[string]string,
-	clientID, clientKey string) (decodedResponse *accountManagerResponse, err error) {
+	clientID, clientKey string,
+) (decodedResponse *accountManagerResponse, err error) {
 	defer recoverPanics(&err)
 
 	apiURL, err := url.Parse(client.url + urlPath)

--- a/app/loginmodule/client_test.go
+++ b/app/loginmodule/client_test.go
@@ -400,7 +400,8 @@ func TestClient_AccountsManagerEndpoints(t *testing.T) {
 			params:       "user_id=123456",
 			action: func(client *Client) (bool, error) {
 				return client.UnlinkClient(context.Background(), "clientID", "clientKeyclientKey", 123456)
-			}},
+			},
+		},
 		{
 			endpoint:     "accounts_manager/delete",
 			errorMessage: "can't delete users",

--- a/app/payloads/common_test.go
+++ b/app/payloads/common_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPayloads_ParseMap(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name      string
 		raw       map[string]interface{}
 		want      interface{}
@@ -118,7 +118,7 @@ func TestConvertIntoMap(t *testing.T) {
 		Field string `json:"field"`
 	}
 	type testStruct struct {
-		notExported   string `json:"not_exported"` // nolint:govet
+		notExported   string `json:"not_exported"` //nolint:govet
 		Normal        string `json:"normal"`
 		WithoutTag    string
 		Skipped       string        `json:"-"`

--- a/app/payloadstest/payloads.go
+++ b/app/payloadstest/payloads.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 // Package payloadstest contains token payloads to be used for tests.
 package payloadstest

--- a/app/rand/rand.go
+++ b/app/rand/rand.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 )
 
-var globalRand = mr.New(mr.NewSource(1))
-var globalLock sync.Mutex
+var (
+	globalRand = mr.New(mr.NewSource(1))
+	globalLock sync.Mutex
+)
 
 // Seed uses the provided seed value to initialize the generator to a deterministic state.
 func Seed(s int64) {
@@ -42,7 +44,7 @@ func String(n int) string {
 	globalLock.Lock()
 	defer globalLock.Unlock()
 
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	s := make([]rune, n)
 	for i := range s {

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -99,7 +99,7 @@ func TestServer_StartHandlesShutdownError(t *testing.T) {
 		exitCode = code
 		lock.Unlock()
 	})
-	monkey.PatchInstanceMethod(reflect.TypeOf(&http.Server{}), "Shutdown",
+	monkey.PatchInstanceMethod(reflect.TypeOf(&http.Server{ReadTimeout: 1 * time.Second}), "Shutdown",
 		func(*http.Server, context.Context) error { return errors.New("some errror") })
 	defer monkey.UnpatchAll()
 

--- a/app/service/base.go
+++ b/app/service/base.go
@@ -4,12 +4,12 @@ package service
 import (
 	"net/http"
 
+	"github.com/spf13/viper"
+
 	"github.com/France-ioi/AlgoreaBackend/app/auth"
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
-
-	"github.com/spf13/viper"
 )
 
 // Base is the common service context data.

--- a/app/service/base_test.go
+++ b/app/service/base_test.go
@@ -23,7 +23,7 @@ func TestBase_GetUser(t *testing.T) {
 	})))
 	defer ts.Close()
 
-	request, _ := http.NewRequest("GET", ts.URL, nil)
+	request, _ := http.NewRequest("GET", ts.URL, http.NoBody)
 	response, err := http.DefaultClient.Do(request)
 	assert.NoError(t, err)
 	if err == nil {

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -45,7 +45,7 @@ func (e APIError) httpResponse() render.Renderer {
 		result.Errors = fieldErrors
 	}
 
-	result.ErrorText = e.Error.Error() // nolint FIXME: should be disabled in prod
+	result.ErrorText = e.Error.Error() //nolint FIXME: should be disabled in prod
 	if len(result.ErrorText) > 0 {
 		result.ErrorText = strings.ToUpper(result.ErrorText[0:1]) + result.ErrorText[1:]
 	}

--- a/app/service/errors_test.go
+++ b/app/service/errors_test.go
@@ -20,7 +20,7 @@ func responseForError(e service.APIError) *httptest.ResponseRecorder {
 }
 
 func responseForHTTPHandler(handler http.Handler) *httptest.ResponseRecorder {
-	req, _ := http.NewRequest("GET", "/dummy", nil)
+	req, _ := http.NewRequest("GET", "/dummy", http.NoBody)
 	recorder := httptest.NewRecorder()
 
 	handler.ServeHTTP(recorder, req)

--- a/app/service/not_found_test.go
+++ b/app/service/not_found_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNotFound(t *testing.T) {
 	assert := assertlib.New(t)
-	req, _ := http.NewRequest("GET", "/dummy", nil)
+	req, _ := http.NewRequest("GET", "/dummy", http.NoBody)
 	recorder := httptest.NewRecorder()
 
 	NotFound(recorder, req)

--- a/app/service/parameters.go
+++ b/app/service/parameters.go
@@ -67,13 +67,14 @@ func ResolveURLQueryGetStringSliceField(req *http.Request, paramName string) ([]
 
 // ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters extracts a list of values
 // out from '<fieldName>_include'/'<fieldName>_exclude' request parameters:
-//   1. If none of '<fieldName>_include'/'<fieldName>_exclude' is present, all the known values are returned.
-//   2. If '<fieldName>_include' is present, then it becomes the result list.
-//   3. If '<fieldName>_exclude' is present, then we exclude all its values from the result list.
+//  1. If none of '<fieldName>_include'/'<fieldName>_exclude' is present, all the known values are returned.
+//  2. If '<fieldName>_include' is present, then it becomes the result list.
+//  3. If '<fieldName>_exclude' is present, then we exclude all its values from the result list.
 //
 // All values from both the request parameters are checked against the list of known values.
 func ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(
-	r *http.Request, fieldName string, knownValuesMap map[string]bool) ([]string, error) {
+	r *http.Request, fieldName string, knownValuesMap map[string]bool,
+) ([]string, error) {
 	var valuesMap map[string]bool
 	valuesToInclude, err := ResolveURLQueryGetStringSliceField(r, fieldName+"_include")
 	if err == nil {

--- a/app/service/parameters_test.go
+++ b/app/service/parameters_test.go
@@ -74,7 +74,7 @@ func TestResolveURLQueryGetInt64SliceField(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetInt64SliceField(req, "ids")
 			if testCase.expectedErrMsg != "" {
 				assert.EqualError(t, err, testCase.expectedErrMsg)
@@ -148,7 +148,7 @@ func TestResolveURLQueryPathInt64Field(t *testing.T) {
 			r.Get(testCase.routeString, handler)
 
 			ts := httptest.NewServer(r)
-			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, nil)
+			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, http.NoBody)
 			response, err := http.DefaultClient.Do(request)
 			if err == nil {
 				_ = response.Body.Close()
@@ -227,7 +227,7 @@ func TestResolveURLQueryPathInt64SliceField(t *testing.T) {
 			}
 			r.Get(`/{ids:.*}something`, handler)
 			ts := httptest.NewServer(r)
-			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, nil)
+			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, http.NoBody)
 			response, err := http.DefaultClient.Do(request)
 			if err == nil {
 				_ = response.Body.Close()
@@ -267,7 +267,7 @@ func TestResolveURLQueryGetStringField(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringField(req, "name")
 			if testCase.expectedErrMsg != "" {
 				assert.EqualError(t, err, testCase.expectedErrMsg)
@@ -320,7 +320,7 @@ func TestResolveURLQueryGetBoolField(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetBoolField(req, "flag")
 			if testCase.expectedErrMsg != "" {
 				assert.EqualError(t, err, testCase.expectedErrMsg)
@@ -359,7 +359,7 @@ func TestResolveURLQueryGetTimeField(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			dateTime, err := ResolveURLQueryGetTimeField(req, "time")
 			if testCase.expectedErrMsg != "" {
 				assert.EqualError(t, err, testCase.expectedErrMsg)
@@ -418,7 +418,7 @@ func TestResolveURLQueryGetStringSliceField(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringSliceField(req, "values")
 			if testCase.expectedErrMsg != "" {
 				assert.EqualError(t, err, testCase.expectedErrMsg)
@@ -495,7 +495,7 @@ func TestResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(t *testi
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, nil)
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(req, "fruits",
 				map[string]bool{"apple": true, "orange": true, "pear": true})
 			if testCase.expectedErrMsg != "" {

--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package service_test
 

--- a/app/service/participant_test.go
+++ b/app/service/participant_test.go
@@ -92,7 +92,8 @@ func TestParticipantMiddleware(t *testing.T) {
 }
 
 func callThroughParticipantMiddleware(userID, asTeamID int64, apiError APIError) (
-	called, enteredService bool, actualUserID int64, resp *http.Response, mock sqlmock.Sqlmock) {
+	called, enteredService bool, actualUserID int64, resp *http.Response, mock sqlmock.Sqlmock,
+) {
 	dbmock, mock := database.NewDBMock()
 	defer func() { _ = dbmock.Close() }()
 	userGuard := monkey.Patch(auth.UserFromContext, func(context.Context) *database.User {
@@ -124,7 +125,7 @@ func callThroughParticipantMiddleware(userID, asTeamID int64, apiError APIError)
 	defer mainSrv.Close()
 
 	// calling web server
-	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, nil)
+	mainRequest, _ := http.NewRequest("GET", mainSrv.URL, http.NoBody)
 	mainRequest.Header.Add("Authorization", "Bearer 1234567")
 	client := &http.Client{}
 	resp, _ = client.Do(mainRequest)

--- a/app/service/query_limiter.go
+++ b/app/service/query_limiter.go
@@ -13,8 +13,8 @@ type QueryLimiter struct {
 }
 
 // NewQueryLimiter creates a QueryLimiter with default settings:
-//  * default limit is 500,
-//  * maximum allowed limit is 1000.
+//   - default limit is 500,
+//   - maximum allowed limit is 1000.
 func NewQueryLimiter() *QueryLimiter {
 	return &QueryLimiter{
 		defaultLimit:    500,

--- a/app/service/query_limiter_test.go
+++ b/app/service/query_limiter_test.go
@@ -91,7 +91,7 @@ func TestQueryLimiter_Apply(t *testing.T) {
 			r.Get("/", handler)
 
 			ts := httptest.NewServer(r)
-			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, nil)
+			request, _ := http.NewRequest("GET", ts.URL+testCase.queryString, http.NoBody)
 			response, err := http.DefaultClient.Do(request)
 			if err == nil {
 				_ = response.Body.Close()

--- a/app/service/responses_test.go
+++ b/app/service/responses_test.go
@@ -16,7 +16,7 @@ func httpResponseForResponse(renderer render.Renderer) *httptest.ResponseRecorde
 	}
 	handler := http.HandlerFunc(fn.ServeHTTP)
 
-	req, _ := http.NewRequest("GET", "/dummy", nil)
+	req, _ := http.NewRequest("GET", "/dummy", http.NoBody)
 	recorder := httptest.NewRecorder()
 
 	handler.ServeHTTP(recorder, req)

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -142,7 +142,8 @@ func chooseSortingRules(r *http.Request, defaultRules string, ignoreSortParamete
 // parseSortingRules returns a slice with used fields and a map fieldName -> sortingType
 // It also checks that there are no unallowed fields in the rules.
 func parseSortingRules(sortingRules string, configuredFields map[string]*FieldSortingParams, tieBreakerFields map[string]FieldType) (
-	usedFields []string, fieldsSortingTypes map[string]sortingType, err error) {
+	usedFields []string, fieldsSortingTypes map[string]sortingType, err error,
+) {
 	sortStatements := strings.Split(sortingRules, ",")
 	usedFields = make([]string, 0, len(sortStatements)+1)
 	fieldsSortingTypes = make(map[string]sortingType, len(sortStatements)+1)
@@ -190,7 +191,8 @@ func mustHaveValidTieBreakerFieldsList(configuredFields map[string]*FieldSorting
 }
 
 func validateSortingField(
-	fieldsSortingTypes map[string]sortingType, fieldName string, configuredFields map[string]*FieldSortingParams, sorting sortingType) error {
+	fieldsSortingTypes map[string]sortingType, fieldName string, configuredFields map[string]*FieldSortingParams, sorting sortingType,
+) error {
 	if _, ok := fieldsSortingTypes[fieldName]; ok {
 		return fmt.Errorf("a field cannot be a sorting parameter more than once: %q", fieldName)
 	}
@@ -228,7 +230,8 @@ func getFieldNameAndSortingTypeFromSortStatement(sortStatement string) (string, 
 // applyOrder appends the "ORDER BY" statement to given query according to the given list of used fields,
 // the fields configuration (configuredFields) and sorting types.
 func applyOrder(query *database.DB, usedFields []string, configuredFields map[string]*FieldSortingParams,
-	fieldsSortingTypes map[string]sortingType) *database.DB {
+	fieldsSortingTypes map[string]sortingType,
+) *database.DB {
 	usedFieldsNumber := len(usedFields)
 	orderStrings := make([]string, 0, usedFieldsNumber)
 	for _, field := range usedFields {
@@ -311,7 +314,8 @@ var safeColumnNameRegexp = regexp.MustCompile("[^a-zA-Z_0-9]")
 
 // applyPagingConditions adds filtering on paging values into the query.
 func applyPagingConditions(query *database.DB, usedFields []string, fieldsSortingTypes map[string]sortingType,
-	configuredFields map[string]*FieldSortingParams, fromValues map[string]interface{}, startFromRowSubQuery interface{}) *database.DB {
+	configuredFields map[string]*FieldSortingParams, fromValues map[string]interface{}, startFromRowSubQuery interface{},
+) *database.DB {
 	if startFromRowSubQuery == nil && len(fromValues) == 0 || startFromRowSubQuery == FromFirstRow {
 		return query
 	}
@@ -336,7 +340,8 @@ func applyPagingConditions(query *database.DB, usedFields []string, fieldsSortin
 
 func constructPagingConditions(usedFields []string, configuredFields map[string]*FieldSortingParams,
 	subQueryNeeded bool, fieldsSortingTypes map[string]sortingType, fromValues map[string]interface{}) (
-	conditions []string, queryValues []interface{}, safeColumnNames []string) {
+	conditions []string, queryValues []interface{}, safeColumnNames []string,
+) {
 	usedFieldsNumber := len(usedFields)
 	safeColumnNames = make([]string, usedFieldsNumber)
 	conditions = make([]string, 0, usedFieldsNumber)
@@ -379,7 +384,8 @@ func constructPagingConditions(usedFields []string, configuredFields map[string]
 }
 
 func joinSubQueryForPaging(query *database.DB, usedFields []string, configuredFields map[string]*FieldSortingParams,
-	startFromRowSubQuery interface{}, safeColumnNames []string, fromValues map[string]interface{}, conditions []string) *database.DB {
+	startFromRowSubQuery interface{}, safeColumnNames []string, fromValues map[string]interface{}, conditions []string,
+) *database.DB {
 	if startFromRowSubQuery == nil {
 		startFromRowQuery := query
 		fieldsToSelect := make([]string, 0, len(fromValues))

--- a/app/service/sorting_test.go
+++ b/app/service/sorting_test.go
@@ -28,7 +28,8 @@ func TestApplySorting(t *testing.T) {
 		wantAPIError     APIError
 		shouldPanic      error
 	}{
-		{name: "sorting (default rules)",
+		{
+			name: "sorting (default rules)",
 			args: args{
 				urlParameters: "",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -41,8 +42,10 @@ func TestApplySorting(t *testing.T) {
 				},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name DESC, id ASC",
-			wantAPIError: NoError},
-		{name: "sorting (request rules)",
+			wantAPIError: NoError,
+		},
+		{
+			name: "sorting (request rules)",
 			args: args{
 				urlParameters: "?sort=name,-id",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -54,8 +57,10 @@ func TestApplySorting(t *testing.T) {
 				},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name ASC, id DESC",
-			wantAPIError: NoError},
-		{name: "sorting (request rules are skipped)",
+			wantAPIError: NoError,
+		},
+		{
+			name: "sorting (request rules are skipped)",
 			args: args{
 				urlParameters: "?sort=name,-id",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -69,8 +74,10 @@ func TestApplySorting(t *testing.T) {
 				},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY id ASC",
-			wantAPIError: NoError},
-		{name: "repeated field",
+			wantAPIError: NoError,
+		},
+		{
+			name: "repeated field",
 			args: args{
 				urlParameters: "?sort=name,name",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -82,8 +89,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`a field cannot be a sorting parameter more than once: "name"`))},
-		{name: "unallowed field",
+			wantAPIError: ErrInvalidRequest(errors.New(`a field cannot be a sorting parameter more than once: "name"`)),
+		},
+		{
+			name: "unallowed field",
 			args: args{
 				urlParameters: "?sort=class",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -95,8 +104,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`unallowed field in sorting parameters: "class"`))},
-		{name: "'null last' for a non-nullable field",
+			wantAPIError: ErrInvalidRequest(errors.New(`unallowed field in sorting parameters: "class"`)),
+		},
+		{
+			name: "'null last' for a non-nullable field",
 			args: args{
 				urlParameters: "?sort=name$",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -108,8 +119,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`'null last' sorting cannot be applied to a non-nullable field: "name"`))},
-		{name: "applies default null sorting for nullable fields",
+			wantAPIError: ErrInvalidRequest(errors.New(`'null last' sorting cannot be applied to a non-nullable field: "name"`)),
+		},
+		{
+			name: "applies default null sorting for nullable fields",
 			args: args{
 				sortingAndPagingParameters: &SortingAndPagingParameters{
 					Fields: map[string]*FieldSortingParams{
@@ -121,8 +134,10 @@ func TestApplySorting(t *testing.T) {
 				},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY name IS NOT NULL, name DESC, id ASC",
-			wantAPIError: NoError},
-		{name: "'null last'",
+			wantAPIError: NoError,
+		},
+		{
+			name: "'null last'",
 			args: args{
 				sortingAndPagingParameters: &SortingAndPagingParameters{
 					Fields: map[string]*FieldSortingParams{
@@ -134,8 +149,10 @@ func TestApplySorting(t *testing.T) {
 				},
 			},
 			wantSQL:      "SELECT id FROM `users` ORDER BY id ASC, name IS NULL, name DESC",
-			wantAPIError: NoError},
-		{name: "add a tie-breaker field",
+			wantAPIError: NoError,
+		},
+		{
+			name: "add a tie-breaker field",
 			args: args{
 				urlParameters: "",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -149,8 +166,10 @@ func TestApplySorting(t *testing.T) {
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, id ASC",
 			wantSQLArguments: nil,
-			wantAPIError:     NoError},
-		{name: "add multiple tie-breaker fields",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "add multiple tie-breaker fields",
 			args: args{
 				urlParameters: "",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -165,8 +184,10 @@ func TestApplySorting(t *testing.T) {
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, group_id ASC, item_id ASC",
 			wantSQLArguments: nil,
-			wantAPIError:     NoError},
-		{name: "add some of tie-breaker fields",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "add some of tie-breaker fields",
 			args: args{
 				urlParameters: "",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -181,8 +202,10 @@ func TestApplySorting(t *testing.T) {
 			},
 			wantSQL:          "SELECT id FROM `users` ORDER BY name DESC, item_id ASC, group_id ASC",
 			wantSQLArguments: nil,
-			wantAPIError:     NoError},
-		{name: "sorting + paging",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "sorting + paging",
 			args: args{
 				urlParameters: "?from.id=1&from.name=Joe&from.flag=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -203,8 +226,10 @@ func TestApplySorting(t *testing.T) {
 				"WHERE ((name < ?) OR (name = ? AND id > ?) OR (name = ? AND id = ? AND bFlag > ?)) " +
 				"ORDER BY name DESC, id ASC, bFlag ASC",
 			wantSQLArguments: []driver.Value{"Joe", "Joe", 1, "Joe", 1, true},
-			wantAPIError:     NoError},
-		{name: "sorting + paging with a nullable field",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "sorting + paging with a nullable field",
 			args: args{
 				urlParameters: "?from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -225,8 +250,10 @@ func TestApplySorting(t *testing.T) {
 				"  (name <=> from_page.name AND id <=> from_page.id AND bFlag > from_page.flag)) " +
 				"ORDER BY name IS NOT NULL, name DESC, id ASC, bFlag ASC",
 			wantSQLArguments: []driver.Value{1},
-			wantAPIError:     NoError},
-		{name: "sorting + paging with a nullable field (null last)",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "sorting + paging with a nullable field (null last)",
 			args: args{
 				urlParameters: "?from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -247,8 +274,10 @@ func TestApplySorting(t *testing.T) {
 				"  (name <=> from_page.name AND id <=> from_page.id AND bFlag > from_page.flag)) " +
 				"ORDER BY name IS NULL, name DESC, id ASC, bFlag ASC",
 			wantSQLArguments: []driver.Value{1},
-			wantAPIError:     NoError},
-		{name: "sorting + paging with a nullable field (null last, nullable field is in the middle)",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "sorting + paging with a nullable field (null last, nullable field is in the middle)",
 			args: args{
 				urlParameters: "?from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -269,8 +298,10 @@ func TestApplySorting(t *testing.T) {
 				"  (bFlag <=> from_page.flag AND name <=> from_page.name AND id > from_page.id)) " +
 				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
 			wantSQLArguments: []driver.Value{1},
-			wantAPIError:     NoError},
-		{name: "does not do paging when StartFromRowQuery = FromFirstRow",
+			wantAPIError:     NoError,
+		},
+		{
+			name: "does not do paging when StartFromRowQuery = FromFirstRow",
 			args: args{
 				urlParameters: "?from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -286,8 +317,10 @@ func TestApplySorting(t *testing.T) {
 			},
 			wantSQL: "SELECT id FROM `users` " +
 				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
-			wantAPIError: NoError},
-		{name: "uses a custom sub-query for the first row if StartFromRowQuery is given",
+			wantAPIError: NoError,
+		},
+		{
+			name: "uses a custom sub-query for the first row if StartFromRowQuery is given",
 			args: args{
 				urlParameters: "?from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -307,8 +340,10 @@ func TestApplySorting(t *testing.T) {
 				"  (bFlag <=> from_page.flag AND IF(from_page.name IS NULL, FALSE, name IS NULL OR name < from_page.name)) OR " +
 				"  (bFlag <=> from_page.flag AND name <=> from_page.name AND id > from_page.id)) " +
 				"ORDER BY bFlag ASC, name IS NULL, name DESC, id ASC",
-			wantAPIError: NoError},
-		{name: "wrong value in from.id field",
+			wantAPIError: NoError,
+		},
+		{
+			name: "wrong value in from.id field",
 			args: args{
 				urlParameters: "?from.id=abc",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -320,8 +355,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`wrong value for from.id (should be int64)`))},
-		{name: "one of the 'from.*' fields is skipped",
+			wantAPIError: ErrInvalidRequest(errors.New(`wrong value for from.id (should be int64)`)),
+		},
+		{
+			name: "one of the 'from.*' fields is skipped",
 			args: args{
 				urlParameters: "?from.id=2",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -334,8 +371,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64, "name": FieldTypeString},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`all 'from' parameters (from.id, from.name) or none of them must be present`))},
-		{name: "unsupported field type",
+			wantAPIError: ErrInvalidRequest(errors.New(`all 'from' parameters (from.id, from.name) or none of them must be present`)),
+		},
+		{
+			name: "unsupported field type",
 			args: args{
 				urlParameters: "?from.name=Joe&from.id=2",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -347,8 +386,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": "interface{}"},
 				},
 			},
-			shouldPanic: errors.New(`unsupported type "interface{}" for field "id"`)},
-		{name: "unknown tie-breaker field",
+			shouldPanic: errors.New(`unsupported type "interface{}" for field "id"`),
+		},
+		{
+			name: "unknown tie-breaker field",
 			args: args{
 				sortingAndPagingParameters: &SortingAndPagingParameters{
 					Fields: map[string]*FieldSortingParams{
@@ -359,8 +400,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"flag": FieldTypeInt64},
 				},
 			},
-			shouldPanic: errors.New(`no such field "flag", cannot use it as a tie-breaker field`)},
-		{name: "nullable field as a tie-breaker field",
+			shouldPanic: errors.New(`no such field "flag", cannot use it as a tie-breaker field`),
+		},
+		{
+			name: "nullable field as a tie-breaker field",
 			args: args{
 				sortingAndPagingParameters: &SortingAndPagingParameters{
 					Fields: map[string]*FieldSortingParams{
@@ -371,8 +414,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64},
 				},
 			},
-			shouldPanic: errors.New(`a nullable field "id" cannot be a tie-breaker field`)},
-		{name: "unallowed from fields",
+			shouldPanic: errors.New(`a nullable field "id" cannot be a tie-breaker field`),
+		},
+		{
+			name: "unallowed from fields",
 			args: args{
 				urlParameters: "?from.field=Joe&from.version=2&from.name=Jane&from.id=1234",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -384,8 +429,10 @@ func TestApplySorting(t *testing.T) {
 					TieBreakers:  SortingAndPagingTieBreakers{"id": FieldTypeInt64, "name": FieldTypeString},
 				},
 			},
-			wantAPIError: ErrInvalidRequest(errors.New(`unallowed paging parameters (from.field, from.version)`))},
-		{name: "paging by time",
+			wantAPIError: ErrInvalidRequest(errors.New(`unallowed paging parameters (from.field, from.version)`)),
+		},
+		{
+			name: "paging by time",
 			args: args{
 				urlParameters: "?from.submitted_at=" + url.QueryEscape("2006-01-02T15:04:05+03:00") + "&from.id=1",
 				sortingAndPagingParameters: &SortingAndPagingParameters{
@@ -400,7 +447,8 @@ func TestApplySorting(t *testing.T) {
 			wantSQL: "SELECT id FROM `users`  WHERE ((submitted_at > ?) OR (submitted_at = ? AND id > ?)) " +
 				"ORDER BY submitted_at ASC, id ASC",
 			wantSQLArguments: []driver.Value{"2006-01-02 12:04:05", "2006-01-02 12:04:05", 1},
-			wantAPIError:     NoError},
+			wantAPIError:     NoError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -424,7 +472,7 @@ func TestApplySorting(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 			}
 
-			request, _ := http.NewRequest("GET", "/"+tt.args.urlParameters, nil)
+			request, _ := http.NewRequest("GET", "/"+tt.args.urlParameters, http.NoBody)
 			query := db.Table("users").Select("id")
 
 			query, gotAPIError := ApplySortingAndPaging(request, query, tt.args.sortingAndPagingParameters)

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package service_test
 
@@ -58,7 +58,7 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.url, nil)
+			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
 			watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(req)
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)
 			assert.Equal(t, tt.wantOk, ok)

--- a/app/service/watched_group_test.go
+++ b/app/service/watched_group_test.go
@@ -29,7 +29,7 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.url, nil)
+			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
 			watchedGroupID, ok, apiError := (&Base{}).ResolveWatchedGroupID(req)
 
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)

--- a/app/servicetest/request.go
+++ b/app/servicetest/request.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 // Package servicetest provides utilities to test services.
 package servicetest
@@ -25,7 +25,8 @@ import (
 func GetResponseForRouteWithMockedDBAndUser(
 	method, path, requestBody string, user *database.User,
 	setMockExpectationsFunc func(sqlmock.Sqlmock),
-	setRouterFunc func(router *chi.Mux, baseService *service.Base)) (*http.Response, sqlmock.Sqlmock, string, error) {
+	setRouterFunc func(router *chi.Mux, baseService *service.Base),
+) (*http.Response, sqlmock.Sqlmock, string, error) {
 	logger, hook := loggingtest.NewNullLogger()
 
 	db, mock := database.NewDBMock()

--- a/app/token/abstract.go
+++ b/app/token/abstract.go
@@ -73,8 +73,10 @@ type Signer interface {
 	Sign(*rsa.PrivateKey) (string, error)
 }
 
-var _ UnmarshalStringer = (*abstract)(nil)
-var _ MarshalStringer = (*abstract)(nil)
+var (
+	_ UnmarshalStringer = (*abstract)(nil)
+	_ MarshalStringer   = (*abstract)(nil)
+)
 
 func marshalJSON(payload interface{}) ([]byte, error) {
 	return (&abstract{Payload: payload}).MarshalJSON()

--- a/app/token/task.go
+++ b/app/token/task.go
@@ -30,8 +30,10 @@ func (tt *Task) Sign(privateKey *rsa.PrivateKey) (string, error) {
 	return tt.MarshalString()
 }
 
-var _ json.Unmarshaler = (*Task)(nil)
-var _ json.Marshaler = (*Task)(nil)
-var _ UnmarshalStringer = (*Task)(nil)
-var _ MarshalStringer = (*Task)(nil)
-var _ Signer = (*Task)(nil)
+var (
+	_ json.Unmarshaler  = (*Task)(nil)
+	_ json.Marshaler    = (*Task)(nil)
+	_ UnmarshalStringer = (*Task)(nil)
+	_ MarshalStringer   = (*Task)(nil)
+	_ Signer            = (*Task)(nil)
+)

--- a/app/token/token.go
+++ b/app/token/token.go
@@ -144,7 +144,8 @@ func IsUnexpectedError(err error) bool {
 // using a platforms's public key for given itemID.
 // The function returns if the platform doesn't use tokens.
 func UnmarshalDependingOnItemPlatform(store *database.DataStore, itemID int64,
-	target interface{}, token []byte, tokenFieldName string) (err error) {
+	target interface{}, token []byte, tokenFieldName string,
+) (err error) {
 	targetRefl := reflect.ValueOf(target)
 	defer recoverPanics(&err)
 

--- a/app/token/token_integration_test.go
+++ b/app/token/token_integration_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package token_test
 

--- a/app/tokentest/sample_keys.go
+++ b/app/tokentest/sample_keys.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 // Package tokentest provides cryptographic keys to be used for tests.
 package tokentest

--- a/bdd_test.go
+++ b/bdd_test.go
@@ -1,4 +1,4 @@
-// +build !unit
+//go:build !unit
 
 package main_test
 

--- a/cmd/db_gen_load.go
+++ b/cmd/db_gen_load.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package cmd
 
@@ -19,9 +19,9 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
-// nolint:gosec
-func init() { // nolint:gochecknoinits,gocyclo,gocognit
-	var dbGenLoadCmd = &cobra.Command{
+//nolint:gosec
+func init() { //nolint:gochecknoinits,gocyclo,gocognit
+	dbGenLoadCmd := &cobra.Command{
 		Use:   "db-gen-load  [environment]",
 		Short: "generate data for load tests",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/db_gen_migrations.go
+++ b/cmd/db_gen_migrations.go
@@ -22,8 +22,8 @@ const (
 )
 
 // nolint:gosec
-func init() { // nolint:gochecknoinits,gocyclo,gocognit
-	var dbGenMigrationsCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits,gocyclo,gocognit
+	dbGenMigrationsCmd := &cobra.Command{
 		Use:   "db-gen-migrations  [environment]",
 		Short: "generate migrations",
 		Long: `This script was used to generate the huge migration renaming most of the DB columns.
@@ -230,7 +230,7 @@ func fullTextReplace(renamedColumns map[string]string, text string) string {
 	return text
 }
 
-// nolint:gosec
+//nolint:gosec
 func getTables(db *sql.DB, dbName string) []string {
 	rows, err := db.Query(`SELECT CONCAT(table_schema, '.', table_name)
                          FROM   information_schema.tables

--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -14,8 +14,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 )
 
-func init() { // nolint:gochecknoinits
-	var migrateCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits
+	migrateCmd := &cobra.Command{
 		Use:   "db-migrate [environment]",
 		Short: "apply schema-change migrations to the database",
 		Long:  `migrate uses go-pg migration tool under the hood supporting the same commands and an additional reset command`,

--- a/cmd/db_migrate_undo.go
+++ b/cmd/db_migrate_undo.go
@@ -13,8 +13,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/appenv"
 )
 
-func init() { // nolint:gochecknoinits
-	var migrateUndoCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits
+	migrateUndoCmd := &cobra.Command{
 		Use:   "db-migrate-undo [environment]",
 		Short: "undo the last schema-change migration applied to the database",
 		Args:  cobra.MaximumNArgs(1),

--- a/cmd/db_recompute.go
+++ b/cmd/db_recompute.go
@@ -11,8 +11,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/appenv"
 )
 
-func init() { // nolint:gochecknoinits
-	var recomputeCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits
+	recomputeCmd := &cobra.Command{
 		Use:   "db-recompute [environment]",
 		Short: "recompute db caches",
 		Long:  `recompute runs recalculation of db caches (groups ancestors, items ancestors, cached permissions, attempt results)`,

--- a/cmd/db_restore.go
+++ b/cmd/db_restore.go
@@ -14,9 +14,9 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/appenv"
 )
 
-// nolint:gosec
-func init() { // nolint:gochecknoinits
-	var restoreCmd = &cobra.Command{
+//nolint:gosec
+func init() { //nolint:gochecknoinits
+	restoreCmd := &cobra.Command{
 		Use:   "db-restore [environment]",
 		Short: "load the last db schema",
 		Args:  cobra.MaximumNArgs(1),
@@ -72,7 +72,7 @@ func init() { // nolint:gochecknoinits
 			for rows.Next() {
 				var tableName string
 				assertNoError(rows.Scan(&tableName), "Unable to parse the database result: ")
-				_, err = tx.Query("DROP TABLE " + tableName) //nolint:rowserrcheck Checked in defer.
+				_, err = tx.Exec("DROP TABLE " + tableName)
 				assertNoError(err, "Unable to drop table: ")
 			}
 

--- a/cmd/delete_temp_users.go
+++ b/cmd/delete_temp_users.go
@@ -13,8 +13,8 @@ import (
 )
 
 // nolint:gosec
-func init() { // nolint:gochecknoinits,gocyclo
-	var deleteTempUsersCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits,gocyclo
+	deleteTempUsersCmd := &cobra.Command{
 		Use:   "delete-temp-users [environment]",
 		Short: "delete all temporary users with expired sessions",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -12,8 +12,8 @@ import (
 )
 
 // nolint:gosec
-func init() { // nolint:gochecknoinits,gocyclo
-	var installCmd = &cobra.Command{
+func init() { //nolint:gochecknoinits,gocyclo
+	installCmd := &cobra.Command{
 		Use:   "install [environment]",
 		Short: "fill the database with required data",
 		Long: `If the root group IDs specified in the config file

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ func Execute() {
 	}
 }
 
-func init() { // nolint:gochecknoinits
+func init() { //nolint:gochecknoinits
 	// persistent flags will be available for every sub-commands
 	// here you can bind command line flags to variables
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,10 +10,10 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/appenv"
 )
 
-func init() { // nolint:gochecknoinits
+func init() { //nolint:gochecknoinits
 	var skipChecks bool
 
-	var serveCmd = &cobra.Command{
+	serveCmd := &cobra.Command{
 		Use:   "serve [environment]",
 		Short: "start http server",
 		Args:  cobra.MaximumNArgs(1),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/France-ioi/AlgoreaBackend
 
-go 1.20
+go 1.13
 
 exclude github.com/SermoDigital/jose v0.9.1
 
@@ -28,17 +28,24 @@ require (
 	github.com/go-playground/locales v0.12.1
 	github.com/go-playground/universal-translator v0.16.0
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/gobuffalo/packr v1.21.0 // indirect
+	github.com/goware/urlx v0.2.0 // indirect
 	github.com/jinzhu/gorm v1.9.6
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/lithammer/dedent v1.1.0
 	github.com/luna-duclos/instrumentedsql v1.1.3
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rubenv/sql-migrate v0.0.0-20181213081019-5a8808c14925
 	github.com/sirupsen/logrus v1.2.0
-	github.com/spf13/cobra v1.6.1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.6.1
 	github.com/thingful/httpmock v0.0.0-20171102191412-cfb4c64b7d81
+	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	gopkg.in/yaml.v2 v2.4.0
+	golang.org/x/text v0.3.8 // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+	gopkg.in/gorp.v1 v1.7.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/France-ioi/AlgoreaBackend
 
-go 1.13
+go 1.20
 
 exclude github.com/SermoDigital/jose v0.9.1
 
@@ -28,24 +28,17 @@ require (
 	github.com/go-playground/locales v0.12.1
 	github.com/go-playground/universal-translator v0.16.0
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/gobuffalo/packr v1.21.0 // indirect
-	github.com/goware/urlx v0.2.0 // indirect
 	github.com/jinzhu/gorm v1.9.6
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/lithammer/dedent v1.1.0
 	github.com/luna-duclos/instrumentedsql v1.1.3
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rubenv/sql-migrate v0.0.0-20181213081019-5a8808c14925
 	github.com/sirupsen/logrus v1.2.0
-	github.com/spf13/cobra v0.0.3
+	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.3.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.1
 	github.com/thingful/httpmock v0.0.0-20171102191412-cfb4c64b7d81
-	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/text v0.3.8 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/gorp.v1 v1.7.2 // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/testhelpers/db.go
+++ b/testhelpers/db.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -21,7 +21,7 @@ import (
 
 const fixtureDir = "testdata" // special directory which is not included in binaries by the compile
 
-func init() { // nolint:gochecknoinits
+func init() { //nolint:gochecknoinits
 	if strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
 		appenv.SetDefaultEnvToTest()
 		// Apply the config to the global logger
@@ -122,7 +122,7 @@ func LoadFixture(db *sql.DB, fileName string) {
 		var err error
 		var data []byte
 		filename := f.Name()
-		data, err = ioutil.ReadFile(filepath.Join(filePath, filename)) // nolint: gosec
+		data, err = ioutil.ReadFile(filepath.Join(filePath, filename)) //nolint: gosec
 		if err != nil {
 			panic(err)
 		}
@@ -190,7 +190,7 @@ func InsertBatch(db *sql.DB, tableName string, data []map[string]interface{}) {
 			valueMarks = append(valueMarks, "?")
 			values = append(values, v)
 		}
-		// nolint:gosec
+		//nolint:gosec
 		query := fmt.Sprintf("INSERT INTO `%s` (%s) VALUES (%s)",
 			tableName, strings.Join(attributes, ", "), strings.Join(valueMarks, ", "))
 		_, err = tx.Exec(query, values...)

--- a/testhelpers/db_time.go
+++ b/testhelpers/db_time.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -15,8 +15,10 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 )
 
-var nowRegexp = regexp.MustCompile(`(?i)\bNOW\s*\(\s*(?:\d+\s*)?\)`)
-var patchedMethods []*monkey.PatchGuard
+var (
+	nowRegexp      = regexp.MustCompile(`(?i)\bNOW\s*\(\s*(?:\d+\s*)?\)`)
+	patchedMethods []*monkey.PatchGuard
+)
 
 // MockDBTime replaces the DB NOW() function call with a given constant value in all the queries.
 func MockDBTime(timeStrRaw string) {

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 

--- a/testhelpers/http.go
+++ b/testhelpers/http.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 

--- a/testhelpers/known_types.go
+++ b/testhelpers/known_types.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 

--- a/testhelpers/loader.go
+++ b/testhelpers/loader.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 // Package testhelpers provides the interface and features to run the Gherkin tests.
 package testhelpers

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -135,7 +135,7 @@ func (ctx *TestContext) DBHasUsers(data *messages.PickleStepArgument_PickleTable
 	return ctx.DBHasTable("users", data)
 }
 
-func (ctx *TestContext) DBGroupsAncestorsAreComputed() error { // nolint
+func (ctx *TestContext) DBGroupsAncestorsAreComputed() error { //nolint
 	gormDB, err := database.Open(ctx.db())
 	if err != nil {
 		return err
@@ -175,7 +175,7 @@ func (ctx *TestContext) DBGroupsAncestorsAreComputed() error { // nolint
 	return nil
 }
 
-func (ctx *TestContext) TableShouldBeEmpty(table string) error { // nolint
+func (ctx *TestContext) TableShouldBeEmpty(table string) error { //nolint
 	db := ctx.db()
 	sqlRows, err := db.Query(fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", table)) //nolint:gosec
 	if err != nil {
@@ -195,7 +195,7 @@ func (ctx *TestContext) TableShouldBeEmpty(table string) error { // nolint
 	return nil
 }
 
-func (ctx *TestContext) TableAtColumnValueShouldBeEmpty(table string, column, valuesStr string) error { // nolint
+func (ctx *TestContext) TableAtColumnValueShouldBeEmpty(table string, column, valuesStr string) error { //nolint
 	values := parseMultipleValuesString(valuesStr)
 
 	db := ctx.db()
@@ -222,17 +222,19 @@ func (ctx *TestContext) TableShouldBe(table string, data *messages.PickleStepArg
 	return ctx.tableAtColumnValueShouldBe(table, []string{""}, nil, unchanged, data)
 }
 
-func (ctx *TestContext) TableShouldStayUnchanged(table string) error { // nolint
+func (ctx *TestContext) TableShouldStayUnchanged(table string) error { //nolint
 	data := ctx.dbTableData[table]
 	if data == nil {
-		data = &messages.PickleStepArgument_PickleTable{Rows: []*messages.PickleStepArgument_PickleTable_PickleTableRow{
-			{Cells: []*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell{{Value: "1"}}}},
+		data = &messages.PickleStepArgument_PickleTable{
+			Rows: []*messages.PickleStepArgument_PickleTable_PickleTableRow{
+				{Cells: []*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell{{Value: "1"}}},
+			},
 		}
 	}
 	return ctx.tableAtColumnValueShouldBe(table, []string{""}, nil, unchanged, data)
 }
 
-func (ctx *TestContext) TableShouldStayUnchangedButTheRowWithColumnValue(table, column, values string) error { // nolint
+func (ctx *TestContext) TableShouldStayUnchangedButTheRowWithColumnValue(table, column, values string) error { //nolint
 	data := ctx.dbTableData[table]
 	if data == nil {
 		data = &messages.PickleStepArgument_PickleTable{Rows: []*messages.PickleStepArgument_PickleTable_PickleTableRow{}}
@@ -254,11 +256,12 @@ func (ctx *TestContext) TableAtColumnValueShouldBe(table, column, values string,
 	return ctx.tableAtColumnValueShouldBe(table, []string{column}, parseMultipleValuesString(values), unchanged, data)
 }
 
-func (ctx *TestContext) TableShouldNotContainColumnValue(table, column, values string) error { // nolint
+func (ctx *TestContext) TableShouldNotContainColumnValue(table, column, values string) error { //nolint
 	return ctx.tableAtColumnValueShouldBe(table, []string{column}, parseMultipleValuesString(values), unchanged,
 		&messages.PickleStepArgument_PickleTable{
 			Rows: []*messages.PickleStepArgument_PickleTable_PickleTableRow{
-				{Cells: []*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell{{Value: column}}}},
+				{Cells: []*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell{{Value: column}}},
+			},
 		})
 }
 
@@ -300,7 +303,8 @@ func combinePickleTables(table1, table2 *messages.PickleStepArgument_PickleTable
 }
 
 func copyCellsIntoCombinedTable(sourceTable *messages.PickleStepArgument_PickleTable, combinedcolumns []string,
-	sourceTableFieldMap map[string]int, combinedTable *messages.PickleStepArgument_PickleTable) {
+	sourceTableFieldMap map[string]int, combinedTable *messages.PickleStepArgument_PickleTable,
+) {
 	for rowNum := 1; rowNum < len(sourceTable.Rows); rowNum++ {
 		newRow := &messages.PickleStepArgument_PickleTable_PickleTableRow{
 			Cells: make([]*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell, 0, len(combinedcolumns)),
@@ -323,7 +327,8 @@ func parseMultipleValuesString(valuesString string) []string {
 var columnRegexp = regexp.MustCompile(`^[a-zA-Z]\w*$`)
 
 func (ctx *TestContext) tableAtColumnValueShouldBe(table string, columns, values []string,
-	rowTransformation rowTransformation, data *messages.PickleStepArgument_PickleTable) error { // nolint
+	rowTransformation rowTransformation, data *messages.PickleStepArgument_PickleTable,
+) error { // nolint
 	// For that, we build a SQL request with only the attributes we are interested about (those
 	// for the test data table) and we convert them to string (in SQL) to compare to table value.
 	// Expect 'null' string in the table to check for nullness
@@ -360,7 +365,8 @@ func (ctx *TestContext) tableAtColumnValueShouldBe(table string, columns, values
 
 // dataTableMatchesSQLRows checks whether the provided data table matches the database rows result.
 func (ctx *TestContext) dataTableMatchesSQLRows(data *messages.PickleStepArgument_PickleTable, sqlRows *sql.Rows,
-	rowTransformation rowTransformation, tableColumns, columns, values []string) error {
+	rowTransformation rowTransformation, tableColumns, columns, values []string,
+) error {
 	iDataRow := 1
 	columnIndexes := getColumnIndexes(data, columns)
 	for sqlRows.Next() {
@@ -398,7 +404,8 @@ func (ctx *TestContext) dataTableMatchesSQLRows(data *messages.PickleStepArgumen
 
 // dataRowMatchesSQLRow checks that a data row matches a row from database.
 func (ctx *TestContext) dataRowMatchesSQLRow(dataRow *messages.PickleStepArgument_PickleTable_PickleTableRow,
-	values []*string, tableColumns []string, rowIndex int) error {
+	values []*string, tableColumns []string, rowIndex int,
+) error {
 	// checking that all columns of the test data table match the SQL row
 	for colIndex, dataCell := range dataRow.Cells {
 		if dataCell == nil {
@@ -482,7 +489,8 @@ func getColumnIndexes(data *messages.PickleStepArgument_PickleTable, columns []s
 
 // getSQLRowsMatching returns the rows that matches (if whereIn) or not (if !whereIn) one of filterColumns at any filterValues.
 func (ctx *TestContext) getSQLRowsMatching(table string, columns, filterColumns, filterValues []string, whereIn bool) (
-	*sql.Rows, func(), error) {
+	*sql.Rows, func(), error,
+) {
 	db := ctx.db()
 
 	selectsJoined := strings.Join(columns, ", ")
@@ -490,7 +498,7 @@ func (ctx *TestContext) getSQLRowsMatching(table string, columns, filterColumns,
 	where, parameters := constructWhereForColumnValues(filterColumns, filterValues, whereIn)
 
 	// exec sql
-	query := fmt.Sprintf("SELECT %s FROM `%s` %s ORDER BY %s", selectsJoined, table, where, selectsJoined) // nolint: gosec
+	query := fmt.Sprintf("SELECT %s FROM `%s` %s ORDER BY %s", selectsJoined, table, where, selectsJoined) //nolint: gosec
 	sqlRows, err := db.Query(query, parameters...)
 
 	closer := func() { _ = sqlRows.Close() }
@@ -506,14 +514,15 @@ func (ctx *TestContext) getNbRowsMatching(table string, columns, values []string
 
 	// exec sql
 	var nbRows int
-	selectValuesInQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s` %s", table, where) // nolint: gosec
+	selectValuesInQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s` %s", table, where) //nolint: gosec
 	err := db.QueryRow(selectValuesInQuery, parameters...).Scan(&nbRows)
 
 	return nbRows, err
 }
 
 func shouldSkipRow(data *messages.PickleStepArgument_PickleTable, rowIndex int, columnIndexes []int,
-	values []string, rowTransformation rowTransformation) bool {
+	values []string, rowTransformation rowTransformation,
+) bool {
 	return rowTransformation != unchanged &&
 		rowIndex < len(data.Rows) &&
 		rowMatchesColumnValues(data.Rows[rowIndex], columnIndexes, values)
@@ -537,7 +546,8 @@ func rowMatchesColumnValues(row *messages.PickleStepArgument_PickleTable_PickleT
 // constructWhereForColumnValues construct the WHERE part of a query matching column with values
 // note: the same values are checked for every column
 func constructWhereForColumnValues(columns, values []string, whereIn bool) (
-	where string, parameters []interface{}) {
+	where string, parameters []interface{},
+) {
 	if len(values) > 0 {
 		questionMarks := "?" + strings.Repeat(", ?", len(values)-1)
 
@@ -565,17 +575,21 @@ func constructWhereForColumnValues(columns, values []string, whereIn bool) (
 	return where, parameters
 }
 
-func (ctx *TestContext) DbTimeNow(timeStrRaw string) error { // nolint
+func (ctx *TestContext) DbTimeNow(timeStrRaw string) error { //nolint
 	MockDBTime(timeStrRaw)
 	return nil
 }
 
-const tableValueFalse = "false"
-const tableValueTrue = "true"
-const tableValueNull = "null"
+const (
+	tableValueFalse = "false"
+	tableValueTrue  = "true"
+	tableValueNull  = "null"
+)
 
-var tableValueNullVar = tableValueNull
-var pTableValueNull = &tableValueNullVar
+var (
+	tableValueNullVar = tableValueNull
+	pTableValueNull   = &tableValueNullVar
+)
 
 // dbDataTableValue converts a string value that we can find the db seeding table to a valid type for the db
 // e.g., the string "null" means the SQL `NULL`.

--- a/testhelpers/steps_loginmodule.go
+++ b/testhelpers/steps_loginmodule.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -150,7 +150,8 @@ func (ctx *TestContext) TheLoginModuleAccountEndpointForTokenReturns(token strin
 }
 
 func (ctx *TestContext) TheLoginModuleUnlinkClientEndpointForUserIDReturns( // nolint
-	userID string, statusCode int, body *messages.PickleStepArgument_PickleDocString) error {
+	userID string, statusCode int, body *messages.PickleStepArgument_PickleDocString,
+) error {
 	httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
 	preprocessedUserID, err := ctx.preprocessString(userID)
 	if err != nil {
@@ -178,7 +179,8 @@ func (ctx *TestContext) TheLoginModuleUnlinkClientEndpointForUserIDReturns( // n
 }
 
 func (ctx *TestContext) TheLoginModuleLTIResultSendEndpointForUserIDContentIDScoreReturns( // nolint
-	userID, contentID, score string, statusCode int, body *messages.PickleStepArgument_PickleDocString) error {
+	userID, contentID, score string, statusCode int, body *messages.PickleStepArgument_PickleDocString,
+) error {
 	httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
 	preprocessedUserID, err := ctx.preprocessString(userID)
 	if err != nil {
@@ -218,18 +220,21 @@ func (ctx *TestContext) TheLoginModuleLTIResultSendEndpointForUserIDContentIDSco
 	return nil
 }
 
-func (ctx *TestContext) TheLoginModuleCreateEndpointWithParamsReturns( // nolint
-	params string, statusCode int, body *messages.PickleStepArgument_PickleDocString) error {
+func (ctx *TestContext) TheLoginModuleCreateEndpointWithParamsReturns( //nolint
+	params string, statusCode int, body *messages.PickleStepArgument_PickleDocString,
+) error {
 	return ctx.theLoginModuleAccountsManagerEndpointWithParamsReturns("create", params, statusCode, body)
 }
 
-func (ctx *TestContext) TheLoginModuleDeleteEndpointWithParamsReturns( // nolint
-	params string, statusCode int, body *messages.PickleStepArgument_PickleDocString) error {
+func (ctx *TestContext) TheLoginModuleDeleteEndpointWithParamsReturns( //nolint
+	params string, statusCode int, body *messages.PickleStepArgument_PickleDocString,
+) error {
 	return ctx.theLoginModuleAccountsManagerEndpointWithParamsReturns("delete", params, statusCode, body)
 }
 
-func (ctx *TestContext) theLoginModuleAccountsManagerEndpointWithParamsReturns( // nolint
-	endpoint, params string, statusCode int, body *messages.PickleStepArgument_PickleDocString) error {
+func (ctx *TestContext) theLoginModuleAccountsManagerEndpointWithParamsReturns( //nolint
+	endpoint, params string, statusCode int, body *messages.PickleStepArgument_PickleDocString,
+) error {
 	httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
 	preprocessedParams, err := ctx.preprocessString(params)
 	if err != nil {

--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -27,7 +27,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/tokentest"
 )
 
-func (ctx *TestContext) IAmUserWithID(userID int64) error { // nolint
+func (ctx *TestContext) IAmUserWithID(userID int64) error { //nolint
 	ctx.userID = userID
 	db, err := database.Open(ctx.db())
 	if err != nil {
@@ -45,7 +45,7 @@ func (ctx *TestContext) IAmUserWithID(userID int64) error { // nolint
 	})
 }
 
-func (ctx *TestContext) TimeNow(timeStr string) error { // nolint
+func (ctx *TestContext) TimeNow(timeStr string) error { //nolint
 	testTime, err := time.Parse(time.RFC3339Nano, timeStr)
 	if err == nil {
 		monkey.Patch(time.Now, func() time.Time { return testTime })
@@ -53,20 +53,20 @@ func (ctx *TestContext) TimeNow(timeStr string) error { // nolint
 	return err
 }
 
-func (ctx *TestContext) TimeIsFrozen() error { // nolint
+func (ctx *TestContext) TimeIsFrozen() error { //nolint
 	currentTime := time.Now()
 	monkey.Patch(time.Now, func() time.Time { return currentTime })
 	return nil
 }
 
-func (ctx *TestContext) TheGeneratedGroupCodeIs(generatedCode string) error { // nolint
+func (ctx *TestContext) TheGeneratedGroupCodeIs(generatedCode string) error { //nolint
 	monkey.Patch(groups.GenerateGroupCode, func() (string, error) { return generatedCode, nil }) // nolint:unparam
 	return nil
 }
 
 var multipleStringsRegexp = regexp.MustCompile(`^((?:\s*,\s*)?"([^"]*)")`)
 
-func (ctx *TestContext) TheGeneratedGroupCodesAre(generatedCodes string) error { // nolint
+func (ctx *TestContext) TheGeneratedGroupCodesAre(generatedCodes string) error { //nolint
 	currentIndex := 0
 	monkey.Patch(groups.GenerateGroupCode, func() (string, error) {
 		currentIndex++
@@ -80,12 +80,12 @@ func (ctx *TestContext) TheGeneratedGroupCodesAre(generatedCodes string) error {
 	return nil
 }
 
-func (ctx *TestContext) TheGeneratedAuthKeyIs(generatedString string) error { // nolint
+func (ctx *TestContext) TheGeneratedAuthKeyIs(generatedString string) error { //nolint
 	monkey.Patch(auth.GenerateKey, func() (string, error) { return generatedString, nil }) // nolint:unparam
 	return nil
 }
 
-func (ctx *TestContext) TheGeneratedAuthKeysAre(generatedStrings string) error { // nolint
+func (ctx *TestContext) TheGeneratedAuthKeysAre(generatedStrings string) error { //nolint
 	currentIndex := 0
 	monkey.Patch(auth.GenerateKey, func() (string, error) {
 		currentIndex++
@@ -160,7 +160,7 @@ func (ctx *TestContext) TheApplicationConfigIs(body *messages.PickleStepArgument
 	return nil
 }
 
-func (ctx *TestContext) TheContextVariableIs(variableName, value string) error { // nolint
+func (ctx *TestContext) TheContextVariableIs(variableName, value string) error { //nolint
 	preprocessed, err := ctx.preprocessString(value)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func (ctx *TestContext) TheContextVariableIs(variableName, value string) error {
 	oldHTTPHandler := ctx.application.HTTPHandler
 	ctx.application.HTTPHandler = chi.NewRouter().With(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			// nolint: golint,staticcheck SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
+			//nolint:lll,golint,staticcheck SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
 			oldHTTPHandler.ServeHTTP(writer, request.WithContext(context.WithValue(request.Context(), variableName, preprocessed)))
 		})
 	}).(*chi.Mux)

--- a/testhelpers/steps_request.go
+++ b/testhelpers/steps_request.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -9,7 +9,7 @@ import (
 	"github.com/cucumber/messages-go/v10"
 )
 
-func (ctx *TestContext) TheRequestHeaderIs(name, value string) error { // nolint
+func (ctx *TestContext) TheRequestHeaderIs(name, value string) error { //nolint
 	value, err := ctx.preprocessString(value)
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func (ctx *TestContext) ISendrequestToWithBody(method string, path string, body 
 	return ctx.iSendrequestGeneric(method, path, body.Content)
 }
 
-func (ctx *TestContext) ISendrequestTo(method string, path string) error { // nolint
+func (ctx *TestContext) ISendrequestTo(method string, path string) error { //nolint
 	return ctx.iSendrequestGeneric(method, path, "")
 }
 
@@ -70,6 +70,7 @@ func (ctx *TestContext) iSendrequestGeneric(method, path, reqBody string) error 
 
 	// do request
 	response, body, err := testRequest(testServer, method, path, headers, strings.NewReader(reqBody))
+	defer func() { _ = response.Body.Close() }()
 	if err != nil {
 		return err
 	}

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -17,7 +17,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
-func (ctx *TestContext) ItShouldBeAJSONArrayWithEntries(count int) error { // nolint
+func (ctx *TestContext) ItShouldBeAJSONArrayWithEntries(count int) error { //nolint
 	var objmap []map[string]*json.RawMessage
 
 	if err := json.Unmarshal([]byte(ctx.lastResponseBody), &objmap); err != nil {
@@ -31,7 +31,7 @@ func (ctx *TestContext) ItShouldBeAJSONArrayWithEntries(count int) error { // no
 	return nil
 }
 
-func (ctx *TestContext) TheResponseCodeShouldBe(code int) error { // nolint
+func (ctx *TestContext) TheResponseCodeShouldBe(code int) error { //nolint
 	if code != ctx.lastResponse.StatusCode {
 		return fmt.Errorf("expected http response code: %d, actual is: %d. \n Data: %s", code, ctx.lastResponse.StatusCode, ctx.lastResponseBody)
 	}
@@ -122,7 +122,7 @@ func compareStrings(expected, actual string) error {
 
 const nullHeaderValue = "[NULL]"
 
-func (ctx *TestContext) TheResponseHeaderShouldBe(headerName string, headerValue string) (err error) { // nolint
+func (ctx *TestContext) TheResponseHeaderShouldBe(headerName string, headerValue string) (err error) { //nolint
 	headerValue, err = ctx.preprocessString(headerValue)
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func (ctx *TestContext) TheResponseHeadersShouldBe(headerName string, headersVal
 	return ctx.TheResponseHeaderShouldBe(headerName, headerValue)
 }
 
-func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err error) { // nolint
+func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err error) { //nolint
 	errorResp := service.ErrorResponse{}
 	// decode response
 	if err = json.Unmarshal([]byte(ctx.lastResponseBody), &errorResp); err != nil {
@@ -173,7 +173,7 @@ func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err erro
 	return nil
 }
 
-func (ctx *TestContext) TheResponseShouldBe(kind string) error { // nolint
+func (ctx *TestContext) TheResponseShouldBe(kind string) error { //nolint
 	var expectedCode int
 	switch kind {
 	case "updated", "deleted":
@@ -191,7 +191,8 @@ func (ctx *TestContext) TheResponseShouldBe(kind string) error { // nolint
 		{
 			"message": "` + kind + `",
 			"success": true
-		}`}); err != nil {
+		}`,
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/testhelpers/steps_template.go
+++ b/testhelpers/steps_template.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -6,7 +6,7 @@ import (
 	"github.com/cucumber/messages-go/v10"
 )
 
-func (ctx *TestContext) TheTemplateConstantIsString(name, value string) error { // nolint
+func (ctx *TestContext) TheTemplateConstantIsString(name, value string) error { //nolint
 	value, err := ctx.preprocessString(value)
 	if err != nil {
 		return err

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 
@@ -23,7 +23,6 @@ var dbPathRegexp = regexp.MustCompile(`^\s*(\w+)\[(\d+)]\[(\w+)]\s*$`)
 
 func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
 	tmpl, err := ctx.templateSet.Parse("template", jsonBody)
-
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +38,7 @@ func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
 
 func (ctx *TestContext) constructTemplateSet() *jet.Set {
 	set := jet.NewSet(jet.SafeWriter(func(w io.Writer, b []byte) {
-		w.Write(b) // nolint:gosec,errcheck
+		w.Write(b) //nolint:gosec,errcheck
 	}))
 
 	set.AddGlobalFunc("currentTimeInFormat", func(a jet.Arguments) reflect.Value {

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 

--- a/testhelpers/threads.go
+++ b/testhelpers/threads.go
@@ -1,4 +1,4 @@
-// +build !prod
+//go:build !prod
 
 package testhelpers
 


### PR DESCRIPTION
-> Update linter to the latest version because of an incompatibility with CI and go1.20
I fixed a few issues, ran automatic formatting tools, and disabled a lot of linters. The number of added linters is really huge and the rate of new ones is fast too. The documentation of golangci-lint shows that only a few of them are enabled by default (https://golangci-lint.run/usage/linters/). Maybe we could change our default policy of "enable-all" and enable only those we are really interested in?