### PR TITLE
List Thread Service: item_id parameter

### DIFF
--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -195,3 +195,37 @@ Feature: List threads
       | @B_UniversityMember_HasValidated5   |
       | @B_UniversityMember_CanWatchAnswer4 |
       | @B_UniversityMember_CanWatchAnswer5 |
+
+    Scenario: Should return only thread from item or descendant when item_id is given
+      Given I am @John
+      And there are the following items:
+        | item              | parent      | type    |
+        | @Root_Task        |             | Task    |
+        | @Chapter1         |             | Chapter |
+        | @Chapter1_Task    | @Chapter1   | Task    |
+        | @Chapter2         |             | Chapter |
+        | @Chapter2_Task    | @Chapter2   | Task    |
+        | @Chapter2_1       | @Chapter2   | Chapter |
+        | @Chapter2_1_Task1 | @Chapter2_1 | Task    |
+        | @Chapter2_1_Task2 | @Chapter2_1 | Task    |
+        | @Chapter3         |             | Chapter |
+      And there are the following threads:
+        | participant | item              | visible_by_participant | message_count |
+        | @John       | @Root_Task        | 1                      | 100           |
+        | @John       | @Chapter1         | 1                      | 101           |
+        | @John       | @Chapter1_Task    | 1                      | 102           |
+        | @John       | @Chapter2         | 1                      | 103           |
+        | @John       | @Chapter2_Task    | 1                      | 104           |
+        | @John       | @Chapter3         | 1                      | 105           |
+        | @John       | @Chapter2_1       | 1                      | 106           |
+        | @John       | @Chapter2_1_Task1 | 1                      | 107           |
+        | @John       | @Chapter2_1_Task2 | 1                      | 108           |
+      And I am @John
+      When I send a GET request to "/threads?is_mine=1&item_id=@Chapter2"
+      Then the response code should be 200
+      And the response at $[*].item.id should be:
+        | @Chapter2         |
+        | @Chapter2_Task    |
+        | @Chapter2_1       |
+        | @Chapter2_1_Task1 |
+        | @Chapter2_1_Task2 |

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -11,6 +11,12 @@ Feature: List threads - robustness
     Then the response code should be 400
     And the response error message should contain "Wrong value for watched_group_id (should be int64)"
 
+  Scenario: item_id should be an integer
+    Given I am @John
+    When I send a GET request to "/threads?is_mine=1&item_id=aaa"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for item_id (should be int64)"
+
   Scenario: The user should be a manager of watched_group_id group
     Given I am @John
     And there is a group @Classroom

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -23,6 +23,13 @@ func (s *ItemStore) VisibleByID(groupID, itemID int64) *DB {
 	return s.Visible(groupID).Where("items.id = ?", itemID)
 }
 
+// WhereItemsAreSelfOrDescendantsOf filters items who are self or descendant of a given item.
+func (conn *DB) WhereItemsAreSelfOrDescendantsOf(itemAncestorID int64) *DB {
+	return conn.
+		Joins("LEFT JOIN items_ancestors ON items_ancestors.child_item_id = items.id").
+		Where("(items_ancestors.ancestor_item_id = ? OR items.id = ?)", itemAncestorID, itemAncestorID)
+}
+
 // IsValidParticipationHierarchyForParentAttempt checks if the given list of item ids is a valid participation hierarchy
 // for the given `parentAttemptID` which means all the following statements are true:
 //   - the first item in `ids` is a root activity/skill (groups.root_activity_id/root_skill_id)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -48,6 +48,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^I am a manager of the group (@\w+) and can watch its members$`, ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^the group (@\w+) is a descendant of the group (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
+	s.Step(`^there are the following items:$`, ctx.ThereAreTheFollowingItems)
 	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
 	s.Step(`^I can watch the group (@\w+)$`, ctx.ICanWatchGroup)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -97,6 +97,17 @@ func (ctx *TestContext) populateDatabase() error {
 		return err
 	}
 
+	// Compute items_ancestors.
+	// This also computes permissions_generated.
+	err = database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+		// We can consider keeping foreign_key_checks,
+		// but it'll break all tests that didn't define items while having permissions.
+		store.Exec("SET FOREIGN_KEY_CHECKS=0")
+		defer store.Exec("SET FOREIGN_KEY_CHECKS=1")
+
+		return store.ItemItems().After()
+	})
+
 	return ctx.DBGroupsAncestorsAreComputed()
 }
 
