### PR TITLE
ListThread service: add is_mine parameter

### DIFF
--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -38,11 +38,13 @@ Feature: List threads
       | @B_SectionMember2_CanViewContent1               | @B_SectionMember2   | content                  |           |
       | @B_SectionMember2_CanViewContent2               | @B_SectionMember2   | content                  |           |
       | @B_SectionMember2_CanViewContentWithDescendants | @B_SectionMember2   | content_with_descendants |           |
-      | @B_UniversityMember_HasNotValidated             | @B_UniversityMember |                          | answer    |
-      | @B_UniversityMember_CanWatchAnswer1             | @B_UniversityMember |                          | answer    |
-      | @B_UniversityMember_CanWatchAnswer2             | @B_UniversityMember |                          | answer    |
-      | @B_UniversityMember_CanWatchAnswer3             | @B_UniversityMember |                          | answer    |
-      | @B_UniversityMember_CanWatchAnswer4             | @B_UniversityMember |                          | answer    |
+      | @B_UniversityMember_HasNotValidated             | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_CanWatchAnswer1             | @B_UniversityMember | info                     | answer    |
+      | @B_UniversityMember_CanWatchAnswer2             | @B_UniversityMember | info                     | answer    |
+      | @B_UniversityMember_CanWatchAnswer3             | @B_UniversityMember | info                     | answer    |
+      | @B_UniversityMember_CanWatchAnswer4             | @B_UniversityMember | info                     | answer    |
+      | @B_UniversityMember_CanWatchAnswer5             | @B_UniversityMember | info                     | answer    |
+      | @B_UniversityMember_CanWatchAnswer6             | @B_UniversityMember | none                     | answer    |
     And there are the following results:
       | item                              | participant         | validated |
       | @B_UniversityMember_HasValidated1 | @B_UniversityMember | 1         |
@@ -52,27 +54,28 @@ Feature: List threads
       | @B_UniversityMember_HasValidated5 | @B_UniversityMember | 1         |
       | @B_UniversityMember_HasValidated6 | @B_UniversityMember | 1         |
     Given there are the following threads:
