### PR TITLE
List threads service with watch_group_id

### DIFF
--- a/app/api/currentuser/refresh.feature
+++ b/app/api/currentuser/refresh.feature
@@ -79,7 +79,6 @@ Feature: Update the local user info cache
     | profile_with_all_fields_set | janedoe@gmail.com | Jane       | Doe       | 456789012  | gb           | 2001-08-03 | 2021            | 0     | I'm Jane Doe | http://jane.freepages.com | Female | true           | Europe/London | true        | true           | true              |
     | profile_with_null_fields    | null              | null       | null      | null       |              | null       | 0               | null  | null         | null                      | null   | false          | null          | false       | false          | false             |
 
-
   Scenario: Update an existing user with badges
     Given the time now is "2019-07-16T22:02:29Z"
     And the DB time now is "2019-07-16 22:02:28"

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -8,8 +8,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
-// swagger:model threadInfo
-type threadInfo struct {
+// swagger:model threadGetResponse
+type threadGetResponse struct {
 	// required: true
 	ParticipantID int64 `json:"participant_id"`
 	// required: true
@@ -19,7 +19,7 @@ type threadInfo struct {
 	Status string `json:"status"`
 }
 
-// swagger:operation GET /items/{item_id}/participant/{participant_id}/thread threads getThread
+// swagger:operation GET /items/{item_id}/participant/{participant_id}/thread threads threadGet
 //
 //		---
 //		summary: Retrieve a thread information
@@ -28,7 +28,7 @@ type threadInfo struct {
 //
 //	  The `status` is `not_started` if the thread hasn't been started
 //
-//				Restrictions:
+//	  Restrictions:
 //	    * one of these conditions matches:
 //	      - the current-user is the thread participant and allowed to "can_view >= content" the item
 //	      - the current-user has the "can_watch >= answer" permission on the item
@@ -52,7 +52,7 @@ type threadInfo struct {
 //			"200":
 //				description: OK. Success response with thread data
 //				schema:
-//					"$ref": "#/definitions/threadInfo"
+//					"$ref": "#/definitions/threadGetResponse"
 //			"400":
 //				"$ref": "#/responses/badRequestResponse"
 //			"401":
@@ -80,11 +80,11 @@ func (srv *Service) getThread(rw http.ResponseWriter, r *http.Request) service.A
 		return service.InsufficientAccessRightsError
 	}
 
-	threadInfo := new(threadInfo)
-	threadInfo.ItemID = itemID
-	threadInfo.ParticipantID = participantID
-	threadInfo.Status = store.Threads().GetThreadStatus(participantID, itemID)
+	threadGetResponse := new(threadGetResponse)
+	threadGetResponse.ItemID = itemID
+	threadGetResponse.ParticipantID = participantID
+	threadGetResponse.Status = store.Threads().GetThreadStatus(participantID, itemID)
 
-	render.Respond(rw, r, threadInfo)
+	render.Respond(rw, r, threadGetResponse)
 	return service.NoError
 }

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -1,0 +1,97 @@
+Feature: Get threads
+  Background:
+    Given there are the following users:
+      | name           | @reference      |
+      | RichardFeynman | @RichardFeynman |
+      | StevenHawking  | @StevenHawking  |
+      | DavidBowie     | @DavidBowie     |
+      | ClaireStudent  | @ClaireStudent  |
+    Given there are the following threads:
+      | participant_id  |
+      | @RichardFeynman |
+      | @ClaireStudent  |
+      | @StevenHawking  |
+      | @DavidBowie     |
+
+  Scenario: Should have all the fields properly set
+    Given I am MarieCurie
+    And there is a group Laboratory referenced by @Laboratory
+    And I am a manager of the group Laboratory
+    And I can watch the group Laboratory
+    And there are the following users:
+      | @reference      | login          | first_name | last_name |
+      | @AlbertEinstein | AlbertEinstein | Albert     | Einstein  |
+      | @PaulDirac      | PaulDirac      | Paul       | Dirac     |
+      And AlbertEinstein the scientist is a member of the group Laboratory
+    And AlbertEinstein has approved access to his personal info for the group Laboratory
+    And PaulDirac the scientist is a member of the group Laboratory
+    And the database has the following table 'items':
+      | id | type | default_language_tag |
+      | 1  | Task | fr                   |
+      | 2  | Task | en                   |
+    And the database has the following table 'items_strings':
+      | item_id | language_tag | title      |
+      | 1       | en           | Beginning  |
+      | 1       | fr           | Debut      |
+      | 2       | en           | Experiment |
+    And the database has the following table 'threads':
+      | item_id | participant_id  | status                  | message_count | latest_update_at    | helper_group_id |
+      | 1       | @AlbertEinstein | waiting_for_trainer     | 0             | 2023-01-01 00:00:01 | @Laboratory     |
+      | 2       | @PaulDirac      | waiting_for_participant | 1             | 2023-01-01 00:00:02 | @Laboratory     |
+    When I send a GET request to "/threads?watched_group_id=@Laboratory"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+      [
+        {
+          "item": {
+            "id": "1",
+            "language_tag": "fr",
+            "title": "Debut",
+            "type": "Task"
+          },
+          "latest_update_at": "2023-01-01T00:00:01Z",
+          "message_count": 0,
+          "participant": {
+            "id": "@AlbertEinstein",
+            "login": "AlbertEinstein",
+            "first_name": "Albert",
+            "last_name": "Einstein"
+          },
+          "status": "waiting_for_trainer"
+        },
+        {
+          "item": {
+            "id": "2",
+            "language_tag": "en",
+            "title": "Experiment",
+            "type": "Task"
+          },
+          "latest_update_at": "2023-01-01T00:00:02Z",
+          "message_count": 1,
+          "participant": {
+            "id": "@PaulDirac",
+            "login": "PaulDirac",
+            "first_name": "",
+            "last_name": ""
+          },
+          "status": "waiting_for_participant"
+        }
+      ]
+    """
+
+  Scenario: Should get the threads whose the participant is a descendant (or self) of the watched_group_id
+    Given I am RichardFeynman
+    And there is a group University referenced by @University
+    And I am a manager of the group University
+    And I can watch the group University
+    And the group FirstYear is a descendant of the group University
+    And ClaireStudent the student is a member of the group FirstYear
+    And StevenHawking the professor is a member of the group University
+    When I send a GET request to "/threads?watched_group_id=@University"
+    Then the response code should be 200
+    And it should be a JSON array with 2 entries
+    And the response should match the following JSONPath:
+      | JSONPath            | value          |
+      | $[*].participant.id | @ClaireStudent |
+      | $[*].participant.id | @StevenHawking |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -1,7 +1,7 @@
 Feature: List threads
   Background:
     And there are the following groups:
-      | name          | parent        | members                                               |
+      | group         | parent        | members                                               |
       | @Consortium   |               | @ConsortiumMember                                     |
       | @A_University | @Consortium   | @A_UniversityMember,@A_UniversityManagerCanWatch      |
       | @B_University | @Consortium   | @B_UniversityMember                                   |
@@ -11,7 +11,7 @@ Feature: List threads
       | @B_Class      | @B_Section    |                                                       |
       | @OtherGroup   |               | @OtherGroupMember                                     |
     And @A_UniversityManagerCanWatch is a manager of the group @A_University and can watch its members
-    And there are the following item tasks:
+    And there are the following tasks:
       | item                                            |
       | @B_SectionMember2_CanViewInfo                   |
       | @B_SectionMember2_CanViewContent1               |
@@ -38,12 +38,6 @@ Feature: List threads
       | @B_SectionMember2_CanViewContent1               | @B_SectionMember2   | content                  |           |
       | @B_SectionMember2_CanViewContent2               | @B_SectionMember2   | content                  |           |
       | @B_SectionMember2_CanViewContentWithDescendants | @B_SectionMember2   | content_with_descendants |           |
-      | @B_UniversityMember_HasValidated1               | @B_UniversityMember |                          |           |
-      | @B_UniversityMember_HasValidated2               | @B_UniversityMember |                          |           |
-      | @B_UniversityMember_HasValidated3               | @B_UniversityMember |                          |           |
-      | @B_UniversityMember_HasValidated4               | @B_UniversityMember |                          |           |
-      | @B_UniversityMember_HasValidated5               | @B_UniversityMember |                          |           |
-      | @B_UniversityMember_HasValidated6               | @B_UniversityMember |                          |           |
       | @B_UniversityMember_HasNotValidated             | @B_UniversityMember |                          | answer    |
       | @B_UniversityMember_CanWatchAnswer1             | @B_UniversityMember |                          | answer    |
       | @B_UniversityMember_CanWatchAnswer2             | @B_UniversityMember |                          | answer    |
@@ -85,7 +79,7 @@ Feature: List threads
     Given I am @LaboratoryManagerCanWatch
     And I am a manager of the group @Laboratory and can watch its members
     And there are the following users:
-      | login                                               | first_name            | last_name            |
+      | user                                                | first_name            | last_name            |
       | @LaboratoryMember_WithApprovedAccessPersonalInfo    | FirstName_Approved    | LastName_Approved    |
       | @LaboratoryMember_WithoutApprovedAccessPersonalInfo | FirstName_NotApproved | LastName_NotApproved |
     And @LaboratoryMember_WithApprovedAccessPersonalInfo is a member of the group @Laboratory who has approved access to his personal info
@@ -148,15 +142,14 @@ Feature: List threads
   Scenario: Should get the threads whose the participant is a descendant of the watched_group_id
     Given I am @A_UniversityManagerCanWatch
     When I send a GET request to "/threads?watched_group_id=@A_University"
-    And it should be a JSON array with 2 entries
     And the response at $[*].participant.id should be:
       | @A_UniversityMember |
-      | @A_ClassMember              |
+      | @A_ClassMember      |
 
   Scenario: Should get the threads whose the participant is equal to the watched_group_id
     Given I am @A_UniversityManagerCanWatch
     When I send a GET request to "/threads?watched_group_id=@A_ClassMember"
-    And it should be a JSON array with 1 entries
+    And the response should be a JSON array with 1 entries
     And the response at $[0].participant.id should be "@A_ClassMember"
 
   Scenario: Should return only the threads in which the participant is the current user and the item is visible when is_mine=1

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -1,19 +1,79 @@
 Feature: Get threads
   Background:
     Given there are the following users:
-      | name           | @reference      |
-      | RichardFeynman | @RichardFeynman |
-      | StevenHawking  | @StevenHawking  |
-      | DavidBowie     | @DavidBowie     |
-      | ClaireStudent  | @ClaireStudent  |
+      | login               |
+      | PresidentConsortium |
+      | PresidentUniversity |
+      | RichardFeynman      |
+      | Mary                |
+      | EtienneKlein        |
+      | Charlotte           |
+      | Baptiste            |
+      | Thibaut             |
+      | DavidBowie          |
+    And there are the following groups:
+      | parent               | name                 |
+      |                      | UniversityConsortium |
+      | UniversityConsortium | University           |
+      | University           | PresidentUniversity  |
+      | University           | FirstYear            |
+      | FirstYear            | Classroom            |
+      | UniversityConsortium | Université           |
+      | Université           | PremièreAnnée        |
+      | PremièreAnnée        | Classe               |
+      |                      | Superstar            |
+    And there are the following group members:
+      | group                | member              |
+      | UniversityConsortium | PresidentConsortium |
+      | University           | RichardFeynman      |
+      | Classroom            | Mary                |
+      | Université           | EtienneKlein        |
+      | PremièreAnnée        | Charlotte           |
+      | PremièreAnnée        | Baptiste            |
+      | PremièreAnnée        | Thibaut             |
+      | Superstar            | DavidBowie          |
+    And there are the following items with permissions:
+      | group        | item                                  | has_validated | can_view                 | can_watch |
+      | Baptiste     | BaptisteCanViewInfo                   |               | info                     |           |
+      | Baptiste     | BaptisteCanViewContent1               |               | content                  |           |
+      | Baptiste     | BaptisteCanViewContent2               |               | content                  |           |
+      | Baptiste     | BaptisteCanViewContentWithDescendants |               | content_with_descendants |           |
+      | EtienneKlein | EtienneKleinHasValidated1             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasValidated2             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasValidated3             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasValidated4             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasValidated5             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasValidated6             | 1             |                          |           |
+      | EtienneKlein | EtienneKleinHasNotValidated           |               |                          | answer    |
+      | EtienneKlein | EtienneKleinCanWatchAnswer1           |               |                          | answer    |
+      | EtienneKlein | EtienneKleinCanWatchAnswer2           |               |                          | answer    |
+      | EtienneKlein | EtienneKleinCanWatchAnswer3           |               |                          | answer    |
+      | EtienneKlein | EtienneKleinCanWatchAnswer4           |               |                          | answer    |
     Given there are the following threads:
-      | participant_id  |
-      | @RichardFeynman |
-      | @ClaireStudent  |
-      | @StevenHawking  |
-      | @DavidBowie     |
+      | participant         | item                                  | helper_group         | status                  | latest_update_at     | comment                                                                                                                |
+      | PresidentConsortium |                                       |                      |                         |                      |                                                                                                                        |
+      | PresidentUniversity |                                       |                      |                         |                      |                                                                                                                        |
+      | Mary                |                                       |                      |                         |                      |                                                                                                                        |
+      | EtienneKlein        | EtienneKleinCanWatchAnswer1           |                      |                         |                      | EtienneKlein is_mine=0 -> notok: must not be the participant                                                           |
+      | Charlotte           | EtienneKleinHasValidated1             | PremièreAnnée        | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread notok: not part of helper group                                                  |
+      | Charlotte           | EtienneKleinHasNotValidated           | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread notok: Has not validated                                                         |
+      | Charlotte           | EtienneKleinHasValidated2             | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | Charlotte           | EtienneKleinHasValidated3             | UniversityConsortium | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | Charlotte           | EtienneKleinCanWatchAnswer2           | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | Charlotte           | EtienneKleinHasValidated4             | Université           | waiting_for_participant |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | Charlotte           | EtienneKleinCanWatchAnswer3           | Université           | waiting_for_participant |                      | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | Charlotte           | EtienneKleinHasValidated5             | Université           | closed                  | 2021-12-20T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: part of helper group, closed thread for less than 2 weeks and validated item |
+      | Charlotte           | EtienneKleinCanWatchAnswer4           | Université           | closed                  | 2021-12-20T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | Charlotte           | EtienneKleinHasValidated6             | Université           | closed                  | 2021-11-00T00:00:00Z | EtienneKlein is_mine=0 -> List thread notok: closed for more than 2 weeks                                              |
+      | Charlotte           | EtienneKleinCanWatchAnswer5           | Université           | closed                  | 2021-11-00T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | Baptiste            | BaptisteCanViewInfo                   |                      |                         |                      | Baptiste is_mine=1 -> notok: can_view < content                                                                        |
+      | Baptiste            | BaptisteCanViewContent1               |                      |                         |                      | Baptiste is_mine=1 -> ok: can_view >= content                                                                          |
+      | Thibaut             | BaptisteCanViewContent2               |                      |                         |                      | Baptiste is_mine=1 -> notok: not the participant                                                                       |
+      | Baptiste            | BaptisteCanViewContentWithDescendants |                      |                         |                      | Baptiste is_mine=1 -> ok: can_view >= content                                                                          |
+      | DavidBowie          |                                       |                      |                         |                      |                                                                                                                        |
+    And the time now is "2022-01-01T00:00:00Z"
 
-  Scenario: Should have all the fields properly set
+  Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am MarieCurie
     And there is a group Laboratory referenced by @Laboratory
     And I am a manager of the group Laboratory
@@ -22,7 +82,7 @@ Feature: Get threads
       | @reference      | login          | first_name | last_name |
       | @AlbertEinstein | AlbertEinstein | Albert     | Einstein  |
       | @PaulDirac      | PaulDirac      | Paul       | Dirac     |
-      And AlbertEinstein the scientist is a member of the group Laboratory
+    And AlbertEinstein the scientist is a member of the group Laboratory
     And AlbertEinstein has approved access to his personal info for the group Laboratory
     And PaulDirac the scientist is a member of the group Laboratory
     And the database has the following table 'items':
@@ -80,18 +140,33 @@ Feature: Get threads
       ]
     """
 
-  Scenario: Should get the threads whose the participant is a descendant (or self) of the watched_group_id
+  Scenario: Should get the threads whose the participant is a descendant of the watched_group_id
     Given I am RichardFeynman
-    And there is a group University referenced by @University
-    And I am a manager of the group University
     And I can watch the group University
-    And the group FirstYear is a descendant of the group University
-    And ClaireStudent the student is a member of the group FirstYear
-    And StevenHawking the professor is a member of the group University
+    And the user Mary is referenced by @Mary
+    And the user PresidentUniversity is referenced by @PresidentUniversity
+    And the group University is referenced by @University
     When I send a GET request to "/threads?watched_group_id=@University"
-    Then the response code should be 200
     And it should be a JSON array with 2 entries
     And the response should match the following JSONPath:
-      | JSONPath            | value          |
-      | $[*].participant.id | @ClaireStudent |
-      | $[*].participant.id | @StevenHawking |
+      | JSONPath            | value                |
+      | $[*].participant.id | @PresidentUniversity |
+      | $[*].participant.id | @Mary                |
+
+  Scenario: Should get the threads whose the participant is equal to the watched_group_id
+    Given I am RichardFeynman
+    And I can watch the group University
+    And the user Mary is referenced by @Mary
+    When I send a GET request to "/threads?watched_group_id=@Mary"
+    And it should be a JSON array with 1 entries
+    And the response should match the following JSONPath:
+      | JSONPath            | value |
+      | $[0].participant.id | @Mary |
+
+  Scenario: Should return only the threads in which the participant is the current user and the item is visible when is_mine=1
+    # Baptiste can see BaptisteCanViewContent and BaptisteCanViewContentWithDescendants
+    # Waiting for implementation of is_mine
+
+  Scenario: Should return only the threads that the current-user can list and in which he is not the participant when is_mine=0
+    # EtienneKlein can see EtienneKleinHasValidated2, EtienneKleinHasValidated3, EtienneKleinCanWatchAnswer2, EtienneKleinHasValidated4, EtienneKleinCanWatchAnswer3, EtienneKleinHasValidated5, EtienneKleinCanWatchAnswer4, EtienneKleinCanWatchAnswer5
+    # Waiting for implementation of is_mine

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -1,58 +1,36 @@
-Feature: Get threads
+Feature: List threads
   Background:
-    Given there are the following users:
-      | login               |
-      | PresidentConsortium |
-      | PresidentUniversity |
-      | RichardFeynman      |
-      | Mary                |
-      | EtienneKlein        |
-      | Charlotte           |
-      | Baptiste            |
-      | Thibaut             |
-      | DavidBowie          |
     And there are the following groups:
-      | parent               | name                 |
-      |                      | UniversityConsortium |
-      | UniversityConsortium | University           |
-      | University           | PresidentUniversity  |
-      | University           | FirstYear            |
-      | FirstYear            | Classroom            |
-      | UniversityConsortium | Université           |
-      | Université           | PremièreAnnée        |
-      | PremièreAnnée        | Classe               |
-      |                      | Superstar            |
-    And there are the following group members:
-      | group                | member              |
-      | UniversityConsortium | PresidentConsortium |
-      | University           | RichardFeynman      |
-      | Classroom            | Mary                |
-      | Université           | EtienneKlein        |
-      | PremièreAnnée        | Charlotte           |
-      | PremièreAnnée        | Baptiste            |
-      | PremièreAnnée        | Thibaut             |
-      | Superstar            | DavidBowie          |
+      | name                 | parent               | members                            |
+      | UniversityConsortium |                      | ConsortiumPresident                |
+      | University           | UniversityConsortium | UniversityPresident,RichardFeynman |
+      | FirstYear            | University           |                                    |
+      | Classroom            | FirstYear            | Mary                               |
+      | Université           | UniversityConsortium | EtienneKlein                       |
+      | PremièreAnnée        | Université           | Charlotte,Baptiste,Thibaut         |
+      | Classe               | PremièreAnnée        |                                    |
+      | Superstar            |                      | DavidBowie                         |
     And there are the following items with permissions:
-      | group        | item                                  | has_validated | can_view                 | can_watch |
-      | Baptiste     | BaptisteCanViewInfo                   |               | info                     |           |
-      | Baptiste     | BaptisteCanViewContent1               |               | content                  |           |
-      | Baptiste     | BaptisteCanViewContent2               |               | content                  |           |
-      | Baptiste     | BaptisteCanViewContentWithDescendants |               | content_with_descendants |           |
-      | EtienneKlein | EtienneKleinHasValidated1             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasValidated2             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasValidated3             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasValidated4             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasValidated5             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasValidated6             | 1             |                          |           |
-      | EtienneKlein | EtienneKleinHasNotValidated           |               |                          | answer    |
-      | EtienneKlein | EtienneKleinCanWatchAnswer1           |               |                          | answer    |
-      | EtienneKlein | EtienneKleinCanWatchAnswer2           |               |                          | answer    |
-      | EtienneKlein | EtienneKleinCanWatchAnswer3           |               |                          | answer    |
-      | EtienneKlein | EtienneKleinCanWatchAnswer4           |               |                          | answer    |
+      | item                                  | group        | has_validated | can_view                 | can_watch |
+      | BaptisteCanViewInfo                   | Baptiste     |               | info                     |           |
+      | BaptisteCanViewContent1               | Baptiste     |               | content                  |           |
+      | BaptisteCanViewContent2               | Baptiste     |               | content                  |           |
+      | BaptisteCanViewContentWithDescendants | Baptiste     |               | content_with_descendants |           |
+      | EtienneKleinHasValidated1             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasValidated2             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasValidated3             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasValidated4             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasValidated5             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasValidated6             | EtienneKlein | 1             |                          |           |
+      | EtienneKleinHasNotValidated           | EtienneKlein |               |                          | answer    |
+      | EtienneKleinCanWatchAnswer1           | EtienneKlein |               |                          | answer    |
+      | EtienneKleinCanWatchAnswer2           | EtienneKlein |               |                          | answer    |
+      | EtienneKleinCanWatchAnswer3           | EtienneKlein |               |                          | answer    |
+      | EtienneKleinCanWatchAnswer4           | EtienneKlein |               |                          | answer    |
     Given there are the following threads:
       | participant         | item                                  | helper_group         | status                  | latest_update_at     | comment                                                                                                                |
-      | PresidentConsortium |                                       |                      |                         |                      |                                                                                                                        |
-      | PresidentUniversity |                                       |                      |                         |                      |                                                                                                                        |
+      | ConsortiumPresident |                                       |                      |                         |                      |                                                                                                                        |
+      | UniversityPresident |                                       |                      |                         |                      |                                                                                                                        |
       | Mary                |                                       |                      |                         |                      |                                                                                                                        |
       | EtienneKlein        | EtienneKleinCanWatchAnswer1           |                      |                         |                      | EtienneKlein is_mine=0 -> notok: must not be the participant                                                           |
       | Charlotte           | EtienneKleinHasValidated1             | PremièreAnnée        | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread notok: not part of helper group                                                  |
@@ -76,15 +54,13 @@ Feature: Get threads
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am MarieCurie
     And there is a group Laboratory referenced by @Laboratory
-    And I am a manager of the group Laboratory
-    And I can watch the group Laboratory
+    And I am a manager of the group Laboratory and can watch its members
     And there are the following users:
       | @reference      | login          | first_name | last_name |
       | @AlbertEinstein | AlbertEinstein | Albert     | Einstein  |
       | @PaulDirac      | PaulDirac      | Paul       | Dirac     |
-    And AlbertEinstein the scientist is a member of the group Laboratory
-    And AlbertEinstein has approved access to his personal info for the group Laboratory
-    And PaulDirac the scientist is a member of the group Laboratory
+    And AlbertEinstein is a member of the group Laboratory who has approved access to his personal info
+    And PaulDirac is a member of the group Laboratory
     And the database has the following table 'items':
       | id | type | default_language_tag |
       | 1  | Task | fr                   |
@@ -144,14 +120,13 @@ Feature: Get threads
     Given I am RichardFeynman
     And I can watch the group University
     And the user Mary is referenced by @Mary
-    And the user PresidentUniversity is referenced by @PresidentUniversity
+    And the user UniversityPresident is referenced by @UniversityPresident
     And the group University is referenced by @University
     When I send a GET request to "/threads?watched_group_id=@University"
     And it should be a JSON array with 2 entries
-    And the response should match the following JSONPath:
-      | JSONPath            | value                |
-      | $[*].participant.id | @PresidentUniversity |
-      | $[*].participant.id | @Mary                |
+    And the response at $[*].participant.id should be:
+      | @UniversityPresident |
+      | @Mary                |
 
   Scenario: Should get the threads whose the participant is equal to the watched_group_id
     Given I am RichardFeynman
@@ -159,9 +134,7 @@ Feature: Get threads
     And the user Mary is referenced by @Mary
     When I send a GET request to "/threads?watched_group_id=@Mary"
     And it should be a JSON array with 1 entries
-    And the response should match the following JSONPath:
-      | JSONPath            | value |
-      | $[0].participant.id | @Mary |
+    And the response at $[0].participant.id should be "@Mary"
 
   Scenario: Should return only the threads in which the participant is the current user and the item is visible when is_mine=1
     # Baptiste can see BaptisteCanViewContent and BaptisteCanViewContentWithDescendants

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -1,66 +1,95 @@
 Feature: List threads
   Background:
     And there are the following groups:
-      | name                 | parent               | members                            |
-      | UniversityConsortium |                      | ConsortiumPresident                |
-      | University           | UniversityConsortium | UniversityPresident,RichardFeynman |
-      | FirstYear            | University           |                                    |
-      | Classroom            | FirstYear            | Mary                               |
-      | Université           | UniversityConsortium | EtienneKlein                       |
-      | PremièreAnnée        | Université           | Charlotte,Baptiste,Thibaut         |
-      | Classe               | PremièreAnnée        |                                    |
-      | Superstar            |                      | DavidBowie                         |
-    And there are the following items with permissions:
-      | item                                  | group        | has_validated | can_view                 | can_watch |
-      | BaptisteCanViewInfo                   | Baptiste     |               | info                     |           |
-      | BaptisteCanViewContent1               | Baptiste     |               | content                  |           |
-      | BaptisteCanViewContent2               | Baptiste     |               | content                  |           |
-      | BaptisteCanViewContentWithDescendants | Baptiste     |               | content_with_descendants |           |
-      | EtienneKleinHasValidated1             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasValidated2             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasValidated3             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasValidated4             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasValidated5             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasValidated6             | EtienneKlein | 1             |                          |           |
-      | EtienneKleinHasNotValidated           | EtienneKlein |               |                          | answer    |
-      | EtienneKleinCanWatchAnswer1           | EtienneKlein |               |                          | answer    |
-      | EtienneKleinCanWatchAnswer2           | EtienneKlein |               |                          | answer    |
-      | EtienneKleinCanWatchAnswer3           | EtienneKlein |               |                          | answer    |
-      | EtienneKleinCanWatchAnswer4           | EtienneKlein |               |                          | answer    |
+      | name          | parent        | members                                               |
+      | @Consortium   |               | @ConsortiumMember                                     |
+      | @A_University | @Consortium   | @A_UniversityMember,@A_UniversityManagerCanWatch      |
+      | @B_University | @Consortium   | @B_UniversityMember                                   |
+      | @A_Section    | @A_University |                                                       |
+      | @B_Section    | @B_University | @B_SectionMember1,@B_SectionMember2,@B_SectionMember3 |
+      | @A_Class      | @A_Section    | @A_ClassMember                                        |
+      | @B_Class      | @B_Section    |                                                       |
+      | @OtherGroup   |               | @OtherGroupMember                                     |
+    And @A_UniversityManagerCanWatch is a manager of the group @A_University and can watch its members
+    And there are the following item tasks:
+      | item                                            |
+      | @B_SectionMember2_CanViewInfo                   |
+      | @B_SectionMember2_CanViewContent1               |
+      | @B_SectionMember2_CanViewContent2               |
+      | @B_SectionMember2_CanViewContentWithDescendants |
+      | @B_UniversityMember_HasValidated1               |
+      | @B_UniversityMember_HasValidated2               |
+      | @B_UniversityMember_HasValidated3               |
+      | @B_UniversityMember_HasValidated4               |
+      | @B_UniversityMember_HasValidated5               |
+      | @B_UniversityMember_HasValidated6               |
+      | @B_UniversityMember_HasNotValidated             |
+      | @B_UniversityMember_CanWatchAnswer1             |
+      | @B_UniversityMember_CanWatchAnswer2             |
+      | @B_UniversityMember_CanWatchAnswer3             |
+      | @B_UniversityMember_CanWatchAnswer4             |
+      | @Item1                                          |
+      | @Item2                                          |
+      | @Item3                                          |
+      | @Item3                                          |
+    And there are the following item permissions:
+      | item                                            | group               | can_view                 | can_watch |
+      | @B_SectionMember2_CanViewInfo                   | @B_SectionMember2   | info                     |           |
+      | @B_SectionMember2_CanViewContent1               | @B_SectionMember2   | content                  |           |
+      | @B_SectionMember2_CanViewContent2               | @B_SectionMember2   | content                  |           |
+      | @B_SectionMember2_CanViewContentWithDescendants | @B_SectionMember2   | content_with_descendants |           |
+      | @B_UniversityMember_HasValidated1               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasValidated2               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasValidated3               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasValidated4               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasValidated5               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasValidated6               | @B_UniversityMember |                          |           |
+      | @B_UniversityMember_HasNotValidated             | @B_UniversityMember |                          | answer    |
+      | @B_UniversityMember_CanWatchAnswer1             | @B_UniversityMember |                          | answer    |
+      | @B_UniversityMember_CanWatchAnswer2             | @B_UniversityMember |                          | answer    |
+      | @B_UniversityMember_CanWatchAnswer3             | @B_UniversityMember |                          | answer    |
+      | @B_UniversityMember_CanWatchAnswer4             | @B_UniversityMember |                          | answer    |
+    And there are the following results:
+      | item                              | participant         | validated |
+      | @B_UniversityMember_HasValidated1 | @B_UniversityMember | 1         |
+      | @B_UniversityMember_HasValidated2 | @B_UniversityMember | 1         |
+      | @B_UniversityMember_HasValidated3 | @B_UniversityMember | 1         |
+      | @B_UniversityMember_HasValidated4 | @B_UniversityMember | 1         |
+      | @B_UniversityMember_HasValidated5 | @B_UniversityMember | 1         |
+      | @B_UniversityMember_HasValidated6 | @B_UniversityMember | 1         |
     Given there are the following threads:
-      | participant         | item                                  | helper_group         | status                  | latest_update_at     | comment                                                                                                                |
-      | ConsortiumPresident |                                       |                      |                         |                      |                                                                                                                        |
-      | UniversityPresident |                                       |                      |                         |                      |                                                                                                                        |
-      | Mary                |                                       |                      |                         |                      |                                                                                                                        |
-      | EtienneKlein        | EtienneKleinCanWatchAnswer1           |                      |                         |                      | EtienneKlein is_mine=0 -> notok: must not be the participant                                                           |
-      | Charlotte           | EtienneKleinHasValidated1             | PremièreAnnée        | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread notok: not part of helper group                                                  |
-      | Charlotte           | EtienneKleinHasNotValidated           | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread notok: Has not validated                                                         |
-      | Charlotte           | EtienneKleinHasValidated2             | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | Charlotte           | EtienneKleinHasValidated3             | UniversityConsortium | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | Charlotte           | EtienneKleinCanWatchAnswer2           | Université           | waiting_for_trainer     |                      | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | Charlotte           | EtienneKleinHasValidated4             | Université           | waiting_for_participant |                      | EtienneKlein is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | Charlotte           | EtienneKleinCanWatchAnswer3           | Université           | waiting_for_participant |                      | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | Charlotte           | EtienneKleinHasValidated5             | Université           | closed                  | 2021-12-20T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: part of helper group, closed thread for less than 2 weeks and validated item |
-      | Charlotte           | EtienneKleinCanWatchAnswer4           | Université           | closed                  | 2021-12-20T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | Charlotte           | EtienneKleinHasValidated6             | Université           | closed                  | 2021-11-00T00:00:00Z | EtienneKlein is_mine=0 -> List thread notok: closed for more than 2 weeks                                              |
-      | Charlotte           | EtienneKleinCanWatchAnswer5           | Université           | closed                  | 2021-11-00T00:00:00Z | EtienneKlein is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | Baptiste            | BaptisteCanViewInfo                   |                      |                         |                      | Baptiste is_mine=1 -> notok: can_view < content                                                                        |
-      | Baptiste            | BaptisteCanViewContent1               |                      |                         |                      | Baptiste is_mine=1 -> ok: can_view >= content                                                                          |
-      | Thibaut             | BaptisteCanViewContent2               |                      |                         |                      | Baptiste is_mine=1 -> notok: not the participant                                                                       |
-      | Baptiste            | BaptisteCanViewContentWithDescendants |                      |                         |                      | Baptiste is_mine=1 -> ok: can_view >= content                                                                          |
-      | DavidBowie          |                                       |                      |                         |                      |                                                                                                                        |
+      | participant         | item                                            | helper_group  | status                  | latest_update_at     | comment                                                                                                                       |
+      | @ConsortiumMember   | @Item1                                          |               |                         |                      |                                                                                                                               |
+      | @A_UniversityMember | @Item2                                          |               |                         |                      |                                                                                                                               |
+      | @A_ClassMember      | @Item3                                          |               |                         |                      |                                                                                                                               |
+      | @B_UniversityMember | @B_UniversityMember_CanWatchAnswer1             |               |                         |                      | @B_UniversityMember is_mine=0 -> notok: must not be the participant                                                           |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated1               | @B_Section    | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread notok: not part of helper group                                                  |
+      | @B_SectionMember1   | @B_UniversityMember_HasNotValidated             | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread notok: Has not validated                                                         |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated2               | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated3               | @Consortium   | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer2             | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated4               | @B_University | waiting_for_participant |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer3             | @B_University | waiting_for_participant |                      | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated5               | @B_University | closed                  | 2021-12-20T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, closed thread for less than 2 weeks and validated item |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer4             | @B_University | closed                  | 2021-12-20T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated6               | @B_University | closed                  | 2021-11-00T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread notok: closed for more than 2 weeks                                              |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer5             | @B_University | closed                  | 2021-11-00T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewInfo                   |               |                         |                      | @B_SectionMember2 is_mine=1 -> notok: can_view < content                                                                      |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewContent1               |               |                         |                      | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
+      | @B_SectionMember3   | @B_SectionMember2_CanViewContent2               |               |                         |                      | @B_SectionMember2 is_mine=1 -> notok: not the participant                                                                     |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewContentWithDescendants |               |                         |                      | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
+      | @OtherGroupMember   | @Item4                                          |               |                         |                      |                                                                                                                               |
     And the time now is "2022-01-01T00:00:00Z"
 
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
-    Given I am MarieCurie
-    And there is a group Laboratory referenced by @Laboratory
-    And I am a manager of the group Laboratory and can watch its members
+    Given I am @LaboratoryManagerCanWatch
+    And I am a manager of the group @Laboratory and can watch its members
     And there are the following users:
-      | @reference      | login          | first_name | last_name |
-      | @AlbertEinstein | AlbertEinstein | Albert     | Einstein  |
-      | @PaulDirac      | PaulDirac      | Paul       | Dirac     |
-    And AlbertEinstein is a member of the group Laboratory who has approved access to his personal info
-    And PaulDirac is a member of the group Laboratory
+      | login                                               | first_name            | last_name            |
+      | @LaboratoryMember_WithApprovedAccessPersonalInfo    | FirstName_Approved    | LastName_Approved    |
+      | @LaboratoryMember_WithoutApprovedAccessPersonalInfo | FirstName_NotApproved | LastName_NotApproved |
+    And @LaboratoryMember_WithApprovedAccessPersonalInfo is a member of the group @Laboratory who has approved access to his personal info
+    And @LaboratoryMember_WithoutApprovedAccessPersonalInfo is a member of the group @Laboratory
     And the database has the following table 'items':
       | id | type | default_language_tag |
       | 1  | Task | fr                   |
@@ -71,9 +100,9 @@ Feature: List threads
       | 1       | fr           | Debut      |
       | 2       | en           | Experiment |
     And the database has the following table 'threads':
-      | item_id | participant_id  | status                  | message_count | latest_update_at    | helper_group_id |
-      | 1       | @AlbertEinstein | waiting_for_trainer     | 0             | 2023-01-01 00:00:01 | @Laboratory     |
-      | 2       | @PaulDirac      | waiting_for_participant | 1             | 2023-01-01 00:00:02 | @Laboratory     |
+      | item_id | participant_id                                      | status                  | message_count | latest_update_at    | helper_group_id |
+      | 1       | @LaboratoryMember_WithApprovedAccessPersonalInfo    | waiting_for_trainer     | 0             | 2023-01-01 00:00:01 | @Laboratory     |
+      | 2       | @LaboratoryMember_WithoutApprovedAccessPersonalInfo | waiting_for_participant | 1             | 2023-01-01 00:00:02 | @Laboratory     |
     When I send a GET request to "/threads?watched_group_id=@Laboratory"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -89,10 +118,10 @@ Feature: List threads
           "latest_update_at": "2023-01-01T00:00:01Z",
           "message_count": 0,
           "participant": {
-            "id": "@AlbertEinstein",
-            "login": "AlbertEinstein",
-            "first_name": "Albert",
-            "last_name": "Einstein"
+            "id": "@LaboratoryMember_WithApprovedAccessPersonalInfo",
+            "login": "LaboratoryMember_WithApprovedAccessPersonalInfo",
+            "first_name": "FirstName_Approved",
+            "last_name": "LastName_Approved"
           },
           "status": "waiting_for_trainer"
         },
@@ -106,8 +135,8 @@ Feature: List threads
           "latest_update_at": "2023-01-01T00:00:02Z",
           "message_count": 1,
           "participant": {
-            "id": "@PaulDirac",
-            "login": "PaulDirac",
+            "id": "@LaboratoryMember_WithoutApprovedAccessPersonalInfo",
+            "login": "LaboratoryMember_WithoutApprovedAccessPersonalInfo",
             "first_name": "",
             "last_name": ""
           },
@@ -117,29 +146,23 @@ Feature: List threads
     """
 
   Scenario: Should get the threads whose the participant is a descendant of the watched_group_id
-    Given I am RichardFeynman
-    And I can watch the group University
-    And the user Mary is referenced by @Mary
-    And the user UniversityPresident is referenced by @UniversityPresident
-    And the group University is referenced by @University
-    When I send a GET request to "/threads?watched_group_id=@University"
+    Given I am @A_UniversityManagerCanWatch
+    When I send a GET request to "/threads?watched_group_id=@A_University"
     And it should be a JSON array with 2 entries
     And the response at $[*].participant.id should be:
-      | @UniversityPresident |
-      | @Mary                |
+      | @A_UniversityMember |
+      | @A_ClassMember              |
 
   Scenario: Should get the threads whose the participant is equal to the watched_group_id
-    Given I am RichardFeynman
-    And I can watch the group University
-    And the user Mary is referenced by @Mary
-    When I send a GET request to "/threads?watched_group_id=@Mary"
+    Given I am @A_UniversityManagerCanWatch
+    When I send a GET request to "/threads?watched_group_id=@A_ClassMember"
     And it should be a JSON array with 1 entries
-    And the response at $[0].participant.id should be "@Mary"
+    And the response at $[0].participant.id should be "@A_ClassMember"
 
   Scenario: Should return only the threads in which the participant is the current user and the item is visible when is_mine=1
-    # Baptiste can see BaptisteCanViewContent and BaptisteCanViewContentWithDescendants
+    # @B_SectionMember2 can see @B_SectionMember2_CanViewContent and @B_SectionMember2_CanViewContentWithDescendants
     # Waiting for implementation of is_mine
 
   Scenario: Should return only the threads that the current-user can list and in which he is not the participant when is_mine=0
-    # EtienneKlein can see EtienneKleinHasValidated2, EtienneKleinHasValidated3, EtienneKleinCanWatchAnswer2, EtienneKleinHasValidated4, EtienneKleinCanWatchAnswer3, EtienneKleinHasValidated5, EtienneKleinCanWatchAnswer4, EtienneKleinCanWatchAnswer5
+    # @B_UniversityMember can see @B_UniversityMember_HasValidated2, @B_UniversityMember_HasValidated3, @B_UniversityMember_CanWatchAnswer2, @B_UniversityMember_HasValidated4, @B_UniversityMember_CanWatchAnswer3, @B_UniversityMember_HasValidated5, @B_UniversityMember_CanWatchAnswer4, @B_UniversityMember_CanWatchAnswer5
     # Waiting for implementation of is_mine

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -1,0 +1,115 @@
+package threads
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/service"
+)
+
+// swagger:response thread
+type thread struct {
+	Item        item        `json:"item" gorm:"embedded;embedded_prefix:item__"`
+	Participant participant `json:"participant" gorm:"embedded;embedded_prefix:participant__"`
+
+	// enum: not_started,waiting_for_participant,waiting_for_trainer,closed
+	Status         string         `json:"status"`
+	LatestUpdateAt *database.Time `json:"latest_update_at"`
+	MessageCount   int            `json:"message_count"`
+}
+
+type item struct {
+	ID          int64  `json:"id,string"`
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	LanguageTag string `json:"language_tag"`
+}
+
+type participant struct {
+	ID        int64  `json:"id,string"`
+	Login     string `json:"login"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// swagger:operation GET /items/{item_id}/participant/{participant_id}/thread threads listThreads
+// ---
+// summary: Service to list the visible threads for a user.
+// description: >
+//
+//	Service to list the visible threads for a user.
+//
+//	* If `watched_group_id` is given, only threads in which the participant is descendant (including self)
+//	  of the `watched_group_id` are returned.
+//	* `first_name` and `last_name` are only returned for the current user or if the user approved access to their personal
+//	  info for some group managed by the current user
+//
+//	Validations:
+//	  * if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
+//	    with `can_watch_members` on `watched_group_id`.
+//
+// parameters:
+//   - name: watched_group_id
+//     in: query
+//     type: integer
+//     format: int64
+//
+// responses:
+//
+//	"200":
+//	  description: OK. Threads data
+//	  schema:
+//	    type: array
+//	    items:
+//	      "$ref": "#/responses/thread"
+//	"400":
+//	  "$ref": "#/responses/badRequestResponse"
+//	"401":
+//	  "$ref": "#/responses/unauthorizedResponse"
+//	"403":
+//	  "$ref": "#/responses/forbiddenResponse"
+//	"500":
+//	  "$ref": "#/responses/internalErrorResponse"
+func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service.APIError {
+	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
+	if apiError != service.NoError {
+		return apiError
+	}
+	if !ok {
+		return service.ErrInvalidRequest(errors.New("not implemented yet: watchedGroupID must be given"))
+	}
+
+	user := srv.GetUser(r)
+	store := srv.GetStore(r)
+
+	var threads []thread
+	err := store.Threads().
+		JoinsItem().
+		JoinsUserParticipant().
+		WhereParticipantIsInGroup(watchedGroupID).
+		JoinsUserAndDefaultItemStrings(user).
+		WithPersonalInfoViewApprovals(user).
+		Order("items.id ASC"). // Default to make the result deterministic.
+		Select(`
+			items.id AS item__id,
+			items.type AS item__type,
+			COALESCE(user_strings.language_tag, default_strings.language_tag) AS item__language_tag,
+			COALESCE(user_strings.title, default_strings.title) AS item__title,
+			threads.participant_id AS participant__id,
+			IF(threads.participant_id = ? OR personal_info_view_approvals.approved, users.first_name, NULL) AS participant__first_name,
+			IF(threads.participant_id = ? OR personal_info_view_approvals.approved, users.last_name, NULL) AS participant__last_name,
+			users.login AS participant__login,
+			threads.status AS status,
+			threads.message_count AS message_count,
+			threads.latest_update_at AS latest_update_at
+		`, user.GroupID, user.GroupID).
+		Scan(&threads).
+		Error()
+	service.MustNotBeError(err)
+
+	render.Respond(rw, r, threads)
+	return service.NoError
+}

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -10,7 +10,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
-// swagger:response thread
+// swagger:model thread
 type thread struct {
 	Item        item        `json:"item" gorm:"embedded;embedded_prefix:item__"`
 	Participant participant `json:"participant" gorm:"embedded;embedded_prefix:participant__"`
@@ -35,44 +35,45 @@ type participant struct {
 	LastName  string `json:"last_name"`
 }
 
-// swagger:operation GET /items/{item_id}/participant/{participant_id}/thread threads listThreads
-// ---
-// summary: Service to list the visible threads for a user.
-// description: >
+// swagger:operation GET /thread threads listThreads
 //
-//	Service to list the visible threads for a user.
+//	---
+//	summary: Service to list the visible threads for a user.
+//	description: >
 //
-//	* If `watched_group_id` is given, only threads in which the participant is descendant (including self)
-//	  of the `watched_group_id` are returned.
-//	* `first_name` and `last_name` are only returned for the current user or if the user approved access to their personal
-//	  info for some group managed by the current user
+//		Service to list the visible threads for a user.
 //
-//	Validations:
-//	  * if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
-//	    with `can_watch_members` on `watched_group_id`.
+//		* If `watched_group_id` is given, only threads in which the participant is descendant (including self)
+//		  of the `watched_group_id` are returned.
+//		* `first_name` and `last_name` are only returned for the current user or if the user approved access to their personal
+//		  info for some group managed by the current user
 //
-// parameters:
-//   - name: watched_group_id
-//     in: query
-//     type: integer
-//     format: int64
+//		Validations:
+//		  * if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
+//		    with `can_watch_members` on `watched_group_id`.
 //
-// responses:
+//	parameters:
+//		- name: watched_group_id
+//			in: query
+//			type: integer
+//			format: int64
 //
-//	"200":
-//	  description: OK. Threads data
-//	  schema:
-//	    type: array
-//	    items:
-//	      "$ref": "#/responses/thread"
-//	"400":
-//	  "$ref": "#/responses/badRequestResponse"
-//	"401":
-//	  "$ref": "#/responses/unauthorizedResponse"
-//	"403":
-//	  "$ref": "#/responses/forbiddenResponse"
-//	"500":
-//	  "$ref": "#/responses/internalErrorResponse"
+//	responses:
+//
+//		"200":
+//			description: OK. Threads data
+//			schema:
+//				type: array
+//				items:
+//					"$ref": "#/definitions/thread"
+//		"400":
+//			"$ref": "#/responses/badRequestResponse"
+//		"401":
+//			"$ref": "#/responses/unauthorizedResponse"
+//		"403":
+//			"$ref": "#/responses/forbiddenResponse"
+//		"500":
+//			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service.APIError {
 	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -1,0 +1,32 @@
+Feature: Get threads - robustness
+  Scenario: Should be logged
+    Given There is a group Classroom
+    When I send a GET request to "/threads?watched_group_id=@Classroom"
+    Then the response code should be 401
+    And the response error message should contain "No access token provided"
+
+  Scenario: watched_group_id should be an integer
+    Given I am John
+    When I send a GET request to "/threads?watched_group_id=aaa"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for watched_group_id (should be int64)"
+
+  Scenario: watched_group_id should be given because the alternative is not implemented yet
+    Given I am John
+    When I send a GET request to "/threads"
+    Then the response code should be 400
+    And the response error message should contain "Not implemented yet: watchedGroupID must be given"
+
+  Scenario: The user should be a manager of watched_group_id group
+    Given I am John
+    And There is a group Classroom
+    When I send a GET request to "/threads?watched_group_id=@Classroom"
+    Then the response code should be 403
+    And the response error message should contain "No rights to watch for watched_group_id"
+
+  Scenario: The user should be able to watch the watched_group_id group
+    Given I am John
+    And I am a manager of the group Classroom
+    When I send a GET request to "/threads?watched_group_id=@Classroom"
+    Then the response code should be 403
+    And the response error message should contain "No rights to watch for watched_group_id"

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -1,33 +1,33 @@
 Feature: List threads - robustness
   Scenario: Should be logged in
-    Given there is a group Classroom referenced by @Classroom
+    Given there is a group @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
 
   Scenario: watched_group_id should be an integer
-    Given I am John
+    Given I am @John
     When I send a GET request to "/threads?watched_group_id=aaa"
     Then the response code should be 400
     And the response error message should contain "Wrong value for watched_group_id (should be int64)"
 
   Scenario: watched_group_id should be given because the alternative is not implemented yet
-    Given I am John
+    Given I am @John
     When I send a GET request to "/threads"
     Then the response code should be 400
     And the response error message should contain "Not implemented yet: watchedGroupID must be given"
 
   Scenario: The user should be a manager of watched_group_id group
-    Given I am John
-    And there is a group Classroom referenced by @Classroom
+    Given I am @John
+    And there is a group @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"
 
   Scenario: The user should be able to watch the watched_group_id group
-    Given I am John
-    And there is a group Classroom referenced by @Classroom
-    And I am a manager of the group Classroom
+    Given I am @John
+    And there is a group @Classroom
+    And I am a manager of the group @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -1,5 +1,5 @@
-Feature: Get threads - robustness
-  Scenario: Should be logged
+Feature: List threads - robustness
+  Scenario: Should be logged in
     Given there is a group Classroom referenced by @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 401

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get threads - robustness
   Scenario: Should be logged
-    Given There is a group Classroom
+    Given there is a group Classroom referenced by @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
@@ -19,13 +19,14 @@ Feature: Get threads - robustness
 
   Scenario: The user should be a manager of watched_group_id group
     Given I am John
-    And There is a group Classroom
+    And there is a group Classroom referenced by @Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"
 
   Scenario: The user should be able to watch the watched_group_id group
     Given I am John
+    And there is a group Classroom referenced by @Classroom
     And I am a manager of the group Classroom
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403

--- a/app/api/threads/threads.go
+++ b/app/api/threads/threads.go
@@ -19,6 +19,7 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Use(render.SetContentType(render.ContentTypeJSON))
 	router.Use(auth.UserMiddleware(srv.Base))
 
+	router.Get("/threads", service.AppHandler(srv.listThreads).ServeHTTP)
 	router.Get("/items/{item_id}/participant/{participant_id}/thread", service.AppHandler(srv.getThread).ServeHTTP)
 	router.Put("/items/{item_id}/participant/{participant_id}/thread", service.AppHandler(srv.updateThread).ServeHTTP)
 }

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -370,6 +370,7 @@ Feature: Update thread
       | 2010    | waiting_for_participant | 11              | In chapter |
 
   Scenario: Participant who can request help on region can request help on class
+  Scenario: Participant who can request help on region can request help on class
     Given I am the user with id "3"
     And there is no thread with "item_id=270,participant_id=3"
     And I can request help to the group with id "12" on the item with id "270"

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -74,26 +74,26 @@ Feature: Update thread - robustness
       | item_id | participant_id | status | helper_group_id | latest_update_at |
 
   Scenario: Should be logged in
-    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread"
+    When I send a PUT request to "/items/10/participant/1/thread"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
 
   Scenario: The item_id parameter should be an int64
-    Given I am RichardFeynman
-    When I send a PUT request to "/items/aaa/participant/@RichardFeynman/thread"
+    Given I am the user with id "1"
+    When I send a PUT request to "/items/aaa/participant/1/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for item_id (should be int64)"
 
   Scenario: The participant_id parameter should be an int64
-    Given I am RichardFeynman
-    When I send a PUT request to "/items/@SomeItem/participant/aaa/thread"
+    Given I am the user with id "1"
+    When I send a PUT request to "/items/10/participant/aaa/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for participant_id (should be int64)"
 
   Scenario: Either status, helper_group_id, message_count or message_count_increment must be given
-    Given I am RichardFeynman
-    And there is a thread with "item_id=@SomeItem,participant_id=@RichardFeynman"
-    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread" with the following body:
+    Given I am the user with id "1"
+    And there is a thread with "item_id=10,participant_id=1"
+    When I send a PUT request to "/items/10/participant/1/thread" with the following body:
       """
       {}
       """
@@ -101,8 +101,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Either status, helper_group_id, message_count or message_count_increment must be given"
 
   Scenario: The item should exist
-    Given I am RichardFeynman
-    When I send a PUT request to "/items/@NonExistentItem/participant/@RichardFeynman/thread" with the following body:
+    Given I am the user with id "1"
+    When I send a PUT request to "/items/404/participant/1/thread" with the following body:
       """
       {
         "message_count": 42
@@ -112,12 +112,12 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: The participant should exist
-    Given I am RichardFeynman
-    When I send a PUT request to "/items/@SomeItem/participant/@NonExistentParticipant/thread" with the following body:
+    Given I am the user with id "1"
+    When I send a PUT request to "/items/5/participant/404/thread" with the following body:
       """
       {
         "status": "waiting_for_trainer",
-        "helper_group_id": @SomeItem
+        "helper_group_id": 10
       }
       """
     Then the response code should be 400
@@ -199,7 +199,7 @@ Feature: Update thread - robustness
   Scenario: >
   Should return access error when the status is not set and
   "can write to thread" condition (3) is not met: user is not part of the help group
-    Given I am RichardFeynman
+    Given I am the user with id "1"
     And I have validated the item with id "40"
     And I can watch answer on item with id "40"
     And there is a thread with "item_id=40,participant_id=3"
@@ -227,8 +227,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: message_count should be positive
-    Given I am RichardFeynman
-    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
+    Given I am the user with id "1"
+    And there is a thread with "item_id=60,participant_id=1"
     When I send a PUT request to "/items/60/participant/3/thread" with the following body:
       """
       {
@@ -249,9 +249,9 @@ Feature: Update thread - robustness
     """
 
   Scenario: Should not contain both message_count and message_count_increment
-    Given I am RichardFeynman
-    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
-    When I send a PUT request to "/items/60/participant/@RichardFeynman/thread" with the following body:
+    Given I am the user with id "1"
+    And there is a thread with "item_id=60,participant_id=1"
+    When I send a PUT request to "/items/60/participant/1/thread" with the following body:
       """
       {
         "message_count": 1,
@@ -406,7 +406,7 @@ Feature: Update thread - robustness
       | 140     | answer_with_grant | waiting_for_participant |
 
   Scenario: Cannot switch between open status if only can_watch>answer but not a part of the helper group, and cannot watch participant
-    Given I am RichardFeynman
+    Given I am the user with id "1"
     And I can watch answer on item with id "150"
     And there is a thread with "item_id=150,participant_id=3,status=waiting_for_participant"
     When I send a PUT request to "/items/150/participant/3/thread" with the following body:
@@ -419,7 +419,7 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: Cannot switch between open status if only item validated but not a part of the helper group, and cannot watch participant
-    Given I am RichardFeynman
+    Given I am the user with id "1"
     And I have validated the item with id "160"
     And there is a thread with "item_id=160,participant_id=3,status=waiting_for_trainer"
     When I send a PUT request to "/items/160/participant/3/thread" with the following body:
@@ -432,9 +432,9 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread exists
-    Given I am RichardFeynman
-    And there is a thread with "item_id=<item_id>,participant_id=@RichardFeynman,status=closed"
-    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
+    Given I am the user with id "1"
+    And there is a thread with "item_id=<item_id>,participant_id=1,status=closed"
+    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -458,8 +458,8 @@ Feature: Update thread - robustness
       | 210     | waiting_for_participant |
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread doesn't exists
-    Given I am RichardFeynman
-    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
+    Given I am the user with id "1"
+    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -485,7 +485,7 @@ Feature: Update thread - robustness
   Scenario Outline: If status is already "closed" and not changing status OR if switching to status "closed": helper_group_id must not be given when thread exists
     Given I am the user with id "1"
     And there is a thread with "item_id=<item_id>,participant_id=1,status=<old_status>"
-    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
+    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
       """
       {
         "status": "<status>",
@@ -558,7 +558,7 @@ Feature: Update thread - robustness
     """
 
   Scenario: helper_group_id is visible to participant but not to current-user
-    Given I am RichardFeynman
+    Given I am the user with id "1"
     And there is a thread with "item_id=310,participant_id=3"
     When I send a PUT request to "/items/310/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -74,26 +74,26 @@ Feature: Update thread - robustness
       | item_id | participant_id | status | helper_group_id | latest_update_at |
 
   Scenario: Should be logged in
-    When I send a PUT request to "/items/10/participant/1/thread"
+    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread"
     Then the response code should be 401
     And the response error message should contain "No access token provided"
 
   Scenario: The item_id parameter should be an int64
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/aaa/participant/1/thread"
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/aaa/participant/@RichardFeynman/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for item_id (should be int64)"
 
   Scenario: The participant_id parameter should be an int64
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/10/participant/aaa/thread"
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@SomeItem/participant/aaa/thread"
     Then the response code should be 400
     And the response error message should contain "Wrong value for participant_id (should be int64)"
 
   Scenario: Either status, helper_group_id, message_count or message_count_increment must be given
-    Given I am the user with id "1"
-    And there is a thread with "item_id=10,participant_id=1"
-    When I send a PUT request to "/items/10/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=@SomeItem,participant_id=@RichardFeynman"
+    When I send a PUT request to "/items/@SomeItem/participant/@RichardFeynman/thread" with the following body:
       """
       {}
       """
@@ -101,8 +101,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Either status, helper_group_id, message_count or message_count_increment must be given"
 
   Scenario: The item should exist
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/404/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@NonExistentItem/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "message_count": 42
@@ -112,12 +112,12 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: The participant should exist
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/5/participant/404/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/@SomeItem/participant/@NonExistentParticipant/thread" with the following body:
       """
       {
         "status": "waiting_for_trainer",
-        "helper_group_id": 10
+        "helper_group_id": @SomeItem
       }
       """
     Then the response code should be 400
@@ -199,7 +199,7 @@ Feature: Update thread - robustness
   Scenario: >
   Should return access error when the status is not set and
   "can write to thread" condition (3) is not met: user is not part of the help group
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I have validated the item with id "40"
     And I can watch answer on item with id "40"
     And there is a thread with "item_id=40,participant_id=3"
@@ -227,8 +227,8 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: message_count should be positive
-    Given I am the user with id "1"
-    And there is a thread with "item_id=60,participant_id=1"
+    Given I am RichardFeynman
+    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
     When I send a PUT request to "/items/60/participant/3/thread" with the following body:
       """
       {
@@ -249,9 +249,9 @@ Feature: Update thread - robustness
     """
 
   Scenario: Should not contain both message_count and message_count_increment
-    Given I am the user with id "1"
-    And there is a thread with "item_id=60,participant_id=1"
-    When I send a PUT request to "/items/60/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=60,participant_id=@RichardFeynman"
+    When I send a PUT request to "/items/60/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "message_count": 1,
@@ -406,7 +406,7 @@ Feature: Update thread - robustness
       | 140     | answer_with_grant | waiting_for_participant |
 
   Scenario: Cannot switch between open status if only can_watch>answer but not a part of the helper group, and cannot watch participant
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I can watch answer on item with id "150"
     And there is a thread with "item_id=150,participant_id=3,status=waiting_for_participant"
     When I send a PUT request to "/items/150/participant/3/thread" with the following body:
@@ -419,7 +419,7 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: Cannot switch between open status if only item validated but not a part of the helper group, and cannot watch participant
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And I have validated the item with id "160"
     And there is a thread with "item_id=160,participant_id=3,status=waiting_for_trainer"
     When I send a PUT request to "/items/160/participant/3/thread" with the following body:
@@ -432,9 +432,9 @@ Feature: Update thread - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread exists
-    Given I am the user with id "1"
-    And there is a thread with "item_id=<item_id>,participant_id=1,status=closed"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    And there is a thread with "item_id=<item_id>,participant_id=@RichardFeynman,status=closed"
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -458,8 +458,8 @@ Feature: Update thread - robustness
       | 210     | waiting_for_participant |
 
   Scenario Outline: If switching to an open status from a non-open status, helper_group_id must be given when thread doesn't exists
-    Given I am the user with id "1"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    Given I am RichardFeynman
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>"
@@ -485,7 +485,7 @@ Feature: Update thread - robustness
   Scenario Outline: If status is already "closed" and not changing status OR if switching to status "closed": helper_group_id must not be given when thread exists
     Given I am the user with id "1"
     And there is a thread with "item_id=<item_id>,participant_id=1,status=<old_status>"
-    When I send a PUT request to "/items/<item_id>/participant/1/thread" with the following body:
+    When I send a PUT request to "/items/<item_id>/participant/@RichardFeynman/thread" with the following body:
       """
       {
         "status": "<status>",
@@ -558,7 +558,7 @@ Feature: Update thread - robustness
     """
 
   Scenario: helper_group_id is visible to participant but not to current-user
-    Given I am the user with id "1"
+    Given I am RichardFeynman
     And there is a thread with "item_id=310,participant_id=3"
     When I send a PUT request to "/items/310/participant/3/thread" with the following body:
       """

--- a/app/database/thread_store.go
+++ b/app/database/thread_store.go
@@ -87,7 +87,7 @@ func (s *ThreadStore) GetThreadQuery(participantID, itemID int64) *DB {
 func (s *ThreadStore) GetThreadStatus(participantID, itemID int64) string {
 	var status string
 
-	err := s.Threads().
+	err := s.
 		GetThreadQuery(participantID, itemID).
 		Select("threads.status AS status").
 		PluckFirst("status", &status).
@@ -181,4 +181,12 @@ func (s *ThreadStore) UserCanChangeStatus(user *User, oldStatus, newStatus strin
 	}
 
 	return false
+}
+
+// WhereParticipantIsInGroup filters the threads on the participant.
+func (s *ThreadStore) WhereParticipantIsInGroup(groupID int64) *DB {
+	return s.Joins(`
+		JOIN groups_ancestors ON
+				 	threads.participant_id = groups_ancestors.child_group_id AND
+					groups_ancestors.ancestor_group_id = ?`, groupID)
 }

--- a/app/database/thread_store.go
+++ b/app/database/thread_store.go
@@ -186,7 +186,25 @@ func (s *ThreadStore) UserCanChangeStatus(user *User, oldStatus, newStatus strin
 // WhereParticipantIsInGroup filters the threads on the participant.
 func (s *ThreadStore) WhereParticipantIsInGroup(groupID int64) *DB {
 	return s.Joins(`
-		JOIN groups_ancestors ON
-				 	threads.participant_id = groups_ancestors.child_group_id AND
-					groups_ancestors.ancestor_group_id = ?`, groupID)
+		JOIN groups_ancestors_active ON
+				 	threads.participant_id = groups_ancestors_active.child_group_id AND
+					groups_ancestors_active.ancestor_group_id = ?`, groupID)
+}
+
+// JoinsItem joins the items table in the query.
+func (s *ThreadStore) JoinsItem() *ThreadStore {
+	return &ThreadStore{
+		NewDataStoreWithTable(
+			s.Joins("JOIN items ON	items.id = threads.item_id"), s.tableName,
+		),
+	}
+}
+
+// JoinsUserParticipant joins the user participant in the query.
+func (s *ThreadStore) JoinsUserParticipant() *ThreadStore {
+	return &ThreadStore{
+		NewDataStoreWithTable(
+			s.Joins("JOIN users ON	users.group_id = threads.participant_id"), s.tableName,
+		),
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.3.2
 	github.com/France-ioi/mapstructure v1.1.3-0.20190228185851-70b68b9b4003
 	github.com/France-ioi/validator v9.29.2-0.20220110032854-1b7299b1a4db+incompatible
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/SermoDigital/jose v0.0.0-20180104203859-803625baeddc
 	github.com/akrylysov/algnhsa v0.12.1
 	github.com/aws/aws-lambda-go v1.28.0
@@ -43,6 +44,7 @@ require (
 
 require (
 	github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a // indirect
+	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/cucumber/gherkin-go/v11 v11.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,11 @@ github.com/France-ioi/mapstructure v1.1.3-0.20190228185851-70b68b9b4003 h1:xWP0Y
 github.com/France-ioi/mapstructure v1.1.3-0.20190228185851-70b68b9b4003/go.mod h1:MUWZRkw6DRv0+CydtqmPpc6Dn2/scLBrgCx5S7XqiaE=
 github.com/France-ioi/validator v9.29.2-0.20220110032854-1b7299b1a4db+incompatible h1:f5cCQN1Ky7J1627LCsU/YvHtDlYKb9gF1MKxpeD4jk0=
 github.com/France-ioi/validator v9.29.2-0.20220110032854-1b7299b1a4db+incompatible/go.mod h1:E1tfbGctgL/lY9mtL8AemtTbTYzmy0XF+Mm54eLu43E=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -19,11 +19,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the database has the following users:$`, ctx.DBHasUsers)
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 
-	s.Step(`^I am (\w+)$`, ctx.IAm)
+	s.Step(`^I am (@\w+)$`, ctx.IAm)
 	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
-	s.Step(`^there is a user (\w+)$`, ctx.ThereIsAUser)
-	s.Step(`^there is a user (\w+) referenced by @(\w+)$`, ctx.ThereIsAUserReferencedBy)
-	s.Step(`^the user (\w+) is referenced by @(\w+)$`, ctx.ThereIsAUserReferencedBy)
+	s.Step(`^there is a user (@\w+)$`, ctx.ThereIsAUser)
 	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
@@ -36,22 +34,22 @@ func FeatureContext(s *godog.Suite) {
 
 	s.Step(`^there are the following groups:$`, ctx.ThereAreTheFollowingGroups)
 	s.Step(`^there is a group with "([^"]*)"$`, ctx.ThereIsAGroupWith)
-	s.Step(`^there is a group (\w+)$`, ctx.ThereIsAGroup)
-	s.Step(`^there is a group (\w+) referenced by @(\w+)$`, ctx.ThereIsAGroupReferencedBy)
-	s.Step(`^the group (\w+) is referenced by @(\w+)`, ctx.ThereIsAGroupReferencedBy)
-	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
+	s.Step(`^there is a group (@\w+)$`, ctx.ThereIsAGroup)
+	s.Step(`^I am a member of the group (@\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
-	s.Step(`^(\w+) is a member of the group (\w+)$`, ctx.UserIsAMemberOfTheGroup)
+	s.Step(`^(@\w+) is a member of the group (@\w+)$`, ctx.UserIsAMemberOfTheGroup)
 	s.Step(
-		`^(\w+) is a member of the group (\w+) who has approved access to his personal info$`,
+		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
 	)
-	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmTheManagerOfTheGroupWithID)
-	s.Step(`^I am a manager of the group (\w+)$`, ctx.IAmTheManagerOfTheGroup)
-	s.Step(`^I am a manager of the group (\w+) and can watch its members$`, ctx.IAmTheManagerOfTheGroupAndCanWatchItsMembers)
-	s.Step(`^the group (\w+) is a descendant of the group (\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
-	s.Step(`^there are the following items with permissions:$`, ctx.ThereAreTheFollowingItemsWithPermissions)
-	s.Step(`^I can watch the group (\w+)$`, ctx.ICanWatchGroup)
+	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmAManagerOfTheGroupWithID)
+	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)
+	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
+	s.Step(`^I am a manager of the group (@\w+) and can watch its members$`, ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
+	s.Step(`^the group (@\w+) is a descendant of the group (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
+	s.Step(`^there are the following item tasks:$`, ctx.ThereAreTheFollowingItemTasks)
+	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
+	s.Step(`^I can watch the group (@\w+)$`, ctx.ICanWatchGroup)
 	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
 		ctx.ICanViewOnItemWithID)
@@ -59,6 +57,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
 
+	s.Step(`^there are the following results:$`, ctx.ThereAreTheFollowingResults)
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
 
 	s.Step(`^there are the following threads:$`, ctx.ThereAreTheFollowingThreads)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -23,6 +23,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
 	s.Step(`^there is a user (\w+)$`, ctx.ThereIsAUser)
 	s.Step(`^there is a user (\w+) referenced by @(\w+)$`, ctx.ThereIsAUserReferencedBy)
+	s.Step(`^the user (\w+) is referenced by @(\w+)$`, ctx.ThereIsAUserReferencedBy)
 	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
@@ -33,15 +34,19 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the application config is:$`, ctx.TheApplicationConfigIs)
 	s.Step(`^the context variable "([^"]*)" is "([^"]*)"$`, ctx.TheContextVariableIs)
 
+	s.Step(`^there are the following groups:$`, ctx.ThereAreTheFollowingGroups)
 	s.Step(`^there is a group with "([^"]*)"$`, ctx.ThereIsAGroupWith)
 	s.Step(`^there is a group (\w+)$`, ctx.ThereIsAGroup)
 	s.Step(`^there is a group (\w+) referenced by @(\w+)$`, ctx.ThereIsAGroupReferencedBy)
+	s.Step(`^the group (\w+) is referenced by @(\w+)`, ctx.ThereIsAGroupReferencedBy)
+	s.Step(`^there are the following group members:$`, ctx.ThereAreTheFollowingGroupMembers)
 	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^(\w+) the (?:\w+) is a member of the group (\w+)$`, ctx.UserIsAMemberOfTheGroup)
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmTheManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (\w+)$`, ctx.IAmTheManagerOfTheGroup)
 	s.Step(`^the group (\w+) is a descendant of the group (\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
+	s.Step(`^there are the following items with permissions:$`, ctx.ThereAreTheFollowingItemsWithPermissions)
 	s.Step(`^I can watch the group (\w+)$`, ctx.ICanWatchGroup)
 	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
@@ -53,7 +58,7 @@ func FeatureContext(s *godog.Suite) {
 
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
 
-	s.Step(`^there are the following threads:$`, ctx.ThereAreThreads)
+	s.Step(`^there are the following threads:$`, ctx.ThereAreTheFollowingThreads)
 	s.Step(`^there is a thread with "([^"]*)"$`, ctx.ThereIsAThreadWith)
 	s.Step(`^there is no thread with "([^"]*)"$`, ctx.ThereIsNoThreadWith)
 	s.Step(`^I am part of the helper group of the thread$`, ctx.IAmPartOfTheHelperGroupOfTheThread)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -1,4 +1,5 @@
 //go:build !prod
+// +build !prod
 
 package testhelpers
 
@@ -20,7 +21,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 
 	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
-	s.Step(`^I am ([^ ]*)$`, ctx.IAm)
+	s.Step(`^I am (\w+)$`, ctx.IAm)
+	s.Step(`^there is a user (\w+)$`, ctx.ThereIsAUser)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
 	s.Step(`^the generated group code is "([^"]*)"$`, ctx.TheGeneratedGroupCodeIs)
@@ -36,6 +38,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
 		ctx.ICanViewOnItemWithID)
 	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
+	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -1,5 +1,4 @@
 //go:build !prod
-// +build !prod
 
 package testhelpers
 
@@ -20,9 +19,11 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the database has the following users:$`, ctx.DBHasUsers)
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 
-	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
 	s.Step(`^I am (\w+)$`, ctx.IAm)
+	s.Step(`^I am the user with id "([^"]*)"$`, ctx.IAmUserWithID)
 	s.Step(`^there is a user (\w+)$`, ctx.ThereIsAUser)
+	s.Step(`^there is a user (\w+) referenced by @(\w+)$`, ctx.ThereIsAUserReferencedBy)
+	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
 	s.Step(`^the generated group code is "([^"]*)"$`, ctx.TheGeneratedGroupCodeIs)
@@ -33,16 +34,26 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the context variable "([^"]*)" is "([^"]*)"$`, ctx.TheContextVariableIs)
 
 	s.Step(`^there is a group with "([^"]*)"$`, ctx.ThereIsAGroupWith)
-	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmTheManagerOfTheGroup)
-	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchParticipantWithID)
+	s.Step(`^there is a group (\w+)$`, ctx.ThereIsAGroup)
+	s.Step(`^there is a group (\w+) referenced by @(\w+)$`, ctx.ThereIsAGroupReferencedBy)
+	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
+	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
+	s.Step(`^(\w+) the (?:\w+) is a member of the group (\w+)$`, ctx.UserIsAMemberOfTheGroup)
+	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmTheManagerOfTheGroupWithID)
+	s.Step(`^I am a manager of the group (\w+)$`, ctx.IAmTheManagerOfTheGroup)
+	s.Step(`^the group (\w+) is a descendant of the group (\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
+	s.Step(`^I can watch the group (\w+)$`, ctx.ICanWatchGroup)
+	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
 		ctx.ICanViewOnItemWithID)
 	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
-	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
-	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
+	s.Step(`^(\w+) has approved access to his personal info for the group (\w+)`, ctx.HasApprovedAccessPersonalInfoForGroup)
+
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
+
+	s.Step(`^there are the following threads:$`, ctx.ThereAreThreads)
 	s.Step(`^there is a thread with "([^"]*)"$`, ctx.ThereIsAThreadWith)
 	s.Step(`^there is no thread with "([^"]*)"$`, ctx.ThereIsNoThreadWith)
 	s.Step(`^I am part of the helper group of the thread$`, ctx.IAmPartOfTheHelperGroupOfTheThread)
