### PR TITLE
bestAnswerGet returns a 404 if permissions are ok but there is no answer

### DIFF
--- a/app/api/answers/get_best.robustness.feature
+++ b/app/api/answers/get_best.robustness.feature
@@ -75,12 +75,6 @@ Feature: Get the best answer - robustness
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
 
-  Scenario: No answer for the item
-    Given I am the user with id "11"
-    When I send a GET request to "/items/210/best-answer"
-    Then the response code should be 403
-    And the response error message should contain "Insufficient access rights"
-
   Scenario: The user is not allowed to watch the participant
     Given I am the user with id "11"
     When I send a GET request to "/items/210/best-answer?watched_group_id=13"

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -30,17 +30,27 @@ func (u *User) Clone() *User {
 	return &result
 }
 
-// CanWatchItemAnswer checks whether the user has can_watch >= answer on an item.
-func (u *User) CanWatchItemAnswer(s *DataStore, itemID int64) bool {
-	userCanWatchAnswer, err := s.Permissions().MatchingUserAncestors(u).
+// HasItemPermission checks whether the user have a certain permission on an item.
+func (u *User) HasItemPermission(s *DataStore, itemID int64, permissionType, permissionValue string) bool {
+	userHasPermission, err := s.Permissions().MatchingUserAncestors(u).
 		Where("permissions.item_id = ?", itemID).
-		WherePermissionIsAtLeast("watch", "answer").
+		WherePermissionIsAtLeast(permissionType, permissionValue).
 		Select("1").
 		Limit(1).
 		HasRows()
 	mustNotBeError(err)
 
-	return userCanWatchAnswer
+	return userHasPermission
+}
+
+// CanWatchItemAnswer checks whether the user has can_watch >= answer on an item.
+func (u *User) CanWatchItemAnswer(s *DataStore, itemID int64) bool {
+	return u.HasItemPermission(s, itemID, "watch", "answer")
+}
+
+// CanViewItemContent checks whether the user has can_view >= content on an item.
+func (u *User) CanViewItemContent(s *DataStore, itemID int64) bool {
+	return u.HasItemPermission(s, itemID, "view", "content")
 }
 
 // CanRequestHelpTo checks whether the user can request help on an item to a group.


### PR DESCRIPTION
Implements the 404 when there is no answer.

Those little queries: CanWatchItemAnswer, CanWatchGroupMembers, etc. seem to appear a lot and are probably executed many times during a user's session. We can consider caching them if we ever find they have a performance impact.