-      | participant         | item                                            | helper_group  | status                  | latest_update_at     | comment                                                                                                                       |
-      | @ConsortiumMember   | @Item1                                          |               |                         |                      |                                                                                                                               |
-      | @A_UniversityMember | @Item2                                          |               |                         |                      |                                                                                                                               |
-      | @A_ClassMember      | @Item3                                          |               |                         |                      |                                                                                                                               |
-      | @B_UniversityMember | @B_UniversityMember_CanWatchAnswer1             |               |                         |                      | @B_UniversityMember is_mine=0 -> notok: must not be the participant                                                           |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated1               | @B_Section    | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread notok: not part of helper group                                                  |
-      | @B_SectionMember1   | @B_UniversityMember_HasNotValidated             | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread notok: Has not validated                                                         |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated2               | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated3               | @Consortium   | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer2             | @B_University | waiting_for_trainer     |                      | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated4               | @B_University | waiting_for_participant |                      | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
-      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer3             | @B_University | waiting_for_participant |                      | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated5               | @B_University | closed                  | 2021-12-20T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, closed thread for less than 2 weeks and validated item |
-      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer4             | @B_University | closed                  | 2021-12-20T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | @B_SectionMember1   | @B_UniversityMember_HasValidated6               | @B_University | closed                  | 2021-11-00T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread notok: closed for more than 2 weeks                                              |
-      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer5             | @B_University | closed                  | 2021-11-00T00:00:00Z | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
-      | @B_SectionMember2   | @B_SectionMember2_CanViewInfo                   |               |                         |                      | @B_SectionMember2 is_mine=1 -> notok: can_view < content                                                                      |
-      | @B_SectionMember2   | @B_SectionMember2_CanViewContent1               |               |                         |                      | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
-      | @B_SectionMember3   | @B_SectionMember2_CanViewContent2               |               |                         |                      | @B_SectionMember2 is_mine=1 -> notok: not the participant                                                                     |
-      | @B_SectionMember2   | @B_SectionMember2_CanViewContentWithDescendants |               |                         |                      | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
-      | @OtherGroupMember   | @Item4                                          |               |                         |                      |                                                                                                                               |
+      | participant         | item                                            | helper_group  | status                  | latest_update_at    | message_count | comment                                                                                                                       |
+      | @ConsortiumMember   | @Item1                                          |               |                         |                     | 0             |                                                                                                                               |
+      | @A_UniversityMember | @Item2                                          |               |                         |                     | 1             |                                                                                                                               |
+      | @A_ClassMember      | @Item3                                          |               |                         |                     | 2             |                                                                                                                               |
+      | @B_UniversityMember | @B_UniversityMember_CanWatchAnswer1             |               |                         |                     | 3             | @B_UniversityMember is_mine=0 -> notok: must not be the participant                                                           |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated1               | @B_Section    | waiting_for_trainer     |                     | 4             | @B_UniversityMember is_mine=0 -> List thread notok: not part of helper group                                                  |
+      | @B_SectionMember1   | @B_UniversityMember_HasNotValidated             | @B_University | waiting_for_trainer     |                     | 5             | @B_UniversityMember is_mine=0 -> List thread notok: Has not validated                                                         |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated2               | @B_University | waiting_for_trainer     |                     | 6             | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated3               | @Consortium   | waiting_for_trainer     |                     | 7             | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer2             | @B_University | waiting_for_trainer     |                     | 8             | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated4               | @B_University | waiting_for_participant |                     | 9             | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, open thread and validated item                         |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer3             | @B_University | waiting_for_participant |                     | 10            | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer6             | @B_University | waiting_for_participant |                     | 11            | @B_UniversityMember is_mine=0 -> List thread notok: cannot view the item                                                      |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated5               | @B_University | closed                  | 2021-12-20 00:00:00 | 12            | @B_UniversityMember is_mine=0 -> List thread ok: part of helper group, closed thread for less than 2 weeks and validated item |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer4             | @B_University | closed                  | 2021-12-20 00:00:00 | 13            | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember1   | @B_UniversityMember_HasValidated6               | @B_University | closed                  | 2021-11-01 00:00:00 | 14            | @B_UniversityMember is_mine=0 -> List thread notok: closed for more than 2 weeks                                              |
+      | @B_SectionMember1   | @B_UniversityMember_CanWatchAnswer5             | @B_University | closed                  | 2021-11-01 00:00:00 | 15            | @B_UniversityMember is_mine=0 -> List thread ok: can_watch >= answer                                                          |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewInfo                   |               |                         |                     | 16            | @B_SectionMember2 is_mine=1 -> notok: can_view < content                                                                      |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewContent1               |               |                         |                     | 17            | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
+      | @B_SectionMember3   | @B_SectionMember2_CanViewContent2               |               |                         |                     | 18            | @B_SectionMember2 is_mine=1 -> notok: not the participant                                                                     |
+      | @B_SectionMember2   | @B_SectionMember2_CanViewContentWithDescendants |               |                         |                     | 19            | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
+      | @OtherGroupMember   | @Item4                                          |               |                         |                     | 20            |                                                                                                                               |
     And the time now is "2022-01-01T00:00:00Z"
 
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
@@ -153,9 +156,23 @@ Feature: List threads
     And the response at $[0].participant.id should be "@A_ClassMember"
 
   Scenario: Should return only the threads in which the participant is the current user and the item is visible when is_mine=1
-    # @B_SectionMember2 can see @B_SectionMember2_CanViewContent and @B_SectionMember2_CanViewContentWithDescendants
-    # Waiting for implementation of is_mine
+    Given I am @B_SectionMember2
+    When I send a GET request to "/threads?is_mine=1"
+    Then the response code should be 200
+    And the response at $[*].item.id should be:
+      | @B_SectionMember2_CanViewContent1               |
+      | @B_SectionMember2_CanViewContentWithDescendants |
 
   Scenario: Should return only the threads that the current-user can list and in which he is not the participant when is_mine=0
