### PR TITLE
Refactor ptrXXX into one function that returns a pointer using generics

### DIFF
--- a/app/api/answers/generate_task_token.go
+++ b/app/api/answers/generate_task_token.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 // swagger:operation POST /answers/{answer_id}/generate-task-token answers answerTaskTokenGenerate
@@ -171,12 +172,12 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 
 	taskToken := token.Task{
 		AccessSolutions:    &accessSolutions,
-		SubmissionPossible: ptrBool(false),
-		HintsAllowed:       ptrBool(false),
+		SubmissionPossible: utils.Ptr(false),
+		HintsAllowed:       utils.Ptr(false),
 		HintsRequested:     answerInfos.HintsRequested,
-		HintsGivenCount:    ptrString(strconv.Itoa(int(answerInfos.HintsCachedCount))),
-		IsAdmin:            ptrBool(false),
-		ReadAnswers:        ptrBool(true),
+		HintsGivenCount:    utils.Ptr(strconv.Itoa(int(answerInfos.HintsCachedCount))),
+		IsAdmin:            utils.Ptr(false),
+		ReadAnswers:        utils.Ptr(true),
 		UserID:             strconv.FormatInt(answerInfos.AuthorID, 10),
 		LocalItemID:        strconv.FormatInt(answerInfos.ItemID, 10),
 		ItemID:             answerInfos.TextID,
@@ -195,6 +196,3 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 	}))
 	return service.NoError
 }
-
-func ptrString(s string) *string { return &s }
-func ptrBool(b bool) *bool       { return &b }

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/servicetest"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 func Test_validateUpdateGroupInput(t *testing.T) {
@@ -195,10 +196,10 @@ func Test_int64PtrEqualValues(t *testing.T) {
 		want bool
 	}{
 		{name: "both are nils", args: args{a: nil, b: nil}, want: true},
-		{name: "a is nil, b is not nil", args: args{a: nil, b: ptrInt64(1)}, want: false},
-		{name: "a is not nil, b is nil", args: args{a: ptrInt64(0), b: nil}, want: false},
-		{name: "both are not nils, but not equal", args: args{a: ptrInt64(0), b: ptrInt64(1)}, want: false},
-		{name: "both are not nils, equal", args: args{a: ptrInt64(1), b: ptrInt64(1)}, want: true},
+		{name: "a is nil, b is not nil", args: args{a: nil, b: utils.Ptr(int64(1))}, want: false},
+		{name: "a is not nil, b is nil", args: args{a: utils.Ptr(int64(0)), b: nil}, want: false},
+		{name: "both are not nils, but not equal", args: args{a: utils.Ptr(int64(0)), b: utils.Ptr(int64(1))}, want: false},
+		{name: "both are not nils, equal", args: args{a: utils.Ptr(int64(1)), b: utils.Ptr(int64(1))}, want: true},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -207,5 +208,3 @@ func Test_int64PtrEqualValues(t *testing.T) {
 		})
 	}
 }
-
-func ptrInt64(i int64) *int64 { return &i }

--- a/app/api/items/generate_task_token.go
+++ b/app/api/items/generate_task_token.go
@@ -12,6 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 // swagger:operation POST /items/{item_id}/attempts/{attempt_id}/generate-task-token items itemTaskTokenGenerate
@@ -169,12 +170,12 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 
 	taskToken := token.Task{
 		AccessSolutions:    &accessSolutions,
-		SubmissionPossible: ptrBool(true),
+		SubmissionPossible: utils.Ptr(true),
 		HintsAllowed:       &itemInfo.HintsAllowed,
 		HintsRequested:     resultInfo.HintsRequested,
-		HintsGivenCount:    ptrString(strconv.Itoa(int(resultInfo.HintsCachedCount))),
-		IsAdmin:            ptrBool(false),
-		ReadAnswers:        ptrBool(true),
+		HintsGivenCount:    utils.Ptr(strconv.Itoa(int(resultInfo.HintsCachedCount))),
+		IsAdmin:            utils.Ptr(false),
+		ReadAnswers:        utils.Ptr(true),
 		UserID:             strconv.FormatInt(user.GroupID, 10),
 		LocalItemID:        strconv.FormatInt(itemID, 10),
 		ItemID:             itemInfo.TextID,
@@ -193,6 +194,3 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 	}))
 	return service.NoError
 }
