### PR TITLE
Add `has_can_request_help_to` in `getItem`

### DIFF
--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -1,5 +1,4 @@
 Feature: Get item view information
-
   Background:
     Given the database has the following table 'groups':
       | id | name       | grade | type  |
@@ -137,7 +136,8 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true
+        "is_owner": true,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -190,7 +190,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -242,7 +243,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "content_with_descendants",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -299,7 +301,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -356,7 +359,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -408,7 +412,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "info",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -465,7 +470,8 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true
+        "is_owner": true,
+        "has_can_request_help_to": false
       }
     }
     """
@@ -482,7 +488,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -542,7 +548,8 @@ Feature: Get item view information
         "can_grant_view": "<expected_can_grant_view>",
         "can_view": "solution",
         "can_watch": "<can_watch_generated>",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
       <expected_watched_group_part>
     }
@@ -568,7 +575,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -628,7 +635,8 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
+        "is_owner": false,
+        "has_can_request_help_to": false
       }
       <expected_watched_group_part>
     }

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -136,9 +136,9 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true
-      },
-      "has_can_request_help_to": false
+        "is_owner": true,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -190,9 +190,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -243,9 +243,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "content_with_descendants",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -301,9 +301,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -359,9 +359,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -412,9 +412,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "info",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -470,9 +470,9 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true
-      },
-      "has_can_request_help_to": false
+        "is_owner": true,
+        "has_can_request_help_to": false
+      }
     }
     """
 
@@ -488,7 +488,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -496,11 +496,11 @@ Feature: Get item view information
     """
     And the template constant "watched_group_permissions" is:
     """
-    , "watched_group": { {{permissions}}, "has_can_request_help_to": false }
+    , "watched_group": { {{permissions}} }
     """
     And the template constant "watched_group_average_score_and_permissions" is:
     """
-    , "watched_group": { {{average_score}}, {{permissions}}, "has_can_request_help_to": false }
+    , "watched_group": { {{average_score}}, {{permissions}} }
     """
     When I send a GET request to "/items/220?watched_group_id=15"
     Then the response code should be 200
@@ -548,9 +548,9 @@ Feature: Get item view information
         "can_grant_view": "<expected_can_grant_view>",
         "can_view": "solution",
         "can_watch": "<can_watch_generated>",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
       <expected_watched_group_part>
     }
     """
@@ -575,7 +575,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -583,11 +583,11 @@ Feature: Get item view information
     """
     And the template constant "watched_group_permissions" is:
     """
-    , "watched_group": { "has_can_request_help_to": false, {{permissions}} }
+    , "watched_group": { {{permissions}} }
     """
     And the template constant "watched_group_average_score_and_permissions" is:
     """
-    , "watched_group": { {{average_score}}, "has_can_request_help_to": false, {{permissions}} }
+    , "watched_group": { {{average_score}}, {{permissions}} }
     """
     When I send a GET request to "/items/220?watched_group_id=15&as_team_id=13"
     Then the response code should be 200
@@ -635,9 +635,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false
-      },
-      "has_can_request_help_to": false
+        "is_owner": false,
+        "has_can_request_help_to": false
+      }
       <expected_watched_group_part>
     }
     """

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -136,9 +136,9 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true,
-        "has_can_request_help_to": false
-      }
+        "is_owner": true
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -190,9 +190,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -243,9 +243,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "content_with_descendants",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -301,9 +301,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -359,9 +359,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -412,9 +412,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "info",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -470,9 +470,9 @@ Feature: Get item view information
         "can_grant_view": "enter",
         "can_view": "solution",
         "can_watch": "result",
-        "is_owner": true,
-        "has_can_request_help_to": false
-      }
+        "is_owner": true
+      },
+      "has_can_request_help_to": false
     }
     """
 
@@ -488,7 +488,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
     """
     And the template constant "average_score" is:
     """
@@ -496,11 +496,11 @@ Feature: Get item view information
     """
     And the template constant "watched_group_permissions" is:
     """
-    , "watched_group": { {{permissions}} }
+    , "watched_group": { {{permissions}}, "has_can_request_help_to": false }
     """
     And the template constant "watched_group_average_score_and_permissions" is:
     """
-    , "watched_group": { {{average_score}}, {{permissions}} }
+    , "watched_group": { {{average_score}}, {{permissions}}, "has_can_request_help_to": false }
     """
     When I send a GET request to "/items/220?watched_group_id=15"
     Then the response code should be 200