-    # @B_UniversityMember can see @B_UniversityMember_HasValidated2, @B_UniversityMember_HasValidated3, @B_UniversityMember_CanWatchAnswer2, @B_UniversityMember_HasValidated4, @B_UniversityMember_CanWatchAnswer3, @B_UniversityMember_HasValidated5, @B_UniversityMember_CanWatchAnswer4, @B_UniversityMember_CanWatchAnswer5
-    # Waiting for implementation of is_mine
+    Given I am @B_UniversityMember
+    When I send a GET request to "/threads?is_mine=0"
+    Then the response code should be 200
+    And the response at $[*].item.id should be:
+      | @B_UniversityMember_HasValidated2   |
+      | @B_UniversityMember_HasValidated3   |
+      | @B_UniversityMember_CanWatchAnswer2 |
+      | @B_UniversityMember_HasValidated4   |
+      | @B_UniversityMember_CanWatchAnswer3 |
+      | @B_UniversityMember_HasValidated5   |
+      | @B_UniversityMember_CanWatchAnswer4 |
+      | @B_UniversityMember_CanWatchAnswer5 |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -28,6 +28,8 @@ Feature: List threads
       | @B_UniversityMember_CanWatchAnswer2             |
       | @B_UniversityMember_CanWatchAnswer3             |
       | @B_UniversityMember_CanWatchAnswer4             |
+      | @B_UniversityMember_CanWatchAnswer5             |
+      | @B_UniversityMember_CanWatchAnswer6             |
       | @Item1                                          |
       | @Item2                                          |
       | @Item3                                          |
@@ -39,6 +41,12 @@ Feature: List threads
       | @B_SectionMember2_CanViewContent2               | @B_SectionMember2   | content                  |           |
       | @B_SectionMember2_CanViewContentWithDescendants | @B_SectionMember2   | content_with_descendants |           |
       | @B_UniversityMember_HasNotValidated             | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated1               | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated2               | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated3               | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated4               | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated5               | @B_UniversityMember | info                     |           |
