### PR TITLE
int64 should be serialized as strings in service responses

### DIFF
--- a/app/api/groups/get_team_descendants.feature
+++ b/app/api/groups/get_team_descendants.feature
@@ -85,19 +85,19 @@ Feature: List team descendants of the group (groupTeamDescendantView)
             "grade": null,
             "last_name": "Baker",
             "login": "janeb",
-            "group_id": 63
+            "group_id": "63"
           },
           {
             "first_name": "Jane",
             "grade": 4,
             "last_name": null,
             "login": "janec",
-            "group_id": 65
+            "group_id": "65"
           },
           {
             "grade": -2,
             "login": "janed",
-            "group_id": 67
+            "group_id": "67"
           }
         ],
         "name": "First Team",
@@ -115,17 +115,17 @@ Feature: List team descendants of the group (groupTeamDescendantView)
           {
             "grade": 1,
             "login": "johna",
-            "group_id": 51
+            "group_id": "51"
           },
           {
             "grade": 2,
             "login": "johnb",
-            "group_id": 53
+            "group_id": "53"
           },
           {
             "grade": 3,
             "login": "johnc",
-            "group_id": 55
+            "group_id": "55"
           }
         ],
         "name": "Super Team",
@@ -155,19 +155,19 @@ Feature: List team descendants of the group (groupTeamDescendantView)
             "grade": null,
             "last_name": "Baker",
             "login": "janeb",
-            "group_id": 63
+            "group_id": "63"
           },
           {
             "first_name": "Jane",
             "grade": 4,
             "last_name": null,
             "login": "janec",
-            "group_id": 65
+            "group_id": "65"
           },
           {
             "grade": -2,
             "login": "janed",
-            "group_id": 67
+            "group_id": "67"
           }
         ],
         "name": "First Team",
@@ -195,17 +195,17 @@ Feature: List team descendants of the group (groupTeamDescendantView)
           {
             "grade": 1,
             "login": "johna",
-            "group_id": 51
+            "group_id": "51"
           },
           {
             "grade": 2,
             "login": "johnb",
-            "group_id": 53
+            "group_id": "53"
           },
           {
             "grade": 3,
             "login": "johnc",
-            "group_id": 55
+            "group_id": "55"
           }
         ],
         "name": "Super Team",