-
-func ptrString(s string) *string { return &s }
-func ptrBool(b bool) *bool       { return &b }

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -18,6 +18,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 // swagger:operation POST /items/save-grade items saveGrade
@@ -120,7 +121,7 @@ func (srv *Service) saveGrade(w http.ResponseWriter, r *http.Request) service.AP
 	}
 
 	if validated || requestData.TaskToken.AccessSolutions != nil && !(*requestData.TaskToken.AccessSolutions) {
-		requestData.TaskToken.AccessSolutions = ptrBool(true)
+		requestData.TaskToken.AccessSolutions = utils.Ptr(true)
 	}
 	requestData.TaskToken.PlatformName = srv.TokenConfig.PlatformName
 	newTaskToken, err := requestData.TaskToken.Sign(srv.TokenConfig.PrivateKey)

--- a/app/database/attempt_store_integration_test.go
+++ b/app/database/attempt_store_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
@@ -76,8 +77,8 @@ func TestAttemptStore_CreateNew_CreatesNewAttempt(t *testing.T) {
 	assert.Equal(t, attemptType{
 		ParticipantID:   10,
 		ID:              1,
-		ParentAttemptID: ptrInt64(200),
-		RootItemID:      ptrInt64(20),
+		ParentAttemptID: utils.Ptr(int64(200)),
+		RootItemID:      utils.Ptr(int64(20)),
 		CreatorID:       100,
 		CreatedAt:       &expectedTime,
 	}, attempt)

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 const someName = "some name"
@@ -869,7 +871,7 @@ func TestDB_ScanIntoSlices(t *testing.T) {
 	assert.NoError(t, dbScan.Error())
 
 	assert.Equal(t, []int64{1, 2, 3}, ids)
-	assert.Equal(t, []*string{ptrString("value"), ptrString("another value"), nil}, fields)
+	assert.Equal(t, []*string{utils.Ptr("value"), utils.Ptr("another value"), nil}, fields)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -900,11 +902,11 @@ func TestDB_ScanIntoSlices_WipesOldData(t *testing.T) {
 	db = db.Table("myTable")
 
 	ids := []int64{10, 20, 30}
-	fields := []*string{ptrString("old value1"), ptrString("old value2"), ptrString("old value3")}
+	fields := []*string{utils.Ptr("old value1"), utils.Ptr("old value2"), utils.Ptr("old value3")}
 
 	db.ScanIntoSlices(&ids, &fields)
 	assert.Equal(t, []int64{1, 2, 3}, ids)
-	assert.Equal(t, []*string{ptrString("value"), ptrString("another value"), nil}, fields)
+	assert.Equal(t, []*string{utils.Ptr("value"), utils.Ptr("another value"), nil}, fields)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -1531,5 +1533,3 @@ func TestDB_InsertIgnoreMaps(t *testing.T) {
 	assert.Equal(t, expectedError, db.InsertIgnoreMaps("myTable", dataRows))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
-
-func ptrString(s string) *string { return &s }

--- a/app/database/group_ancestor_store_test.go
+++ b/app/database/group_ancestor_store_test.go
@@ -50,5 +50,3 @@ func TestGroupAncestorStore_ManagedByUser(t *testing.T) {
 		})
 	}
 }
-
-func ptrInt64(i int64) *int64 { return &i }

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
@@ -213,7 +214,7 @@ var generatedPermissionsUnchanged = []permissionsGeneratedResultRow{
 }
 
 var (
-	currentTimePtr = (*database.Time)(ptrTime(time.Now().UTC()))
+	currentTimePtr = (*database.Time)(utils.Ptr(time.Now().UTC()))
 	userID         = int64(111)
 	userIDPtr      = &userID
 )
@@ -283,7 +284,7 @@ func testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipan
 		name:              name,
 		action:            action,
 		relationsToChange: allTheIDs,
-		maxParticipants:   ptrInt(8),
+		maxParticipants:   utils.Ptr(8),
 		wantResult: database.GroupGroupTransitionResults{
 			1: "full", 2: "full", 3: "full", 6: "full", 7: "full",
 
@@ -340,7 +341,7 @@ func testTransitionAcceptingPendingRequestEnforcingMaxParticipants(name string, 
 		action:                     action,
 		relationsToChange:          allTheIDs,
 		createPendingCycleWithType: pendingType.PendingType(),
-		maxParticipants:            ptrInt(5),
+		maxParticipants:            utils.Ptr(5),
 		wantResult: buildExpectedGroupTransitionResults(database.GroupGroupTransitionResults{
 			acceptedID: "full", 30: "cycle",
 		}),
@@ -432,7 +433,7 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 			action:                     database.AdminCreatesInvitation,
 			createPendingCycleWithType: "join_request",
 			relationsToChange:          allTheIDs,
-			maxParticipants:            ptrInt(9),
+			maxParticipants:            utils.Ptr(9),
 			wantResult: database.GroupGroupTransitionResults{
 				1: "success", 3: "success", 6: "success", 7: "success",
 				2: "unchanged",
@@ -466,7 +467,7 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 			action:                     database.AdminCreatesInvitation,
 			createPendingCycleWithType: "join_request",
 			relationsToChange:          allTheIDs,
-			maxParticipants:            ptrInt(8),
+			maxParticipants:            utils.Ptr(8),
 			wantResult: database.GroupGroupTransitionResults{
 				1: "full", 3: "full", 6: "full", 7: "full",
 				2: "unchanged",
@@ -524,7 +525,7 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 			name:              "UserCreatesJoinRequest (max participants limit is not exceeded)",
 			action:            database.UserCreatesJoinRequest,
 			relationsToChange: allTheIDs,
-			maxParticipants:   ptrInt(6),
+			maxParticipants:   utils.Ptr(6),
 			approvals: map[int64]database.GroupApprovals{
 				1: {PersonalInfoViewApproval: true, LockMembershipApproval: true, WatchApproval: true},
 				6: {PersonalInfoViewApproval: true, LockMembershipApproval: true, WatchApproval: false},
@@ -569,7 +570,7 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 				6: {PersonalInfoViewApproval: true, LockMembershipApproval: true, WatchApproval: false},
 				7: {PersonalInfoViewApproval: false, LockMembershipApproval: false, WatchApproval: true},
 			},
-			maxParticipants: ptrInt(5),
+			maxParticipants: utils.Ptr(5),
 			wantResult: database.GroupGroupTransitionResults{
 				1: "full", 6: "full", 7: "full",
 				3: "unchanged",
@@ -600,7 +601,7 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 		testTransitionAcceptingPendingRequest("AdminAcceptsJoinRequest",
 			database.AdminAcceptsJoinRequest, 3, database.JoinRequestCreated, database.JoinRequestAccepted, true, nil),
 		testTransitionAcceptingPendingRequest("AdminAcceptsJoinRequest (max participants limit is not exceeded)",
-			database.AdminAcceptsJoinRequest, 3, database.JoinRequestCreated, database.JoinRequestAccepted, false, ptrInt(7)),
+			database.AdminAcceptsJoinRequest, 3, database.JoinRequestCreated, database.JoinRequestAccepted, false, utils.Ptr(7)),
 		testTransitionAcceptingPendingRequestEnforcingMaxParticipants(
 			"AdminAcceptsJoinRequest", database.AdminAcceptsJoinRequest, 3, database.JoinRequestCreated),
 		{
@@ -753,20 +754,20 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 		testTransitionAcceptingNoRelationAndAnyPendingRequest(
 			"UserCreatesAcceptedJoinRequest", database.UserCreatesAcceptedJoinRequest, database.JoinRequestAccepted, true, nil),
 		testTransitionAcceptingNoRelationAndAnyPendingRequest("UserCreatesAcceptedJoinRequest (max participants limit is not exceeded)",
-			database.UserCreatesAcceptedJoinRequest, database.JoinRequestAccepted, false, ptrInt(9)),
+			database.UserCreatesAcceptedJoinRequest, database.JoinRequestAccepted, false, utils.Ptr(9)),
 		testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipants(
 			"UserCreatesAcceptedJoinRequest (enforce max participants)",
 			database.UserCreatesAcceptedJoinRequest, false),
 		testTransitionAcceptingNoRelationAndAnyPendingRequest(
 			"UserJoinsGroupByBadge", database.UserJoinsGroupByBadge, database.JoinedByBadge, true, nil),
 		testTransitionAcceptingNoRelationAndAnyPendingRequest("UserJoinsGroupByBadge (max participants limit is not exceeded)",
-			database.UserJoinsGroupByBadge, database.JoinedByBadge, false, ptrInt(9)),
+			database.UserJoinsGroupByBadge, database.JoinedByBadge, false, utils.Ptr(9)),
 		testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipants(
 			"UserJoinsGroupByBadge (enforce max participants)", database.UserJoinsGroupByBadge, false),
 		testTransitionAcceptingNoRelationAndAnyPendingRequest(
 			"UserJoinsGroupByCode", database.UserJoinsGroupByCode, database.JoinedByCode, true, nil),
 		testTransitionAcceptingNoRelationAndAnyPendingRequest("UserJoinsGroupByCode (max participants limit is not exceeded)",
-			database.UserJoinsGroupByCode, database.JoinedByCode, false, ptrInt(9)),
+			database.UserJoinsGroupByCode, database.JoinedByCode, false, utils.Ptr(9)),
 		testTransitionAcceptingNoRelationAndAnyPendingRequestEnforcingMaxParticipants(
 			"UserJoinsGroupByCode (enforce max participants)", database.UserJoinsGroupByCode, false),
 		{
@@ -1003,7 +1004,7 @@ func generateApprovalsTests(expectedTime *database.Time) []approvalsTest {
 }
 
 func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestsOnAcceptingJoinRequests(t *testing.T) {
-	expectedTime := (*database.Time)(ptrTime(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC)))
+	expectedTime := (*database.Time)(utils.Ptr(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC)))
 	for _, tt := range generateApprovalsTests(expectedTime) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -1145,7 +1146,7 @@ func TestGroupGroupStore_Transition_ReplacesJoinRequestByInvitationWhenNotNotEno
 
 func TestGroupGroupStore_Transition_ChecksApprovalsFromParametersOnAcceptingInvitations(t *testing.T) {
 	const success = "success"
-	expectedTime := (*database.Time)(ptrTime(time.Date(2019, 6, 1, 0, 0, 0, 0, time.UTC)))
+	expectedTime := (*database.Time)(utils.Ptr(time.Date(2019, 6, 1, 0, 0, 0, 0, time.UTC)))
 	database.MockNow("2019-06-01 00:00:00")
 	defer database.RestoreNow()
 
@@ -1424,5 +1425,3 @@ func assertGeneratedPermissionsEqual(
 		Order("group_id, item_id").Scan(&generatedPermissions).Error())
 	assert.EqualValues(t, expected, generatedPermissions)
 }
-
-func ptrInt(i int) *int { return &i }

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -361,6 +361,3 @@ func Test_GroupStore_DeleteGroup(t *testing.T) {
 	assert.NoError(t, groupStore.Table("groups_propagate").Pluck("id", &ids).Error())
 	assert.Empty(t, ids)
 }
-
-func ptrString(s string) *string { return &s }
-func ptrInt64(i int64) *int64    { return &i }

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
@@ -1033,8 +1034,8 @@ func TestItemStore_TriggerBeforeInsert_SetsPlatformID(t *testing.T) {
 		wantPlatformID *int64
 	}{
 		{name: "url is null", url: nil, wantPlatformID: nil},
-		{name: "chooses a platform with higher priority", url: ptrString("1234"), wantPlatformID: ptrInt64(2)},
-		{name: "url doesn't match any regexp", url: ptrString("34"), wantPlatformID: nil},
+		{name: "chooses a platform with higher priority", url: utils.Ptr("1234"), wantPlatformID: utils.Ptr(int64(2))},
+		{name: "url doesn't match any regexp", url: utils.Ptr("34"), wantPlatformID: nil},
 	}
 	for _, test := range tests {
 		test := test
@@ -1075,13 +1076,13 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 		updateMap      map[string]interface{}
 		wantPlatformID *int64
 	}{
-		{name: "url is unchanged", updateMap: map[string]interface{}{"type": "Chapter"}, wantPlatformID: ptrInt64(1)},
+		{name: "url is unchanged", updateMap: map[string]interface{}{"type": "Chapter"}, wantPlatformID: utils.Ptr(int64(1))},
 		{name: "new url is null", updateMap: map[string]interface{}{"url": nil}, wantPlatformID: nil},
 		{
-			name: "chooses a platform with higher priority", updateMap: map[string]interface{}{"url": ptrString("12345")},
-			wantPlatformID: ptrInt64(2),
+			name: "chooses a platform with higher priority", updateMap: map[string]interface{}{"url": utils.Ptr("12345")},
+			wantPlatformID: utils.Ptr(int64(2)),
 		},
-		{name: "new url doesn't match any regexp", updateMap: map[string]interface{}{"url": ptrString("34")}, wantPlatformID: nil},
+		{name: "new url doesn't match any regexp", updateMap: map[string]interface{}{"url": utils.Ptr("34")}, wantPlatformID: nil},
 	}
 	for _, test := range tests {
 		test := test
@@ -1124,17 +1125,17 @@ func TestItemStore_PlatformsTriggerAfterInsert_SetsPlatformID(t *testing.T) {
 		{
 			name:   "recalculates items linked to platforms with lower priority or no platform",
 			regexp: "1", priority: 3,
-			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), ptrInt64(2)},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(2)), utils.Ptr(int64(1)), utils.Ptr(int64(2)), utils.Ptr(int64(2))},
 		},
 		{
 			name:   "recalculates items linked to platforms with lower priority or no platform (higher priority)",
 			regexp: "1", priority: 6,
-			wantPlatformIDs: []*int64{ptrInt64(5), ptrInt64(4), ptrInt64(5), nil},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(5)), utils.Ptr(int64(4)), utils.Ptr(int64(5)), nil},
 		},
 		{
 			name:   "recalculates only item without a platform when the new platform has the lowest priority",
 			regexp: "1", priority: -1,
-			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), ptrInt64(2), ptrInt64(2)},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(4)), utils.Ptr(int64(1)), utils.Ptr(int64(2)), utils.Ptr(int64(2))},
 		},
 	}
 	for _, test := range tests {
@@ -1178,27 +1179,27 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 		{
 			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (only priority is changed)",
 			regexp: "^1.*", priority: 3,
-			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), nil},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(2)), utils.Ptr(int64(1)), utils.Ptr(int64(2)), nil},
 		},
 		{
 			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (only regexp is changed)",
 			regexp: "1", priority: 4,
-			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(1), ptrInt64(2), nil},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(2)), utils.Ptr(int64(1)), utils.Ptr(int64(2)), nil},
 		},
 		{
 			name:   "recalculates items linked to platforms with lower priority or no platform or the modified platform (higher priority)",
 			regexp: "1", priority: 6,
-			wantPlatformIDs: []*int64{ptrInt64(2), ptrInt64(4), ptrInt64(2), nil},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(2)), utils.Ptr(int64(4)), utils.Ptr(int64(2)), nil},
 		},
 		{
 			name:   "recalculates only item without a platform when the new platform has the lowest priority",
 			regexp: "1", priority: -1,
-			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), ptrInt64(3), nil},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(4)), utils.Ptr(int64(1)), utils.Ptr(int64(3)), nil},
 		},
 		{
 			name:   "doesn't recalculate anything when regexp & priority stays unchanged",
 			regexp: "^1.*", priority: 4,
-			wantPlatformIDs: []*int64{ptrInt64(4), ptrInt64(1), nil, ptrInt64(2)},
+			wantPlatformIDs: []*int64{utils.Ptr(int64(4)), utils.Ptr(int64(1)), nil, utils.Ptr(int64(2))},
 		},
 	}
 	for _, test := range tests {

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -5,7 +5,6 @@ package database_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -778,8 +777,6 @@ func testPropagates(t *testing.T, column, propagationColumn, valueForParent stri
 		assert.Equal(t, expectedValue, result)
 	})
 }
