### PR TITLE
Item navigation: do not return activities as skill children

### DIFF
--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -249,7 +249,7 @@ func (srv *Service) getItemChildren(rw http.ResponseWriter, httpReq *http.Reques
 			`items.allows_multiple_attempts, category, score_weight, content_view_propagation,
 				upper_view_levels_propagation, grant_view_propagation, watch_propagation, edit_propagation,
 				items.id, items.type, items.default_language_tag,
-				validation_type, display_details_in_parent, duration, entry_participant_type, no_score,
+				items.validation_type, items.display_details_in_parent, items.duration, items.entry_participant_type, items.no_score,
 				IFNULL(can_view_generated_value, 1) AS can_view_generated_value,
 				IFNULL(can_grant_view_generated_value, 1) AS can_grant_view_generated_value,
 				IFNULL(can_watch_generated_value, 1) AS can_watch_generated_value,
@@ -283,7 +283,9 @@ func constructItemChildrenQuery(dataStore *database.DataStore, parentItemID, gro
 		dataStore, groupID, requiredViewPermissionOnItems, watchedGroupIDSet, watchedGroupID, columnList, columnListValues,
 		externalColumnList,
 		func(db *database.DB) *database.DB {
-			return db.Joins("JOIN items_items ON items_items.parent_item_id = ? AND items_items.child_item_id = items.id", parentItemID)
+			return db.Joins("JOIN items_items ON items_items.parent_item_id = ? AND items_items.child_item_id = items.id", parentItemID).
+				Joins("JOIN items AS parent_item ON parent_item.id = ?", parentItemID).
+				Where("(parent_item.type = 'Skill' AND items.type = 'Skill') OR parent_item.type <> 'Skill'")
 		},
 		func(db *database.DB) *database.DB {
 			return db.Joins("JOIN items_items ON items_items.child_item_id = item_id").

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -283,8 +283,8 @@ func constructItemChildrenQuery(dataStore *database.DataStore, parentItemID, gro
 		dataStore, groupID, requiredViewPermissionOnItems, watchedGroupIDSet, watchedGroupID, columnList, columnListValues,
 		externalColumnList,
 		func(db *database.DB) *database.DB {
-			return db.Joins("JOIN items_items ON items_items.parent_item_id = ? AND items_items.child_item_id = items.id", parentItemID).
-				Joins("JOIN items AS parent_item ON parent_item.id = ?", parentItemID).
+			return db.Joins("JOIN items AS parent_item ON parent_item.id = ?", parentItemID).
+				Joins("JOIN items_items ON items_items.parent_item_id = parent_item.id AND items_items.child_item_id = items.id").
 				Where("(parent_item.type = 'Skill' AND items.type = 'Skill') OR parent_item.type <> 'Skill'")
 		},
 		func(db *database.DB) *database.DB {

--- a/app/api/items/get_navigation.feature
+++ b/app/api/items/get_navigation.feature
@@ -221,6 +221,86 @@ Feature: Get navigation for an item
       }
       """
 
+  Scenario: Should only return Skills and compute has_visible children on Skills only when we get navigation on a Skill
+    Given the database has the following table 'groups':
+      | id   | name | type |
+      | 1000 | user | User |
+    And the database has the following table 'users':
+      | login | temp_user | group_id |
+      | user  | 0         | 1000     |
+    And the groups ancestors are computed
+    And the database has the following table 'items':
+      | id   | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
+      | 1000 | Skill   | en                   | false    | false                   | User                   |
+      | 1100 | Skill   | en                   | false    | false                   | User                   |
+      | 1110 | Skill   | en                   | false    | false                   | User                   |
+      | 1120 | Task    | en                   | false    | false                   | User                   |
+      | 1200 | Skill   | en                   | false    | false                   | User                   |
+      | 1210 | Skill   | en                   | false    | false                   | User                   |
+      | 1220 | Task    | en                   | false    | false                   | User                   |
+      | 1300 | Skill   | en                   | false    | false                   | User                   |
+      | 1400 | Chapter | en                   | false    | false                   | User                   |
+      | 1500 | Task    | en                   | false    | false                   | User                   |
+    And the database has the following table 'permissions_generated':
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
+      | 1000     | 1000    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1100    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1110    | none               | none                     | none                | none               | false              |
+      | 1000     | 1120    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1200    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1210    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1220    | none               | none                     | none                | none               | false              |
+      | 1000     | 1300    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1400    | solution           | solution_with_grant      | none                | none               | false              |
+      | 1000     | 1500    | solution           | solution_with_grant      | none                | none               | false              |
+      And the database has the following table 'items_items':
+      | parent_item_id | child_item_id | child_order | content_view_propagation |
+      | 1000           | 1100          | 1           | none                     |
+      | 1100           | 1110          | 1           | none                     |
+      | 1100           | 1120          | 2           | none                     |
+      | 1000           | 1200          | 2           | as_info                  |
+      | 1200           | 1210          | 1           | as_info                  |
+      | 1200           | 1220          | 2           | as_info                  |
+      | 1000           | 1300          | 3           | as_content               |
+      | 1000           | 1400          | 4           | as_content               |
+      | 1000           | 1500          | 5           | as_content               |
+    And the database has the following table 'items_strings':
+      | item_id | language_tag | title              |
+      | 1000    | en           | Parent Skill       |
+      | 1100    | en           | Child lvl1 Skill 1 |
+      | 1110    | en           | Child lvl2 Skill   |
+      | 1120    | en           | Child lvl2 Task    |
+      | 1200    | en           | Child lvl1 Skill 2 |
+      | 1210    | en           | Child lvl2 Skill 2 |
+      | 1220    | en           | Child lvl1 Task 2  |
+      | 1300    | en           | Child lvl1 Skill 3 |
+      | 1400    | en           | Child lvl1 Chapter |
+      | 1500    | en           | Child lvl1 Task    |
+    And the database has the following table 'attempts':
+      | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at |
+      | 0  | 1000           | 2020-01-01 00:00:00 | null         | null              | null     |
+    And the database has the following table 'results':
+      | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
+      | 0          | 1000           | 1000    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1100    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1120    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1200    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1210    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1300    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1400    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+      | 0          | 1000           | 1500    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
+    Given I am the user with id "1000"
+    When I send a GET request to "/items/1000/navigation?attempt_id=0"
+    Then the response code should be 200
+    And the response at $.children[*].string.title should be:
+      | Child lvl1 Skill 1 |
+      | Child lvl1 Skill 2 |
+      | Child lvl1 Skill 3 |
+    And the response at $.children[*].has_visible_children should be:
+      | false |
+      | true  |
+      | false |
+
   Scenario Outline: Get navigation (with child_attempt_id)
     Given I am the user with id "11"
     When I send a GET request to "/items/200/navigation?child_attempt_id=<child_attempt_id>"

--- a/app/api/items/get_navigation.feature
+++ b/app/api/items/get_navigation.feature
@@ -292,14 +292,11 @@ Feature: Get navigation for an item
     Given I am the user with id "1000"
     When I send a GET request to "/items/1000/navigation?attempt_id=0"
     Then the response code should be 200
-    And the response at $.children[*].string.title should be:
-      | Child lvl1 Skill 1 |
-      | Child lvl1 Skill 2 |
-      | Child lvl1 Skill 3 |
-    And the response at $.children[*].has_visible_children should be:
-      | false |
-      | true  |
-      | false |
+    And the response at $.children[*] should be:
+      | string.title       | has_visible_children |
+      | Child lvl1 Skill 1 | false                |
+      | Child lvl1 Skill 2 | true                 |
+      | Child lvl1 Skill 3 | false                |
 
   Scenario Outline: Get navigation (with child_attempt_id)
     Given I am the user with id "11"

--- a/app/api/items/get_navigation.go
+++ b/app/api/items/get_navigation.go
@@ -69,6 +69,10 @@ type itemWatchedGroupStat struct {
 //
 //		Returns data needed to display the navigation menu (for `item_id` and its children)
 //		within the context of the given `{attempt_id}`/`{child_attempt_id}` (one of those should be given).
+//
+//		If the given `item_id` is a Skill, the children returned are only Skills.
+//		If it is a Chapter, the children returned are Tasks and Chapters.
+//
 //		Only items visible to the current user (or to the `{as_team_id}` team) are shown.
 //		If `{watched_group_id}` is given, some additional info about the given group's results on the items is shown.
 //

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -68,8 +68,8 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 		Joins(`
 			JOIN items AS child_items
 			  ON child_items.id = items_items.child_item_id
-			 AND (items.type = "Skill" AND child_items.type = "Skill")
-				OR items.type <> "Skill"
+			 AND ((items.type = "Skill" AND child_items.type = "Skill")
+					 OR items.type <> "Skill")
 		`).
 		Where("items_items.parent_item_id = items.id").
 		Select("1").

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/goware/urlx v0.2.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZ
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/goware/urlx v0.2.0 h1:E4bW8qSmhUgJ7Z5qY93mfN+IiUPXi66iua1Wza0wP7I=
 github.com/goware/urlx v0.2.0/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -120,6 +120,7 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *messages.P
 	for i := 0; i < len(wants.Rows); i++ {
 		switch result := jsonPathResArr[i].(type) {
 		case bool:
+			// Convert boolean results to strings because the values we check are coming from Gherkin as strings.
 			sortedResults[i] = strconv.FormatBool(result)
 		default:
 			sortedResults[i] = result.(string)

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -118,7 +118,12 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *messages.P
 	sortedResults := make([]string, len(wants.Rows))
 	sortedWants := make([]string, len(wants.Rows))
 	for i := 0; i < len(wants.Rows); i++ {
-		sortedResults[i] = jsonPathResArr[i].(string)
+		switch result := jsonPathResArr[i].(type) {
+		case bool:
+			sortedResults[i] = strconv.FormatBool(result)
+		default:
+			sortedResults[i] = result.(string)
+		}
 		sortedWants[i] = ctx.replaceReferencesByIDs(wants.Rows[i].Cells[0].Value)
 	}
 


### PR DESCRIPTION
fixes #959 

- Added new test case with a navigation request on a Skill

- Updated Gherkin helper `TheResponseAtShouldBe` to handle comparisons on boolean values

- Added the go-cmp package by Google (https://github.com/google/go-cmp) to make it easier to compare two slices of maps.

- `TheResponseAtShouldBe` has been updated to handle the check of multiple fields like this:
```
    And the response at $.children[*] should be:
      | string.title       | has_visible_children |
      | Child lvl1 Skill 1 | false                |
      | Child lvl1 Skill 2 | true                 |
      | Child lvl1 Skill 3 | false                |
```

The column is a `JSONPath`, or just the name of the field, which can also be considered as a `JSONPath`.

We need that because if we do two checks in a row:
- `And the response at $.children[*].string.title should be:`
- `And the response at $.children[*].has_visible_children should be:`
 
We would validate that there are two rows with `has_visible_children=false`, but it would not validate that they correspond to the rows with titles:
- `Child lvl1 Skill 1`
- `Child lvl1 Skill 3`