### PR TITLE
Bug: Duplicate in thread listing service

### DIFF
--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -197,17 +197,19 @@ Feature: List threads
   Scenario: Should return only thread from item or descendant when item_id is given
     Given I am @John
     And there are the following items:
-      | item              | parent      | type    |
-      | @Root_Task        |             | Task    |
-      | @Chapter1         |             | Chapter |
-      | @Chapter1_Task    | @Chapter1   | Task    |
-      | @Chapter2         |             | Chapter |
-      | @Chapter2_Task    | @Chapter2   | Task    |
-      | @Chapter2_1       | @Chapter2   | Chapter |
-      | @Chapter2_1_Task1 | @Chapter2_1 | Task    |
-      | @Chapter2_1_Task2 | @Chapter2_1 | Task    |
-      | @Chapter3         |             | Chapter |
-    And there are the following threads:
+      | item              | parent                          | type    |
+      | @Root_Task        |                                 | Task    |
+      | @Chapter1         |                                 | Chapter |
+      | @Chapter1_Task    | @Chapter1                       | Task    |
+      | @ChapterRoot_2A   |                                 | Chapter |
+      | @ChapterRoot_2B   |                                 | Chapter |
+      | @Chapter2         | @Chapter_Root_2,@ChapterRoot_2B | Chapter |
+      | @Chapter2_Task    | @Chapter2                       | Task    |
+      | @Chapter2_1       | @Chapter2                       | Chapter |
+      | @Chapter2_1_Task1 | @Chapter2_1                     | Task    |
+      | @Chapter2_1_Task2 | @Chapter2_1                     | Task    |
+      | @Chapter3         |                                 | Chapter |
+      And there are the following threads:
       | participant | item              | visible_by_participant | message_count |
       | @John       | @Root_Task        | 1                      | 100           |
       | @John       | @Chapter1         | 1                      | 101           |

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -236,6 +236,7 @@ func (srv *Service) constructListThreadsQuery(r *http.Request, params listThread
 		JoinsUserAndDefaultItemStrings(user).
 		WithPersonalInfoViewApprovals(user).
 		Select(`
+			DISTINCT
 			items.id AS item__id,
 			items.type AS item__type,
 			COALESCE(user_strings.language_tag, default_strings.language_tag) AS item__language_tag,

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -653,7 +653,11 @@ func (ctx *TestContext) ThereAreTheFollowingItems(items *messages.PickleStepArgu
 		})
 
 		if _, ok := item["parent"]; ok {
-			ctx.addItemItem(item["parent"], item["item"])
+			parents := strings.Split(item["parent"], ",")
+
+			for _, parent := range parents {
+				ctx.addItemItem(parent, item["item"])
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #986 

The bug appeared when the asked item was in more than one parent chapter. Came from the fact we use a join on `item_ancestors` to get the item's children: the same thread appeared as many times as it was a `child_item_id` in `item_ancestors`.

To reproduce, added the ability to set more than one `parent` to an item in Gherkin definitions.

### FIX:
Added a `DISTINCT`.

### Also considered:
- Using a subquery to filter `item_id` with all its children instead of a join, but I think its less efficient