@@ -60,6 +71,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response error message should contain "(.*)"$`, ctx.TheResponseErrorMessageShouldContain)
 
 	s.Step(`^it should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
+	s.Step(`^the response should match the following JSONPath:$`,
+		ctx.TheResponseShouldMatchFollowingJSONPath)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)
 	s.Step(`^the table "([^"]*)" should be empty$`, ctx.TableShouldBeEmpty)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -47,7 +47,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^I am a manager of the group (@\w+) and can watch its members$`, ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^the group (@\w+) is a descendant of the group (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
-	s.Step(`^there are the following item tasks:$`, ctx.ThereAreTheFollowingItemTasks)
+	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
 	s.Step(`^I can watch the group (@\w+)$`, ctx.ICanWatchGroup)
 	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
@@ -77,10 +77,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response should be "([^"]*)"$`, ctx.TheResponseShouldBe)
 	s.Step(`^the response error message should contain "(.*)"$`, ctx.TheResponseErrorMessageShouldContain)
 
-	s.Step(`^it should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
+	s.Step(`^the response should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
 	s.Step(`^the response at ([^ ]+) should be "([^"]+)"$`, ctx.TheResponseAtShouldBeTheValue)
 	s.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
-	s.Step(`^the response should match the following JSONPath:$`, ctx.TheResponseAtShouldBe)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)
 	s.Step(`^the table "([^"]*)" should be empty$`, ctx.TableShouldBeEmpty)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -39,12 +39,16 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^there is a group (\w+)$`, ctx.ThereIsAGroup)
 	s.Step(`^there is a group (\w+) referenced by @(\w+)$`, ctx.ThereIsAGroupReferencedBy)
 	s.Step(`^the group (\w+) is referenced by @(\w+)`, ctx.ThereIsAGroupReferencedBy)
-	s.Step(`^there are the following group members:$`, ctx.ThereAreTheFollowingGroupMembers)
 	s.Step(`^I am a member of the group (\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
-	s.Step(`^(\w+) the (?:\w+) is a member of the group (\w+)$`, ctx.UserIsAMemberOfTheGroup)
+	s.Step(`^(\w+) is a member of the group (\w+)$`, ctx.UserIsAMemberOfTheGroup)
+	s.Step(
+		`^(\w+) is a member of the group (\w+) who has approved access to his personal info$`,
+		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
+	)
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmTheManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (\w+)$`, ctx.IAmTheManagerOfTheGroup)
+	s.Step(`^I am a manager of the group (\w+) and can watch its members$`, ctx.IAmTheManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^the group (\w+) is a descendant of the group (\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
 	s.Step(`^there are the following items with permissions:$`, ctx.ThereAreTheFollowingItemsWithPermissions)
 	s.Step(`^I can watch the group (\w+)$`, ctx.ICanWatchGroup)
@@ -54,7 +58,6 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
-	s.Step(`^(\w+) has approved access to his personal info for the group (\w+)`, ctx.HasApprovedAccessPersonalInfoForGroup)
 
 	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
 
@@ -76,8 +79,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response error message should contain "(.*)"$`, ctx.TheResponseErrorMessageShouldContain)
 
 	s.Step(`^it should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
-	s.Step(`^the response should match the following JSONPath:$`,
-		ctx.TheResponseShouldMatchFollowingJSONPath)
+	s.Step(`^the response at ([^ ]+) should be "([^"]+)"$`, ctx.TheResponseAtShouldBeTheValue)
+	s.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
+	s.Step(`^the response should match the following JSONPath:$`, ctx.TheResponseAtShouldBe)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)
 	s.Step(`^the table "([^"]*)" should be empty$`, ctx.TableShouldBeEmpty)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -12,12 +12,16 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/rand"
 )
 