-
-func ptrTime(t time.Time) *time.Time { return &t }
 
 func assertPermissionsGeneratedResultRowsEqual(t *testing.T, expected, got []permissionsGeneratedResultRow) {
 	if len(got) != len(expected) {

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
@@ -38,7 +39,7 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 		{
 			name: "with info", participantID: 11, attemptID: 2, itemID: 12,
 			wantHintsInfo: &database.HintsInfo{
-				HintsRequested: ptrString(`[0,1,"hint",null]`),
+				HintsRequested: utils.Ptr(`[0,1,"hint",null]`),
 				HintsCached:    4,
 			},
 		},

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
@@ -140,7 +141,7 @@ func TestResultStore_Propagate_CreatesNew(t *testing.T) {
 			name:               "should not create new results for items above the root_item_id",
 			fixtures:           []string{`permissions_generated: [{group_id: 3, item_id: 111, can_view_generated: info}]`},
 			expectedNewResults: []existingResultsRow{{ParticipantID: 3, AttemptID: 1, ItemID: 222}},
-			rootItemID:         ptrInt64(222),
+			rootItemID:         utils.Ptr(int64(222)),
 		},
 	} {
 		test := test

--- a/app/database/user_test.go
+++ b/app/database/user_test.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 func TestUser_Clone(t *testing.T) {
 	ts := time.Now()
 	user := &User{
-		Login: "login", LoginID: ptrInt64(5), DefaultLanguage: "fr",
-		IsTempUser: true, IsAdmin: true, GroupID: 2, AccessGroupID: ptrInt64(4), NotificationsReadAt: (*Time)(&ts),
+		Login: "login", LoginID: utils.Ptr(int64(5)), DefaultLanguage: "fr",
+		IsTempUser: true, IsAdmin: true, GroupID: 2, AccessGroupID: utils.Ptr(int64(4)), NotificationsReadAt: (*Time)(&ts),
 	}
 	userClone := user.Clone()
 	assert.False(t, userClone == user)

--- a/app/payloads/common_test.go
+++ b/app/payloads/common_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/app/formdata"
 	"github.com/France-ioi/AlgoreaBackend/app/payloadstest"
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 func TestPayloads_ParseMap(t *testing.T) {
@@ -29,15 +30,15 @@ func TestPayloads_ParseMap(t *testing.T) {
 				LocalItemID:        "901756573345831409",
 				PlatformName:       "test_dmitry",
 				RandomSeed:         "556371821693219925",
-				HintsGivenCount:    ptrString("0"),
-				HintsAllowed:       ptrBool(false),
-				HintPossible:       ptrBool(true),
-				AccessSolutions:    ptrBool(true),
-				ReadAnswers:        ptrBool(true),
-				Login:              ptrString("test"),
-				SubmissionPossible: ptrBool(true),
-				SupportedLangProg:  ptrString("*"),
-				IsAdmin:            ptrBool(false),
+				HintsGivenCount:    utils.Ptr("0"),
+				HintsAllowed:       utils.Ptr(false),
+				HintPossible:       utils.Ptr(true),
+				AccessSolutions:    utils.Ptr(true),
+				ReadAnswers:        utils.Ptr(true),
+				Login:              utils.Ptr("test"),
+				SubmissionPossible: utils.Ptr(true),
+				SupportedLangProg:  utils.Ptr("*"),
+				IsAdmin:            utils.Ptr(false),
 				Converted: TaskTokenConverted{
 					UserID:        556371821693219925,
 					LocalItemID:   901756573345831409,
@@ -144,5 +145,3 @@ func TestConvertIntoMap(t *testing.T) {
 		},
 	}, got)
 }
-
-func ptrString(s string) *string { return &s }

--- a/app/payloads/task_token.go
+++ b/app/payloads/task_token.go
@@ -63,6 +63,4 @@ func (tt *TaskToken) Bind() error {
 	return nil
 }
 
-func ptrBool(b bool) *bool { return &b }
-
 var _ Binder = (*TaskToken)(nil)

--- a/app/payloads/task_token_test.go
+++ b/app/payloads/task_token_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/app/utils"
 )
 
 func TestTaskToken_Bind(t *testing.T) {
@@ -59,7 +61,7 @@ func TestTaskToken_MarshalJSON(t *testing.T) {
 	tt := &TaskToken{
 		UserID:          "10",
 		AttemptID:       "200",
-		AccessSolutions: ptrBool(true),
+		AccessSolutions: utils.Ptr(true),
 	}
 	result, err := json.Marshal(ConvertIntoMap(tt))
 	assert.NoError(t, err)

--- a/app/utils/pointer.go
+++ b/app/utils/pointer.go
@@ -1,0 +1,8 @@
+package utils
+
+// Ptr returns a pointer to a literal.
+// Use for initializations.
+// e.g., var pb *bool = Ptr(true).
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
To avoid the duplication of the same functions over and over.

See https://stackoverflow.com/questions/30716354/how-do-i-do-a-literal-int64-in-go