### PR TITLE
Refactor withGradings() into the database package

### DIFF
--- a/app/api/answers/answers.go
+++ b/app/api/answers/answers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-chi/render"
 
 	"github.com/France-ioi/AlgoreaBackend/app/auth"
-	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
@@ -37,12 +36,4 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	routerWithParticipant.Get("/items/{item_id}/current-answer", service.AppHandler(srv.getCurrentAnswer).ServeHTTP)
 	routerWithParticipant.Post("/items/{item_id}/attempts/{attempt_id}/answers", service.AppHandler(srv.answerCreate).ServeHTTP)
 	routerWithParticipant.Put("/items/{item_id}/attempts/{attempt_id}/answers/current", service.AppHandler(srv.updateCurrentAnswer).ServeHTTP)
-}
-
-func withGradings(answersQuery *database.DB) *database.DB {
-	return answersQuery.
-		Joins("LEFT JOIN gradings ON gradings.answer_id = answers.id").
-		Select(`answers.id, answers.author_id, answers.item_id, answers.attempt_id, answers.participant_id,
-			answers.type, answers.state, answers.answer, answers.created_at, gradings.score,
-			gradings.graded_at`)
 }

--- a/app/api/answers/get_current.go
+++ b/app/api/answers/get_current.go
@@ -70,20 +70,13 @@ func (srv *Service) getCurrentAnswer(rw http.ResponseWriter, httpReq *http.Reque
 		return service.InsufficientAccessRightsError
 	}
 
-	var result []map[string]interface{}
-	err = withGradings(
-		srv.GetStore(httpReq).Answers().GetCurrentAnswerQuery(participantID, itemID, attemptID),
-	).
-		ScanIntoSliceOfMaps(&result).
-		Error()
-	service.MustNotBeError(err)
-	if len(result) == 0 {
-		result = make([]map[string]interface{}, 1)
-		result[0] = map[string]interface{}{
+	answer, hasAnswer := store.Answers().GetCurrentAnswer(participantID, itemID, attemptID)
+	if !hasAnswer {
+		answer = map[string]interface{}{
 			"type": nil,
 		}
 	}
-	convertedResult := service.ConvertSliceOfMapsFromDBToJSON(result)[0]
+	convertedResult := service.ConvertMapFromDBToJSON(answer)
 
 	render.Respond(rw, httpReq, convertedResult)
 	return service.NoError

--- a/app/database/answer_store.go
+++ b/app/database/answer_store.go
@@ -5,6 +5,20 @@ type AnswerStore struct {
 	*DataStore
 }
 
+// WithGradings creates a composable query for getting answers joined with gradings (via answer_id).
+func (s *AnswerStore) WithGradings() *AnswerStore {
+	return &AnswerStore{
+		NewDataStoreWithTable(
+			s.Select(`
+					answers.id, answers.author_id, answers.item_id, answers.attempt_id, answers.participant_id,
+					answers.type, answers.state, answers.answer, answers.created_at, gradings.score,
+					gradings.graded_at
+				`).
+				Joins("LEFT JOIN gradings ON gradings.answer_id = answers.id"), s.tableName,
+		),
+	}
+}
+
 // WithUsers creates a composable query for getting answers joined with users (via author_id).
 func (s *AnswerStore) WithUsers() *AnswerStore {
 	return &AnswerStore{
@@ -34,15 +48,26 @@ func (s *AnswerStore) WithItems() *AnswerStore {
 	}
 }
 
-// GetCurrentAnswerQuery returns a query to get the current answer of a participant-item-attempt triplet.
-func (s *AnswerStore) GetCurrentAnswerQuery(participantID, itemID, attemptID int64) *DB {
-	return s.
+// GetCurrentAnswer returns the current answer of a participant-item-attempt triplet.
+func (s *AnswerStore) GetCurrentAnswer(participantID, itemID, attemptID int64) (map[string]interface{}, bool) {
+	var result []map[string]interface{}
+	err := s.
+		WithGradings().
 		Where("participant_id = ?", participantID).
 		Where("attempt_id = ?", attemptID).
 		Where("item_id = ?", itemID).
 		Where("type = 'Current'").
 		Order("created_at DESC").
-		Limit(1)
+		Limit(1).
+		ScanIntoSliceOfMaps(&result).
+		Error()
+	mustNotBeError(err)
+
+	if len(result) == 0 {
+		return map[string]interface{}{}, false
+	}
+
+	return result[0], true
 }
 
 // SubmitNewAnswer inserts a new row with type='Submission', created_at=NOW()


### PR DESCRIPTION
Additional refactoring after making changes to `GetCurrentAnswer`. The way `withGradings()` was used is weird and not consistent with how joined queries are constructed elsewhere.

- There is no reason to have database logic defined in the root of a service package.
- This is not consistent with the way WithXXX methods are used elsewhere for joins.

Also move all the database logic related to creating the get current answer query into its own method. This also simplifies the rendering of the answer because there is no need to jungle with a slice, whereas we never have more than one item coming from the query.