@@ -109,10 +120,10 @@ func (ctx *TestContext) isInDatabase(tableName, key string) bool {
 	return ok
 }
 
-func mergeFields(row1, row2 map[string]interface{}) map[string]interface{} {
-	merged := row1
-	for key, value := range row2 {
-		merged[key] = value
+func mergeFields(oldValues, newValues map[string]interface{}) map[string]interface{} {
+	merged := oldValues
+	for key, newValue := range newValues {
+		merged[key] = newValue
 	}
 
 	return merged
@@ -123,19 +134,7 @@ func (ctx *TestContext) addInDatabase(tableName, key string, row map[string]inte
 		ctx.dbTables[tableName] = make(map[string]map[string]interface{})
 	}
 
-	if oldRow, ok := ctx.dbTables[tableName][key]; ok {
-		row = mergeFields(oldRow, row)
-	}
-
 	ctx.dbTables[tableName][key] = row
-}
-
-func (ctx *TestContext) getUserKey(fields map[string]string) string {
-	if _, ok := fields["group_id"]; !ok {
-		panic(fmt.Errorf("getUserKey: %v must have a group_id", fields))
-	}
-
-	return fields["group_id"]
 }
 
 // addUser adds a user in database.
@@ -156,7 +155,13 @@ func (ctx *TestContext) addUser(fields map[string]string) {
 		}
 	}
 
-	ctx.addInDatabase("users", ctx.getUserKey(fields), dbFields)
+	userKey := strconv.FormatInt(dbFields["group_id"].(int64), 10)
+
+	if oldFields, ok := ctx.dbTables["users"][userKey]; ok {
+		dbFields = mergeFields(oldFields, dbFields)
+	}
+
+	ctx.addInDatabase("users", userKey, dbFields)
 }
 
 // addGroup adds a group in database.
@@ -170,7 +175,7 @@ func (ctx *TestContext) addGroup(group, name, groupType string) {
 	})
 }
 
-// addPermissionGenerated adds a permission generated in the database.
+// addPersonalInfoViewApprovedFor adds a permission generated in the database.
 func (ctx *TestContext) addPersonalInfoViewApprovedFor(childGroup, parentGroup string) {
 	parentGroupID := ctx.getReference(parentGroup)
 	childGroupID := ctx.getReference(childGroup)
@@ -216,39 +221,27 @@ func (ctx *TestContext) addGroupManager(manager, group, canWatchMembers string) 
 	)
 }
 
