### PR TITLE
List threads: order, pagination and filters

### DIFF
--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -159,7 +159,7 @@ Feature: List threads
           "status": "waiting_for_trainer"
         }
       ]
-    """
+      """
 
   Scenario: Should get the threads whose the participant is a descendant of the watched_group_id
     Given I am @A_UniversityManagerCanWatch
@@ -266,7 +266,7 @@ Feature: List threads
     And there are the following threads:
       | participant | item             | visible_by_participant | latest_update_at    |
       | @John       | @TaskMinUpdateAt | 1                      | 2023-01-01 00:00:01 |
-      | @John       | @TaskMaxUpdateAt | 1                      | 2023-01-01 00:00:02  |
+      | @John       | @TaskMaxUpdateAt | 1                      | 2023-01-01 00:00:02 |
     And I am @John
     When I send a GET request to "/threads?is_mine=1&limit=1&sort=latest_update_at&from.item_id=<from.item_id>&from.participant_id=<from.participant_id>"
     Then the response code should be 200
@@ -298,3 +298,26 @@ Feature: List threads
       | status              | result_item                  |
       | waiting_for_trainer | @TaskWaitingForTrainerThread |
       | closed              | @TaskClosedThread            |
+
+  Scenario Outline: Should return only the thread with latest_update_at>latest_update_gt if parameter latest_update_gt is given
+    Given I am @John
+    And there are the following items:
+      | item   | type |
+      | @Task1 | Task |
+      | @Task2 | Task |
+      | @Task3 | Task |
+    And there are the following threads:
+      | participant | item   | visible_by_participant | latest_update_at    |
+      | @John       | @Task1 | 1                      | 2023-01-01 00:00:01 |
+      | @John       | @Task2 | 1                      | 2023-01-01 00:00:02 |
+      | @John       | @Task3 | 1                      | 2023-01-01 00:00:03 |
+    And I am @John
+    When I send a GET request to "/threads?is_mine=1&latest_update_gt=<latest_update_gt>&sort=latest_update_at"
+    Then the response code should be 200
+    And the response should be a JSON array with <nb_results> entries
+    And the response at $[0].item.id should be "<first_result_item>"
+    Examples:
+      | latest_update_gt     | first_result_item | nb_results |
+      | 2023-01-01T00:00:00Z | @Task1            | 3          |
+      | 2023-01-01T00:00:02Z | @Task3            | 1          |
+      | 2023-01-01T00:00:03Z |                   | 0          |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -276,3 +276,25 @@ Feature: List threads
       | from.item_id     | from.participant_id | nb_results | result_item      |
       | @TaskMinUpdateAt | @John               | 1          | @TaskMaxUpdateAt |
       | @TaskMaxUpdateAt | @John               | 0          |                  |
+
+  Scenario Outline: Should filter by status if parameter status is given
+    Given I am @John
+    And there are the following items:
+      | item                             | type |
+      | @TaskWaitingForParticipantThread | Task |
+      | @TaskWaitingForTrainerThread     | Task |
+      | @TaskClosedThread                | Task |
+    And there are the following threads:
+      | participant | item                             | status                  | visible_by_participant |
+      | @John       | @TaskWaitingForParticipantThread | waiting_for_participant | 1                      |
+      | @John       | @TaskWaitingForTrainerThread     | waiting_for_trainer     | 1                      |
+      | @John       | @TaskClosedThread                | closed                  | 1                      |
+    And I am @John
+    When I send a GET request to "/threads?is_mine=1&status=<status>"
+    Then the response code should be 200
+    And the response should be a JSON array with 1 entries
+    And the response at $[0].item.id should be "<result_item>"
+    Examples:
+      | status              | result_item                  |
+      | waiting_for_trainer | @TaskWaitingForTrainerThread |
+      | closed              | @TaskClosedThread            |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -122,25 +122,8 @@ Feature: List threads
     When I send a GET request to "/threads?watched_group_id=@Laboratory"
     Then the response code should be 200
     And the response body should be, in JSON:
-    """
+      """
       [
-        {
-          "item": {
-            "id": "1",
-            "language_tag": "fr",
-            "title": "Debut",
-            "type": "Task"
-          },
-          "latest_update_at": "2023-01-01T00:00:01Z",
-          "message_count": 0,
-          "participant": {
-            "id": "@LaboratoryMember_WithApprovedAccessPersonalInfo",
-            "login": "LaboratoryMember_WithApprovedAccessPersonalInfo",
-            "first_name": "FirstName_Approved",
-            "last_name": "LastName_Approved"
-          },
-          "status": "waiting_for_trainer"
-        },
         {
           "item": {
             "id": "2",
@@ -157,6 +140,23 @@ Feature: List threads
             "last_name": ""
           },
           "status": "waiting_for_participant"
+        },
+        {
+          "item": {
+            "id": "1",
+            "language_tag": "fr",
+            "title": "Debut",
+            "type": "Task"
+          },
+          "latest_update_at": "2023-01-01T00:00:01Z",
+          "message_count": 0,
+          "participant": {
+            "id": "@LaboratoryMember_WithApprovedAccessPersonalInfo",
+            "login": "LaboratoryMember_WithApprovedAccessPersonalInfo",
+            "first_name": "FirstName_Approved",
+            "last_name": "LastName_Approved"
+          },
+          "status": "waiting_for_trainer"
         }
       ]
     """
@@ -196,36 +196,83 @@ Feature: List threads
       | @B_UniversityMember_CanWatchAnswer4 |
       | @B_UniversityMember_CanWatchAnswer5 |
 
-    Scenario: Should return only thread from item or descendant when item_id is given
-      Given I am @John
-      And there are the following items:
-        | item              | parent      | type    |
-        | @Root_Task        |             | Task    |
-        | @Chapter1         |             | Chapter |
-        | @Chapter1_Task    | @Chapter1   | Task    |
-        | @Chapter2         |             | Chapter |
-        | @Chapter2_Task    | @Chapter2   | Task    |
-        | @Chapter2_1       | @Chapter2   | Chapter |
-        | @Chapter2_1_Task1 | @Chapter2_1 | Task    |
-        | @Chapter2_1_Task2 | @Chapter2_1 | Task    |
-        | @Chapter3         |             | Chapter |
-      And there are the following threads:
-        | participant | item              | visible_by_participant | message_count |
-        | @John       | @Root_Task        | 1                      | 100           |
-        | @John       | @Chapter1         | 1                      | 101           |
-        | @John       | @Chapter1_Task    | 1                      | 102           |
-        | @John       | @Chapter2         | 1                      | 103           |
-        | @John       | @Chapter2_Task    | 1                      | 104           |
-        | @John       | @Chapter3         | 1                      | 105           |
-        | @John       | @Chapter2_1       | 1                      | 106           |
-        | @John       | @Chapter2_1_Task1 | 1                      | 107           |
-        | @John       | @Chapter2_1_Task2 | 1                      | 108           |
+  Scenario: Should return only thread from item or descendant when item_id is given
+    Given I am @John
+    And there are the following items:
+      | item              | parent      | type    |
+      | @Root_Task        |             | Task    |
+      | @Chapter1         |             | Chapter |
+      | @Chapter1_Task    | @Chapter1   | Task    |
+      | @Chapter2         |             | Chapter |
+      | @Chapter2_Task    | @Chapter2   | Task    |
+      | @Chapter2_1       | @Chapter2   | Chapter |
+      | @Chapter2_1_Task1 | @Chapter2_1 | Task    |
+      | @Chapter2_1_Task2 | @Chapter2_1 | Task    |
+      | @Chapter3         |             | Chapter |
+    And there are the following threads:
+      | participant | item              | visible_by_participant | message_count |
+      | @John       | @Root_Task        | 1                      | 100           |
+      | @John       | @Chapter1         | 1                      | 101           |
+      | @John       | @Chapter1_Task    | 1                      | 102           |
+      | @John       | @Chapter2         | 1                      | 103           |
+      | @John       | @Chapter2_Task    | 1                      | 104           |
+      | @John       | @Chapter3         | 1                      | 105           |
+      | @John       | @Chapter2_1       | 1                      | 106           |
+      | @John       | @Chapter2_1_Task1 | 1                      | 107           |
+      | @John       | @Chapter2_1_Task2 | 1                      | 108           |
+    And I am @John
+    When I send a GET request to "/threads?is_mine=1&item_id=@Chapter2"
+    Then the response code should be 200
+    And the response at $[*].item.id should be:
+      | @Chapter2         |
+      | @Chapter2_Task    |
+      | @Chapter2_1       |
+      | @Chapter2_1_Task1 |
+      | @Chapter2_1_Task2 |
+
+  Scenario Outline: Should support sort and limit parameters
+    Given I am @John
+    And there are the following items:
+      | item   | type |
+      | @Task1 | Task |
+      | @Task2 | Task |
+      | @Task3 | Task |
+      | @Task4 | Task |
+    And there are the following threads:
+      | participant | item                   | visible_by_participant | message_count | latest_update_at    |
+      | @John       | @TaskSecondMaxUpdateAt | 1                      | 100           | 2023-01-01 00:00:10 |
+      | @John       | @TaskMinUpdateAt       | 1                      | 101           | 2023-01-01 00:00:01 |
+      | @John       | @TaskMaxUpdateAt       | 1                      | 102           | 2023-01-01 00:00:11 |
+      | @John       | @TaskSecondMinUpdateAt | 1                      | 103           | 2023-01-01 00:00:02 |
       And I am @John
-      When I send a GET request to "/threads?is_mine=1&item_id=@Chapter2"
-      Then the response code should be 200
-      And the response at $[*].item.id should be:
-        | @Chapter2         |
-        | @Chapter2_Task    |
-        | @Chapter2_1       |
-        | @Chapter2_1_Task1 |
-        | @Chapter2_1_Task2 |
+    When I send a GET request to "/threads?is_mine=1&limit=<limit>&sort=<sort>"
+    Then the response code should be 200
+    And the response should be a JSON array with <nb_results> entries
+    And the response at $[<result_item_index>].item.id should be "<result_item>"
+    Examples:
+      | sort              | limit | nb_results | result_item_index | result_item            |
+      | latest_update_at  | 1     | 1          | 0                 | @TaskMinUpdateAt       |
+      | latest_update_at  | 1     | 1          | 0                 | @TaskMinUpdateAt       |
+      | -latest_update_at | 1     | 1          | 0                 | @TaskMaxUpdateAt       |
+      | -latest_update_at | 2     | 2          | 0                 | @TaskMaxUpdateAt       |
+      | -latest_update_at | 2     | 2          | 1                 | @TaskSecondMaxUpdateAt |
+
+  Scenario Outline: Should support pagination parameters
+    Given I am @John
+    And there are the following items:
+      | item             | type |
+      | @TaskMinUpdateAt | Task |
+      | @TaskMaxUpdateAt | Task |
+    And there are the following threads:
+      | participant | item             | visible_by_participant | latest_update_at    |
+      | @John       | @TaskMinUpdateAt | 1                      | 2023-01-01 00:00:01 |
+      | @John       | @TaskMaxUpdateAt | 1                      | 2023-01-01 00:00:02  |
+    And I am @John
+    When I send a GET request to "/threads?is_mine=1&limit=1&sort=latest_update_at&from.item_id=<from.item_id>&from.participant_id=<from.participant_id>"
+    Then the response code should be 200
+    And the response should be a JSON array with <nb_results> entries
+    And the response at $[0].item.id should be "<result_item>"
+    Examples:
+      | from.item_id     | from.participant_id | nb_results | result_item      |
+      | @TaskMinUpdateAt | @John               | 1          | @TaskMaxUpdateAt |
+      | @TaskMaxUpdateAt | @John               | 0          |                  |

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -49,3 +49,9 @@ Feature: List threads - robustness
       | is_mine |
       | 0       |
       | 1       |
+
+   Scenario: Should return an error if sort parameter is invalid
+     Given I am @John
+     When I send a GET request to "/threads?is_mine=1&sort=invalid"
+     Then the response code should be 400
+     And the response error message should contain "Unallowed field in sorting parameters"

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -50,8 +50,14 @@ Feature: List threads - robustness
       | 0       |
       | 1       |
 
-   Scenario: Should return an error if sort parameter is invalid
-     Given I am @John
-     When I send a GET request to "/threads?is_mine=1&sort=invalid"
-     Then the response code should be 400
-     And the response error message should contain "Unallowed field in sorting parameters"
+  Scenario: Should return an error if sort parameter is invalid
+    Given I am @John
+    When I send a GET request to "/threads?is_mine=1&sort=invalid"
+    Then the response code should be 400
+    And the response error message should contain "Unallowed field in sorting parameters"
+
+  Scenario: Should return an error if latest_update_gt isn't in the right format
+    Given I am @John
+    When I send a GET request to "/threads?is_mine=1&latest_update_gt=2023-01-01T00:00:99"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for latest_update_gt (should be time (rfc3339))"

--- a/app/service/parameters.go
+++ b/app/service/parameters.go
@@ -122,8 +122,9 @@ func ResolveURLQueryGetTimeField(httpReq *http.Request, name string) (time.Time,
 
 // ResolveURLQueryGetBoolField extracts a get-parameter of type bool (0 or 1) from the query, fails if the value is empty.
 func ResolveURLQueryGetBoolField(httpReq *http.Request, name string) (bool, error) {
-	if len(httpReq.URL.Query()[name]) == 0 {
-		return false, fmt.Errorf("missing %s", name)
+	err := checkQueryGetFieldIsNotMissing(httpReq, name)
+	if err != nil {
+		return false, err
 	}
 	strValue := httpReq.URL.Query().Get(name)
 	if strValue == "0" {
@@ -148,10 +149,16 @@ func ResolveURLQueryPathInt64Field(httpReq *http.Request, name string) (int64, e
 	return int64Value, nil
 }
 
+// URLQueryPathHasField checks whether a field is present in the query.
+func URLQueryPathHasField(httpReq *http.Request, name string) bool {
+	return len(httpReq.URL.Query()[name]) > 0
+}
+
 func checkQueryGetFieldIsNotMissing(httpReq *http.Request, name string) error {
-	if len(httpReq.URL.Query()[name]) == 0 {
+	if !URLQueryPathHasField(httpReq, name) {
 		return fmt.Errorf("missing %s", name)
 	}
+
 	return nil
 }
 

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -80,7 +80,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response error message should contain "(.*)"$`, ctx.TheResponseErrorMessageShouldContain)
 
 	s.Step(`^the response should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
-	s.Step(`^the response at ([^ ]+) should be "([^"]+)"$`, ctx.TheResponseAtShouldBeTheValue)
+	s.Step(`^the response at ([^ ]+) should be "([^"]*)"$`, ctx.TheResponseAtShouldBeTheValue)
 	s.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -43,7 +43,9 @@ func (ctx *TestContext) TheResponseAtShouldBeTheValue(jsonPath, value string) er
 	}
 
 	jsonPathRes, err := jsonpath.Get(jsonPath, JSONResponse)
-	if err != nil {
+	if err != nil && value == "" {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("TheResponseAtShouldBeTheValue: Cannot get JsonPath: %v", err)
 	}
 


### PR DESCRIPTION
#fixes 888

The tests for sorting, pagination and filters are as simple as possible. Hopefully without sacrificing reliability.

Only `latest_update_at` has been added for sorting. But we can add more parameters.

For paging, `from.item_id` and `form.participant_id` have been added, those are the primary key of threads.

If `status` filter is given with an invalid value, the service will return nothing because nothing matches. We could also check that the value is a valid status.

The issue specified format ISO8601 for date-time. RFC3339 (eg. "2006-01-02T15:04:05Z07:00") seems to be equivalent and there already was a function ResolveURLQueryGetTimeField using it.

This is the last PR for the listThreads feature.