--- a/app/api/groups/get_team_descendants.go
+++ b/app/api/groups/get_team_descendants.go
@@ -153,7 +153,7 @@ func (srv *Service) getTeamDescendants(w http.ResponseWriter, r *http.Request) s
 
 type teamDescendantMember struct {
 	// required:true
-	GroupID int64 `json:"group_id"`
+	GroupID int64 `json:"group_id,string"`
 
 	*structures.UserPersonalInfo
 	ShowPersonalInfo bool `json:"-"`

--- a/app/api/threads/get_thread.feature
+++ b/app/api/threads/get_thread.feature
@@ -67,8 +67,8 @@ Feature: Get thread
     And the response body should be, in JSON:
       """
         {
-          "participant_id": 1,
-          "item_id": 21,
+          "participant_id": "1",
+          "item_id": "21",
           "status": "waiting_for_trainer",
           "token": "{{threadToken}}"
         }

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -15,9 +15,9 @@ import (
 // swagger:model threadGetResponse
 type threadGetResponse struct {
 	// required: true
-	ParticipantID int64 `json:"participant_id"`
+	ParticipantID int64 `json:"participant_id,string"`
 	// required: true
-	ItemID int64 `json:"item_id"`
+	ItemID int64 `json:"item_id,string"`
 	// required: true
 	// enum: not_started,waiting_for_participant,waiting_for_trainer,closed
 	Status      string `json:"status"`

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/render"
 	"github.com/spf13/viper"
 
 	"github.com/France-ioi/AlgoreaBackend/app/api"
@@ -17,6 +18,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
 	"github.com/France-ioi/AlgoreaBackend/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/app/rand"
+	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/version"
 )
 
@@ -75,6 +77,9 @@ func (app *Application) Reset(config *viper.Viper) error {
 		logging.WithField("module", "database").Error(err)
 		return err
 	}
+
+	// Set up responder.
+	render.Respond = service.AppResponder
 
 	// Set up middlewares
 	router := chi.NewRouter()

--- a/app/service/responses_test.go
+++ b/app/service/responses_test.go
@@ -73,3 +73,226 @@ func TestResponse_Render(t *testing.T) {
 	assertlib.Equal(t, `{"success":true,"message":"success"}`+"\n", recorder.Body.String())
 	assertlib.Equal(t, http.StatusOK, recorder.Code)
 }
+
+func TestCheckInt64JsonHasStringTag(t *testing.T) {
+	type structTypeInvalid struct {
+		A  bool
+		ID int64 `json:"id"`
+	}
+	type structTypeValid struct {
+		A  bool
+		ID int64 `json:"id,string"`
+	}
+	type structSliceTypeInvalid struct {
+		B     bool
+		Slice []structTypeInvalid
+	}
+	type structSliceTypeValid struct {
+		B     bool
+		Slice []structTypeValid
+	}
+	type structMapTypeInvalid struct {
+		B   bool
+		Map map[string]structTypeInvalid
+	}
+	type structMapTypeValid struct {
+		B   bool
+		Map map[string]structTypeValid
+	}
+
+	tests := []struct {
+		name                string
+		definitionStructure interface{}
+		shouldPanic         bool
+	}{
+		{
+			name: "int64/uint64 without JSON tag should pass",
+			definitionStructure: &struct {
+				A   bool
+				ID  int64
+				UID uint64
+			}{},
+			shouldPanic: false,
+		},
+		{
+			name: "int64 with JSON tag, without string, should panic",
+			definitionStructure: &struct {
+				A  bool
+				ID int64 `json:"id"`
+			}{},
+			shouldPanic: true,
+		},
+		{
+			name: "uint64 with JSON tag, without string, should panic",
+			definitionStructure: &struct {
+				A  bool
+				ID uint64 `json:"id"`
+			}{},
+			shouldPanic: true,
+		},
+		{
+			name: "int64 in sub-struct with JSON tag, without string, should panic",
+			definitionStructure: &struct {
+				A      bool
+				Inside struct {
+					Inside2 struct {
+						B  bool
+						ID int64 `json:"id"`
+					}
+				}
+			}{},
+			shouldPanic: true,
+		},
+		{
+			name: "int64/uint64 with JSON tag ignored, should pass",
+			definitionStructure: &struct {
+				A   bool
+				ID  int64  `json:"-"`
+				UID uint64 `json:"-"`
+			}{},
+			shouldPanic: false,
+		},
+		{
+			name: "int64/uint64 with JSON tag, with string, should pass",
+			definitionStructure: &struct {
+				A   bool
+				ID  int64  `json:"id,string"`
+				ID2 uint64 `json:"id2,string"`
+			}{},
+			shouldPanic: false,
+		},
+		{
+			name: "should panic with top-level slice containing invalid structures",
+			definitionStructure: []structTypeInvalid{
+				{
+					A:  false,
+					ID: 1,
+				},
+				{
+					A:  false,
+					ID: 2,
+				},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "should pass with top-level slice containing valid structures",
+			definitionStructure: []structTypeValid{
+				{
+					A:  false,
+					ID: 1,
+				},
+				{
+					A:  false,
+					ID: 2,
+				},
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "should panic with sub-level slice containing invalid structures",
+			definitionStructure: structSliceTypeInvalid{
+				B: false,
+				Slice: []structTypeInvalid{
+					{
+						A:  false,
+						ID: 1,
+					},
+					{
+						A:  false,
+						ID: 2,
+					},
+				},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "should pass with sub-level slice containing valid structures",
+			definitionStructure: structSliceTypeValid{
+				B: false,
+				Slice: []structTypeValid{
+					{
+						A:  false,
+						ID: 1,
+					},
+					{
+						A:  false,
+						ID: 2,
+					},
+				},
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "should panic with top-level map containing invalid structures",
+			definitionStructure: map[string]interface{}{
+				"a": structTypeInvalid{
+					A:  false,
+					ID: 1,
+				},
+				"b": structTypeInvalid{
+					A:  false,
+					ID: 2,
+				},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "should pass with top-level map containing valid structures",
+			definitionStructure: map[string]interface{}{
+				"a": structTypeValid{
+					A:  false,
+					ID: 1,
+				},
+				"b": structTypeValid{
+					A:  false,
+					ID: 2,
+				},
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "should panic with sub-level map containing invalid structures",
+			definitionStructure: structMapTypeInvalid{
+				B: false,
+				Map: map[string]structTypeInvalid{
+					"a": {
+						A:  false,
+						ID: 1,
+					},
+					"b": {
+						A:  false,
+						ID: 2,
+					},
+				},
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "should pass with sub-level map containing valid structures",
+			definitionStructure: structMapTypeValid{
+				B: false,
+				Map: map[string]structTypeValid{
+					"a": {
+						A:  false,
+						ID: 1,
+					},
+					"b": {
+						A:  false,
+						ID: 2,
+					},
+				},
+			},
+			shouldPanic: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assertlib.Panics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
+			} else {
+				assertlib.NotPanics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #990 

We have to make sure that all `int64` are encoded as strings in responses.

The retained solution is to override the "responder" that serializes the responses as JSON, and add a check that deeply inspect the serialized object, returning an error whenever there is a field that is serialized, and is an `int64` or an `uint64`, and doesn't have the `string` JSON metadata.

Since it is a deep inspect, it was restricted to be done in test environment, so there will be no overheat in production.

In tests, an exception will be returned whenever a response with an int64 that is not a string is rendered.

Other solutions considered:
- Doing a static check on the code: it would return false positives for structures with int64 but not serialized in responses
- Checking the serialized response content, but we cannot say if a number is a `int32` or `int64`. We also cannot discriminate by name of the field, since `can_request_help_to` for example doesn't end by "id".

Note: Also corrected service `groupTeamDescendantView` that was triggered by the checks.