-// addPermissionGenerated adds a permission generated in the database.
-func (ctx *TestContext) addPermissionGenerated(group, item, watchType, watchValue string) {
+// addPermissionsGranted adds a permission granted in the database.
+func (ctx *TestContext) addPermissionGranted(group, item, permission, permissionValue string) {
 	groupID := ctx.getReference(group)
 	itemID := ctx.getReference(item)
 
-	permissionsGeneratedTable := "permissions_generated"
+	permissionsGrantedTable := "permissions_granted"
 	key := strconv.FormatInt(groupID, 10) + "," + strconv.FormatInt(itemID, 10)
-	if !ctx.isInDatabase(permissionsGeneratedTable, key) {
-		ctx.addInDatabase(permissionsGeneratedTable, key, map[string]interface{}{
-			"group_id": groupID,
-			"item_id":  itemID,
+
+	if !ctx.isInDatabase(permissionsGrantedTable, key) {
+		ctx.addInDatabase(permissionsGrantedTable, key, map[string]interface{}{
+			"group_id":        groupID,
+			"source_group_id": groupID,
+			"item_id":         itemID,
 		})
 	}
 
-	ctx.dbTables[permissionsGeneratedTable][key]["can_"+watchType+"_generated"] = watchValue
-}
+	if permission == "can_request_help_to" {
+		permissionValue = strconv.FormatInt(ctx.getReference(permissionValue), 10)
+	}
 
-// addPermissionsGranted adds a permission granted in the database.
-func (ctx *TestContext) addPermissionGranted(group, sourceGroup, item, canRequestHelpTo string) {
-	groupID := ctx.getReference(group)
-	sourceGroupID := ctx.getReference(sourceGroup)
-	itemID := ctx.getReference(item)
-
-	ctx.addInDatabase(
-		"permissions_granted",
-		strconv.FormatInt(groupID, 10)+","+strconv.FormatInt(itemID, 10),
-		map[string]interface{}{
-			"group_id":            groupID,
-			"source_group_id":     sourceGroupID,
-			"item_id":             itemID,
-			"can_request_help_to": canRequestHelpTo,
-		},
-	)
+	ctx.dbTables[permissionsGrantedTable][key][permission] = permissionValue
 }
 
 // addAttempt adds an attempt in database.
@@ -283,15 +276,57 @@ func (ctx *TestContext) addResult(attemptID, participant, item string, validated
 	)
 }
 
-// addItem adds an item in the database.
-func (ctx *TestContext) addItem(item string) {
-	itemID := ctx.getReference(item)
+// addItemItem adds an item-item in the database.
+func (ctx *TestContext) addItemItem(parentItem, childItem string) {
+	parentItemID := ctx.getReference(parentItem)
+	childItemID := ctx.getReference(childItem)
 
-	ctx.addInDatabase("items", strconv.FormatInt(itemID, 10), map[string]interface{}{
-		"id":                   itemID,
-		"default_language_tag": "en",
-		"type":                 "Task",
-	})
+	ctx.addInDatabase(
+		"items_items",
+		strconv.FormatInt(parentItemID, 10)+","+strconv.FormatInt(childItemID, 10),
+		map[string]interface{}{
+			"parent_item_id": parentItemID,
+			"child_item_id":  childItemID,
+			"child_order":    rand.Int31n(1000),
+		},
+	)
+}
+
+// addItem adds an item in the database.
+func (ctx *TestContext) addItem(fields map[string]string) {
+	dbFields := make(map[string]interface{})
+	for key, value := range fields {
+		if key == "item" {
+			key = "id"
+		}
+
+		switch {
+		case strings.HasSuffix(key, "id"):
+			dbFields[key] = ctx.getReference(value)
+		case value[0] == ReferencePrefix:
+			dbFields[key] = value[1:]
+		default:
+			dbFields[key] = value
+		}
+	}
+
+	itemKey := strconv.FormatInt(dbFields["id"].(int64), 10)
+
+	if oldFields, ok := ctx.dbTables["items"][itemKey]; ok {
+		dbFields = mergeFields(oldFields, dbFields)
+	}
+
+	if _, ok := dbFields["type"]; !ok {
+		dbFields["type"] = "Task"
+	}
+	if _, ok := dbFields["default_language_tag"]; !ok {
+		dbFields["default_language_tag"] = "en"
+	}
+	if _, ok := dbFields["text_id"]; !ok && fields["item"][0] == ReferencePrefix {
+		dbFields["text_id"] = fields["item"][1:]
+	}
+
+	ctx.addInDatabase("items", itemKey, dbFields)
 }
 
 // getThreadKey gets a thread unique key for the thread's map.
@@ -549,12 +584,33 @@ func (ctx *TestContext) ICanWatchGroupWithID(group string) error {
 	}))
 }
 
+// ThereAreTheFollowingItems defines items.
+func (ctx *TestContext) ThereAreTheFollowingItems(items *messages.PickleStepArgument_PickleTable) error {
+	for i := 1; i < len(items.Rows); i++ {
+		item := ctx.getRowMap(i, items)
+
+		ctx.addItem(map[string]string{
+			"item": item["item"],
+			"type": item["type"],
+		})
+
+		if _, ok := item["parent"]; ok {
+			ctx.addItemItem(item["parent"], item["item"])
+		}
+	}
+
+	return nil
+}
+
 // ThereAreTheFollowingTasks defines item tasks.
 func (ctx *TestContext) ThereAreTheFollowingTasks(tasks *messages.PickleStepArgument_PickleTable) error {
 	for i := 1; i < len(tasks.Rows); i++ {
 		task := ctx.getRowMap(i, tasks)
 
-		ctx.addItem(task["item"])
+		ctx.addItem(map[string]string{
+			"item": task["item"],
+			"type": "Task",
+		})
 	}
 
 	return nil
@@ -668,7 +724,7 @@ func (ctx *TestContext) IAmAMemberOfTheGroup(name string) error {
 
 // UserCanOnItemWithID gives a user a permission on an item.
 func (ctx *TestContext) UserCanOnItemWithID(watchType, watchValue, user, item string) error {
-	ctx.addPermissionGenerated(user, item, watchType, watchValue)
+	ctx.addPermissionGranted(user, item, "can_"+watchType, watchValue)
 
 	return nil
 }
@@ -678,13 +734,13 @@ func (ctx *TestContext) ICanOnItemWithID(watchType, watchValue, item string) err
 	return ctx.UserCanOnItemWithID(watchType, watchValue, ctx.user, item)
 }
 
-func (ctx *TestContext) UserCanViewOnItemWithID(watchValue, user, item string) error {
-	return ctx.UserCanOnItemWithID("view", watchValue, user, item)
+func (ctx *TestContext) UserCanViewOnItemWithID(viewValue, user, item string) error {
+	return ctx.UserCanOnItemWithID("view", viewValue, user, item)
 }
 
 // ICanViewOnItemWithID gives the user a "view" permission on an item.
-func (ctx *TestContext) ICanViewOnItemWithID(watchValue, item string) error {
-	return ctx.UserCanOnItemWithID("view", watchValue, ctx.user, item)
+func (ctx *TestContext) ICanViewOnItemWithID(viewValue, item string) error {
+	return ctx.UserCanOnItemWithID("view", viewValue, ctx.user, item)
 }
 
 // UserCanWatchOnItemWithID gives a user a "watch" permission on an item.
@@ -715,7 +771,9 @@ func (ctx *TestContext) ThereAreTheFollowingResults(results *messages.PickleStep
 	for i := 1; i < len(results.Rows); i++ {
 		result := ctx.getRowMap(i, results)
 
-		ctx.addItem(result["item"])
+		ctx.addItem(map[string]string{
+			"item": result["item"],
+		})
 
 		err := ctx.UserHaveValidatedItemWithID(result["participant"], result["item"])
 		if err != nil {
@@ -733,37 +791,42 @@ func (ctx *TestContext) IHaveValidatedItemWithID(item string) error {
 
 // ThereAreTheFollowingThreads create threads.
 func (ctx *TestContext) ThereAreTheFollowingThreads(threads *messages.PickleStepArgument_PickleTable) error {
-	if len(threads.Rows) > 1 {
-		for i := 1; i < len(threads.Rows); i++ {
-			thread := ctx.getRowMap(i, threads)
-			threadParameters := make(map[string]string)
+	for i := 1; i < len(threads.Rows); i++ {
+		thread := ctx.getRowMap(i, threads)
+		threadParameters := make(map[string]string)
 
-			threadParameters["participant_id"] = thread["participant"]
+		threadParameters["participant_id"] = thread["participant"]
 
-			if thread["item"] != "" {
-				threadParameters["item_id"] = thread["item"]
-			}
+		if thread["item"] != "" {
+			threadParameters["item_id"] = thread["item"]
+		}
 
-			if thread["helper_group"] != "" {
-				threadParameters["helper_group_id"] = thread["helper_group"]
-			}
+		if thread["helper_group"] != "" {
+			threadParameters["helper_group_id"] = thread["helper_group"]
+		}
 
-			if thread["status"] != "" {
-				threadParameters["status"] = thread["status"]
-			}
+		if thread["status"] != "" {
+			threadParameters["status"] = thread["status"]
+		}
 
-			if thread["latest_update_at"] != "" {
-				threadParameters["latest_update_at"] = thread["latest_update_at"]
-			}
+		if thread["latest_update_at"] != "" {
+			threadParameters["latest_update_at"] = thread["latest_update_at"]
+		}
 
-			if thread["message_count"] != "" {
-				threadParameters["message_count"] = thread["message_count"]
-			}
+		if thread["message_count"] != "" {
+			threadParameters["message_count"] = thread["message_count"]
+		}
 
-			err := ctx.ThereIsAThreadWith(getParameterString(threadParameters))
+		if thread["visible_by_participant"] == "1" {
+			err := ctx.UserCanViewOnItemWithID("content", thread["participant"], thread["item"])
 			if err != nil {
 				return err
 			}
+		}
+
+		err := ctx.ThereIsAThreadWith(getParameterString(threadParameters))
+		if err != nil {
+			return err
 		}
 	}
 
@@ -778,7 +841,10 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 	if _, ok := thread["item_id"]; !ok {
 		thread["item_id"] = strconv.FormatInt(rand.Int63(), 10)
 	}
-	ctx.addItem(thread["item_id"])
+
+	ctx.addItem(map[string]string{
+		"item": thread["item_id"],
+	})
 
 	// add helper_group_id
 	if _, ok := thread["helper_group_id"]; !ok {
@@ -831,7 +897,9 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 func (ctx *TestContext) ThereIsNoThreadWith(parameters string) error {
 	thread := ctx.getParameterMap(parameters)
 
-	ctx.addItem(thread["item_id"])
+	ctx.addItem(map[string]string{
+		"item": thread["item_id"],
+	})
 
 	return nil
 }
@@ -853,8 +921,8 @@ func (ctx *TestContext) IAmPartOfTheHelperGroupOfTheThread() error {
 func (ctx *TestContext) ICanRequestHelpToTheGroupWithIDOnTheItemWithID(group, item string) error {
 	ctx.addPermissionGranted(
 		ctx.user,
-		ctx.user,
 		item,
+		"can_request_help_to",
 		group,
 	)
 

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -47,6 +47,7 @@ type TestContext struct {
 	identifierReferences map[string]int64
 	dbTables             map[string]map[string]map[string]interface{}
 	currentThreadKey     string
+	needPopulateDatabase bool
 }
 
 var db *sql.DB
@@ -70,6 +71,7 @@ func (ctx *TestContext) SetupTestContext(pickle *messages.Pickle) { // nolint
 	ctx.templateSet = ctx.constructTemplateSet()
 	ctx.identifierReferences = make(map[string]int64)
 	ctx.dbTables = make(map[string]map[string]map[string]interface{})
+	ctx.needPopulateDatabase = false
 
 	// reset the seed to get predictable results on PRNG for tests
 	rand.Seed(1)


### PR DESCRIPTION
Related to issue #888 

Handles the `item_id` parameter.

A few remarks:

1) The test have a new column in the definition of `threads`: `visible_by_participant`. The reasoning is the following:

In order to test for the `item_id` filter, we need that the defined threads are visible to the user. There are more than one way for a thread to be visible for a user, depending on the options that are used (`watched_id`, `is_mine`). And even then, the rules contains many conditions. Those ways were all already tested by the previous tests.

If we were to add manually the permissions for the threads to be visible again, we'll have a redundancy in the tests. And if one day we change the rules by which the threads are visible, we'll need to change all the tests that are unrelated to this change.

So we define a notion that the thread is visible in a column, and the test engine makes whatever necessary to make it visible. If we ever need to change how, we'll just have one update to do. We can't be sure now that `visible_by_participant` is the right approach, but all the following tests for the other filters, sorting and pagination will have to use the same method, which might change.

This issue of redundancy where every time we redefine some notions with their low level correspondence is present in many other tests in the app. It makes the whole architecture very rigid. It would be nice to reach a level where each low level notion is tested only once, and then for all tests that uses those same notions, a higher level correspondence is used.


2) The new tests automatically fills the tables `permissions_generated`, `items_ancestors` and `groups_ancestors` in the same way that is used within the app. So we only have to define the contents of `items_items`, `groups_groups` and `permissions_granted`.

This automatic filling have been disabled for older tests because they were breaking. Some of those tests define tables with inconsistencies (eg. defining both `permissions_granted` and `permissions_generated` with different values like in `update_item.feature`: https://github.com/France-ioi/AlgoreaBackend/blob/getThreadsItemID/app/api/items/update_item.feature#L25). Then, those tests also check that the content of ill-defined tables didn't change (eg. `And the table "items_ancestors" should stay unchanged`). 

This point is actually linked to the first one. It probably happened because of the lack of higher-level definitions. Everything was defined at the lowest level, then one day the low level details changed, but all the tests weren't updated. Those tests didn't break but are now in an inconsistent state. It is something to keep in mind because it'll make further refactoring and/or decoupling harder.