-// getParametersMap parses parameters in format key1=val1,key2=val2,... into a map.
-func getParametersMap(parameters string) map[string]string {
+// ctx.getParametersMap parses parameters in format key1=val1,key2=val2,... into a map.
+func (ctx *TestContext) getParametersMap(parameters string) map[string]string {
 	parametersMap := make(map[string]string)
 	arrayParameters := strings.Split(parameters, ",")
 	for _, paramKeyValue := range arrayParameters {
 		keyVal := strings.Split(paramKeyValue, "=")
+		if keyVal[1][0] == '@' {
+			keyVal[1] = ctx.replaceReferencesByIDs(keyVal[1])
+		}
+
 		parametersMap[keyVal[0]] = keyVal[1]
 	}
 
@@ -37,7 +41,6 @@ func getParametersString(parameters map[string]string) string {
 	return str
 }
 
-// populateDatabase populate the database with all the initialized data.
 func (ctx *TestContext) populateDatabase() error {
 	db, err := database.Open(ctx.db())
 	if err != nil {
@@ -186,22 +189,27 @@ func (ctx *TestContext) addThread(itemID, participantID, helperGroupID, status, 
 
 // IAm Sets the current user.
 func (ctx *TestContext) IAm(name string) error {
-	userID := rand.Int63()
-
-	err := ctx.ThereIsAUserWith(getParametersString(map[string]string{
-		"id":   strconv.FormatInt(userID, 10),
-		"name": name,
-	}))
+	err := ctx.ThereIsAUser(name)
 	if err != nil {
 		return err
 	}
 
-	return ctx.IAmUserWithID(userID)
+	return ctx.IAmUserWithID(ctx.getReferenceFor(name))
+}
+
+// ThereIsAUser create a user.
+func (ctx *TestContext) ThereIsAUser(name string) error {
+	userID := ctx.getReferenceFor(name)
+
+	return ctx.ThereIsAUserWith(getParametersString(map[string]string{
+		"id":   strconv.FormatInt(userID, 10),
+		"name": name,
+	}))
 }
 
 // ThereIsAUserWith creates a new user.
 func (ctx *TestContext) ThereIsAUserWith(parameters string) error {
-	user := getParametersMap(parameters)
+	user := ctx.getParametersMap(parameters)
 
 	ctx.addUser(user["id"], user["name"])
 
@@ -214,7 +222,7 @@ func (ctx *TestContext) ThereIsAUserWith(parameters string) error {
 
 // ThereIsAGroupWith creates a new group.
 func (ctx *TestContext) ThereIsAGroupWith(parameters string) error {
-	group := getParametersMap(parameters)
+	group := ctx.getParametersMap(parameters)
 
 	ctx.addGroup(group["id"], "Group "+group["id"])
 	ctx.addGroupAncestor(group["id"], group["id"])
@@ -268,6 +276,11 @@ func (ctx *TestContext) IAmAMemberOfTheGroupWithID(groupID int64) error {
 	return nil
 }
 
+// IAmAMemberOfTheGroup puts a user in a group.
+func (ctx *TestContext) IAmAMemberOfTheGroup(name string) error {
+	return ctx.IAmAMemberOfTheGroupWithID(ctx.getReferenceFor(name))
+}
+
 // ICanOnItemWithID gives the user a permission on an item.
 func (ctx *TestContext) ICanOnItemWithID(watchType, watchValue string, itemID int64) error {
 	ctx.addPermissionGenerated(strconv.FormatInt(ctx.userID, 10), strconv.FormatInt(itemID, 10), watchType, watchValue)
@@ -302,7 +315,7 @@ func (ctx *TestContext) IHaveValidatedItemWithID(itemID int64) error {
 
 // ThereIsAThreadWith creates a thread.
 func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
-	thread := getParametersMap(parameters)
+	thread := ctx.getParametersMap(parameters)
 
 	// add item
 	ctx.addItem(thread["item_id"], "en", "Task")
@@ -341,7 +354,7 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 
 // ThereIsNoThreadWith states that a given thread doesn't exist.
 func (ctx *TestContext) ThereIsNoThreadWith(parameters string) error {
-	thread := getParametersMap(parameters)
+	thread := ctx.getParametersMap(parameters)
 
 	ctx.addItem(thread["item_id"], "en", "Task")
 

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -21,6 +21,11 @@ const (
 	deleted
 )
 
+const (
+	UserGroupID = "group_id"
+	UserLogin   = "login"
+)
+
 func (ctx *TestContext) DBHasTable(table string, data *messages.PickleStepArgument_PickleTable) error { // nolint
 	db := ctx.db()
 
@@ -110,11 +115,11 @@ func (ctx *TestContext) DBHasUsers(data *messages.PickleStepArgument_PickleTable
 		groupIDColumnNumber := -1
 		loginColumnNumber := -1
 		for number, cell := range head {
-			if cell.Value == "group_id" {
+			if cell.Value == UserGroupID {
 				groupIDColumnNumber = number
 				continue
 			}
-			if cell.Value == "login" {
+			if cell.Value == UserLogin {
 				loginColumnNumber = number
 				continue
 			}

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -25,10 +25,16 @@ func (ctx *TestContext) DBHasTable(table string, data *messages.PickleStepArgume
 	db := ctx.db()
 
 	if len(data.Rows) > 1 {
+		referenceColumnIndex := -1
 		head := data.Rows[0].Cells
 		fields := make([]string, 0, len(head))
 		marks := make([]string, 0, len(head))
-		for _, cell := range head {
+
+		for i, cell := range head {
+			if cell.Value == "@reference" {
+				referenceColumnIndex = i
+			}
+
 			fields = append(fields, database.QuoteName(cell.Value))
 			marks = append(marks, "?")
 		}
@@ -42,10 +48,12 @@ func (ctx *TestContext) DBHasTable(table string, data *messages.PickleStepArgume
 			" (" + strings.Join(fields, ", ") + ") VALUES " + finalMarksString
 		vals := make([]interface{}, 0, (len(data.Rows)-1)*len(head))
 		for i := 1; i < len(data.Rows); i++ {
-			for _, cell := range data.Rows[i].Cells {
-				var err error
-				if cell.Value, err = ctx.preprocessString(cell.Value); err != nil {
-					return err
+			for j, cell := range data.Rows[i].Cells {
+				if j != referenceColumnIndex {
+					var err error
+					if cell.Value, err = ctx.preprocessString(cell.Value); err != nil {
+						return err
+					}
 				}
 				vals = append(vals, dbDataTableValue(cell.Value))
 			}

--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 
 func (ctx *TestContext) IAmUserWithID(userID int64) error { //nolint
 	ctx.userID = userID
+	ctx.user = strconv.FormatInt(userID, 10)
+
 	db, err := database.Open(ctx.db())
 	if err != nil {
 		return err

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -4,11 +4,13 @@ package testhelpers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/cucumber/messages-go/v10"
 	"github.com/pmezard/go-difflib/difflib"
 
@@ -25,10 +27,81 @@ func (ctx *TestContext) ItShouldBeAJSONArrayWithEntries(count int) error { //nol
 	}
 
 	if count != len(objmap) {
-		return fmt.Errorf("the result does not have the expected length. Expected: %d, received: %d", count, len(objmap))
+		return fmt.Errorf("the result does not have the expected length. Expected: %d, received: %d on %v",
+			count, len(objmap), ctx.lastResponseBody)
 	}
 
 	return nil
+}
+
+// TheResponseShouldMatchFollowingJSONPath checks whether the response contains the right JSONPath values.
+func (ctx *TestContext) TheResponseShouldMatchFollowingJSONPath(dataTable *messages.PickleStepArgument_PickleTable) error {
+	headerRow := dataTable.Rows[0]
+	for i := 1; i < len(dataTable.Rows); i++ {
+		JSONPath := ""
+		value := ""
+
+		row := dataTable.Rows[i]
+		for j := 0; j < len(row.Cells); j++ {
+			cell := row.Cells[j]
+
+			switch headerRow.Cells[j].Value {
+			case "JSONPath":
+				JSONPath = cell.Value
+			case "value":
+				value = ctx.replaceReferencesByIDs(cell.Value)
+			default:
+				return fmt.Errorf("call TheResponseShouldMatchFollowingJSONPath: unrecognized column name: %v", headerRow.Cells[j].Value)
+			}
+		}
+
+		if JSONPath == "" || value == "" {
+			return errors.New("call TheResponseShouldMatchFollowingJSONPath: undefined JSONPath or value")
+		}
+
+		match, err := ctx.responseMatchesJSONPath(JSONPath, value)
+		if err != nil {
+			return fmt.Errorf("error while trying to match JSONPath %v with response %v: %v",
+				JSONPath, ctx.lastResponseBody, err)
+		} else if !match {
+			return fmt.Errorf("the response's JSONPath %v doesn't match the value %v for response %v",
+				JSONPath, value, ctx.lastResponseBody)
+		}
+	}
+
+	return nil
+}
+
+// responseMatchesJSONPath checks whether the response matches a value at a JSONPath.
+func (ctx *TestContext) responseMatchesJSONPath(jsonPath, value string) (bool, error) {
+	// Note: Unmarshal could be cached.
+	// Note: When XPath returns an array, it could be possible to use cache/sort to make if more efficient
+
+	var JSONResponse interface{}
+	err := json.Unmarshal([]byte(ctx.lastResponseBody), &JSONResponse)
+	if err != nil {
+		return false, err
+	}
+
+	res, err := jsonpath.Get(jsonPath, JSONResponse)
+	if err != nil {
+		return false, err
+	}
+
+	switch result := res.(type) {
+	case []interface{}:
+		for _, val := range result {
+			if val == value {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	case interface{}:
+		return result == value, nil
+	default:
+		return false, fmt.Errorf("type %v from jsonpath.Get not handled", result)
+	}
 }
 
 func (ctx *TestContext) TheResponseCodeShouldBe(code int) error { //nolint
@@ -122,7 +195,7 @@ func compareStrings(expected, actual string) error {
 
 const nullHeaderValue = "[NULL]"
 
-func (ctx *TestContext) TheResponseHeaderShouldBe(headerName string, headerValue string) (err error) { //nolint
+func (ctx *TestContext) TheResponseHeaderShouldBe(headerName string, headerValue string) (err error) { // nolint
 	headerValue, err = ctx.preprocessString(headerValue)
 	if err != nil {
 		return err
@@ -160,7 +233,7 @@ func (ctx *TestContext) TheResponseHeadersShouldBe(headerName string, headersVal
 	return ctx.TheResponseHeaderShouldBe(headerName, headerValue)
 }
 
-func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err error) { //nolint
+func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err error) { // nolint
 	errorResp := service.ErrorResponse{}
 	// decode response
 	if err = json.Unmarshal([]byte(ctx.lastResponseBody), &errorResp); err != nil {
@@ -173,7 +246,7 @@ func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err erro
 	return nil
 }
 
-func (ctx *TestContext) TheResponseShouldBe(kind string) error { //nolint
+func (ctx *TestContext) TheResponseShouldBe(kind string) error { // nolint
 	var expectedCode int
 	switch kind {
 	case "updated", "deleted":

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -83,9 +83,9 @@ func (ctx *TestContext) replaceReferencesByIDs(str string) string {
 
 		if capture[0] == ReferencePrefix {
 			return strconv.FormatInt(ctx.getReferenceFor(capture[1:]), 10)
-		} else {
-			return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
 		}
+
+		return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
 	})
 }
 

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -25,43 +25,12 @@ var (
 	replaceReferencesRegexp = regexp.MustCompile(`(^|\W)(@\w+)`)
 )
 
-// setReference sets a reference id.
-func (ctx *TestContext) setReference(reference, value string) {
-	referenceName := reference
-	if referenceName[0] != ReferencePrefix {
-		referenceName = string(ReferencePrefix) + reference
-	}
-
-	id, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx.identifierReferences[referenceName] = id
-}
-
-// getReferenceFor gets the ID from a reference.
-func (ctx *TestContext) getReferenceFor(name string) int64 {
-	id, err := strconv.ParseInt(name, 10, 64)
-	if err == nil {
+// getOrCreateReferenceFor gets the ID from a reference, or create the reference if it doesn't exist.
+func (ctx *TestContext) getReference(reference string) int64 {
+	if id, err := strconv.ParseInt(reference, 10, 64); err == nil {
 		return id
 	}
 
-	if name[0] != ReferencePrefix {
-		name = string(ReferencePrefix) + name
-	}
-
-	value, ok := ctx.identifierReferences[name]
-	if !ok {
-		panic(fmt.Errorf("getReferenceFor: %s reference not found", name))
-	}
-
-	return value
-}
-
-// getOrCreateReferenceFor gets the ID from a reference, or create the reference if it doesn't exist.
-func (ctx *TestContext) getOrCreateReferenceFor(name string) int64 {
-	reference := string(ReferencePrefix) + name
 	if value, ok := ctx.identifierReferences[reference]; ok {
 		return value
 	}
@@ -82,10 +51,10 @@ func (ctx *TestContext) replaceReferencesByIDs(str string) string {
 		// - /@Reference (or another non-alphanum character in front)
 
 		if capture[0] == ReferencePrefix {
-			return strconv.FormatInt(ctx.getReferenceFor(capture[1:]), 10)
+			return strconv.FormatInt(ctx.getReference(capture), 10)
 		}
 
-		return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
+		return string(capture[0]) + strconv.FormatInt(ctx.getReference(capture[1:]), 10)
 	})
 }
 

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -15,13 +15,42 @@ import (
 	"github.com/CloudyKit/jet"
 	"github.com/SermoDigital/jose/crypto"
 
+	"github.com/France-ioi/AlgoreaBackend/app/rand"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
 	"github.com/France-ioi/AlgoreaBackend/app/tokentest"
 )
 
 var dbPathRegexp = regexp.MustCompile(`^\s*(\w+)\[(\d+)]\[(\w+)]\s*$`)
+var replaceReferencesRegexp = regexp.MustCompile(`(^|\W)(@\w+)`)
+
+// getReferenceFor gets the ID from a reference, or set it if it doesn't exist.
+func (ctx *TestContext) getReferenceFor(name string) int64 {
+	if _, ok := ctx.identifierReferences[name]; !ok {
+		ctx.identifierReferences[name] = rand.Int63()
+	}
+
+	return ctx.identifierReferences[name]
+}
+
+// replaceReferencesByIDs changes the references (@ref) in a string by the referenced identifiers (ID).
+func (ctx *TestContext) replaceReferencesByIDs(str string) string {
+	// a reference should either be at the beginning of the string (^), or after a non alpha-num character (\W).
+	// we don't want to rewrite email addresses.
+	return replaceReferencesRegexp.ReplaceAllStringFunc(str, func(capture string) string {
+		// capture is either:
+		// - @Reference
+		// - /@Reference (or another non-alphanum character in front)
+
+		if capture[0] == '@' {
+			return strconv.FormatInt(ctx.getReferenceFor(capture[1:]), 10)
+		} else {
+			return string(capture[0]) + strconv.FormatInt(ctx.getReferenceFor(capture[2:]), 10)
+		}
+	})
+}
 
 func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
+	jsonBody = ctx.replaceReferencesByIDs(jsonBody)
 	tmpl, err := ctx.templateSet.Parse("template", jsonBody)
 	if err != nil {
 		return "", err

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -34,6 +34,7 @@ type TestContext struct {
 	// nolint
 	application          *app.Application // do NOT call it directly, use `app()`
 	userID               int64            // userID that will be used for the next requests
+	user                 string           // user reference of the logged user
 	featureQueries       []dbquery
 	lastResponse         *http.Response
 	lastResponseBody     string

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -32,19 +32,20 @@ type dbquery struct {
 // TestContext implements context for tests.
 type TestContext struct {
 	// nolint
-	application      *app.Application // do NOT call it directly, use `app()`
-	userID           int64            // userID that will be used for the next requests
-	featureQueries   []dbquery
-	lastResponse     *http.Response
-	lastResponseBody string
-	logsHook         *loggingtest.Hook
-	logsRestoreFunc  func()
-	inScenario       bool
-	dbTableData      map[string]*messages.PickleStepArgument_PickleTable
-	templateSet      *jet.Set
-	requestHeaders   map[string][]string
-	dbTables         map[string]map[string]map[string]interface{}
-	currentThreadKey string
+	application          *app.Application // do NOT call it directly, use `app()`
+	userID               int64            // userID that will be used for the next requests
+	featureQueries       []dbquery
+	lastResponse         *http.Response
+	lastResponseBody     string
+	logsHook             *loggingtest.Hook
+	logsRestoreFunc      func()
+	inScenario           bool
+	dbTableData          map[string]*messages.PickleStepArgument_PickleTable
+	templateSet          *jet.Set
+	requestHeaders       map[string][]string
+	identifierReferences map[string]int64
+	dbTables             map[string]map[string]map[string]interface{}
+	currentThreadKey     string
 }
 
 var db *sql.DB
@@ -66,6 +67,7 @@ func (ctx *TestContext) SetupTestContext(pickle *messages.Pickle) { // nolint
 	ctx.requestHeaders = map[string][]string{}
 	ctx.dbTableData = make(map[string]*messages.PickleStepArgument_PickleTable)
 	ctx.templateSet = ctx.constructTemplateSet()
+	ctx.identifierReferences = make(map[string]int64)
 	ctx.dbTables = make(map[string]map[string]map[string]interface{})
 
 	// reset the seed to get predictable results on PRNG for tests


### PR DESCRIPTION
Issue #888 

Only implemented `watch_group_id` for now.

A new package have been included: [github.com/PaesslerAG/jsonpath](https://github.com/PaesslerAG/jsonpath)

It is used so that we can directly check that some value at some location in the JSON matches. [*] means that the order doesn't matter. With this functionality, we don't need to verify the whole response for each test anymore, so:

- The tests are less brittle. If we add/rename/remove a field, or change the order of the fields in the response, we don't have to change all the tests anymore
-  The responsibility of each test is more focused on a single functionality, rather than each test testing the same things many times, + one single thing
- Easier to visualize when the result contains a list of items: only one line per item

The definitions are a higher level than the database tables to avoid defining too many tables and having to cross-check the references every time.

I already added the test data for the implementation of `is_mine`, which is not implement yet, because it had a big impact on the structure of the data.