### PR TITLE
itemCreate: Add request_help_propagation permissions on parent-item and parent-child relations

### DIFF
--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -107,6 +107,8 @@ type itemParent struct {
 	WatchPropagation bool `json:"watch_propagation"`
 	// default: true
 	EditPropagation bool `json:"edit_propagation"`
+	// default: true
+	RequestHelpPropagation bool `json:"request_help_propagation"`
 }
 
 // NewItemRequest is the expected input for new created item
@@ -429,7 +431,7 @@ func generateOldPropagationLevelsMap(store *database.DataStore, itemID *int64) m
 	service.MustNotBeError(store.ItemItems().ChildrenOf(*itemID).WithWriteLock().
 		Select(`child_item_id AS item_id, category, score_weight,
 				        content_view_propagation_value, upper_view_levels_propagation_value,
-						    grant_view_propagation, watch_propagation, edit_propagation`).
+						    grant_view_propagation, watch_propagation, edit_propagation, request_help_propagation`).
 		Scan(&oldRelations).Error())
 	oldPropagationLevelsMap := make(map[int64]*itemsRelationData, len(oldRelations))
 	for index := range oldRelations {
@@ -605,6 +607,8 @@ func (srv *Service) insertItem(store *database.DataStore, user *database.User, f
 						formData, "parent.watch_propagation", newItemRequest.Parent.WatchPropagation, true).(bool),
 					EditPropagation: valueOrDefault(
 						formData, "parent.edit_propagation", newItemRequest.Parent.EditPropagation, true).(bool),
+					RequestHelpPropagation: valueOrDefault(
+						formData, "parent.request_help_propagation", newItemRequest.Parent.RequestHelpPropagation, true).(bool),
 				})
 		}
 		parentChildSpec = append(parentChildSpec,

--- a/app/api/items/create_item.robustness.feature
+++ b/app/api/items/create_item.robustness.feature
@@ -640,7 +640,7 @@ Feature: Create item - robustness
       | category     | "wrong" | category must be one of [Undefined Discovery Application Validation Challenge] |
       | score_weight | "wrong" | expected type 'int8', got unconvertible type 'string'                          |
 
-  Scenario Outline: Not enough permissions for setting propagation in items_items
+  Scenario Outline: Not enough permissions for setting propagation in children items_items
     Given I am the user with id "11"
     And the database table 'items' has also the following row:
       | id | default_language_tag |
@@ -685,7 +685,8 @@ Feature: Create item - robustness
       | upper_view_levels_propagation | as_content_with_descendants | can_grant_view_generated | content                  | Not enough permissions for setting upper_view_levels_propagation |
       | grant_view_propagation        | true                        | can_grant_view_generated | solution                 | Not enough permissions for setting grant_view_propagation        |
       | watch_propagation             | true                        | can_watch_generated      | answer                   | Not enough permissions for setting watch_propagation             |
-      | edit_propagation              | true                        | can_edit_generated       | all                      | Not enough permissions for setting edit_propagation             |
+      | edit_propagation              | true                        | can_edit_generated       | all                      | Not enough permissions for setting edit_propagation              |
+      | request_help_propagation      | true                        | can_grant_view_generated | enter                    | Not enough permissions for setting request_help_propagation      |
 
   Scenario: Non-unique children item IDs
     Given I am the user with id "11"


### PR DESCRIPTION
Related to #968 

It has already been done for `itemUpdate` here: https://github.com/France-ioi/AlgoreaBackend/commit/d64a5abbc20c034245d23160233c11afab38ef70

### Rights to set
`request_help_propagation` can be set to `1` if the current user has `can_grant_view>=content` on the child of the relation, and `can_edit>=children` on the parent of the relation.

### For parent->item:
Default to `true` because current-user owns the item it create, so he has `can_grant_view>=content` on it, and also has `can_edit>=children` on the parent because otherwise he could not set the parent.

### For item->child:
- Current-user owns the item so he has `can_edit>=children` on it; we only need to make sure he has `can_grant_view>=content` on the child of the relation. A robustness test have been added to cover this case.
- The default value `1` if the current-user has `can_grant_view>=content`, otherwise, `0`.