### PR TITLE
accessTokenCreate: Create a temp user in case of failed authorization only if create_temp_user_if_not_authorized=true

### DIFF
--- a/app/api/auth/create_access_token.feature
+++ b/app/api/auth/create_access_token.feature
@@ -867,7 +867,7 @@ Feature: Create an access token
     And the table "group_membership_changes" should be empty
     And the table "group_managers" should be empty
 
-  Scenario Outline: Should create a temp user when nor code, nor the Authorization header is given
+  Scenario Outline: Should create a temp user when nor code, nor the Authorization header is given, and we want a temporary user
     Given the generated auth key is "generated_auth_key"
     And I send a POST request to "/auth/token<query>"
     Then the response code should be 201
@@ -877,15 +877,16 @@ Feature: Create an access token
       | group_id            | login_id | login        | temp_user | default_language            | ABS(TIMESTAMPDIFF(SECOND, registered_at, NOW())) < 3 | last_ip   |
       | 5577006791947779410 | 0        | tmp-49727887 | true      | <expected_default_language> | true                                                 | 127.0.0.1 |
     Examples:
-      | query                | expected_default_language |
-      |                      | fr                        |
-      | ?default_language=en | en                        |
-      | ?default_language=fr | fr                        |
+      | query                                                     | expected_default_language |
+      | ?create_temp_user_if_not_authorized=1                     | fr                        |
+      | ?default_language=en&create_temp_user_if_not_authorized=1 | en                        |
+      | ?default_language=fr&create_temp_user_if_not_authorized=1 | fr                        |
+
 
   Scenario: Should create a temp user when code is not given, and the Authorization is invalid
     Given the generated auth key is "generated_auth_key"
     And the "Authorization" request header is "invalid"
