### PR TITLE
403 on path-from-root while there is a path

### DIFF
--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -177,7 +177,7 @@ func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *d
 	groupsWithRootItems := participantAncestors.Union(groupsManagedByParticipant.SubQuery())
 
 	visibleItems := store.Permissions().MatchingUserAncestors(user).
-		Where("permissions.can_view_generated_value >= ?", store.PermissionsGranted().ViewIndexByName("info")).
+		WherePermissionIsAtLeast("view", "info").
 		Joins("JOIN items ON items.id = permissions.item_id").
 		Select("items.id, requires_explicit_entry, MAX(can_view_generated_value) AS can_view_generated_value").
 		Group("items.id")
@@ -185,47 +185,83 @@ func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *d
 	canViewContentIndex := store.PermissionsGranted().ViewIndexByName("content")
 
 	var pathStrings []string
-	service.MustNotBeError(store.Raw(`
-			WITH RECURSIVE paths (path, last_item_id, last_attempt_id) AS (
-				WITH groups_with_root_items AS ?,
-					visible_items AS ?,
-					root_items AS (
-						SELECT visible_items.id AS id FROM groups_with_root_items JOIN visible_items ON visible_items.id = root_activity_id
-						UNION
-						SELECT visible_items.id FROM groups_with_root_items JOIN visible_items ON visible_items.id = root_skill_id),
-					item_ancestors AS (
-						SELECT visible_items.id, requires_explicit_entry, can_view_generated_value
+	service.MustNotBeError(store.Raw(
+		`
+			WITH RECURSIVE
+				groups_with_root_items AS ?,
+				visible_items AS ?,
+				root_items AS (
+					(SELECT visible_items.id AS id
+						 FROM groups_with_root_items
+									JOIN visible_items
+									ON (visible_items.id = root_activity_id OR visible_items.id = root_skill_id))
+				),
+				item_ancestors AS (
+					(SELECT visible_items.id, requires_explicit_entry, can_view_generated_value
 						FROM items_ancestors
-						JOIN visible_items ON visible_items.id = items_ancestors.ancestor_item_id WHERE child_item_id = ?
-						UNION
-						SELECT id, requires_explicit_entry, can_view_generated_value FROM visible_items WHERE id = ?),
-					root_ancestors AS (
-						SELECT item_ancestors.id, requires_explicit_entry, can_view_generated_value
-						FROM item_ancestors
-						JOIN root_items ON root_items.id = item_ancestors.id)
-				(SELECT CAST(root_ancestors.id AS CHAR(1024)), root_ancestors.id, attempts.id
-				FROM root_ancestors
-				JOIN attempts ON attempts.participant_id = ? AND
-					(NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
-				JOIN results ON results.participant_id = attempts.participant_id AND
-					attempts.id = results.attempt_id AND results.item_id = root_ancestors.id
-				WHERE (root_ancestors.id = ? OR root_ancestors.can_view_generated_value >= ?) AND
-					(results.started_at IS NOT NULL))
-				UNION
-				(SELECT CONCAT(paths.path, '/', item_ancestors.id), item_ancestors.id, attempts.id
-				FROM paths
-				JOIN items_items ON items_items.parent_item_id = paths.last_item_id
-				JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
-				JOIN attempts ON attempts.participant_id = ? AND
-					(NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id) AND
-					IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.last_attempt_id
-				JOIN results ON results.participant_id = attempts.participant_id AND
-						attempts.id = results.attempt_id AND results.item_id = item_ancestors.id
-				WHERE paths.last_item_id <> ? AND (item_ancestors.id = ? OR item_ancestors.can_view_generated_value >= ?) AND
-					(results.started_at IS NOT NULL)))
-			SELECT path FROM paths WHERE paths.last_item_id = ? GROUP BY path ORDER BY path`,
-		groupsWithRootItems.SubQuery(), visibleItems.SubQuery(), itemID, itemID, participantID, itemID, canViewContentIndex,
-		participantID, itemID, itemID, canViewContentIndex, itemID).
+								 JOIN visible_items ON visible_items.id = items_ancestors.ancestor_item_id
+					 WHERE child_item_id = ?)
+					UNION
+					(SELECT id, requires_explicit_entry, can_view_generated_value
+						 FROM visible_items
+						WHERE id = ?)
+				),
+				root_ancestors AS (
+					(SELECT item_ancestors.id, requires_explicit_entry, can_view_generated_value
+						 FROM item_ancestors
+								  JOIN root_items ON root_items.id = item_ancestors.id)
+				),
+				paths (path, last_item_id, last_attempt_id) AS (
+					(SELECT CAST(root_ancestors.id AS CHAR(1024)),
+									root_ancestors.id,
+									attempts.id
+					   FROM root_ancestors
+								  JOIN attempts
+									ON attempts.participant_id = ?
+									   AND (NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
+									JOIN results
+									ON results.participant_id = attempts.participant_id
+									   AND attempts.id = results.attempt_id
+									   AND results.item_id = root_ancestors.id
+						WHERE (root_ancestors.id = ? OR root_ancestors.can_view_generated_value >= ?)
+						  AND	(results.started_at IS NOT NULL))
+					UNION
+					(SELECT CONCAT(paths.path, '/', item_ancestors.id),
+									item_ancestors.id,
+									attempts.id
+						 FROM paths
+									JOIN items_items ON items_items.parent_item_id = paths.last_item_id
+									JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
+									JOIN attempts
+									ON attempts.participant_id = ?
+									   AND (NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id)
+									   AND IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.last_attempt_id
+									JOIN results
+									ON results.participant_id = attempts.participant_id
+									   AND attempts.id = results.attempt_id
+										 AND results.item_id = item_ancestors.id
+						 WHERE paths.last_item_id <> ?
+							 AND (item_ancestors.id = ? OR item_ancestors.can_view_generated_value >= ?)
+							 AND (results.started_at IS NOT NULL)
+					)
+				)
+			SELECT path FROM paths
+			 WHERE paths.last_item_id = ?
+			 GROUP BY path
+			 ORDER BY path`,
+		groupsWithRootItems.SubQuery(),
+		visibleItems.SubQuery(),
+		itemID,
+		itemID,
+		participantID,
+		itemID,
+		canViewContentIndex,
+		participantID,
+		itemID,
+		itemID,
+		canViewContentIndex,
+		itemID,
+	).
 		ScanIntoSlices(&pathStrings).Error())
 
 	if len(pathStrings) == 0 {

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -17,24 +17,31 @@ import (
 //	description: >
 //		Finds a path from any of root items to a given item.
 //
-//
 //		The path consists only of the items visible to the participant
 //		(`can_view`>='content' for all the items except for the last one and `can_view`>='info' for the last one).
-//		Of all possible paths the service chooses the one having missing/not-started results located closer
-//		to the end of the path, preferring paths having less missing/not-started results and having higher values of `attempt_id`.
-//		The chain of attempts of the path cannot have missing results for items requiring explicit entry or not started results
-//		within or below ended/not-allowing-submissions attempts.
 //
+//		Of all possible paths, the service chooses the one having:
+//			* missing/not-started results located closer to the end of the path,
+//			* preferring paths having less missing/not-started results,
+//			* and having higher values of `attempt_id`.
 //
-//		If `as_team_id` is given, the attempts/results of the path are linked to the `as_team_id` group instead of the user's self group.
+//		For a path to be returned, each of its items must:
+//			* Either have `require_explicit_entry`=0 ,
+//			* Or if it has `require_explicit_entry=1`,
+//				then the following condition must be fulfilled, except if it is the last item of the path:
+//				the item must have at least one result with `started`=1 AND its attempt must have
+//					(`attempt.ended_at` IS NULL) AND (`NOW()` < `attempt.allows_submissions_until`)).
+//				In other words, we only return a path to a contest's item if the contest has been started and is still open.
 //
+//		If `as_team_id` is given, the attempts/results of the path are linked to the `as_team_id` group instead of
+//		the current user group.
 //
-//			Restrictions:
+//		Restrictions:
 //
-//		* if `as_team_id` is given, it should be a user's parent team group,
-//		* at least one path should exist,
+//			* if `as_team_id` is given, it should be a user's parent team group,
+//			* at least one path should exist,
 //
-//		otherwise the 'forbidden' error is returned.
+//			Otherwise the 'forbidden' error is returned.
 //	parameters:
 //		- name: item_id
 //			in: path
@@ -134,17 +141,22 @@ func findItemPath(store *database.DataStore, participantID, itemID int64) []stri
 								  CAST(LPAD(attempts.id, 20, 0) AS CHAR(1024)),
 								  attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
 						 FROM root_ancestors
-								  JOIN attempts
+								  LEFT JOIN attempts
 									ON attempts.participant_id = ?
 									   AND (NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
 								  LEFT JOIN results
 									ON results.participant_id = attempts.participant_id
 									   AND attempts.id = results.attempt_id
 										 AND results.item_id = root_ancestors.id
-					  WHERE (root_ancestors.id = ? OR root_ancestors.can_view_generated_value >= ?)
-						  AND (NOT root_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
-						  AND (results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until)
-						  AND (results.attempt_id IS NOT NULL OR attempts.id = 0))
+						WHERE root_ancestors.id = ?
+					     OR (
+										attempts.id IS NOT NULL
+								AND	root_ancestors.can_view_generated_value >= ?
+						  	AND (NOT root_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
+						  	AND (results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until)
+						  	AND (results.attempt_id IS NOT NULL OR attempts.id = 0)
+							 )
+					)
 				 	UNION
 				 	(SELECT CONCAT(paths.path, '/', item_ancestors.id),
 								  item_ancestors.id,
@@ -155,7 +167,7 @@ func findItemPath(store *database.DataStore, participantID, itemID int64) []stri
 						 FROM paths
 								  JOIN items_items ON items_items.parent_item_id = paths.last_item_id
 								  JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
-								  JOIN attempts
+								  LEFT JOIN attempts
 									ON attempts.participant_id = ?
 									   AND (NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id)
 									   AND IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.last_attempt_id
@@ -163,10 +175,17 @@ func findItemPath(store *database.DataStore, participantID, itemID int64) []stri
 									ON results.participant_id = attempts.participant_id
 									   AND attempts.id = results.attempt_id
 										 AND results.item_id = item_ancestors.id
-					 WHERE paths.last_item_id <> ?
-						 AND (item_ancestors.id = ? OR item_ancestors.can_view_generated_value >= ?)
-						 AND (NOT item_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
-						 AND (results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until AND paths.is_active)
+					 	WHERE paths.last_item_id <> ?
+						 AND (
+									item_ancestors.id = ?
+									OR (
+											 item_ancestors.can_view_generated_value >= ?
+									 AND (NOT item_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
+									 AND (   results.started_at IS NOT NULL
+												OR (attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until AND paths.is_active)
+									 )
+									)
+						 )
 				  )
 				)
 			SELECT path FROM paths

--- a/app/api/items/path_from_root.robustness.feature
+++ b/app/api/items/path_from_root.robustness.feature
@@ -15,16 +15,21 @@ Feature: Find an item path - robustness
       | 104             | 101            |
     And the groups ancestors are computed
     And the database has the following table 'items':
-      | id | url                                                                     | type   | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
-      | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 0                        | fr                   | false                   |
-      | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | false                   |
-      | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | true                    |
-      | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill  | 1                        | fr                   | false                   |
+      | id | url                                                                     | type  | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
+      | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 0                        | fr                   | false                   |
+      | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | false                   |
+      | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | true                    |
+      | 71 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | false                   |
+      | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill | 1                        | fr                   | false                   |
+    And the database has the following table 'items_items':
+      | parent_item_id | child_item_id | child_order |
+      | 70             | 71            | 1           |
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated |
       | 101      | 50      | none               |
       | 101      | 60      | content            |
       | 101      | 70      | content            |
+      | 101      | 71      | content            |
       | 101      | 90      | content            |
     And the database has the following table 'attempts':
       | participant_id | id |
@@ -80,6 +85,6 @@ Feature: Find an item path - robustness
 
   Scenario: No path
     Given I am the user with id "101"
-    When I send a GET request to "/items/70/path-from-root"
+    When I send a GET request to "/items/71/path-from-root"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"


### PR DESCRIPTION
Related to #850

The queries were too difficult to read in their current form, there were adapted in the following way to make it easier (in the first commit):
- Following the formatting style guide here https://www.sqlstyle.guide/
- All the WITH declarations have been grouped at the same level, instead of having them nested

Given the response here: https://github.com/France-ioi/AlgoreaBackend/issues/850#issuecomment-1584288727 . `resultStartPath` hasn't been changed.

New tests have been added in `path_from_root_integration_test.go`:
- The item with id `23` is a contest sub-item. It has been added as a child of `22` (22 has `require_explicit_entry=1`)
- For all the previous tests that were asking a path with `22`:
* If they **returned no path**, because `22` has `require_explicit_entry=1` and didn't pass the other conditions, they now **PASS** because `22` is the last element of the path and doesn't require those other conditions anymore
* If they **returned a path**, because `22` was entered and has the other conditions were fulfilled, we now ask for `23`, so that `22` is a non-last element, and thus requires those conditions to be fulfilled.