### PR TITLE
Breadcrumb from root: add not started paths

### DIFF
--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -8,7 +8,7 @@ Feature: Find all breadcrumbs to an item
       | 93  | Class | null             | 90            |
       | 94  | Club  | null             | null          |
       | 101 | User  | null             | null          |
-      | 102 | Team  | null             | 60            |
+      | 102 | Team  | 100              | 60            |
       | 111 | User  | null             | null          |
     And the database has the following table 'users':
       | login | group_id | default_language |
@@ -28,33 +28,39 @@ Feature: Find all breadcrumbs to an item
       | 91         | 94       | false             |
       | 111        | 92       | false             |
     And the database has the following table 'items':
-      | id | url                    | type    | default_language_tag | text_id               |
-      | 10 | null                   | Chapter | en                   | id10                  |
-      | 50 | http://taskplatform/50 | Task    | en                   | -_ '#&?:=/\.,+%¤€aéàd |
-      | 60 | http://taskplatform/60 | Task    | en                   | id60                  |
-      | 70 | http://taskplatform/70 | Task    | fr                   | id70                  |
-      | 80 | null                   | Chapter | en                   | id80                  |
-      | 90 | null                   | Chapter | en                   | id90                  |
+      | id  | url                    | type    | default_language_tag | text_id               | requires_explicit_entry |
+      | 10  | null                   | Chapter | en                   | id10                  | false                   |
+      | 50  | http://taskplatform/50 | Task    | en                   | -_ '#&?:=/\.,+%¤€aéàd | false                   |
+      | 60  | http://taskplatform/60 | Task    | en                   | id60                  | false                   |
+      | 70  | http://taskplatform/70 | Task    | fr                   | id70                  | false                   |
+      | 80  | null                   | Chapter | en                   | id80                  | false                   |
+      | 90  | null                   | Chapter | en                   | id90                  | false                   |
+      | 100 | null                   | Chapter | en                   | id100                 | false                   |
+      | 101 | null                   | Task    | en                   | id101                 | true                    |
     And the database has the following table 'items_strings':
-      | item_id | language_tag | title            |
-      | 10      | fr           | Graphe: Methodes |
-      | 10      | en           | Graph: Methods   |
-      | 50      | en           | DFS              |
-      | 60      | en           | Reduce Graph     |
-      | 70      | fr           | null             |
-      | 80      | en           | Trees            |
-      | 90      | en           | Queues           |
+      | item_id | language_tag | title                                         |
+      | 10      | fr           | Graphe: Methodes                              |
+      | 10      | en           | Graph: Methods                                |
+      | 50      | en           | DFS                                           |
+      | 60      | en           | Reduce Graph                                  |
+      | 70      | fr           | null                                          |
+      | 80      | en           | Trees                                         |
+      | 90      | en           | Queues                                        |
+      | 100     | en           | Chapter Containing Explicit Entry Not Started |
+      | 101     | en           | Explicit Entry Not Started                    |
     And the database has the following table 'items_items':
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
       | 80             | 90            | 1           |
+      | 100            | 101           | 1           |
     And the database has the following table 'items_ancestors':
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
       | 80               | 90            |
+      | 100              | 101           |
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated       |
       | 102      | 60      | none                     |
@@ -64,6 +70,8 @@ Feature: Find all breadcrumbs to an item
       | 111      | 50      | content_with_descendants |
       | 111      | 80      | content                  |
       | 111      | 90      | info                     |
+      | 111      | 100     | content                  |
+      | 111      | 101     | content                  |
     And the database has the following table 'attempts':
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |
@@ -82,7 +90,8 @@ Feature: Find all breadcrumbs to an item
       | 0          | 111            | 10      | 2020-01-01 00:00:00 |
       | 0          | 111            | 50      | 2020-01-01 00:00:00 |
       | 1          | 111            | 80      | 2020-01-01 00:00:00 |
-      | 1          | 111            | 90      | 2020-01-01 00:00:00                    |
+      | 1          | 111            | 90      | 2020-01-01 00:00:00 |
+      | 0          | 111            | 100     | 2020-01-01 00:00:00 |
 
   Scenario Outline: Find breadcrumbs for the current user
     Given I am the user with id "111"
