### PR TITLE
updatePermissions: can update can_request_help_to with a group or with group AllUsers

### DIFF
--- a/app/api/groups/update_permissions_can_request_help_to.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.feature
@@ -1,0 +1,79 @@
+# Those scenario cannot, for now, be merged with those in update_permissions.feature
+#
+# Reason: The scenario in this file are defined with new Gherkin features which allows higher-level definitions.
+#         Those features require the propagation of permissions to run.
+# Problem: the permissions defined in update_permissions.feature contain inconsistent data.
+#          It means that if we move the definitions of the table permissions_generated into the equivalent in permissions_granted,
+#          and then we run the propagation of permissions, we get a different result than
+#          the permissions currently defined in permissions_generated, and many tests then fail.
+#          If those permissions definitions get fixed, then this file can be merged with them.
+Feature: Change item access rights for a group - can_request_help_to
+  Background:
+    Given allUsersGroup is defined as the group @AllUsers
+    And there are the following groups:
+      | group           | parent | members  |
+      | @AllUsers       |        |          |
+      | @School         |        | @Teacher |
+      | @Class          |        |          |
+      | @OldHelperGroup |        |          |
+      | @NewHelperGroup |        |          |
+    And @Teacher is a manager of the group @Class and can grant group access
+    And there are the following tasks:
+      | item  |
+      | @Item |
+    And there are the following item permissions:
+      | item  | group    | can_view | can_grant_view |
+      | @Item | @Teacher | info     | content        |
+
+  Scenario Outline: Should update can_request_help_to to the desired value when rights are appropriate
+    Given I am @Teacher
+    # @OldHelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @OldHelperGroup
+    # @OldHelperGroup is visible by @Class
+    And the group @Class is a descendant of the group @OldHelperGroup
+    # @NewHelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @NewHelperGroup
+    # @NewHelperGroup is visible by @Class
+    And the group @Class is a descendant of the group @NewHelperGroup
+    And there are the following item permissions:
+      | item  | group  | can_view | can_request_help_to           |
+      | @Item | @Class | info     | <initial_can_request_help_to> |
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "id": <changed_can_request_help_to_request>
+          }
+        }
+      """
+    Then the response code should be 200
+    Then the response should be "updated"
+    And the table "permissions_granted" at group_id "@Class" should be:
+      | group_id | item_id | source_group_id | can_request_help_to              |
+      | @Class   | @Item   | @Class          | <changed_can_request_help_to_db> |
+    Examples:
+      | initial_can_request_help_to | changed_can_request_help_to_request | changed_can_request_help_to_db |
+      |                             | "@NewHelperGroup"                   | @NewHelperGroup                |
+      |                             | null                                | null                           |
+      | @OldHelperGroup             | "@NewHelperGroup"                   | @NewHelperGroup                |
+      | @OldHelperGroup             | null                                | null                           |
+      | @OldHelperGroup             | "@OldHelperGroup"                   | @OldHelperGroup                |
+
+  Scenario: Should update can_request_help_to to AllUsers group when specified
+    Given I am @Teacher
+    And there are the following item permissions:
+      | item  | group  | can_view | can_request_help_to |
+      | @Item | @Class | info     |                     |
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "is_all_users_group": true
+          }
+        }
+      """
+    Then the response code should be 200
+    Then the response should be "updated"
+    And the table "permissions_granted" at group_id "@Class" should be:
+      | group_id | item_id | source_group_id | can_request_help_to |
+      | @Class   | @Item   | @Class          | @AllUsers           |

