### PR TITLE
Docfixes related to thread services

### DIFF
--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -42,13 +42,14 @@ type threadGetResponse struct {
 //
 //
 //		Restrictions:
-//			* one of these conditions matches:
+//			* one of these conditions must match:
 //				- the current-user is the thread participant and allowed to "can_view >= content" the item
 //				- the current-user has the "can_watch >= answer" permission on the item
 //				- the following rules all matches:
 //					* the current-user is descendant of the thread helper_group
 //					* the thread is either open (=waiting_for_participant or =waiting_for_trainer), or closed for less than 2 weeks
 //					* the current-user has validated the item
+//			Otherwise, a forbidden error is returned.
 //
 //	parameters:
 //		- name: item_id

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -8,21 +8,26 @@ import (
 	"github.com/go-chi/render"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
+	"github.com/France-ioi/AlgoreaBackend/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
 )
 
 // swagger:model threadGetResponse
 type threadGetResponse struct {
-	// required: true
+	// required:true
 	ParticipantID int64 `json:"participant_id,string"`
-	// required: true
+	// required:true
 	ItemID int64 `json:"item_id,string"`
-	// required: true
+	// required:true
 	// enum: not_started,waiting_for_participant,waiting_for_trainer,closed
 	Status string `json:"status"`
-	// required: true
+	// The ThreadToken
+	// required:true
 	ThreadToken string `json:"token"`
+	// This field is not really present, it is here only to document the content of token.
+	// required:false
+	TokenForDoc *payloads.ThreadToken `json:"token_not_present_only_for_doc,omitempty"`
 }
 
 // swagger:operation GET /items/{item_id}/participant/{participant_id}/thread threads threadGet

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -37,7 +37,9 @@ type threadGetResponse struct {
 //	description: >
 //		Retrieve a thread information.
 //
+//
 //		The `status` is `not_started` if the thread hasn't been started
+//
 //
 //		Restrictions:
 //			* one of these conditions matches:

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -20,7 +20,8 @@ type threadGetResponse struct {
 	ItemID int64 `json:"item_id,string"`
 	// required: true
 	// enum: not_started,waiting_for_participant,waiting_for_trainer,closed
-	Status      string `json:"status"`
+	Status string `json:"status"`
+	// required: true
 	ThreadToken string `json:"token"`
 }
 

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -90,6 +90,7 @@ type listThreadParameters struct {
 //		Validations:
 //			* if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
 //				with `can_watch_members` on `watched_group_id`.
+//				Otherwise, a forbidden error is returned.
 //
 //
 //		Extra:

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -68,9 +68,12 @@ type listThreadParameters struct {
 //
 //		Service to list the visible threads for a user.
 //
+//
 //		Exactly one of [`watched_group_id`, `is_mine`] is given.
 //
+//
 //		Only thread for which the item has can_view>=content for the current user are returned.
+//
 //
 //		* If `is_mine` = 1, only threads for which the participant is the current-user and for which the current-user has
 //			`can_view >= content` on the item are returned.
@@ -83,9 +86,11 @@ type listThreadParameters struct {
 //		* `first_name` and `last_name` are only returned for the current user, or if the user approved access to their personal
 //			info for some group managed by the current user.
 //
+//
 //		Validations:
 //			* if `watched_group_id` is given: the current-user must be (implicitly or explicitly) a manager
 //				with `can_watch_members` on `watched_group_id`.
+//
 //
 //		Extra:
 //			* By default, ordering is by `latest_update_at` DESC.

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -67,6 +67,15 @@ type updateThreadRequest struct {
 //				to write (see doc) (if `status` is given, checks related to status supersede this one).
 //			* at most one of `message_count_increment`, `message_count` must be given
 //
+//
+//		A forbidden error is returned when:
+//			* Trying to write to a thread, including changing its status, without having the rights to do so.
+//			* The provided `helper_group_id` doesn't match the restrictions.
+//
+//
+//		If the parameters given are inconsistent, a bad request error is returned with the reason of the error.
+//
+//
 //	parameters:
 //		- name: item_id
 //			in: path

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -43,9 +43,12 @@ type updateThreadRequest struct {
 //
 //		Service to update thread information.
 //
+//
 //		If the thread doesn't exist, it is created.
 //
+//
 //		Once a thread has been created, it cannot be deleted or set back to `not_started`.
+//
 //
 //		Validations and restrictions:
 //			* if `status` is given:

--- a/app/payloads/thread_token.go
+++ b/app/payloads/thread_token.go
@@ -3,16 +3,33 @@ package payloads
 import "crypto/rsa"
 
 // ThreadToken represents data inside a thread token.
+// swagger:model ThreadToken
 type ThreadToken struct {
-	Date          string `json:"date" validate:"dmy-date"` // dd-mm-yyyy
-	ItemID        string `json:"item_id"`
+	// Format dd-mm-yyyy
+	// required:true
+	Date string `json:"date" validate:"dmy-date"`
+	// required:true
+	ItemID string `json:"item_id"`
+	// required:true
 	ParticipantID string `json:"participant_id"`
-	UserID        string `json:"user_id"`   // Current user.
-	IsMine        bool   `json:"is_mine"`   // Whether the thread is from the current user.
-	CanWatch      bool   `json:"can_watch"` // Whether the current user can post new content.
-	CanWrite      bool   `json:"can_write"` // Whether the current user can post new content on the thread
-	Exp           string `json:"exp"`       // Expiry date in the number of seconds since 01/01/1970 UTC.
+	// Current user.
+	// required:true
+	UserID string `json:"user_id"`
+	// Whether the thread is from the current user.
+	// required:true
+	IsMine bool `json:"is_mine"`
+	// Whether the current user can post new content.
+	// required:true
+	CanWatch bool `json:"can_watch"`
+	// Whether the current user can post new content on the thread
+	// required:true
+	CanWrite bool `json:"can_write"`
+	// Expiry date in the number of seconds since 01/01/1970 UTC.
+	// required:true
+	Exp string `json:"exp"`
 
-	PublicKey  *rsa.PublicKey
+	// swagger:ignore
+	PublicKey *rsa.PublicKey
+	// swagger:ignore
 	PrivateKey *rsa.PrivateKey
 }


### PR DESCRIPTION
Related to #988 

DONE: Just point 6 would require to find out why it happens because I don't have the issue in local.


- [x] 1. Question: why "token" not required in threadGet?
There might be a reason but it seems not obvious as I cannot guess it immediately. It may make sense to add the reason in the service description, otherwise I don't know what to do with not-set token.

> FIXED. The field is always present so it should be required.


- [x] 2. threadUpdate
ItemID and ParticipantID does not follow the convention of camel case for the backend. As there are given in the url, I assume the itemID and participantID do not have to be given in body anyway I assume.

> FIXED. Those fields were copied in the structure for code factorization reasons and weren't intended to appear in the doc. They're now removed.


- [x] 3. In threadGet, I would find useful to describe what is in the token.

> FIXED. But with a little hack: Added a field named `token_not_present_only_for_doc` which shows the content in the documentation. This field never appear in the response, but has to be here for the doc. Didn't find another way.


- [x] 4. Some services have can_request_help_to appears only in services that support this permission (see service description), and only if it is set. I would expect the value to be null when it is set but the permission not given to the user. It is not clear if it is valid value as the field is not indicated as nullable. Anyway, shouldn't it be an array as we cannot aggregate groups?

> We might consider that this point will be resolved when we implement aggregation of `can_request_help_to` (see comment: https://github.com/France-ioi/AlgoreaBackend/issues/988#issuecomment-1684024829)


- [x] 5. threadGet: there is probably a line break missing in the thread hasn't been started Restrictions:

> FIXED.


- [ ] 6. In the swagger doc, the "thread" section disappear from the menu as soon as you click on another service, for instance [this one](https://franceioi-algorea.s3.eu-west-3.amazonaws.com/spec/v1.10.0.html#tag/group-memberships/operation/groupRemoveMembers). Swagger bug or something bad in the metadata?

> MAYBE. It works on my machine where I'm using the latest swagger. Upon examination, there is a slight difference in the CSS on the menu. Made a PR that upgrades swagger in CI, hopefully it'll resolve the issue: https://github.com/France-ioi/AlgoreaBackend/pull/996


- [x] 7. Unlike most other services,threadGet, listThreads, threadUpdate do not clearly state what happens if validations or restrictions are failing.

> FIXED.