+      | @B_UniversityMember_HasValidated6               | @B_UniversityMember | info                     |           |
       | @B_UniversityMember_CanWatchAnswer1             | @B_UniversityMember | info                     | answer    |
       | @B_UniversityMember_CanWatchAnswer2             | @B_UniversityMember | info                     | answer    |
       | @B_UniversityMember_CanWatchAnswer3             | @B_UniversityMember | info                     | answer    |

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -43,20 +43,30 @@ type participant struct {
 //
 //		Service to list the visible threads for a user.
 //
+//		Exactly one of [`watched_group_id`, `is_mine`] is given
+//
+//		* If `is_mine` = 1, only threads for which the participant is the current-user and for which the current-user has
+//			`can_view >= content` on the item are returned.
+//		* If `is_mine` = 0, only threads that the current-user
+//			[https://france-ioi.github.io/algorea-devdoc/forum/forum-perm/#listing--reading-a-thread](can list) and for which
+//			the current-user is NOT the participant are returned.
 //		* If `watched_group_id` is given, only threads in which the participant is descendant (including self)
-//		  of the `watched_group_id` are returned.
+//			of the `watched_group_id` are returned.
 //		* `first_name` and `last_name` are only returned for the current user or if the user approved access to their personal
-//		  info for some group managed by the current user
+//			info for some group managed by the current user.
 //
 //		Validations:
-//		  * if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
-//		    with `can_watch_members` on `watched_group_id`.
+//			* if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
+//				with `can_watch_members` on `watched_group_id`.
 //
 //	parameters:
 //		- name: watched_group_id
 //			in: query
 //			type: integer
 //			format: int64
+//		- name: is_mine
+//			in: query
+//			type: boolean
 //
 //	responses:
 //
@@ -75,22 +85,58 @@ type participant struct {
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service.APIError {
-	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
+	watchedGroupID, isMine, apiError := srv.resolveListThreadParameters(r)
 	if apiError != service.NoError {
 		return apiError
-	}
-	if !ok {
-		return service.ErrInvalidRequest(errors.New("not implemented yet: watchedGroupID must be given"))
 	}
 
 	user := srv.GetUser(r)
 	store := srv.GetStore(r)
 
 	var threads []thread
-	err := store.Threads().
+	query := store.Threads().
 		JoinsItem().
-		JoinsUserParticipant().
-		WhereParticipantIsInGroup(watchedGroupID).
+		JoinsUserParticipant()
+
+	switch {
+	case watchedGroupID != 0:
+		query = query.WhereParticipantIsInGroup(watchedGroupID)
+	case isMine:
+		query = query.NewThreadStore(query.
+			WhereGroupHasPermissionOnItems(user.GroupID, "view", "content").
+			Where("threads.participant_id = ?", user.GroupID),
+		)
+
+	case !isMine:
+		// The user needs to:
+		// - be allowed to view the item, AND
+		// - not be the participant of the thread, AND
+		// - one of the following conditions:
+		//		* [canWatchAnswerQuery] have can_watch>=answer permission on the item, OR:
+		//		* [userCanHelpQuery] The conditions of "WhereUserCanHelp"
+
+		// It doesn't seem to be very efficient to do this. We could try to leverage the fact that MatchingGroupAncestors
+		// is used in both canWatchAnswerQuery and WhereItemsAreVisible, if we measure perf issues.
+		canWatchAnswerQuery := store.Threads().
+			Select("items.id").
+			WhereUserHasPermissionOnItems(user, "watch", "answer").
+			SubQuery()
+
+		userCanHelpQuery := store.Threads().
+			WhereUserCanHelp(user).
+			Select("threads.item_id, threads.participant_id").
+			SubQuery()
+
+		query = query.NewThreadStore(query.
+			WhereItemsAreVisible(user.GroupID).
+			Where("threads.participant_id != ?", user.GroupID).
+			Where("threads.item_id IN (?) OR (threads.item_id, threads.participant_id) IN (?)", canWatchAnswerQuery, userCanHelpQuery),
+		)
+	default:
+		return service.ErrNotFound(errors.New("not implemented"))
+	}
+
+	err := query.
 		JoinsUserAndDefaultItemStrings(user).
 		WithPersonalInfoViewApprovals(user).
 		Order("items.id ASC"). // Default to make the result deterministic.
@@ -113,4 +159,24 @@ func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service
 
 	render.Respond(rw, r, threads)
 	return service.NoError
+}
+
+func (srv *Service) resolveListThreadParameters(r *http.Request) (watchedGroupID int64, isMine bool, apiError service.APIError) {
+	var watchedGroupOK bool
+	watchedGroupID, watchedGroupOK, apiError = srv.ResolveWatchedGroupID(r)
+	if apiError != service.NoError {
+		return 0, false, apiError
+	}
+
+	var isMineError error
+	isMine, isMineError = service.ResolveURLQueryGetBoolField(r, "is_mine")
+
+	if watchedGroupOK && isMineError == nil {
+		return 0, false, service.ErrInvalidRequest(errors.New("must not provide watched_group_id and is_mine at the same time"))
+	}
+	if !watchedGroupOK && isMineError != nil {
+		return 0, false, service.ErrInvalidRequest(errors.New("one of watched_group_id or is_mine must be given"))
+	}
+
+	return watchedGroupID, isMine, service.NoError
 }

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -101,6 +101,7 @@ func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service
 	switch {
 	case watchedGroupID != 0:
 		query = query.WhereParticipantIsInGroup(watchedGroupID)
+
 	case isMine:
 		query = query.NewThreadStore(query.
 			WhereGroupHasPermissionOnItems(user.GroupID, "view", "content").

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -132,8 +132,6 @@ func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service
 			Where("threads.participant_id != ?", user.GroupID).
 			Where("threads.item_id IN (?) OR (threads.item_id, threads.participant_id) IN (?)", canWatchAnswerQuery, userCanHelpQuery),
 		)
-	default:
-		return service.ErrNotFound(errors.New("not implemented"))
 	}
 
 	err := query.

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -11,12 +11,6 @@ Feature: List threads - robustness
     Then the response code should be 400
     And the response error message should contain "Wrong value for watched_group_id (should be int64)"
 
-  Scenario: watched_group_id should be given because the alternative is not implemented yet
-    Given I am @John
-    When I send a GET request to "/threads"
-    Then the response code should be 400
-    And the response error message should contain "Not implemented yet: watchedGroupID must be given"
-
   Scenario: The user should be a manager of watched_group_id group
     Given I am @John
     And there is a group @Classroom
@@ -31,3 +25,21 @@ Feature: List threads - robustness
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"
+
+  Scenario: Should have one of watched_group_id and is_mine given
+    Given I am @John
+    When I send a GET request to "/threads"
+    Then the response code should be 400
+    And the response error message should contain "One of watched_group_id or is_mine must be given"
+
+  Scenario Outline: Should not have watched_group_id and is_mine set a the same time
+    Given I am @John
+    And there is a group @Classroom
+    And I am a manager of the group @Classroom and can watch its members
+    When I send a GET request to "/threads?watched_group_id=@Classroom&is_mine=<is_mine>"
+    Then the response code should be 400
+    And the response error message should contain "Must not provide watched_group_id and is_mine at the same time"
+    Examples:
+      | is_mine |
+      | 0       |
+      | 1       |

--- a/app/utils/datetime.go
+++ b/app/utils/datetime.go
@@ -1,0 +1,6 @@
+// Package utils contains utility functions used by all modules.
+package utils
+
+// DateTimeFormat const is defined in go 1.20 in time.DateTime
+// remove when swagger circleci image is updated to go 1.20.
+const DateTimeFormat = "2006-01-02 15:04:05"

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -37,7 +37,6 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^there is a group (@\w+)$`, ctx.ThereIsAGroup)
 	s.Step(`^I am a member of the group (@\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
-	s.Step(`^there are the following group members:$`, ctx.ThereAreTheFollowingGroupMembers)
 	s.Step(`^(@\w+) is a member of the group (@\w+)$`, ctx.UserIsAMemberOfTheGroup)
 	s.Step(
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -37,11 +37,13 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^there is a group (@\w+)$`, ctx.ThereIsAGroup)
 	s.Step(`^I am a member of the group (@\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
+	s.Step(`^there are the following group members:$`, ctx.ThereAreTheFollowingGroupMembers)
 	s.Step(`^(@\w+) is a member of the group (@\w+)$`, ctx.UserIsAMemberOfTheGroup)
 	s.Step(
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
 	)
+
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmAManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)
 	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -642,6 +642,20 @@ func (ctx *TestContext) UserIsAMemberOfTheGroup(user, group string) error {
 	return ctx.GroupIsAChildOfTheGroup(user, group)
 }
 
+// ThereAreTheFollowingGroupMembers defines group memberships.
+func (ctx *TestContext) ThereAreTheFollowingGroupMembers(groupMembers *messages.PickleStepArgument_PickleTable) error {
+	for i := 1; i < len(groupMembers.Rows); i++ {
+		groupMember := ctx.getRowMap(i, groupMembers)
+
+		err := ctx.GroupIsAChildOfTheGroup(groupMember["member"], groupMember["group"])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo puts a user in a group with approved access to his personnel info.
 func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo(user, group string) error {
 	err := ctx.UserIsAMemberOfTheGroup(user, group)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -669,6 +669,7 @@ func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonal
 	if err != nil {
 		return err
 	}
+
 	ctx.addPersonalInfoViewApprovedFor(user, group)
 
 	return nil

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/rand"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 const ReferencePrefix = '@'
@@ -299,17 +300,23 @@ func (ctx *TestContext) getThreadKey(itemID, participantID int64) string {
 }
 
 // addThread adds a thread in database.
-func (ctx *TestContext) addThread(item, participant, helperGroup, status, messageCount string) {
+func (ctx *TestContext) addThread(item, participant, helperGroup, status, messageCount, latestUpdateAt string) {
 	itemID := ctx.getReference(item)
 	participantID := ctx.getReference(participant)
 	helperGroupID := ctx.getReference(helperGroup)
 
+	latestUpdateAtDate, err := time.Parse(utils.DateTimeFormat, latestUpdateAt)
+	if err != nil {
+		panic(err)
+	}
+
 	ctx.addInDatabase("threads", ctx.getThreadKey(itemID, participantID), map[string]interface{}{
-		"item_id":         itemID,
-		"participant_id":  participantID,
-		"helper_group_id": helperGroupID,
-		"status":          status,
-		"message_count":   messageCount,
+		"item_id":          itemID,
+		"participant_id":   participantID,
+		"helper_group_id":  helperGroupID,
+		"status":           status,
+		"message_count":    messageCount,
+		"latest_update_at": latestUpdateAtDate,
 	})
 }
 
@@ -762,6 +769,10 @@ func (ctx *TestContext) ThereAreTheFollowingThreads(threads *messages.PickleStep
 				threadParameters["latest_update_at"] = thread["latest_update_at"]
 			}
 
+			if thread["message_count"] != "" {
+				threadParameters["message_count"] = thread["message_count"]
+			}
+
 			err := ctx.ThereIsAThreadWith(getParameterString(threadParameters))
 			if err != nil {
 				return err
@@ -807,12 +818,24 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 		thread["message_count"] = "0"
 	}
 
+	// add latest update at
+	if _, ok := thread["latest_update_at"]; !ok {
+		thread["latest_update_at"] = time.Now().Format(utils.DateTimeFormat)
+	}
+
 	ctx.currentThreadKey = ctx.getThreadKey(
 		ctx.getReference(thread["item_id"]),
 		ctx.getReference(thread["participant_id"]),
 	)
 
-	ctx.addThread(thread["item_id"], thread["participant_id"], thread["helper_group_id"], thread["status"], thread["message_count"])
+	ctx.addThread(
+		thread["item_id"],
+		thread["participant_id"],
+		thread["helper_group_id"],
+		thread["status"],
+		thread["message_count"],
+		thread["latest_update_at"],
+	)
 
 	return nil
 }

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -649,20 +649,6 @@ func (ctx *TestContext) UserIsAMemberOfTheGroup(user, group string) error {
 	return ctx.GroupIsAChildOfTheGroup(user, group)
 }
 
-// ThereAreTheFollowingGroupMembers defines group memberships.
-func (ctx *TestContext) ThereAreTheFollowingGroupMembers(groupMembers *messages.PickleStepArgument_PickleTable) error {
-	for i := 1; i < len(groupMembers.Rows); i++ {
-		groupMember := ctx.getRowMap(i, groupMembers)
-
-		err := ctx.GroupIsAChildOfTheGroup(groupMember["member"], groupMember["group"])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo puts a user in a group with approved access to his personnel info.
 func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo(user, group string) error {
 	err := ctx.UserIsAMemberOfTheGroup(user, group)


### PR DESCRIPTION
Issue #888 

This PR handles the `is_mine` parameter for the listThread service.

Some rights between this and the getThread have been factorized into `WhereUserCanHelp`:
```
	// the following rules all matches:
	// the current-user is descendant of the thread helper_group
	// the thread is either open (=waiting_for_participant or =waiting_for_trainer), or closed for less than 2 weeks
	// the current-user has validated the item
```

The function `NewThreadStore` has been added because when we use a function defined on *DB, we end up being unable to use functions defined on *ThreadStore anymore, because we get a *DB in return. The reason relates to types: A *ThreadStore is a *DataStore is a *DB, but a *DB is not a *ThreadStore.

I'm not sure what's the best thing to do here, maybe there exists a pattern that would handle this case smoothly in go. The code seems to struggle with this everywhere, where the pattern used is:
```
func (s *ItemAncestorStore) DescendantsOf(ancestorID int64) *ItemItemStore {
	return &ItemItemStore{NewDataStoreWithTable(
		s.Where("items_ancestors.ancestor_item_id = ?", ancestorID), s.tableName,
	)}
}
```
At other times, it returns a *DB instead of a DataStore to avoid this issue. But then we lose consistence with some methods defined on a specific store which returns a specific *DataStore (eg. *ThreadStore, *GroupStore, ...), and others who return a *DB. It would be nice to decide which pattern to use for uniformization, and if possible for simplicity.


Note: I would have liked to add a "default" to the switch statement in list_threads to guarantee the correctness of the parameters. But the parameters are checked before in a function, and it made the code within the default unreachable, so it didn't pass the code coverage tests.