### PR TITLE
All responses have a Backend-Version header with the version injected in main

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/rand"
+	"github.com/France-ioi/AlgoreaBackend/app/version"
 )
 
 // Application is the core state of the app.
@@ -77,6 +78,8 @@ func (app *Application) Reset(config *viper.Viper) error {
 
 	// Set up middlewares
 	router := chi.NewRouter()
+
+	router.Use(version.AddVersionHeader)
 
 	router.Use(middleware.RealIP) // must be before logger or any middleware using remote IP
 	if serverConfig.GetBool("compress") {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/app/version"
 )
 
 /* note that the tests of app.New() are very incomplete (even if all exec path are covered) */
@@ -38,7 +39,7 @@ func TestNew_Success(t *testing.T) {
 	assert.NotNil(app.Database)
 	assert.NotNil(app.HTTPHandler)
 	assert.NotNil(app.apiCtx)
-	assert.Len(app.HTTPHandler.Middlewares(), 7)
+	assert.Len(app.HTTPHandler.Middlewares(), 8)
 	assert.True(len(app.HTTPHandler.Routes()) > 0)
 	assert.Equal("/*", app.HTTPHandler.Routes()[0].Pattern) // test default val
 }
@@ -49,7 +50,7 @@ func TestNew_SuccessNoCompress(t *testing.T) {
 	_ = os.Setenv("ALGOREA_SERVER__COMPRESS", "false")
 	defer func() { _ = os.Unsetenv("ALGOREA_SERVER__COMPRESS") }()
 	app, _ := New()
-	assert.Len(app.HTTPHandler.Middlewares(), 6)
+	assert.Len(app.HTTPHandler.Middlewares(), 7)
 }
 
 func TestNew_NotDefaultRootPath(t *testing.T) {
@@ -206,6 +207,7 @@ func TestMiddlewares_OnSuccess(t *testing.T) {
 	// check that the compression has been applied but the length in the logs is not altered by compression i
 	assert.Equal(23, hook.LastEntry().Data["resp_bytes_length"])
 	assert.Equal("gzip", response.Header.Get("Content-Encoding"))
+	assert.Equal(version.Version, response.Header.Get("Backend-Version"))
 }
 
 func TestNew_MountsPprofInDev(t *testing.T) {

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -1,0 +1,16 @@
+// Package version exposes the app version
+package version
+
+import "net/http"
+
+// Version is the app version.
+var Version string
+
+// AddVersionHeader adds the Backend-Version header in the responses.
+func AddVersionHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Backend-Version", Version)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	appVersion "github.com/France-ioi/AlgoreaBackend/app/version"
 	"github.com/France-ioi/AlgoreaBackend/cmd"
 )
 
@@ -10,5 +11,7 @@ var (
 )
 
 func main() {
+	appVersion.Version = version
+
 	cmd.Execute()
 }


### PR DESCRIPTION
fixes #840 

Uses a middleware to inject `Backend-Version` on all responses.

The version is globally accessible as `version.Version`.

I also considered storing the version in the Application{} struct, but it required passing the version in many different places, in tests, and in all commands.