@@ -548,9 +548,9 @@ Feature: Get item view information
         "can_grant_view": "<expected_can_grant_view>",
         "can_view": "solution",
         "can_watch": "<can_watch_generated>",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
       <expected_watched_group_part>
     }
     """
@@ -575,7 +575,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true}
     """
     And the template constant "average_score" is:
     """
@@ -583,11 +583,11 @@ Feature: Get item view information
     """
     And the template constant "watched_group_permissions" is:
     """
-    , "watched_group": { {{permissions}} }
+    , "watched_group": { "has_can_request_help_to": false, {{permissions}} }
     """
     And the template constant "watched_group_average_score_and_permissions" is:
     """
-    , "watched_group": { {{average_score}}, {{permissions}} }
+    , "watched_group": { {{average_score}}, "has_can_request_help_to": false, {{permissions}} }
     """
     When I send a GET request to "/items/220?watched_group_id=15&as_team_id=13"
     Then the response code should be 200
@@ -635,9 +635,9 @@ Feature: Get item view information
         "can_grant_view": "none",
         "can_view": "solution",
         "can_watch": "none",
-        "is_owner": false,
-        "has_can_request_help_to": false
-      }
+        "is_owner": false
+      },
+      "has_can_request_help_to": false
       <expected_watched_group_part>
     }
     """

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -137,7 +137,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -191,7 +191,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -244,7 +244,7 @@ Feature: Get item view information
         "can_view": "content_with_descendants",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -302,7 +302,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -360,7 +360,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -413,7 +413,7 @@ Feature: Get item view information
         "can_view": "info",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -471,7 +471,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
     }
     """
@@ -488,7 +488,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -549,7 +549,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "<can_watch_generated>",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
       <expected_watched_group_part>
     }
@@ -575,7 +575,7 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "has_can_request_help_to": false}
+      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "can_request_help_to": false}
     """
     And the template constant "average_score" is:
     """
