### PR TITLE
Add can_request_help_to to grantedPermissionsView

### DIFF
--- a/app/api/groups/get_granted_permissions.feature
+++ b/app/api/groups/get_granted_permissions.feature
@@ -46,25 +46,25 @@ Feature: Get permissions granted to group
       | 102      | fr           | Chapitre B |
       | 104      | fr           | Chapitre C |
     And the database table 'permissions_granted' has also the following rows:
-      | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
-      | 31       | 102     | 10              | group_membership | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 101     | 25              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 101     | 25              | item_unlocking   | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 101     | 25              | self             | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 101     | 25              | other            | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 102     | 25              | group_membership | info     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 101     | 26              | group_membership | none     | enter          | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 25       | 104     | 26              | group_membership | none     | none           | result    | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 10       | 101     | 25              | group_membership | none     | none           | none      | children | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 10       | 102     | 25              | group_membership | none     | none           | none      | none     | true     | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 10       | 101     | 26              | group_membership | none     | none           | none      | none     | false    | true                      | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 10       | 102     | 26              | group_membership | none     | none           | none      | none     | false    | false                     | 2999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 9        | 101     | 25              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
-      | 23       | 102     | 23              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
-      | 23       | 102     | 25              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
-      | 25       | 101     | 10              | group_membership | none     | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
-      | 25       | 103     | 25              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-      | 31       | 101     | 27              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_request_help_to | can_make_session_official | can_enter_from      | can_enter_until     |
+      | 31       | 102     | 10              | group_membership | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | item_unlocking   | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | self             | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 25              | other            | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 102     | 25              | group_membership | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 101     | 26              | group_membership | none     | enter          | none      | none     | false    | 25                  | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 104     | 26              | group_membership | none     | none           | result    | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 101     | 25              | group_membership | none     | none           | none      | children | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 25              | group_membership | none     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 101     | 26              | group_membership | none     | none           | none      | none     | false    | null                | true                      | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 26              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 2999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 9        | 101     | 25              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 23       | 102     | 23              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 23       | 102     | 25              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 25       | 101     | 10              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
+      | 25       | 103     | 25              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 31       | 101     | 27              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
     And the database table 'permissions_generated' has also the following rows:
       | group_id | item_id | can_grant_view_generated | can_watch_generated | can_edit_generated |
       | 8        | 101     | enter                    | none                | none               |
@@ -135,7 +135,7 @@ Feature: Get permissions granted to group
         "permissions": {
           "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
           "can_grant_view": "enter", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
-          "is_owner": false
+          "is_owner": false, "can_request_help_to": 25
         },
         "source_group": {"id": "26", "name": "other class"}
       },
@@ -238,7 +238,7 @@ Feature: Get permissions granted to group
         "permissions": {
           "can_edit": "none", "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
           "can_grant_view": "enter", "can_make_session_official": false, "can_view": "none", "can_watch": "none",
-          "is_owner": false
+          "is_owner": false, "can_request_help_to": 25
         },
         "source_group": {"id": "26", "name": "other class"}
       },

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -218,6 +218,7 @@ func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request
 			can_watch AS permissions__can_watch, can_edit AS permissions__can_edit,
 			can_make_session_official AS permissions__can_make_session_official,
 			is_owner AS permissions__is_owner, can_enter_from AS permissions__can_enter_from,
+			can_request_help_to AS permissions__can_request_help_to,
 			can_enter_until AS permissions__can_enter_until`)
 
 	query = service.NewQueryLimiter().Apply(r, query)

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -69,6 +69,8 @@ type grantedPermissionsViewResultRow struct {
 //		or descendants of the `group_id` group managed by the current user with `can_grant_group_access` permission.
 //
 //		* The current user must be a manager (with `can_grant_group_access` permission) of `{group_id}`.
+//
+//		Returns permission `can_request_help_to` if it is set.
 //	parameters:
 //		- name: group_id
 //			in: path

--- a/app/structures/structures.go
+++ b/app/structures/structures.go
@@ -21,8 +21,8 @@ type ItemPermissions struct {
 	CanEdit string `json:"can_edit"`
 	// required: true
 	IsOwner bool `json:"is_owner"`
-	// appears only in services that support this permission, and only if it is set
-	// required: true
+	// appears only in services that support this permission (see service description), and only if it is set
+	// required: false
 	CanRequestHelpTo *int64 `json:"can_request_help_to,omitempty"`
 }
 

--- a/app/structures/structures.go
+++ b/app/structures/structures.go
@@ -21,6 +21,9 @@ type ItemPermissions struct {
 	CanEdit string `json:"can_edit"`
 	// required: true
 	IsOwner bool `json:"is_owner"`
+	// appears only in services that support this permission, and only if it is set
+	// required: true
+	CanRequestHelpTo *int64 `json:"can_request_help_to,omitempty"`
 }
 
 // ItemString represents a title with a related language tag for an item.


### PR DESCRIPTION
Part 1 of https://github.com/France-ioi/AlgoreaBackend/issues/968

Here we want to add `can_request_help_to` only to the service `grantedPermissionsView`. The problem is that the structure containing the permissions is reused in many different services: basically, every time `permissions` appears in a response.

There are a few options:
- Either we update all the services to add the new field. But it's not that easy because we would have to update all the tests and all the SELECT statements.
- We can also redefine the permission structure in this case. Not easy because it is nested into other structures. If we want a different structure, we have to duplicate a tree of structures.
- The solution implemented: add `omitempty` to the definition of the structure. With this, `can_request_help_to` appears in the resulting JSON only if it is defined. So the output of existing services doesn't change. **But the catch is:** if `can_request_help_to` is `null`, the parameter will not appear at all in the response. A comment was added to appear in the API doc.