### PR TITLE
PermissionView: add can_request_help_to in granted permissions

### DIFF
--- a/app/api/groups/get_permissions.feature
+++ b/app/api/groups/get_permissions.feature
@@ -76,7 +76,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
@@ -134,7 +135,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2017-12-31T23:59:59Z", "can_enter_until": "9998-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -192,7 +194,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -250,7 +253,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -308,7 +312,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -366,7 +371,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -424,7 +430,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -482,7 +489,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -540,7 +548,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -598,7 +607,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -656,7 +666,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2021-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -714,7 +725,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2029-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -772,7 +784,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2029-12-31T23:59:59Z", "can_enter_until": "2020-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
@@ -830,7 +843,8 @@ Feature: Get permissions for a group
         "granted": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2011-12-31T23:59:59Z", "can_enter_until": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": null
         },
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -1,0 +1,59 @@
+# Those scenario cannot, for now, be merged with those in get_permissions.feature
+#
+# Reason: The scenario in this file are defined with new Gherkin features which allows higher-level definitions.
+#         Those features require the propagation of permissions to run.
+# Problem: the permissions defined in get_permissions.feature contain inconsistent data.
+#          It means that if we move the definitions of the table permissions_generated into the equivalent in permissions_granted,
+#          and then we run the propagation of permissions, we get a different result than
+#          the permissions currently defined in permissions_generated, and many tests then fail.
+#          If those permissions definitions get fixed, then this file can be merged with them.
+Feature: Get permissions can_request_help_to for a group
+  Background:
+    Given allUsersGroup is defined as the group @AllUsers
+    And there are the following groups:
+      | group     | parent | members  |
+      | @AllUsers |        |          |
+      | @School   |        | @Teacher |
+      | @Class    |        |          |
+    And @Teacher is a manager of the group @Class and can grant group access
+    And there are the following tasks:
+      | item  |
+      | @Item |
+    And there are the following item permissions:
+      | item  | group    | is_owner | can_request_help_to |
+      | @Item | @Teacher | true     |                     |
+
+  Scenario: Should return helper group when set and visible by the current user
+    Given I am @Teacher
+    And there is a group @HelperGroup
+    # @HelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @HelperGroup
+    And there are the following item permissions:
+      | item  | group  | is_owner | can_request_help_to |
+      | @Item | @Class | false    | @HelperGroup        |
+    When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
+    Then the response code should be 200
+    And the response at $.granted.can_request_help_to should be:
+      | id           | name              |
+      | @HelperGroup | Group HelperGroup |
+
+  Scenario: Should not return helper group when set and not visible by the current user
+    Given I am @Teacher
+    And there is a group @HelperGroup
+    And there are the following item permissions:
+      | item  | group  | is_owner | can_request_help_to |
+      | @Item | @Class | false    | @HelperGroup        |
+    When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
+    Then the response code should be 200
+    And the response at $.granted.can_request_help_to should be "null"
+
+  Scenario: Should return helper group as "AllUsers" group when set to its value
+    Given I am @Teacher
+    And there are the following item permissions:
+      | item  | group  | is_owner | can_request_help_to |
+      | @Item | @Class | false    | @AllUsers           |
+    When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
+    Then the response code should be 200
+    And the response at $.granted.can_request_help_to should be:
+      | is_all_users_group |
+      | true               |

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -47,6 +47,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)
 	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^I am a manager of the group (@\w+) and can watch its members$`, ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
+	s.Step(`(@\w+) is a manager of the group (@\w+) and can grant group access`, ctx.UserIsAManagerOfTheGroupAndCanGrantGroupAccess)
 	s.Step(`^the group (@\w+) is a descendant of the group (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
 	s.Step(`^there are the following items:$`, ctx.ThereAreTheFollowingItems)
 	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -41,6 +41,7 @@ func FeatureContext(s *godog.Suite) {
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
 	)
+	s.Step(`allUsersGroup is defined as the group (@\w+)$`, ctx.AllUsersGroupIsDefinedAsTheGroup)
 
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmAManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -48,6 +48,9 @@ func getParameterString(parameters map[string]string) string {
 
 // referenceToName returns the name of a reference.
 func referenceToName(reference string) string {
+	if reference == "" {
+		return ""
+	}
 	if reference[0] == ReferencePrefix {
 		return reference[1:]
 	}
@@ -483,7 +486,7 @@ func (ctx *TestContext) ThereIsAGroupWith(parameters string) error {
 	group := ctx.getParameterMap(parameters)
 
 	if _, ok := group["name"]; !ok {
-		group["name"] = "Group " + group["id"]
+		group["name"] = "Group " + referenceToName(group["id"])
 	}
 	if _, ok := group["type"]; !ok {
 		group["type"] = "Class"
@@ -533,7 +536,7 @@ func (ctx *TestContext) UserIsAManagerOfTheGroupWith(parameters string) error {
 
 	canWatchMembers := "0"
 	canGrantGroupAccess := "0"
-	watchedGroupName := group["user_id"] + " manages " + group["name"]
+	watchedGroupName := group["user_id"] + " manages " + referenceToName(group["name"])
 
 	if group["can_watch_members"] == strTrue {
 		canWatchMembers = "1"
@@ -610,7 +613,7 @@ func (ctx *TestContext) UserIsAManagerOfTheGroupAndCanGrantGroupAccess(user, gro
 // theGroupIsADescendantOfTheGroup sets a group as a descendant of another.
 func (ctx *TestContext) theGroupIsADescendantOfTheGroup(descendant, parent string) error {
 	// we add another group in between to increase the robustness of the tests.
-	middle := parent + " -> X -> " + descendant
+	middle := parent + " -> X -> " + referenceToName(descendant)
 
 	groups := []string{descendant, middle, parent}
 	for _, group := range groups {

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -126,7 +126,7 @@ func (ctx *TestContext) DBHasUsers(data *messages.PickleStepArgument_PickleTable
 		}
 
 		for i := 1; i < len(data.Rows); i++ {
-			login := "null"
+			login := tableValueNull
 			if loginColumnNumber != -1 {
 				login = data.Rows[i].Cells[loginColumnNumber].Value
 			}

--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -155,7 +155,7 @@ func (ctx *TestContext) SignedTokenIsDistributed(
 func (ctx *TestContext) TheApplicationConfigIs(yamlConfig *messages.PickleStepArgument_PickleDocString) error {
 	config := viper.New()
 	config.SetConfigType("yaml")
-	preprocessedConfig, err := ctx.preprocessString(yamlConfig.Content)
+	preprocessedConfig, err := ctx.preprocessString(ctx.replaceReferencesByIDs(yamlConfig.Content))
 	if err != nil {
 		return err
 	}

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -108,31 +108,39 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *messages.P
 		return err
 	}
 
-	wantsHasHeader := len(wants.Rows[0].Cells) > 1
+	switch typedJSONRes := jsonPathRes.(type) {
+	case []interface{}:
+		wantsHasHeader := len(wants.Rows[0].Cells) > 1
 
-	wantLength := len(wants.Rows)
-	if wantsHasHeader {
-		wantLength--
+		wantLength := len(wants.Rows)
+		if wantsHasHeader {
+			wantLength--
+		}
+
+		// The result is an array (eg. "element": [...])
+		if len(typedJSONRes) != wantLength {
+			return fmt.Errorf(
+				"TheResponseAtShouldBe: The JsonPath result length should be %v but is %v for %v",
+				wantLength,
+				len(typedJSONRes),
+				typedJSONRes,
+			)
+		}
+
+		if wantsHasHeader {
+			return ctx.wantRowsMatchesJSONPathResultArr(wants, typedJSONRes)
+		}
+
+		return ctx.wantValuesMatchesJSONPathResultArr(wants, typedJSONRes)
+	case map[string]interface{}:
+		// The result is an object (eg. "element": {"a": 0, "b": 0})
+		return ctx.wantValuesMatchesJSONPathResultObject(wants, typedJSONRes)
 	}
 
-	jsonPathResArr := jsonPathRes.([]interface{})
-	if len(jsonPathResArr) != wantLength {
-		return fmt.Errorf(
-			"TheResponseAtShouldBe: The JsonPath result length should be %v but is %v for %v",
-			wantLength,
-			len(jsonPathResArr),
-			jsonPathResArr,
-		)
-	}
-
-	if wantsHasHeader {
-		return ctx.wantRowsMatchesJSONPathResult(wants, jsonPathResArr)
-	}
-
-	return ctx.wantValuesMatchesJSONPathResult(wants, jsonPathResArr)
+	panic(fmt.Sprintf("TheResponseAtShouldBe: Unhandled case for %v", jsonPathRes))
 }
 
-func (ctx *TestContext) wantRowsMatchesJSONPathResult(
+func (ctx *TestContext) wantRowsMatchesJSONPathResultArr(
 	wants *messages.PickleStepArgument_PickleTable,
 	jsonPathResArr []interface{},
 ) error {
@@ -198,7 +206,7 @@ func sortSliceForEasyComparison(
 	return slice
 }
 
-func (ctx *TestContext) wantValuesMatchesJSONPathResult(
+func (ctx *TestContext) wantValuesMatchesJSONPathResultArr(
 	wants *messages.PickleStepArgument_PickleTable,
 	jsonPathResArr []interface{},
 ) error {
@@ -217,6 +225,26 @@ func (ctx *TestContext) wantValuesMatchesJSONPathResult(
 
 	if !cmp.Equal(sortedResults, sortedWants) {
 		return fmt.Errorf("wantValuesMatchesJSONPathResult: The values (sorted) are %v but should have been: %v", sortedResults, sortedWants)
+	}
+
+	return nil
+}
+
+func (ctx *TestContext) wantValuesMatchesJSONPathResultObject(
+	wants *messages.PickleStepArgument_PickleTable,
+	jsonPathResObject map[string]interface{},
+) error {
+	headerCells := wants.Rows[0].Cells
+	objectCells := wants.Rows[1].Cells
+
+	for i := 0; i < len(headerCells); i++ {
+		key := headerCells[i].Value
+		wantedValue := ctx.replaceReferencesByIDs(objectCells[i].Value)
+		actualValue := jsonPathResObject[key]
+
+		if !jsonPathResultMatchesValue(actualValue, wantedValue) {
+			return fmt.Errorf("wantValuesMatchesJSONPathResultObject: [%v] should be %v but is %v", key, wantedValue, actualValue)
+		}
 	}
 
 	return nil

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -93,7 +93,11 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 	case interface{}:
 	}
 
-	return jsonPathRes == value
+	if jsonPathRes == nil && value == "null" {
+		return true
+	}
+
+	return jsonPathRes == expected
 }
 
 // TheResponseAtShouldBe checks that the response at a JSONPath matches multiple values.

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -78,13 +78,14 @@ func (ctx *TestContext) TheResponseAtShouldBeTheValue(jsonPath, value string) er
 }
 
 func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
+	var expected interface{} = value
+
 	switch jsonPathResultTyped := jsonPathRes.(type) {
+	case bool:
+		expected, _ = strconv.ParseBool(value)
 	case string:
 	case float64:
-		valueFloat, _ := strconv.ParseFloat(value, 64)
-		if valueFloat == jsonPathResultTyped {
-			return true
-		}
+		expected, _ = strconv.ParseFloat(value, 64)
 	case []interface{}:
 		// When the result is an empty array, matches if we're looking for an empty value.
 		if len(jsonPathResultTyped) == 0 && value == "" {

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -46,6 +46,7 @@ type TestContext struct {
 	identifierReferences map[string]int64
 	dbTables             map[string]map[string]map[string]interface{}
 	currentThreadKey     string
+	allUsersGroup        string
 	needPopulateDatabase bool
 }
 


### PR DESCRIPTION
Related to #968 

The query is a little tricky, added a detailed comment to explain why is was done like this.
The tests have been put in another Gherkin file, reason is in comments.

Also for the Gherkin tests:
* Added support for edge cases in checking response parts:
- When an object is `null`
- When we want to compare to a `bool`
* Added the possibility to compare a full object with the feature `the response at XXX should be:": checks that the designed jsonPath contains exactly the properties listed.
* Added a feature for setting a group as the `AllUsers` group without having to refer to the configuration in the test*
* Added a feature to give the manager the permission `can grant group access`