@@ -93,13 +102,80 @@ Feature: Find all breadcrumbs to an item
       <expected_output>
       """
   Examples:
-    | service_url                                   | expected_output                                                                                                                                                                                                                   |
-    | /items/50/breadcrumbs-from-roots              | [[{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]]                                                                                                                                                            |
-    | /items/by-text-id/-_%20%27%23%26%3F%3A%3D%2F%5C.%2C%2B%25%C2%A4%E2%82%ACa%C3%A9%C3%A0d/breadcrumbs-from-roots | [[{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]]                                                                                                                                                            |
-    | /items/10/breadcrumbs-from-roots              | [[{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]]                                                                                                                                            |
-    | /items/by-text-id/id10/breadcrumbs-from-roots | [[{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]]                                                                                                                                            |
-    | /items/90/breadcrumbs-from-roots              | [[{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}], [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]] |
-    | /items/by-text-id/id90/breadcrumbs-from-roots | [[{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}], [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]] |
+    | service_url                                                                                                   | expected_output                                                                                                                                                                                                                                                                                                       |
+    | /items/50/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                                      |
+    | /items/by-text-id/-_%20%27%23%26%3F%3A%3D%2F%5C.%2C%2B%25%C2%A4%E2%82%ACa%C3%A9%C3%A0d/breadcrumbs-from-roots | [{"started_by_participant": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                                      |
+    | /items/10/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                                      |
+    | /items/by-text-id/id10/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                                      |
+    | /items/90/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
+    | /items/by-text-id/id90/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
+
+  Scenario: Should return a breadcrumb when there is missing results, like path-from-root
+    Given the database has the following table 'users':
+      | login | group_id | default_language |
+      | user  | 1000     | en               |
+    And the database has the following table 'groups':
+      | id   | type  | root_activity_id |
+      | 1000 | User  | null             |
+      | 1001 | Class | 1010             |
+    And the database has the following table 'groups_groups':
+      | parent_group_id | child_group_id |
+      | 1001            | 1000           |
+    And the groups ancestors are computed
+    And the database has the following table 'items':
+      | id   | url                      | type    | default_language_tag | text_id |
+      | 1010 | null                     | Chapter | en                   | id1010  |
+      | 1011 | null                     | Chapter | en                   | id1011  |
+      | 1012 | null                     | Chapter | en                   | id1012  |
+      | 1020 | http://taskplatform/1020 | Task    | en                   | id1020  |
+    And the database has the following table 'items_strings':
+      | item_id | language_tag | title     |
+      | 1010    | en           | Chapter 1 |
+      | 1011    | en           | Chapter 2 |
+      | 1012    | en           | Chapter 3 |
+      | 1020    | en           | Item      |
+    And the database has the following table 'items_items':
+      | parent_item_id | child_item_id | child_order |
+      | 1010           | 1011          | 1           |
+      | 1011           | 1012          | 1           |
+      | 1012           | 1020          | 1           |
+    And the database has the following table 'items_ancestors':
+      | ancestor_item_id | child_item_id |
+      | 1010             | 1011          |
+      | 1010             | 1012          |
+      | 1010             | 1020          |
+      | 1011             | 1012          |
+      | 1011             | 1020          |
+      | 1012             | 1020          |
+    And the database has the following table 'permissions_generated':
+      | group_id | item_id | can_view_generated       |
+      | 1000     | 1010    | content_with_descendants |
+      | 1000     | 1011    | content_with_descendants |
+      | 1000     | 1012    | content_with_descendants |
+      | 1000     | 1020    | content                  |
+      And the database has the following table 'attempts':
+      | id | participant_id | root_item_id | parent_attempt_id |
+      | 0  | 1000           | null         | null              |
+    And the database has the following table 'results':
+      | attempt_id | participant_id | item_id | started_at          |
+      | 0          | 1000           | 1010    | 2020-01-01 00:00:00 |
+    And I am the user with id "1000"
+    When I send a GET request to "/items/1020/breadcrumbs-from-roots"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+      """
+      [
+        {
+          "started_by_participant": true,
+          "path": [
+            {"id": "1010", "title": "Chapter 1", "language_tag": "en", "type": "Chapter"},
+            {"id": "1011", "title": "Chapter 2", "language_tag": "en", "type": "Chapter"},
+            {"id": "1012", "title": "Chapter 3", "language_tag": "en", "type": "Chapter"},
+            {"id": "1020", "title": "Item", "language_tag": "en", "type": "Task"}
+          ]
+        }
+      ]
+      """
 
   Scenario Outline: Find breadcrumbs for a team
     Given I am the user with id "111"
@@ -108,15 +184,21 @@ Feature: Find all breadcrumbs to an item
     And the response body should be, in JSON:
       """
       [
-        [
-          {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
-          {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
-          {"id": "70", "title": null, "language_tag": "fr", "type": "Task"}
-        ],
-        [
-          {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
-          {"id": "70","title": null, "language_tag": "fr", "type": "Task"}
-        ]
+        {
+          "started_by_participant": true,
+          "path": [
+            {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
+            {"id": "70","title": null, "language_tag": "fr", "type": "Task"}
+          ]
+        },
+        {
+          "started_by_participant": true,
+          "path": [
+            {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
+            {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
+            {"id": "70", "title": null, "language_tag": "fr", "type": "Task"}
+          ]
+        }
       ]
       """
     Examples:
@@ -131,14 +213,43 @@ Feature: Find all breadcrumbs to an item
     And the response body should be, in JSON:
       """
       [
-        [
-          {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
-          {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}
-        ],
-        [{"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}]
+        {
+          "started_by_participant": true,
+          "path": [
+            {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}
+          ]
+        },
+        {
+          "started_by_participant": true,
+          "path": [
+            {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
+            {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}
+          ]
+        }
       ]
       """
     Examples:
       | service_url                                   |
       | /items/60/breadcrumbs-from-roots              |
       | /items/by-text-id/id60/breadcrumbs-from-roots |
+
+  Scenario Outline: Should return not started paths
+    Given I am the user with id "111"
+    When I send a GET request to "<service_url>?participant_id=102"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+      """
+      [
+        {
+          "started_by_participant": false,
+          "path": [
+            {"id": "100", "title": "Chapter Containing Explicit Entry Not Started", "language_tag": "en", "type": "Chapter"},
+            {"id": "101", "title": "Explicit Entry Not Started", "language_tag": "en", "type": "Task"}
+          ]
+        }
+      ]
+      """
+    Examples:
+      | service_url                                    |
+      | /items/101/breadcrumbs-from-roots              |
+      | /items/by-text-id/id101/breadcrumbs-from-roots |

--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -110,7 +110,7 @@ Feature: Find all breadcrumbs to an item
     | /items/90/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
     | /items/by-text-id/id90/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
 
-  Scenario: Should return a breadcrumb when there is missing results, like path-from-root
+  Scenario: Should return a breadcrumb when there are missing results, like path-from-root
     Given the database has the following table 'users':
       | login | group_id | default_language |
       | user  | 1000     | en               |

--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -166,7 +166,7 @@ Feature: Find all breadcrumbs to an item
       """
       [
         {
-          "started_by_participant": true,
+          "started_by_participant": false,
           "path": [
             {"id": "1010", "title": "Chapter 1", "language_tag": "en", "type": "Chapter"},
             {"id": "1011", "title": "Chapter 2", "language_tag": "en", "type": "Chapter"},

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -189,7 +189,7 @@ func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *d
 			breadcrumb = append(breadcrumb, breadcrumbElement{ID: idInt64})
 		}
 		breadcrumbs = append(breadcrumbs, breadcrumbPath{
-			StartedByParticipant: itemPath.IsActive,
+			StartedByParticipant: itemPath.IsStarted,
 			Path:                 breadcrumb,
 		})
 	}

--- a/app/api/items/get_breadcrumbs_from_roots.robustness.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.robustness.feature
@@ -3,6 +3,7 @@ Feature: Find all breadcrumbs to an item - robustness
     Given the database has the following table 'groups':
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |
+      | 91  | Other | 50               | null          |
       | 101 | User  | null             | null          |
       | 102 | Team  | 60               | null          |
       | 111 | User  | null             | null          |

--- a/app/api/items/get_breadcrumbs_from_roots.robustness.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.robustness.feature
@@ -2,10 +2,9 @@ Feature: Find all breadcrumbs to an item - robustness
   Background:
     Given the database has the following table 'groups':
       | id  | type  | root_activity_id | root_skill_id |
-      | 90  | Class | 10               | 20            |
-      | 91  | Other | 50               | null          |
+      | 90  | Class | 10               | null          |
       | 101 | User  | null             | null          |
-      | 102 | Team  | 60               | 30            |
+      | 102 | Team  | 60               | null          |
       | 111 | User  | null             | null          |
     And the database has the following table 'users':
       | login | group_id | default_language |
@@ -24,43 +23,29 @@ Feature: Find all breadcrumbs to an item - robustness
     And the database has the following table 'items':
       | id | url                    | type    | default_language_tag | requires_explicit_entry | text_id |
       | 10 | null                   | Chapter | en                   | false                   | id10    |
-      | 20 | http://taskplatform/20 | Task    | en                   | true                    | id20    |
-      | 30 | http://taskplatform/30 | Task    | en                   | false                   | id30    |
-      | 40 | http://taskplatform/40 | Task    | en                   | false                   | id40    |
-      | 50 | http://taskplatform/50 | Task    | en                   | false                   | id50    |
       | 60 | http://taskplatform/60 | Task    | en                   | false                   | id60    |
       | 70 | http://taskplatform/70 | Task    | fr                   | false                   | id70    |
     And the database has the following table 'items_strings':
       | item_id | language_tag | title            |
       | 10      | fr           | Graphe: Methodes |
       | 10      | en           | Graph: Methods   |
-      | 20      | en           | BFS              |
-      | 50      | en           | DFS              |
       | 60      | en           | Reduce Graph     |
       | 70      | fr           | null             |
     And the database has the following table 'items_items':
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
-      | 10             | 20            | 1           |
-      | 30             | 40            | 1           |
       | 60             | 70            | 2           |
     And the database has the following table 'items_ancestors':
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
-      | 10               | 20            |
       | 10               | 70            |
-      | 30               | 40            |
       | 60               | 70            |
     And the database has the following table 'permissions_generated':
-      | group_id | item_id | can_view_generated       |
-      | 102      | 60      | info                     |
-      | 111      | 10      | info                     |
-      | 111      | 20      | info                     |
-      | 111      | 60      | none                     |
-      | 111      | 70      | none                     |
-      | 111      | 30      | content_with_descendants |
-      | 111      | 40      | content_with_descendants |
-      | 111      | 50      | content_with_descendants |
+      | group_id | item_id | can_view_generated |
+      | 102      | 60      | info               |
+      | 111      | 10      | info               |
+      | 111      | 60      | none               |
+      | 111      | 70      | none               |
     And the database has the following table 'attempts':
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |
@@ -70,8 +55,6 @@ Feature: Find all breadcrumbs to an item - robustness
       | 2  | 102            | 10           | null              |
       | 3  | 102            | 10           | null              |
       | 4  | 102            | 10           | null              |
-      | 5  | 102            | 30           | null              |
-      | 6  | 102            | 40           | 4                 |
     And the database has the following table 'results':
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 102            | 10      | 2020-01-01 00:00:00 |
@@ -80,12 +63,7 @@ Feature: Find all breadcrumbs to an item - robustness
       | 3          | 102            | 10      | 2020-01-01 00:00:00 |
       | 3          | 102            | 60      | 2020-01-01 00:00:00 |
       | 3          | 102            | 70      | 2020-01-01 00:00:00 |
-      | 3          | 102            | 20      | null                |
-      | 4          | 102            | 20      | 2020-01-01 00:00:00 |
-      | 5          | 102            | 30      | 2020-01-01 00:00:00 |
-      | 6          | 102            | 40      | 2020-01-01 00:00:00 |
       | 0          | 111            | 10      | 2020-01-01 00:00:00 |
-      | 0          | 111            | 50      | 2020-01-01 00:00:00 |
 
   Scenario: Invalid item_id
     And I am the user with id "111"
@@ -132,7 +110,3 @@ Feature: Find all breadcrumbs to an item - robustness
     | /items/by-text-id/id70/breadcrumbs-from-roots |
     | /items/60/breadcrumbs-from-roots              |
     | /items/by-text-id/id60/breadcrumbs-from-roots |
-    | /items/20/breadcrumbs-from-roots              |
-    | /items/by-text-id/id20/breadcrumbs-from-roots |
-    | /items/40/breadcrumbs-from-roots              |
-    | /items/by-text-id/id40/breadcrumbs-from-roots |

--- a/app/api/items/path_from_root_export_integration_test.go
+++ b/app/api/items/path_from_root_export_integration_test.go
@@ -1,9 +1,0 @@
-//go:build !unit
-
-package items
-
-import "github.com/France-ioi/AlgoreaBackend/app/database"
-
-func FindItemPath(store *database.DataStore, participantID, itemID int64) []string {
-	return findItemPath(store, participantID, itemID)
-}

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -16,6 +16,9 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 	type args struct {
 		participantID int64
 		itemID        int64
+		user          *database.User
+		pathRootBy    items.PathRootType // items.PathRootUser is tested in get_breadcrumb_from_roots.feature.
+		limit         int
 	}
 	tests := []struct {
 		name    string
@@ -30,7 +33,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: info}
 					- {group_id: 200, item_id: 2, can_view_generated: info}
 			`,
-			args: args{participantID: 101, itemID: 2},
+			args: args{
+				participantID: 101,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "fails if not enough permissions for the second item",
@@ -39,7 +48,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: none}
 			`,
-			args: args{participantID: 101, itemID: 2},
+			args: args{
+				participantID: 101,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "supports a root activity as a first item",
@@ -48,7 +63,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: info}
 			`,
-			args: args{participantID: 101, itemID: 2},
+			args: args{
+				participantID: 101,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
@@ -58,7 +79,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 200, item_id: 3, can_view_generated: content}
 					- {group_id: 200, item_id: 4, can_view_generated: info}
 			`,
-			args: args{participantID: 101, itemID: 4},
+			args: args{
+				participantID: 101,
+				itemID:        4,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
@@ -73,7 +100,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				attempts:
 					- {participant_id: 102, id: 0}
 			`,
-			args: args{participantID: 102, itemID: 2},
+			args: args{
+				participantID: 102,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
@@ -88,7 +121,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				attempts:
 					- {participant_id: 102, id: 0}
 			`,
-			args: args{participantID: 102, itemID: 4},
+			args: args{
+				participantID: 102,
+				itemID:        4,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
@@ -104,7 +143,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				attempts:
 					- {participant_id: 103, id: 0}
 			`,
-			args: args{participantID: 103, itemID: 2},
+			args: args{
+				participantID: 103,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
@@ -120,7 +165,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				attempts:
 					- {participant_id: 103, id: 0}
 			`,
-			args: args{participantID: 103, itemID: 4},
+			args: args{
+				participantID: 103,
+				itemID:        4,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
@@ -130,7 +181,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 100, item_id: 1, can_view_generated: content}
 					- {group_id: 100, item_id: 2, can_view_generated: content}
 			`,
-			args: args{participantID: 100, itemID: 2},
+			args: args{
+				participantID: 100,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
@@ -145,7 +202,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				permissions_generated:
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
-			args: args{participantID: 100, itemID: 10},
+			args: args{
+				participantID: 100,
+				itemID:        10,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"10"}, IsActive: false}},
 		},
 		{
@@ -159,7 +222,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {group_id: 100, item_id: 1, can_view_generated: content}
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
-			args: args{participantID: 100, itemID: 10},
+			args: args{
+				participantID: 100,
+				itemID:        10,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "10"}, IsActive: false}},
 		},
 		{
@@ -183,7 +252,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 100, attempt_id: 3, item_id: 22}
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 			`,
-			args: args{participantID: 100, itemID: 23},
+			args: args{
+				participantID: 100,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
 		},
 		{
@@ -199,7 +274,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 22}
 			`,
-			args: args{participantID: 103, itemID: 23},
+			args: args{
+				participantID: 103,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"22", "23"}, IsActive: true}},
 		},
 		{
@@ -213,7 +294,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				results:
 					- {participant_id: 101, attempt_id: 1, item_id: 2}
 			`,
-			args: args{participantID: 101, itemID: 2},
+			args: args{
+				participantID: 101,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
@@ -249,7 +336,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
 		},
 		{
@@ -284,7 +377,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
 		},
 		{
@@ -323,7 +422,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 7, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
 		},
 		{
@@ -339,7 +444,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 22},
+			args: args{
+				participantID: 101,
+				itemID:        22,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: true}},
 		},
 		{
@@ -357,7 +468,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 0, item_id: 23, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "get paths whose attempt chains have not started results below an attempt not allowing submissions for the last item",
@@ -374,7 +491,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{participantID: 101, itemID: 22},
+			args: args{
+				participantID: 101,
+				itemID:        22,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
 		},
 		{
@@ -392,7 +515,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "get paths whose attempt chains have not started results below an ended attempt for the last item",
@@ -409,7 +538,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{participantID: 101, itemID: 22},
+			args: args{
+				participantID: 101,
+				itemID:        22,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
 		},
 		{
@@ -427,7 +562,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "supports path with attempt chains having ended or not allowing submissions attempts",
@@ -445,7 +586,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23},
+			args: args{
+				participantID: 101,
+				itemID:        23,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: false}},
 		},
 		{
@@ -459,7 +606,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
-			args: args{participantID: 103, itemID: 1},
+			args: args{
+				participantID: 103,
+				itemID:        1,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
 		},
 		{
@@ -474,7 +627,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 					- {participant_id: 103, attempt_id: 1, item_id: 2}
 			`,
-			args: args{participantID: 103, itemID: 2},
+			args: args{
+				participantID: 103,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 		},
 		{
 			name: "get paths whose attempt chains have not started results for an ended attempt for the last item",
@@ -487,7 +646,13 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
-			args: args{participantID: 103, itemID: 1},
+			args: args{
+				participantID: 103,
+				itemID:        1,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
 			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
 		},
 		{
@@ -502,7 +667,80 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 					- {participant_id: 103, attempt_id: 1, item_id: 2}
 			`,
-			args: args{participantID: 103, itemID: 2},
+			args: args{
+				participantID: 103,
+				itemID:        2,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
+		},
+		{
+			name: "returns all the paths when there is more than one",
+			fixture: `
+					groups:
+						- {id: 103, root_activity_id: 100}
+						- {id: 1030, root_activity_id: 101}
+					groups_groups:
+						- {parent_group_id: 1030, child_group_id: 103}
+					items:
+						- {id: 100, default_language_tag: fr}
+						- {id: 101, default_language_tag: fr}
+					items_items:
+						- {parent_item_id: 100, child_item_id: 101, child_order: 1}
+					permissions_generated:
+						- {group_id: 103, item_id: 100, can_view_generated: content}
+						- {group_id: 103, item_id: 101, can_view_generated: content}
+					attempts:
+						- {participant_id: 103, id: 0}
+					results:
+						- {participant_id: 103, attempt_id: 0, item_id: 100}
+						- {participant_id: 103, attempt_id: 0, item_id: 101}
+				`,
+			args: args{
+				participantID: 103,
+				itemID:        101,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         0,
+			},
+			want: []items.ItemPath{
+				{Path: []string{"101"}, IsActive: true},
+				{Path: []string{"100", "101"}, IsActive: true},
+			},
+		},
+		{
+			name: "returns only one path when there is more than one but we ask for one only",
+			fixture: `
+					groups:
+						- {id: 103, root_activity_id: 100}
+						- {id: 1030, root_activity_id: 101}
+					groups_groups:
+						- {parent_group_id: 1030, child_group_id: 103}
+					items:
+						- {id: 100, default_language_tag: fr}
+						- {id: 101, default_language_tag: fr}
+					items_items:
+						- {parent_item_id: 100, child_item_id: 101, child_order: 1}
+					permissions_generated:
+						- {group_id: 103, item_id: 100, can_view_generated: content}
+						- {group_id: 103, item_id: 101, can_view_generated: content}
+					attempts:
+						- {participant_id: 103, id: 0}
+					results:
+						- {participant_id: 103, attempt_id: 0, item_id: 100}
+						- {participant_id: 103, attempt_id: 0, item_id: 101}
+				`,
+			args: args{
+				participantID: 103,
+				itemID:        101,
+				user:          &database.User{},
+				pathRootBy:    items.PathRootParticipant,
+				limit:         1,
+			},
+			want: []items.ItemPath{
+				{Path: []string{"101"}, IsActive: true},
+			},
 		},
 	}
 	const globalFixture = `
@@ -537,7 +775,14 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				assert.NoError(t, s.ItemItems().After())
 				return nil
 			}))
-			got = items.FindItemPaths(store, tt.args.participantID, tt.args.itemID, true)
+			got = items.FindItemPaths(
+				store,
+				&database.User{},
+				tt.args.participantID,
+				tt.args.itemID,
+				tt.args.pathRootBy,
+				tt.args.limit,
+			)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
-func Test_findItemPath(t *testing.T) {
+func Test_FindItemPathFirstPathOnly(t *testing.T) {
 	type args struct {
 		participantID int64
 		itemID        int64
@@ -21,7 +21,7 @@ func Test_findItemPath(t *testing.T) {
 		name    string
 		fixture string
 		args    args
-		want    []string
+		want    []items.ItemPath
 	}{
 		{
 			name: "fails if not enough permissions for the first item",
@@ -49,7 +49,7 @@ func Test_findItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 2, can_view_generated: info}
 			`,
 			args: args{participantID: 101, itemID: 2},
-			want: []string{"1", "2"},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
 			name: "supports a root skill as a first item",
@@ -59,7 +59,7 @@ func Test_findItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 4, can_view_generated: info}
 			`,
 			args: args{participantID: 101, itemID: 4},
-			want: []string{"3", "4"},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
 			name: "supports a root activity of a managed group as a first item",
@@ -74,7 +74,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 102, id: 0}
 			`,
 			args: args{participantID: 102, itemID: 2},
-			want: []string{"1", "2"},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
 			name: "supports a root skill of a managed group as a first item",
@@ -89,7 +89,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 102, id: 0}
 			`,
 			args: args{participantID: 102, itemID: 4},
-			want: []string{"3", "4"},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
 			name: "supports a root activity of a group managed by an ancestor as a first item",
@@ -105,7 +105,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 103, id: 0}
 			`,
 			args: args{participantID: 103, itemID: 2},
-			want: []string{"1", "2"},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
 			name: "supports a root skill of a group managed by an ancestor as a first item",
@@ -121,7 +121,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 103, id: 0}
 			`,
 			args: args{participantID: 103, itemID: 4},
-			want: []string{"3", "4"},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
 		},
 		{
 			name: "supports permissions given directly",
@@ -131,7 +131,7 @@ func Test_findItemPath(t *testing.T) {
 					- {group_id: 100, item_id: 2, can_view_generated: content}
 			`,
 			args: args{participantID: 100, itemID: 2},
-			want: []string{"1", "2"},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
 			name: "should return the element if it's the only one with explicit entry and without started result",
@@ -146,7 +146,7 @@ func Test_findItemPath(t *testing.T) {
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
 			args: args{participantID: 100, itemID: 10},
-			want: []string{"10"},
+			want: []items.ItemPath{{Path: []string{"10"}, IsActive: false}},
 		},
 		{
 			name: "should return the path if the last element has explicit entry and no started result",
@@ -160,7 +160,7 @@ func Test_findItemPath(t *testing.T) {
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
 			args: args{participantID: 100, itemID: 10},
-			want: []string{"1", "10"},
+			want: []items.ItemPath{{Path: []string{"1", "10"}, IsActive: false}},
 		},
 		{
 			name: "steps into child attempts for items requiring explicit entry",
@@ -184,7 +184,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 			`,
 			args: args{participantID: 100, itemID: 23},
-			want: []string{"1", "2", "22", "23"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
 		},
 		{
 			name: "supports paths starting with an item requiring explicit entry",
@@ -200,7 +200,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 22}
 			`,
 			args: args{participantID: 103, itemID: 23},
-			want: []string{"22", "23"},
+			want: []items.ItemPath{{Path: []string{"22", "23"}, IsActive: true}},
 		},
 		{
 			name: "can find a path without a result for the first item",
@@ -214,7 +214,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2}
 			`,
 			args: args{participantID: 101, itemID: 2},
-			want: []string{"1", "2"},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
 		},
 		{
 			name: "prefers the path for the last (by id) existing attempt chain with started results",
@@ -250,7 +250,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
 			args: args{participantID: 101, itemID: 23},
-			want: []string{"1", "21", "22", "23"},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
 		},
 		{
 			name: "prefers the path for the attempt chain with the highest score",
@@ -285,7 +285,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
 			args: args{participantID: 101, itemID: 23},
-			want: []string{"1", "2", "22", "23"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
 		},
 		{
 			name: "prefers the path for the last (by id) attempt chain among all chains with started results for the same items",
@@ -324,7 +324,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 7, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
 			args: args{participantID: 101, itemID: 23},
-			want: []string{"1", "21", "22", "23"},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
 		},
 		{
 			name: "get paths whose attempt chains have missing results for last item requiring explicit entry",
@@ -340,7 +340,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
 			`,
 			args: args{participantID: 101, itemID: 22},
-			want: []string{"1", "2", "22"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: true}},
 		},
 		{
 			name: "ignores paths whose attempt chains have missing results for items requiring explicit entry for a non-last item",
@@ -375,7 +375,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
 			args: args{participantID: 101, itemID: 22},
-			want: []string{"1", "2", "22"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results below an attempt not allowing submissions for non-last item",
@@ -410,7 +410,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
 			args: args{participantID: 101, itemID: 22},
-			want: []string{"1", "2", "22"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results below an ended attempt for non-last item",
@@ -446,7 +446,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 2, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
 			args: args{participantID: 101, itemID: 23},
-			want: []string{"1", "2", "22", "23"},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: false}},
 		},
 		{
 			name: "get paths whose attempt chains have not started results for an attempt not allowing submissions for the last item",
@@ -460,7 +460,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
 			args: args{participantID: 103, itemID: 1},
-			want: []string{"1"},
+			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results for an attempt not allowing submissions for non-last item",
@@ -488,7 +488,7 @@ func Test_findItemPath(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
 			args: args{participantID: 103, itemID: 1},
-			want: []string{"1"},
+			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results for an ended attempt for non-last item",
@@ -531,13 +531,13 @@ func Test_findItemPath(t *testing.T) {
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)
-			var got []string
+			var got []items.ItemPath
 			assert.NoError(t, store.InTransaction(func(s *database.DataStore) error {
 				assert.NoError(t, s.GroupGroups().After())
 				assert.NoError(t, s.ItemItems().After())
 				return nil
 			}))
-			got = items.FindItemPath(store, tt.args.participantID, tt.args.itemID)
+			got = items.FindItemPaths(store, tt.args.participantID, tt.args.itemID, true)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/testhelpers"
 )
 
-func Test_FindItemPathFirstPathOnly(t *testing.T) {
+func Test_FindItemPath(t *testing.T) {
 	type args struct {
 		participantID int64
 		itemID        int64
@@ -742,6 +742,51 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				{Path: []string{"100", "101"}, IsStarted: true},
 			},
 		},
+		{
+			name: "is_started should be true when the path is started by the participant, not if only by the user",
+			fixture: `
+					groups:
+						- {id: 998, root_activity_id: 1000}
+						- {id: 999, root_activity_id: 1001}
+						- {id: 1000}
+						- {id: 1001}
+					groups_groups:
+						- {parent_group_id: 998, child_group_id: 1000}
+						- {parent_group_id: 998, child_group_id: 1001}
+						- {parent_group_id: 999, child_group_id: 1000}
+						- {parent_group_id: 999, child_group_id: 1001}
+					items:
+						- {id: 1000, default_language_tag: fr}
+						- {id: 1001, default_language_tag: fr}
+					items_items:
+						- {parent_item_id: 1000, child_item_id: 1001, child_order: 1}
+					permissions_generated:
+						- {group_id: 1000, item_id: 1000, can_view_generated: content}
+						- {group_id: 1000, item_id: 1001, can_view_generated: content}
+						- {group_id: 1001, item_id: 1000, can_view_generated: content}
+						- {group_id: 1001, item_id: 1001, can_view_generated: content}
+					attempts:
+						- {participant_id: 1000, id: 0}
+						- {participant_id: 1001, id: 0}
+					results:
+						- {participant_id: 1000, attempt_id: 0, item_id: 1001, started_at: 2020-01-01 01:01:01}
+						- {participant_id: 1001, attempt_id: 0, item_id: 1000, started_at: 2020-01-01 01:01:01}
+						- {participant_id: 1001, attempt_id: 0, item_id: 1001, started_at: 2020-01-01 01:01:01}
+				`,
+			args: args{
+				participantID: 1000,
+				itemID:        1001,
+				user: &database.User{
+					GroupID: 1001,
+				},
+				pathRootBy: items.PathRootUser,
+				limit:      0,
+			},
+			want: []items.ItemPath{
+				{Path: []string{"1001"}, IsStarted: true},
+				{Path: []string{"1000", "1001"}, IsStarted: false},
+			},
+		},
 	}
 	const globalFixture = `
 		groups: [{id: 100}, {id: 101}, {id: 200, root_activity_id: 1, root_skill_id: 3}]
@@ -777,7 +822,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 			}))
 			got = items.FindItemPaths(
 				store,
-				&database.User{},
+				tt.args.user,
 				tt.args.participantID,
 				tt.args.itemID,
 				tt.args.pathRootBy,

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -70,7 +70,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
 			name: "supports a root skill as a first item",
@@ -86,7 +86,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
 			name: "supports a root activity of a managed group as a first item",
@@ -107,7 +107,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
 			name: "supports a root skill of a managed group as a first item",
@@ -128,7 +128,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
 			name: "supports a root activity of a group managed by an ancestor as a first item",
@@ -150,7 +150,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
 			name: "supports a root skill of a group managed by an ancestor as a first item",
@@ -172,7 +172,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"3", "4"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
 			name: "supports permissions given directly",
@@ -188,7 +188,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
 			name: "should return the element if it's the only one with explicit entry and without started result",
@@ -209,7 +209,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"10"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"10"}, IsStarted: false}},
 		},
 		{
 			name: "should return the path if the last element has explicit entry and no started result",
@@ -229,7 +229,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "10"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1", "10"}, IsStarted: false}},
 		},
 		{
 			name: "steps into child attempts for items requiring explicit entry",
@@ -259,7 +259,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "supports paths starting with an item requiring explicit entry",
@@ -281,7 +281,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"22", "23"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "can find a path without a result for the first item",
@@ -301,7 +301,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
 			name: "prefers the path for the last (by id) existing attempt chain with started results",
@@ -343,7 +343,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "prefers the path for the attempt chain with the highest score",
@@ -384,7 +384,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "prefers the path for the last (by id) attempt chain among all chains with started results for the same items",
@@ -429,7 +429,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "get paths whose attempt chains have missing results for last item requiring explicit entry",
@@ -451,7 +451,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: true}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have missing results for items requiring explicit entry for a non-last item",
@@ -498,7 +498,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results below an attempt not allowing submissions for non-last item",
@@ -545,7 +545,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results below an ended attempt for non-last item",
@@ -593,7 +593,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
 			name: "get paths whose attempt chains have not started results for an attempt not allowing submissions for the last item",
@@ -613,7 +613,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results for an attempt not allowing submissions for non-last item",
@@ -653,7 +653,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				pathRootBy:    items.PathRootParticipant,
 				limit:         1,
 			},
-			want: []items.ItemPath{{Path: []string{"1"}, IsActive: false}},
+			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
 			name: "ignores paths whose attempt chains have not started results for an ended attempt for non-last item",
@@ -694,8 +694,8 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					attempts:
 						- {participant_id: 103, id: 0}
 					results:
-						- {participant_id: 103, attempt_id: 0, item_id: 100}
-						- {participant_id: 103, attempt_id: 0, item_id: 101}
+						- {participant_id: 103, attempt_id: 0, item_id: 100, started_at: 2020-01-01 01:01:01}
+						- {participant_id: 103, attempt_id: 0, item_id: 101, started_at: 2020-01-01 01:01:01}
 				`,
 			args: args{
 				participantID: 103,
@@ -705,8 +705,8 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				limit:         0,
 			},
 			want: []items.ItemPath{
-				{Path: []string{"101"}, IsActive: true},
-				{Path: []string{"100", "101"}, IsActive: true},
+				{Path: []string{"100", "101"}, IsStarted: true},
+				{Path: []string{"101"}, IsStarted: true},
 			},
 		},
 		{
@@ -728,8 +728,8 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 					attempts:
 						- {participant_id: 103, id: 0}
 					results:
-						- {participant_id: 103, attempt_id: 0, item_id: 100}
-						- {participant_id: 103, attempt_id: 0, item_id: 101}
+						- {participant_id: 103, attempt_id: 0, item_id: 100, started_at: 2020-01-01 01:01:01}
+						- {participant_id: 103, attempt_id: 0, item_id: 101, started_at: 2020-01-01 01:01:01}
 				`,
 			args: args{
 				participantID: 103,
@@ -739,7 +739,7 @@ func Test_FindItemPathFirstPathOnly(t *testing.T) {
 				limit:         1,
 			},
 			want: []items.ItemPath{
-				{Path: []string{"101"}, IsActive: true},
+				{Path: []string{"100", "101"}, IsStarted: true},
 			},
 		},
 	}


### PR DESCRIPTION
```
dle
Bref, oui, en effet, pour certaines utilisations en effet (pas encore vrmt implémentée correctement dans le
frontend), il faut plutôt tous les paths, mm ceux pas encore visités...
donc soit il faut soit un autre service, soit un parameter pour dire d'inclure ou pas les non visités par le
participants, soit le mettre dans l'output.
Ce qui est probablement plus flex pour le frontend pour les utilisations souhaitées/futures, c'est mettre dans
l'output si le path est starté par le participant (en précisant bien que c'est visité par le participant) (edited) 

Geoffrey Huck
et pour `breadcrumb-from-root`, je vais utiliser la même requête que `path-from-root` mais en retournant tous
les chemins trouvés plutôt que seulement le premier, et en ajoutant un champ booléen `started_by_participant`
```

### Idea

`BreadcrumbsFromRoot` now returns an additional boolean field `started_by_participant` with each path.

 To find the path, the query was merged with the one `PathFromRoot`, with 2 variations:
- We get all results, whereas we take only the first one in `PathFromRoot`
- The root items of the path are computed for the `user`, whereas in `PathFromRoot` it is for the `participant`. I don't know the reason but many existing tests are supporting this.

Tests have been updated to reflect the changes.

**Note:** The query may return a path more than once, for example when a path exists with different attempts.
`FindItemsPath` function has been updated to de-duplicate the path returned


### `is_active` and `is_started`

There is two notions for a path:
- `is_active` is when the all the items have either a `result.started_at`, or if it is possible right `NOW()` to make a submission for the item/attempt, typically with the attempt 0
- `is_started`is when all the items have a `result.started_at`

A mistake was made initially when we returned `is_active` instead of `is_started`. It was corrected in commit https://github.com/France-ioi/AlgoreaBackend/pull/991/commits/b3deec450a1fae7d7a83c3dcc5ff707e005d29cc . We want `is_started`.


Also added a test to make sure `is_started` is computed for the `participant` and not to the `user`.