-    And I send a POST request to "/auth/token"
+    And I send a POST request to "/auth/token?create_temp_user_if_not_authorized=1"
     Then the response code should be 201
     And the response at $.data.access_token should be "generated_auth_key"
     And the response at $.data.expires_in should be "7200"

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -204,13 +204,9 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) se
 			service.AppHandler(srv.refreshAccessToken).
 				ServeHTTP(w, r.WithContext(context.WithValue(requestContext, parsedRequestData, requestData)))
 		} else {
-			createTempUser := false
-			if len(r.URL.Query()["create_temp_user_if_not_authorized"]) > 0 {
-				var err error
-				createTempUser, err = service.ResolveURLQueryGetBoolField(r, "create_temp_user_if_not_authorized")
-				if err != nil {
-					return service.ErrInvalidRequest(err)
-				}
+			createTempUser, err := service.ResolveURLQueryGetBoolFieldWithDefault(r, "create_temp_user_if_not_authorized", false)
+			if err != nil {
+				return service.ErrInvalidRequest(err)
 			}
 
 			if createTempUser {

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -71,7 +71,16 @@ const parsedRequestData ctxKey = iota
 //			This happens when the frontend app loads, and the user is not logged-in, or if the authentication
 //			is not valid anymore.
 //			Then,
+//			if `create_temp_user_if_not_authorized`=`true`,
 //			we create a temporary user and log-in the user as it.
+//			This happens from the frontend when a user that was once logged-in comes back to the website after the token expired.
+//			Otherwise,
+//			if `create_temp_user_if_not_authorized`=`false`,
+//			an error is returned.
+//			This happens from the frontend when a user that is logged-in becomes inactive for a while, while the tab is	still open.
+//			When the tab is then restored, for example, after the computer comes back from sleep,
+//			it tries to reconnect but the token has expired.
+//			Note, when the tab is open and active, the frontend automatically refreshes the token before it expires.
 //
 //
 //		If attributes of the old and the new 'access_token' cookies are different (or the token is returned in the JSON),
@@ -122,7 +131,14 @@ const parsedRequestData ctxKey = iota
 //			type: integer
 //			enum: [0,1]
 //			default: 0
+//		- name: create_temp_user_if_not_authorized
+//			description: Whether to create a temporary user if the token is not provided or expired.
+//			in: query
+//			type: integer
+//			enum: [0,1]
+//			default: 0
 //		- name: default_language
+//			description: The temporary user's default language.	Only if `create_temp_user_if_not_authorized`=`true`.
 //			in: query
 //			type: string
 //			maxLength: 3
@@ -152,8 +168,9 @@ const parsedRequestData ctxKey = iota
 //						description: If true, set the cookie with the `SameSite`='Strict' attribute value and with `SameSite`='None' otherwise
 //	responses:
 //		"201":
-//			description: "Created.
-//			Success response with the new access token"
+//			description: >
+//				Created.
+//				Success response with the new access token"
 //			in: body
 //			schema:
 //				"$ref": "#/definitions/userCreateTmpResponse"
@@ -182,20 +199,35 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) se
 		}
 	} else {
 		// The code is not given, requesting a new token from the given token.
-
-		requestContext, isSuccess, _ := auth.ValidatesUserAuthentication(srv.Base, w, r)
+		requestContext, isSuccess, authErr := auth.ValidatesUserAuthentication(srv.Base, w, r)
 		if isSuccess {
 			service.AppHandler(srv.refreshAccessToken).
 				ServeHTTP(w, r.WithContext(context.WithValue(requestContext, parsedRequestData, requestData)))
 		} else {
-			// createTempUser checks that the Authorization header is not present.
-			// But from here, we want to be able to create a temporary user if the authorization is invalid,
-			// for example, because it expired.
-			// Since we don't need its value anymore, we just delete it.
-			r.Header.Del("Authorization")
+			createTempUser := false
+			if len(r.URL.Query()["create_temp_user_if_not_authorized"]) > 0 {
+				var err error
+				createTempUser, err = service.ResolveURLQueryGetBoolField(r, "create_temp_user_if_not_authorized")
+				if err != nil {
+					return service.ErrInvalidRequest(err)
+				}
+			}
 
-			service.AppHandler(srv.createTempUser).
-				ServeHTTP(w, r)
+			if createTempUser {
+				// createTempUser checks that the Authorization header is not present.
+				// But from here, we want to be able to create a temporary user if the authorization is invalid,
+				// for example, because it expired.
+				// Since we don't need its value anymore, we just delete it.
+				r.Header.Del("Authorization")
+
+				service.AppHandler(srv.createTempUser).
+					ServeHTTP(w, r)
+			} else {
+				return service.APIError{
+					HTTPStatusCode: auth.GetAuthErrorCodeFromError(authErr),
+					Error:          authErr,
+				}
+			}
 		}
 
 		return service.NoError

--- a/app/api/auth/create_access_token.robustness.feature
+++ b/app/api/auth/create_access_token.robustness.feature
@@ -1,9 +1,37 @@
 Feature: Login callback - robustness
+  Scenario: Should be an error when create_temp_user_if_not_authorized is not a boolean
+    When I send a POST request to "/auth/token?create_temp_user_if_not_authorized=invalid"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for create_temp_user_if_not_authorized (should have a boolean value (0 or 1))"
+
   Scenario: Both code and Authorization header are present
     Given the "Authorization" request header is "Bearer 1234567890"
     When I send a POST request to "/auth/token?code=somecode"
     Then the response code should be 400
     And the response error message should contain "Only one of the 'code' parameter and the 'Authorization' header can be given"
+    And the table "users" should stay unchanged
+    And the table "groups" should stay unchanged
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+    And the table "sessions" should stay unchanged
+    And the table "refresh_tokens" should stay unchanged
+
+  Scenario: Should be an error when nor code given, nor auth token given, and we don't want to create a temporary user
+    When I send a POST request to "/auth/token"
+    Then the response code should be 401
+    And the response error message should contain "No access token provided"
+    And the table "users" should stay unchanged
+    And the table "groups" should stay unchanged
+    And the table "groups_groups" should stay unchanged
+    And the table "groups_ancestors" should stay unchanged
+    And the table "sessions" should stay unchanged
+    And the table "refresh_tokens" should stay unchanged
+
+  Scenario: Should be an error when no code given, and auth token is invalid (could have expired), and we don't want to create a temporary user
+    When I send a POST request to "/auth/token"
+    And the "Authorization" request header is "invalid"
+    Then the response code should be 401
+    And the response error message should contain "No access token provided"
     And the table "users" should stay unchanged
     And the table "groups" should stay unchanged
     And the table "groups_groups" should stay unchanged

--- a/app/service/parameters.go
+++ b/app/service/parameters.go
@@ -136,6 +136,24 @@ func ResolveURLQueryGetBoolField(httpReq *http.Request, name string) (bool, erro
 	return false, fmt.Errorf("wrong value for %s (should have a boolean value (0 or 1))", name)
 }
 
+// ResolveURLQueryGetBoolFieldWithDefault extracts a get-parameter of type bool (0 or 1) from the query.
+// If it is not provided, `defaultValue` is returned.
+func ResolveURLQueryGetBoolFieldWithDefault(httpReq *http.Request, name string, defaultValue bool) (bool, error) {
+	if !URLQueryPathHasField(httpReq, name) {
+		return defaultValue, nil
+	}
+
+	strValue := httpReq.URL.Query().Get(name)
+	if strValue == "0" {
+		return false, nil
+	}
+	if strValue == "1" {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("wrong value for %s (should have a boolean value (0 or 1))", name)
+}
+
 // ResolveURLQueryPathInt64Field extracts a path element of type int64 from the query.
 func ResolveURLQueryPathInt64Field(httpReq *http.Request, name string) (int64, error) {
 	strValue := chi.URLParam(httpReq, name)

--- a/app/service/parameters_test.go
+++ b/app/service/parameters_test.go
@@ -332,6 +332,79 @@ func TestResolveURLQueryGetBoolField(t *testing.T) {
 	}
 }
 
+func TestResolveURLQueryGetBoolFieldWithDefault(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		queryString    string
+		defaultValue   bool
+		expectedValue  bool
+		expectedErrMsg string
+	}{
+		{
+			desc:           "no param with default false",
+			queryString:    "",
+			defaultValue:   false,
+			expectedValue:  false,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "no param with default true",
+			queryString:    "",
+			defaultValue:   true,
+			expectedValue:  true,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "wrong param name",
+			queryString:    "flag1=1",
+			defaultValue:   false,
+			expectedValue:  false,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "true value given",
+			queryString:    "flag=1",
+			defaultValue:   false,
+			expectedValue:  true,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "false value given with default false",
+			queryString:    "flag=0",
+			defaultValue:   false,
+			expectedValue:  false,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "false value given with default true",
+			queryString:    "flag=0",
+			defaultValue:   true,
+			expectedValue:  false,
+			expectedErrMsg: "",
+		},
+		{
+			desc:           "wrong value given",
+			queryString:    "flag=2",
+			defaultValue:   false,
+			expectedValue:  false,
+			expectedErrMsg: "wrong value for flag (should have a boolean value (0 or 1))",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.desc, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/health-check?"+testCase.queryString, http.NoBody)
+			list, err := ResolveURLQueryGetBoolFieldWithDefault(req, "flag", testCase.defaultValue)
+			if testCase.expectedErrMsg != "" {
+				assert.EqualError(t, err, testCase.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.expectedValue, list)
+		})
+	}
+}
+
 func TestResolveURLQueryGetTimeField(t *testing.T) {
 	testCases := []struct {
 		desc           string


### PR DESCRIPTION
Retrieve and adapted the test that was previously deleted.

The way the error is returned is a little weird with the use of `GetAuthErrorCodeFromError`.
This is because we use the `auth middleware service` to check if the authorization is valid, and this service cannot use the module used to create apiError (`service`) because it would make a `circular dependency error` (was tried last time).

We could change that by putting `apiError` in another module, but since it's the only exception, it might be too much.

Also documented the reason of this functionality in the service comment to keep a record.

Finally, added a function to retrieve a boolean from the query with a default value if it is not present as the code to do it is a little bit ugly and complex.