@@ -636,7 +636,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "has_can_request_help_to": false
+        "can_request_help_to": false
       }
       <expected_watched_group_part>
     }

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -89,11 +89,6 @@ type itemRootNodeNotChapterFields struct {
 // only if watched_group_id is given.
 type itemResponseWatchedGroupItemInfo struct {
 	Permissions *structures.ItemPermissions `json:"permissions,omitempty"`
-
-	// Whether a `can_request_help_to` permission is defined on the item for the watched_group.
-	// The field is only shown when the current user can view the permissions of the watched group.
-	HasCanRequestHelpTo *bool `json:"has_can_request_help_to,omitempty"`
-
 	// Average score of all "end-members" within the watched group
 	// (or of the watched group itself if it is a user or a team).
 	// The score of an "end-member" is the max of his `results.score` or 0 if no results.
@@ -147,10 +142,6 @@ type itemResponse struct {
 	*itemRootNodeNotChapterFields
 
 	WatchedGroup *itemResponseWatchedGroupItemInfo `json:"watched_group,omitempty"`
-
-	// Whether a `can_request_help_to` permission is defined on the item for the current-user.
-	// required: true
-	HasCanRequestHelpTo bool `json:"has_can_request_help_to"`
 }
 
 // swagger:operation GET /items/{item_id} items itemView
@@ -472,7 +463,7 @@ func constructItemResponseFromDBData(
 		SupportedLanguageTags:        strings.Split(rawData.SupportedLanguageTags, ","),
 	}
 
-	result.HasCanRequestHelpTo = hasCanRequestHelpTo
+	result.Permissions.HasCanRequestHelpTo = &hasCanRequestHelpTo
 
 	if rawData.CanViewGeneratedValue == permissionGrantedStore.ViewIndexByName("solution") {
 		result.String.itemStringRootNodeWithSolutionAccess = &itemStringRootNodeWithSolutionAccess{
@@ -494,7 +485,7 @@ func constructItemResponseFromDBData(
 		}
 		if rawData.CanViewWatchedGroupPermissions {
 			result.WatchedGroup.Permissions = rawData.WatchedGroupPermissions.AsItemPermissions(permissionGrantedStore)
-			result.WatchedGroup.HasCanRequestHelpTo = &watchedGroupHasCanRequestHelpTo
+			result.WatchedGroup.Permissions.HasCanRequestHelpTo = &watchedGroupHasCanRequestHelpTo
 		}
 	}
 

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -89,6 +89,11 @@ type itemRootNodeNotChapterFields struct {
 // only if watched_group_id is given.
 type itemResponseWatchedGroupItemInfo struct {
 	Permissions *structures.ItemPermissions `json:"permissions,omitempty"`
+
+	// Whether a `can_request_help_to` permission is defined on the item for the watched_group.
+	// The field is only shown when the current user can view the permissions of the watched group.
+	HasCanRequestHelpTo *bool `json:"has_can_request_help_to,omitempty"`
+
 	// Average score of all "end-members" within the watched group
 	// (or of the watched group itself if it is a user or a team).
 	// The score of an "end-member" is the max of his `results.score` or 0 if no results.
@@ -142,6 +147,10 @@ type itemResponse struct {
 	*itemRootNodeNotChapterFields
 
 	WatchedGroup *itemResponseWatchedGroupItemInfo `json:"watched_group,omitempty"`
+
+	// Whether a `can_request_help_to` permission is defined on the item for the current-user.
+	// required: true
+	HasCanRequestHelpTo bool `json:"has_can_request_help_to"`
 }
 
 // swagger:operation GET /items/{item_id} items itemView
@@ -463,7 +472,7 @@ func constructItemResponseFromDBData(
 		SupportedLanguageTags:        strings.Split(rawData.SupportedLanguageTags, ","),
 	}
 
-	result.Permissions.HasCanRequestHelpTo = &hasCanRequestHelpTo
+	result.HasCanRequestHelpTo = hasCanRequestHelpTo
 
 	if rawData.CanViewGeneratedValue == permissionGrantedStore.ViewIndexByName("solution") {
 		result.String.itemStringRootNodeWithSolutionAccess = &itemStringRootNodeWithSolutionAccess{
@@ -485,7 +494,7 @@ func constructItemResponseFromDBData(
 		}
 		if rawData.CanViewWatchedGroupPermissions {
 			result.WatchedGroup.Permissions = rawData.WatchedGroupPermissions.AsItemPermissions(permissionGrantedStore)
-			result.WatchedGroup.Permissions.HasCanRequestHelpTo = &watchedGroupHasCanRequestHelpTo
+			result.WatchedGroup.HasCanRequestHelpTo = &watchedGroupHasCanRequestHelpTo
 		}
 	}
 

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -79,15 +79,15 @@ type getItemCommonFields struct {
 	commonItemFields
 
 	// required: true
-	Permissions itemPermissionsWithHasCanRequestHelpTo `json:"permissions"`
+	Permissions itemPermissionsWithCanRequestHelpTo `json:"permissions"`
 }
 
-type itemPermissionsWithHasCanRequestHelpTo struct {
+type itemPermissionsWithCanRequestHelpTo struct {
 	structures.ItemPermissions
 
 	// Whether a `can_request_help_to` permission is defined.
 	// required: true
-	HasCanRequestHelpTo bool `json:"has_can_request_help_to"`
+	CanRequestHelpTo bool `json:"can_request_help_to"`
 }
 
 type itemRootNodeNotChapterFields struct {
@@ -103,7 +103,7 @@ type itemRootNodeNotChapterFields struct {
 
 // only if watched_group_id is given.
 type itemResponseWatchedGroupItemInfo struct {
-	Permissions *itemPermissionsWithHasCanRequestHelpTo `json:"permissions,omitempty"`
+	Permissions *itemPermissionsWithCanRequestHelpTo `json:"permissions,omitempty"`
 
 	// Average score of all "end-members" within the watched group
 	// (or of the watched group itself if it is a user or a team).
@@ -461,9 +461,9 @@ func constructItemResponseFromDBData(
 	result := &itemResponse{
 		getItemCommonFields: &getItemCommonFields{
 			commonItemFields: *rawData.asItemCommonFields(permissionGrantedStore),
-			Permissions: itemPermissionsWithHasCanRequestHelpTo{
-				ItemPermissions:     *rawData.AsItemPermissions(permissionGrantedStore),
-				HasCanRequestHelpTo: hasCanRequestHelpTo,
+			Permissions: itemPermissionsWithCanRequestHelpTo{
+				ItemPermissions:  *rawData.AsItemPermissions(permissionGrantedStore),
+				CanRequestHelpTo: hasCanRequestHelpTo,
 			},
 		},
 		String: itemStringRoot{
@@ -504,9 +504,9 @@ func constructItemResponseFromDBData(
 			result.WatchedGroup.AverageScore = &rawData.WatchedGroupAverageScore
 		}
 		if rawData.CanViewWatchedGroupPermissions {
-			result.WatchedGroup.Permissions = &itemPermissionsWithHasCanRequestHelpTo{
-				ItemPermissions:     *rawData.WatchedGroupPermissions.AsItemPermissions(permissionGrantedStore),
-				HasCanRequestHelpTo: watchedGroupHasCanRequestHelpTo,
+			result.WatchedGroup.Permissions = &itemPermissionsWithCanRequestHelpTo{
+				ItemPermissions:  *rawData.WatchedGroupPermissions.AsItemPermissions(permissionGrantedStore),
+				CanRequestHelpTo: watchedGroupHasCanRequestHelpTo,
 			}
 		}
 	}

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -20,7 +20,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item3               | @Chapter3 | Task    |                          |
       | @Item4               | @Chapter4 | Task    | true                     |
 
-  Scenario Outline: has_can_request_help_to should be true if there is a can_request_help_to permission
+  Scenario Outline: permissions.has_can_request_help_to should be true if there is a can_request_help_to permission
     Given I am @Student
     And there are the following item permissions:
       | item                 | group    | can_view | can_request_help_to | can_request_help is defined                        |
@@ -33,7 +33,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item4               | @School  | solution |                     |                                                    |
     When I send a GET request to "/items/<item_id>"
     Then the response code should be 200
-    And the response at $.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
     Examples:
       | item_id              | has_can_request_help_to |
       | @Item1               | true                    |
@@ -42,7 +42,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item3               | true                    |
       | @Item4               | true                    |
 
-  Scenario Outline: watched_group.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
+  Scenario Outline: watched_group.permissions.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
     Given I am @Teacher
     And there are the following item permissions:
       | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                        |
@@ -57,7 +57,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
   When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
     Then the response code should be 200
-    And the response at $.watched_group.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.watched_group.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
     Examples:
       | item_id              | has_can_request_help_to |
       | @Item1               | true                    |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -1,4 +1,4 @@
-Feature: Get permissions has_can_request_help_to for an item
+Feature: Get permissions can_request_help_to for an item
   Background:
     Given there are the following groups:
       | group               | parent  | members               |
@@ -20,7 +20,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item3               | @Chapter3 | Task    |                          |
       | @Item4               | @Chapter4 | Task    | true                     |
 
-  Scenario Outline: permissions.has_can_request_help_to should be true if there is a can_request_help_to permission
+  Scenario Outline: permissions.can_request_help_to should be true if there is a can_request_help_to permission
     Given I am @Student
     And there are the following item permissions:
       | item                 | group    | can_view | can_request_help_to | can_request_help is defined                        |
@@ -33,16 +33,16 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item4               | @School  | solution |                     |                                                    |
     When I send a GET request to "/items/<item_id>"
     Then the response code should be 200
-    And the response at $.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.permissions.can_request_help_to should be "<can_request_help_to>"
     Examples:
-      | item_id              | has_can_request_help_to |
-      | @Item1               | true                    |
-      | @Item2               | true                    |
-      | @Item2_NoPropagation | false                   |
-      | @Item3               | true                    |
-      | @Item4               | true                    |
+      | item_id              | can_request_help_to |
+      | @Item1               | true                |
+      | @Item2               | true                |
+      | @Item2_NoPropagation | false               |
+      | @Item3               | true                |
+      | @Item4               | true                |
 
-  Scenario Outline: watched_group.permissions.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
+  Scenario Outline: watched_group.permissions.can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
     Given I am @Teacher
     And there are the following item permissions:
       | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                        |
@@ -57,11 +57,11 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
     When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
     Then the response code should be 200
-    And the response at $.watched_group.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.watched_group.permissions.can_request_help_to should be "<can_request_help_to>"
     Examples:
-      | item_id              | has_can_request_help_to |
-      | @Item1               | true                    |
-      | @Item2               | true                    |
-      | @Item2_NoPropagation | false                   |
-      | @Item3               | true                    |
-      | @Item4               | true                    |
+      | item_id              | can_request_help_to |
+      | @Item1               | true                |
+      | @Item2               | true                |
+      | @Item2_NoPropagation | false               |
+      | @Item3               | true                |
+      | @Item4               | true                |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -19,6 +19,7 @@ Feature: Get permissions can_request_help_to for an item
       | @Item2_NoPropagation | Task    |
       | @Item3               | Task    |
       | @Item4               | Task    |
+      | @Item4_NoPropagation | Task    |
     And there are the following item relations:
       | item                 | parent    | request_help_propagation |
       | @Item1               | @Chapter1 |                          |
@@ -26,18 +27,20 @@ Feature: Get permissions can_request_help_to for an item
       | @Item2_NoPropagation | @Chapter2 | false                    |
       | @Item3               | @Chapter3 |                          |
       | @Item4               | @Chapter4 | true                     |
+      | @Item4_NoPropagation | @Chapter4 | false                    |
 
   Scenario Outline: permissions.can_request_help_to should be true if there is a can_request_help_to permission
     Given I am @Student
     And there are the following item permissions:
-      | item                 | group    | can_view | can_request_help_to | can_request_help is defined                        |
-      | @Item1               | @Student | solution | @HelperGroup1       | Directly on item, current-user                     |
-      | @Item2               | @Student | solution |                     |                                                    |
-      | @Item2_NoPropagation | @Student | solution |                     |                                                    |
-      | @Chapter2            | @Student |          | @HelperGroup2       | On item's ancestor                                 |
-      | @Item3               | @School  | solution | @HelperGroup3       | On item, on an ancestor of current-user            |
-      | @Chapter4            | @School  |          | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
-      | @Item4               | @School  | solution |                     |                                                    |
+      | item                 | group    | can_view | can_request_help_to | can_request_help is defined                                                           |
+      | @Item1               | @Student | solution | @HelperGroup1       | Directly on item, current-user                                                        |
+      | @Item2               | @Student | solution |                     |                                                                                       |
+      | @Item2_NoPropagation | @Student | solution |                     |                                                                                       |
+      | @Chapter2            | @Student |          | @HelperGroup2       | On @Item2 and @Item2_NoPropagation ancestor                                           |
+      | @Item3               | @School  | solution | @HelperGroup3       | On @Item3, on an ancestor (@School) of current-user                                   |
+      | @Chapter4            | @School  |          | @HelperGroup4       | On @Item4 and @Item4_NoPropagation ancestor, on an ancestor (@School) of current-user |
+      | @Item4               | @School  | solution |                     |                                                                                       |
+      | @Item4_NoPropagation | @School  | solution |                     |                                                                                       |
     When I send a GET request to "/items/<item_id>"
     Then the response code should be 200
     And the response at $.permissions.can_request_help_to should be "<can_request_help_to>"
@@ -48,20 +51,22 @@ Feature: Get permissions can_request_help_to for an item
       | @Item2_NoPropagation | false               |
       | @Item3               | true                |
       | @Item4               | true                |
+      | @Item4_NoPropagation | false               |
 
   Scenario Outline: watched_group.permissions.can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
     Given I am @Teacher
     And there are the following item permissions:
-      | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                        |
-      | @Item1               | @Teacher     | solution | answer    |                     |                                                    |
-      | @Item2               | @Teacher     | solution | answer    |                     |                                                    |
-      | @Item2_NoPropagation | @Teacher     | solution | answer    |                     |                                                    |
-      | @Item3               | @Teacher     | solution | answer    |                     |                                                    |
-      | @Item4               | @Teacher     | solution | answer    |                     |                                                    |
-      | @Item1               | @Class       |          |           | @HelperGroup1       | Directly on item, current-user                     |
-      | @Chapter2            | @Class       |          |           | @HelperGroup2       | On item's ancestor                                 |
-      | @Item3               | @ClassParent |          |           | @HelperGroup3       | On item, on an ancestor of current-user            |
-      | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
+      | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                                                                |
+      | @Item1               | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item2               | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item2_NoPropagation | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item3               | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item4               | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item4_NoPropagation | @Teacher     | solution | answer    |                     |                                                                                            |
+      | @Item1               | @Class       |          |           | @HelperGroup1       | Directly on @Item1, current-user                                                           |
+      | @Chapter2            | @Class       |          |           | @HelperGroup2       | On @Item2 and @Item2_NoPropagation ancestor                                                |
+      | @Item3               | @ClassParent |          |           | @HelperGroup3       | On @Item3, on an ancestor (@ClassParent) of current-user                                   |
+      | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On @Item4 and @Item4_NoPropagation ancestor, on an ancestor (@ClassParent) of current-user |
     When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
     Then the response code should be 200
     And the response at $.watched_group.permissions.can_request_help_to should be "<can_request_help_to>"
@@ -72,3 +77,4 @@ Feature: Get permissions can_request_help_to for an item
       | @Item2_NoPropagation | false               |
       | @Item3               | true                |
       | @Item4               | true                |
+      | @Item4_NoPropagation | false               |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -9,16 +9,23 @@ Feature: Get permissions can_request_help_to for an item
       | @Class              | @School | @Student,@HelperGroup |
     And @Teacher is a manager of the group @Class and can watch its members
     And there are the following items:
-      | item                 | parent    | type    | request_help_propagation |
-      | @Chapter1            |           | Chapter |                          |
-      | @Chapter2            |           | Chapter |                          |
-      | @Chapter3            |           | Chapter |                          |
-      | @Chapter4            |           | Chapter |                          |
-      | @Item1               | @Chapter1 | Task    |                          |
-      | @Item2               | @Chapter2 | Task    | true                     |
-      | @Item2_NoPropagation | @Chapter2 | Task    | false                    |
-      | @Item3               | @Chapter3 | Task    |                          |
-      | @Item4               | @Chapter4 | Task    | true                     |
+      | item                 | type    |
+      | @Chapter1            | Chapter |
+      | @Chapter2            | Chapter |
+      | @Chapter3            | Chapter |
+      | @Chapter4            | Chapter |
+      | @Item1               | Task    |
+      | @Item2               | Task    |
+      | @Item2_NoPropagation | Task    |
+      | @Item3               | Task    |
+      | @Item4               | Task    |
+    And there are the following item relations:
+      | item                 | parent    | request_help_propagation |
+      | @Item1               | @Chapter1 |                          |
+      | @Item2               | @Chapter2 | true                     |
+      | @Item2_NoPropagation | @Chapter2 | false                    |
+      | @Item3               | @Chapter3 |                          |
+      | @Item4               | @Chapter4 | true                     |
 
   Scenario Outline: permissions.can_request_help_to should be true if there is a can_request_help_to permission
     Given I am @Student

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -20,7 +20,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item3               | @Chapter3 | Task    |                          |
       | @Item4               | @Chapter4 | Task    | true                     |
 
-  Scenario Outline: permissions.has_can_request_help_to should be true if there is a can_request_help_to permission
+  Scenario Outline: has_can_request_help_to should be true if there is a can_request_help_to permission
     Given I am @Student
     And there are the following item permissions:
       | item                 | group    | can_view | can_request_help_to | can_request_help is defined                        |
@@ -33,7 +33,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item4               | @School  | solution |                     |                                                    |
     When I send a GET request to "/items/<item_id>"
     Then the response code should be 200
-    And the response at $.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.has_can_request_help_to should be "<has_can_request_help_to>"
     Examples:
       | item_id              | has_can_request_help_to |
       | @Item1               | true                    |
@@ -42,7 +42,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Item3               | true                    |
       | @Item4               | true                    |
 
-  Scenario Outline: watched_group.permissions.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
+  Scenario Outline: watched_group.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
     Given I am @Teacher
     And there are the following item permissions:
       | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                        |
@@ -57,7 +57,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
   When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
     Then the response code should be 200
-    And the response at $.watched_group.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    And the response at $.watched_group.has_can_request_help_to should be "<has_can_request_help_to>"
     Examples:
       | item_id              | has_can_request_help_to |
       | @Item1               | true                    |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -1,0 +1,67 @@
+Feature: Get permissions has_can_request_help_to for an item
+  Background:
+    Given there are the following groups:
+      | group               | parent  | members               |
+      | @InaccessibleSchool |         | @InaccessibleGroup    |
+      | @School             |         | @TeacherGroup         |
+      | @TeacherGroup       |         | @Teacher              |
+      | @ClassParent        |         | @Class                |
+      | @Class              | @School | @Student,@HelperGroup |
+    And @Teacher is a manager of the group @Class and can watch its members
+    And there are the following items:
+      | item                 | parent    | type    | request_help_propagation |
+      | @Chapter1            |           | Chapter |                          |
+      | @Chapter2            |           | Chapter |                          |
+      | @Chapter3            |           | Chapter |                          |
+      | @Chapter4            |           | Chapter |                          |
+      | @Item1               | @Chapter1 | Task    |                          |
+      | @Item2               | @Chapter2 | Task    | true                     |
+      | @Item2_NoPropagation | @Chapter2 | Task    | false                    |
+      | @Item3               | @Chapter3 | Task    |                          |
+      | @Item4               | @Chapter4 | Task    | true                     |
+
+  Scenario Outline: permissions.has_can_request_help_to should be true if there is a can_request_help_to permission
+    Given I am @Student
+    And there are the following item permissions:
+      | item                 | group    | can_view | can_request_help_to | can_request_help is defined                        |
+      | @Item1               | @Student | solution | @HelperGroup1       | Directly on item, current-user                     |
+      | @Item2               | @Student | solution |                     |                                                    |
+      | @Item2_NoPropagation | @Student | solution |                     |                                                    |
+      | @Chapter2            | @Student |          | @HelperGroup2       | On item's ancestor                                 |
+      | @Item3               | @School  | solution | @HelperGroup3       | On item, on an ancestor of current-user            |
+      | @Chapter4            | @School  |          | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
+      | @Item4               | @School  | solution |                     |                                                    |
+    When I send a GET request to "/items/<item_id>"
+    Then the response code should be 200
+    And the response at $.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    Examples:
+      | item_id              | has_can_request_help_to |
+      | @Item1               | true                    |
+      | @Item2               | true                    |
+      | @Item2_NoPropagation | false                   |
+      | @Item3               | true                    |
+      | @Item4               | true                    |
+
+  Scenario Outline: watched_group.permissions.has_can_request_help_to should be true if there is a can_request_help_to permission for the watched_group
+    Given I am @Teacher
+    And there are the following item permissions:
+      | item                 | group        | can_view | can_watch | can_request_help_to | can_request_help is defined                        |
+      | @Item1               | @Teacher     | solution | answer    |                     |                                                    |
+      | @Item2               | @Teacher     | solution | answer    |                     |                                                    |
+      | @Item2_NoPropagation | @Teacher     | solution | answer    |                     |                                                    |
+      | @Item3               | @Teacher     | solution | answer    |                     |                                                    |
+      | @Item4               | @Teacher     | solution | answer    |                     |                                                    |
+      | @Item1               | @Class       |          |           | @HelperGroup1       | Directly on item, current-user                     |
+      | @Chapter2            | @Class       |          |           | @HelperGroup2       | On item's ancestor                                 |
+      | @Item3               | @ClassParent |          |           | @HelperGroup3       | On item, on an ancestor of current-user            |
+      | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
+  When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
+    Then the response code should be 200
+    And the response at $.watched_group.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
+    Examples:
+      | item_id              | has_can_request_help_to |
+      | @Item1               | true                    |
+      | @Item2               | true                    |
+      | @Item2_NoPropagation | false                   |
+      | @Item3               | true                    |
+      | @Item4               | true                    |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -55,7 +55,7 @@ Feature: Get permissions has_can_request_help_to for an item
       | @Chapter2            | @Class       |          |           | @HelperGroup2       | On item's ancestor                                 |
       | @Item3               | @ClassParent |          |           | @HelperGroup3       | On item, on an ancestor of current-user            |
       | @Chapter4            | @ClassParent |          |           | @HelperGroup4       | On item's ancestor, on an ancestor of current-user |
-  When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
+    When I send a GET request to "/items/<item_id>?watched_group_id=@Class"
     Then the response code should be 200
     And the response at $.watched_group.permissions.has_can_request_help_to should be "<has_can_request_help_to>"
     Examples:

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -337,6 +337,25 @@ func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
 	`, itemID)
 }
 
+// HasCanRequestHelpTo checks whether there is a can_request_help_to permission on an item-group.
+// The checks are made on item's ancestor while can_request_help_propagation=1, and on group's ancestors.
+func (s *ItemStore) HasCanRequestHelpTo(itemID, groupID int64) bool {
+	itemAncestorsRequestHelpPropagationQuery := s.Items().getAncestorsRequestHelpPropagationQuery(itemID)
+
+	hasCanRequestHelpTo, err := s.Users().
+		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", groupID).
+		Joins(`JOIN permissions_granted ON
+			permissions_granted.group_id = groups_ancestors_active.ancestor_group_id AND
+			(permissions_granted.item_id = ? OR permissions_granted.item_id IN (?))`, itemID, itemAncestorsRequestHelpPropagationQuery.SubQuery()).
+		Where("permissions_granted.can_request_help_to IS NOT NULL").
+		Select("1").
+		Limit(1).
+		HasRows()
+	mustNotBeError(err)
+
+	return hasCanRequestHelpTo
+}
+
 // GetItemIDFromTextID gets the item_id from the text_id of an item.
 func (s *ItemStore) GetItemIDFromTextID(textID string) (itemID int64, err error) {
 	err = s.Select("items.id AS id").

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -340,7 +340,7 @@ func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
 // HasCanRequestHelpTo checks whether there is a can_request_help_to permission on an item-group.
 // The checks are made on item's ancestor while can_request_help_propagation=1, and on group's ancestors.
 func (s *ItemStore) HasCanRequestHelpTo(itemID, groupID int64) bool {
-	itemAncestorsRequestHelpPropagationQuery := s.Items().getAncestorsRequestHelpPropagationQuery(itemID)
+	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
 
 	hasCanRequestHelpTo, err := s.Users().
 		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", groupID).

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -339,7 +339,7 @@ func (ctx *TestContext) getItemItemKey(parentItemID, childItemID int64) string {
 }
 
 // addItemItem adds an item-item in the database.
-func (ctx *TestContext) addItemItem(parentItem, childItem string, requestHelpPropagation bool) {
+func (ctx *TestContext) addItemItem(parentItem, childItem string) {
 	parentItemID := ctx.getReference(parentItem)
 	childItemID := ctx.getReference(childItem)
 
@@ -347,10 +347,9 @@ func (ctx *TestContext) addItemItem(parentItem, childItem string, requestHelpPro
 		"items_items",
 		ctx.getItemItemKey(parentItemID, childItemID),
 		map[string]interface{}{
-			"parent_item_id":           parentItemID,
-			"child_item_id":            childItemID,
-			"child_order":              rand.Int31n(1000),
-			"request_help_propagation": requestHelpPropagation,
+			"parent_item_id": parentItemID,
+			"child_item_id":  childItemID,
+			"child_order":    rand.Int31n(1000),
 		},
 	)
 }
@@ -678,19 +677,10 @@ func (ctx *TestContext) ThereAreTheFollowingItems(items *messages.PickleStepArgu
 		})
 
 		if _, ok := item["parent"]; ok {
-			requestHelpPropagation := false
-			if _, ok := item["request_help_propagation"]; ok {
-				var err error
-				requestHelpPropagation, err = strconv.ParseBool(item["request_help_propagation"])
-				if err != nil {
-					return err
-				}
-			}
-
 			parents := strings.Split(item["parent"], ",")
 
 			for _, parent := range parents {
-				ctx.addItemItem(parent, item["item"], requestHelpPropagation)
+				ctx.addItemItem(parent, item["item"])
 			}
 		}
 	}

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -339,7 +339,7 @@ func (ctx *TestContext) getItemItemKey(parentItemID, childItemID int64) string {
 }
 
 // addItemItem adds an item-item in the database.
-func (ctx *TestContext) addItemItem(parentItem, childItem string) {
+func (ctx *TestContext) addItemItem(parentItem, childItem string, requestHelpPropagation bool) {
 	parentItemID := ctx.getReference(parentItem)
 	childItemID := ctx.getReference(childItem)
 
@@ -347,9 +347,10 @@ func (ctx *TestContext) addItemItem(parentItem, childItem string) {
 		"items_items",
 		ctx.getItemItemKey(parentItemID, childItemID),
 		map[string]interface{}{
-			"parent_item_id": parentItemID,
-			"child_item_id":  childItemID,
-			"child_order":    rand.Int31n(1000),
+			"parent_item_id":           parentItemID,
+			"child_item_id":            childItemID,
+			"child_order":              rand.Int31n(1000),
+			"request_help_propagation": requestHelpPropagation,
 		},
 	)
 }
@@ -677,10 +678,19 @@ func (ctx *TestContext) ThereAreTheFollowingItems(items *messages.PickleStepArgu
 		})
 
 		if _, ok := item["parent"]; ok {
+			requestHelpPropagation := false
+			if _, ok := item["request_help_propagation"]; ok {
+				var err error
+				requestHelpPropagation, err = strconv.ParseBool(item["request_help_propagation"])
+				if err != nil {
+					return err
+				}
+			}
+
 			parents := strings.Split(item["parent"], ",")
 
 			for _, parent := range parents {
-				ctx.addItemItem(parent, item["item"])
+				ctx.addItemItem(parent, item["item"], requestHelpPropagation)
 			}
 		}
 	}


### PR DESCRIPTION
fixes #989 

Added a boolean field `HasCanRequestHelpTo` in the permission structure. As it was done with `CanRequestHelpTo`, it is annoted to be available only if it is mentioned in the description of the service. I tried to find another way to do it, by duplicating the structure for permissions, but it ended up requiring many changes in other files.

The recursive query to check `help_request_propagation` was already made so it's been reused.