### PR TITLE
Add make validate-swagger to validate swagger annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,9 @@ test-bdd:
 lint: $(GOLANGCILINT)
 	$(GOLANGCILINT) run -v --deadline 10m0s
 
+validate-swagger:
+	swagger generate spec --scan-models -o ./swagger.yaml && swagger validate ./swagger.yaml
+
 dbdoc: $(MYSQL_CONNECTOR_JAVA) $(SCHEMASPY)
 	$(call check_defined, DBNAME)
 	$(call check_defined, DBHOST)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Open it in a browser:
 swagger serve ./swagger.yaml
 ```
 
+Once swagger is installed, you can validate swagger annotations project-wide with:
+```
+make validate-swagger
+```
+
 ## Create a release
 
 In order to create a release:


### PR DESCRIPTION
Adds:
`make validate-swagger`

To avoid going in the README to copy-paste the generate and the validate commands every time.

It would be even nicer to have a pre-commit rule, but running the command takes ~30s. We would have to fine-tune it a little more to make sure it runs only if required.