--- a/app/api/groups/update_permissions_can_request_help_to.robustness.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.robustness.feature
@@ -1,0 +1,168 @@
+# Those scenario cannot, for now, be merged with those in update_permissions.feature
+#
+# Reason: The scenario in this file are defined with new Gherkin features which allows higher-level definitions.
+#         Those features require the propagation of permissions to run.
+# Problem: the permissions defined in update_permissions.feature contain inconsistent data.
+#          It means that if we move the definitions of the table permissions_generated into the equivalent in permissions_granted,
+#          and then we run the propagation of permissions, we get a different result than
+#          the permissions currently defined in permissions_generated, and many tests then fail.
+#          If those permissions definitions get fixed, then this file can be merged with them.
+Feature: Change item access rights for a group - can_request_help_to
+  Background:
+    Given allUsersGroup is defined as the group @AllUsers
+    And there are the following groups:
+      | group        | parent | members  |
+      | @AllUsers    |        |          |
+      | @School      |        | @Teacher |
+      | @Class       |        |          |
+      | @HelperGroup |        |          |
+    And @Teacher is a manager of the group @Class and can grant group access
+    And there are the following tasks:
+      | item  |
+      | @Item |
+    And there are the following item permissions:
+      | item  | group  | can_view |
+      | @Item | @Class | info     |
+
+  Scenario: Should be an exception when can_request_help_to is not an int64
+    Given I am @Teacher
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": "aaa"
+        }
+      """
+    Then the response code should be 400
+    And the response error message should contain "Invalid input data"
+
+  Scenario: Should be an exception when can_request_help_to_all_users is not a boolean
+    Given I am @Teacher
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "is_all_users_group": 1
+          }
+        }
+      """
+    Then the response code should be 400
+    And the response error message should contain "Invalid input data"
+
+  Scenario: Should be an exception when trying to set can_request_help_to and can_request_help_to_all_users at the same time
+    Given I am @Teacher
+    # @HelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @HelperGroup
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "id": "@HelperGroup",
+            "is_all_users_group": true
+          }
+        }
+      """
+    Then the response code should be 400
+    And the response body should be, in JSON:
+      """
+      {
+        "success": false,
+        "message": "Bad Request",
+        "error_text": "Invalid input data",
+        "errors":{
+          "can_request_help_to": ["cannot set can_request_help_to id and is_all_users_group at the same time"]
+        }
+      }
+      """
+
+  Scenario Outline: Should be access denied when the user doesn't have can_grant_view>=content but group is visible by both the current user and the receiver
+    Given I am @Teacher
+    # @HelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @HelperGroup
+    # @HelperGroup is visible by @Class
+    And the group @Class is a descendant of the group @HelperGroup
+    And there is a group @OldHelperGroup
+    And there are the following item permissions:
+      | item  | group    | can_grant_view | can_view | can_request_help_to |
+      | @Item | @Teacher | enter          | info     |                     |
+      | @Item | @Class   | none           | info     | @OldHelperGroup     |
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "id": <helper_group>
+          }
+        }
+      """
+    Then the response code should be 400
+    And the response body should be, in JSON:
+      """
+      {
+        "success": false,
+        "message": "Bad Request",
+        "error_text": "Invalid input data",
+        "errors":{
+          "can_request_help_to": ["the current user doesn't have the right to update can_request_help_to"]
+        }
+      }
+      """
+    Examples:
+      | helper_group |
+      | @HelperGroup |
+      | @AllUsers    |
+      | null         |
+
+  Scenario: Should be access denied when trying to set can_request_help_to to a group not visible by the giver (current-user)
+    Given I am @Teacher
+    # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
+    And @Class is a manager of the group @HelperGroup and can watch its members
+    And there are the following item permissions:
+      | item  | group    | can_grant_view |
+      | @Item | @Teacher | content        |
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "id": "@HelperGroup"
+          }
+        }
+      """
+    Then the response code should be 400
+    And the response body should be, in JSON:
+      """
+      {
+        "success": false,
+        "message": "Bad Request",
+        "error_text": "Invalid input data",
+        "errors":{
+          "can_request_help_to": ["can_request_help_to is not visible either by the current-user or the groupID"]
+        }
+      }
+      """
+
+  Scenario: Should be access denied when trying to set can_request_help_to to a group no visible by the receiver
+    Given I am @Teacher
+    # @HelperGroup is visible by @Teacher
+    And the group @Teacher is a descendant of the group @HelperGroup
+    And there are the following item permissions:
+      | item  | group    | can_grant_view |
+      | @Item | @Teacher | content        |
+    When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
+      """
+        {
+          "can_request_help_to": {
+            "id": "@HelperGroup"
+          }
+        }
+      """
+    Then the response code should be 400
+    And the response body should be, in JSON:
+      """
+      {
+        "success": false,
+        "message": "Bad Request",
+        "error_text": "Invalid input data",
+        "errors":{
+          "can_request_help_to": ["can_request_help_to is not visible either by the current-user or the groupID"]
+        }
+      }
+      """

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -20,6 +20,8 @@ const (
 	strTrue         = "true"
 )
 
+var itemPermissionKeys = []string{"can_view", "can_grant_view", "can_watch", "can_edit", "is_owner", "can_request_help_to"}
+
 // ctx.getParameterMap parses parameters in format key1=val1,key2=val2,... into a map.
 func (ctx *TestContext) getParameterMap(parameters string) map[string]string {
 	parameterMap := make(map[string]string)
@@ -677,29 +679,19 @@ func (ctx *TestContext) ThereAreTheFollowingItemPermissions(itemPermissions *mes
 	for i := 1; i < len(itemPermissions.Rows); i++ {
 		itemPermission := ctx.getRowMap(i, itemPermissions)
 
-		if itemPermission["can_view"] != "" {
-			err := ctx.UserCanViewOnItemWithID(itemPermission["can_view"], itemPermission["group"], itemPermission["item"])
-			if err != nil {
-				return err
-			}
+		err := ctx.applyUserPermissionsOnItem(itemPermission)
+		if err != nil {
+			return err
 		}
+	}
 
-		if itemPermission["can_watch"] != "" {
-			err := ctx.UserCanWatchOnItemWithID(itemPermission["can_watch"], itemPermission["group"], itemPermission["item"])
-			if err != nil {
-				return err
-			}
-		}
+	return nil
+}
 
-		if itemPermission["is_owner"] != "" {
-			err := ctx.UserIsOwnerOfItemWithID(itemPermission["is_owner"], itemPermission["group"], itemPermission["item"])
-			if err != nil {
-				return err
-			}
-		}
-
-		if itemPermission["can_request_help_to"] != "" {
-			err := ctx.UserCanRequestHelpToOnItemWithID(itemPermission["can_request_help_to"], itemPermission["group"], itemPermission["item"])
+func (ctx *TestContext) applyUserPermissionsOnItem(itemPermission map[string]string) error {
+	for _, permissionKey := range itemPermissionKeys {
+		if permissionValue, ok := itemPermission[permissionKey]; ok {
+			err := ctx.UserSetPermissionOnItemWithID(permissionKey, permissionValue, itemPermission["group"], itemPermission["item"])
 			if err != nil {
 				return err
 			}
@@ -832,6 +824,7 @@ func (ctx *TestContext) ICanOnItemWithID(watchType, watchValue, item string) err
 	return ctx.UserSetPermissionOnItemWithID(watchType, watchValue, ctx.user, item)
 }
 
+// UserCanViewOnItemWithID gives a user a can_view permission on an item.
 func (ctx *TestContext) UserCanViewOnItemWithID(viewValue, user, item string) error {
 	return ctx.UserSetPermissionOnItemWithID("can_view", viewValue, user, item)
 }
@@ -839,6 +832,11 @@ func (ctx *TestContext) UserCanViewOnItemWithID(viewValue, user, item string) er
 // ICanViewOnItemWithID gives the user a "view" permission on an item.
 func (ctx *TestContext) ICanViewOnItemWithID(viewValue, item string) error {
 	return ctx.UserSetPermissionOnItemWithID("can_view", viewValue, ctx.user, item)
+}
+
+// UserCanGrantViewOnItemWithID gives a user a can_grant_view permission on an item.
+func (ctx *TestContext) UserCanGrantViewOnItemWithID(viewValue, user, item string) error {
+	return ctx.UserSetPermissionOnItemWithID("can_grant_view", viewValue, user, item)
 }
 
 // UserCanWatchOnItemWithID gives a user a "watch" permission on an item.

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -338,11 +338,17 @@ func (ctx *TestContext) TableShouldStayUnchangedButTheRowsWithColumnValueShouldB
 }
 
 func (ctx *TestContext) TableAtColumnValueShouldBe(table, column, values string, data *messages.PickleStepArgument_PickleTable) error { // nolint
-	return ctx.tableAtColumnValueShouldBe(table, []string{column}, parseMultipleValuesString(values), unchanged, data)
+	return ctx.tableAtColumnValueShouldBe(
+		table,
+		[]string{column},
+		parseMultipleValuesString(ctx.replaceReferencesByIDs(values)),
+		unchanged,
+		data,
+	)
 }
 
 func (ctx *TestContext) TableShouldNotContainColumnValue(table, column, values string) error { //nolint
-	return ctx.tableAtColumnValueShouldBe(table, []string{column}, parseMultipleValuesString(values), unchanged,
+	return ctx.tableAtColumnValueShouldBe(table, []string{column}, parseMultipleValuesString(ctx.replaceReferencesByIDs(values)), unchanged,
 		&messages.PickleStepArgument_PickleTable{
 			Rows: []*messages.PickleStepArgument_PickleTable_PickleTableRow{
 				{Cells: []*messages.PickleStepArgument_PickleTable_PickleTableRow_PickleTableCell{{Value: column}}},


### PR DESCRIPTION
Related to #968 

As in previous PR, tests have been put in different *.feature files to use the new system.

Notes:

1:
Setting `can_request_help_to` with the id of the `AllUsers` group has been done by modifying directly the dataMap used to update the fields in database. If we find the field `is_all_users_group`, we replace it by `can_request_help_to`: `allUsersGroupID`.

2:
Multiple validators have been used to validate the input. This allows to have a different error message when it fail. It also allows the robustness test to be more robust, because it is checked if they fail for the right reason.

3. Added a comment about why MAX() was used for the request as I found it weird.

4. The methods to check if a `group is visible` were implemented only with a user. But in this case we need to use it on a group. So the functions have been duplicated and factorized. The names are a bit ugly though... `ManagedUsersAndAncestorsOfManagedGroupsForGroup`, `AncestorsOfJoinedGroupsForGroup`, `PickVisibleGroupsForGroup`.