### PR TITLE
Get permission service: clean "can_request_help" usage

### DIFF
--- a/app/api/groups/get_participant_progress.feature
+++ b/app/api/groups/get_participant_progress.feature
@@ -574,11 +574,11 @@ Feature: Display the current progress of a participant on children of an item (g
     When I send a GET request to "/items/1020/participant-progress?as_team_id=14"
     Then the response code should be 200
     And the response at $.item.item_id should be "1020"
-    And the response should not be defined at $.children
+    And the response at $.children should be "<undefined>"
 
   Scenario: Should not return the children when the current user doesn't have a started result on the requested item with watched_group_id
     Given I am the user with id "22"
     When I send a GET request to "/items/210/participant-progress?watched_group_id=67"
     Then the response code should be 200
     And the response at $.item.item_id should be "210"
-    And the response should not be defined at $.children
+    And the response at $.children should be "<undefined>"

--- a/app/api/groups/get_permissions.feature
+++ b/app/api/groups/get_permissions.feature
@@ -82,27 +82,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "none", "can_grant_view": "none", "can_edit": "none", "can_watch": "none",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -141,27 +146,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content_with_descendants", "can_grant_view": "solution", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -200,27 +210,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -259,27 +274,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -318,27 +338,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -377,27 +402,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -436,27 +466,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -495,27 +530,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         }
       }
     """
@@ -554,27 +594,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """
@@ -613,27 +658,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "9999-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """
@@ -672,27 +722,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2021-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2022-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2024-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2026-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2028-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """
@@ -731,27 +786,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2021-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2027-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2025-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2023-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2021-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """
@@ -790,27 +850,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2022-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2028-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2026-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2024-12-31T23:59:59Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2022-12-31T23:59:59Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """
@@ -849,27 +914,32 @@ Feature: Get permissions for a group
         "computed": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         },
         "granted_via_group_membership": {
           "can_view": "content", "can_grant_view": "content", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_item_unlocking": {
           "can_view": "info", "can_grant_view": "enter", "can_edit": "all", "can_watch": "answer",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_self": {
           "can_view": "content", "can_grant_view": "content_with_descendants", "can_edit": "children", "can_watch": "result",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": false, "is_owner": false
+          "can_make_session_official": false, "is_owner": false,
+          "can_request_help_to": []
         },
         "granted_via_other": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_edit": "all_with_grant", "can_watch": "answer_with_grant",
           "can_enter_from": "2019-07-16T22:02:28Z",
-          "can_make_session_official": true, "is_owner": true
+          "can_make_session_official": true, "is_owner": true,
+          "can_request_help_to": []
         }
       }
     """

--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -37,32 +37,44 @@ type grantedPermissionsStruct struct {
 	CanRequestHelpTo *canRequestHelpTo `json:"can_request_help_to"`
 }
 
-type permissionsWithCanEnterFrom struct {
+type aggregatedPermissionsWithCanEnterFromStruct struct {
 	permissionsStruct
 	// The next time the group can enter the item (>= NOW())
 	// required: true
 	CanEnterFrom string `json:"can_enter_from"`
+	// required: true
+	CanRequestHelpTo []canRequestHelpTo `json:"can_request_help_to"`
 }
 
 // Computed permissions for the group
 // (respecting permissions of its ancestors).
-type computedPermissions struct{ permissionsWithCanEnterFrom }
+type computedPermissions struct {
+	aggregatedPermissionsWithCanEnterFromStruct
+}
 
 // Permissions granted to the group or its ancestors
 // via `origin` = 'group_membership' excluding the row from `granted`.
-type permissionsGrantedViaGroupMembership struct{ permissionsWithCanEnterFrom }
+type permissionsGrantedViaGroupMembership struct {
+	aggregatedPermissionsWithCanEnterFromStruct
+}
 
 // Permissions granted to the group or its ancestors
 // via `origin` = 'item_unlocking'.
-type permissionsGrantedViaItemUnlocking struct{ permissionsWithCanEnterFrom }
+type permissionsGrantedViaItemUnlocking struct {
+	aggregatedPermissionsWithCanEnterFromStruct
+}
 
 // Permissions granted to the group or its ancestors
 // via `origin` = 'self'.
-type permissionsGrantedViaSelf struct{ permissionsWithCanEnterFrom }
+type permissionsGrantedViaSelf struct {
+	aggregatedPermissionsWithCanEnterFromStruct
+}
 
 // Permissions granted to the group or its ancestors
 // via `origin` = 'other'.
-type permissionsGrantedViaOther struct{ permissionsWithCanEnterFrom }
+type permissionsGrantedViaOther struct {
+	aggregatedPermissionsWithCanEnterFromStruct
+}
 
 // swagger:model permissionsViewResponse
 type permissionsViewResponse struct {
@@ -343,7 +355,7 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 			CanEnterUntil:    service.ConvertDBTimeToJSONTime(permissionsRow["granted_directly_can_enter_until"]),
 			CanRequestHelpTo: canRequestHelpToPermission,
 		},
-		Computed: computedPermissions{permissionsWithCanEnterFrom{
+		Computed: computedPermissions{aggregatedPermissionsWithCanEnterFromStruct{
 			permissionsStruct: permissionsStruct{
 				ItemPermissions: structures.ItemPermissions{
 					CanView:      permissionsGrantedStore.ViewNameByIndex(int(permissionsRow["generated_can_view_value"].(int64))),
@@ -354,9 +366,10 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 				},
 				CanMakeSessionOfficial: permissionsRow["generated_can_make_session_official"].(int64) == 1,
 			},
-			CanEnterFrom: service.ConvertDBTimeToJSONTime(permissionsRow["generated_can_enter_from"]),
+			CanEnterFrom:     service.ConvertDBTimeToJSONTime(permissionsRow["generated_can_enter_from"]),
+			CanRequestHelpTo: make([]canRequestHelpTo, 0),
 		}},
-		GrantedViaGroupMembership: permissionsGrantedViaGroupMembership{permissionsWithCanEnterFrom{
+		GrantedViaGroupMembership: permissionsGrantedViaGroupMembership{aggregatedPermissionsWithCanEnterFromStruct{
 			permissionsStruct: permissionsStruct{
 				ItemPermissions: structures.ItemPermissions{
 					CanView:      permissionsGrantedStore.ViewNameByIndex(int(permissionsRow["granted_anc_membership_can_view_value"].(int64))),
@@ -367,9 +380,10 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 				},
 				CanMakeSessionOfficial: permissionsRow["granted_anc_membership_can_make_session_official"].(int64) == 1,
 			},
-			CanEnterFrom: service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_membership_can_enter_from"]),
+			CanEnterFrom:     service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_membership_can_enter_from"]),
+			CanRequestHelpTo: make([]canRequestHelpTo, 0),
 		}},
-		GrantedViaItemUnlocking: permissionsGrantedViaItemUnlocking{permissionsWithCanEnterFrom{
+		GrantedViaItemUnlocking: permissionsGrantedViaItemUnlocking{aggregatedPermissionsWithCanEnterFromStruct{
 			permissionsStruct: permissionsStruct{
 				ItemPermissions: structures.ItemPermissions{
 					CanView:      permissionsGrantedStore.ViewNameByIndex(int(permissionsRow["granted_anc_unlocking_can_view_value"].(int64))),
@@ -380,9 +394,10 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 				},
 				CanMakeSessionOfficial: permissionsRow["granted_anc_unlocking_can_make_session_official"].(int64) == 1,
 			},
-			CanEnterFrom: service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_unlocking_can_enter_from"]),
+			CanEnterFrom:     service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_unlocking_can_enter_from"]),
+			CanRequestHelpTo: make([]canRequestHelpTo, 0),
 		}},
-		GrantedViaSelf: permissionsGrantedViaSelf{permissionsWithCanEnterFrom{
+		GrantedViaSelf: permissionsGrantedViaSelf{aggregatedPermissionsWithCanEnterFromStruct{
 			permissionsStruct: permissionsStruct{
 				ItemPermissions: structures.ItemPermissions{
 					CanView:      permissionsGrantedStore.ViewNameByIndex(int(permissionsRow["granted_anc_self_can_view_value"].(int64))),
@@ -393,9 +408,10 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 				},
 				CanMakeSessionOfficial: permissionsRow["granted_anc_self_can_make_session_official"].(int64) == 1,
 			},
-			CanEnterFrom: service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_self_can_enter_from"]),
+			CanEnterFrom:     service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_self_can_enter_from"]),
+			CanRequestHelpTo: make([]canRequestHelpTo, 0),
 		}},
-		GrantedViaOther: permissionsGrantedViaOther{permissionsWithCanEnterFrom{
+		GrantedViaOther: permissionsGrantedViaOther{aggregatedPermissionsWithCanEnterFromStruct{
 			permissionsStruct: permissionsStruct{
 				ItemPermissions: structures.ItemPermissions{
 					CanView:      permissionsGrantedStore.ViewNameByIndex(int(permissionsRow["granted_anc_other_can_view_value"].(int64))),
@@ -406,7 +422,8 @@ func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) servi
 				},
 				CanMakeSessionOfficial: permissionsRow["granted_anc_other_can_make_session_official"].(int64) == 1,
 			},
-			CanEnterFrom: service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_other_can_enter_from"]),
+			CanEnterFrom:     service.ConvertDBTimeToJSONTime(permissionsRow["granted_anc_other_can_enter_from"]),
+			CanRequestHelpTo: make([]canRequestHelpTo, 0),
 		}},
 	})
 	return service.NoError

--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -30,10 +30,9 @@ type permissionsStruct struct {
 type canRequestHelpTo struct {
 	// required: true
 	ID int64 `json:"id,string"`
-	// The name is only set if the group is visible to the current user.
-	// Nullable
-	// required: true
-	Name *string `json:"name"`
+	// The name is present only if the group is visible to the current user.
+	// required: false
+	Name *string `json:"name,omitempty"`
 	// Whether the group is the "all-users" group.
 	// required: true
 	IsAllUsersGroup bool `json:"is_all_users_group"`

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -11,12 +11,13 @@ Feature: Get permissions can_request_help_to for a group
   Background:
     Given allUsersGroup is defined as the group @AllUsers
     And there are the following groups:
-      | group              | parent             | members  |
-      | @AllUsers          |                    |          |
-      | @School            |                    | @Teacher |
-      | @ClassParentParent |                    |          |
-      | @ClassParent       | @ClassParentParent |          |
-      | @Class             | @ClassParent       |          |
+      | group                    | parent                   | members  |
+      | @AllUsers                |                          |          |
+      | @School                  |                          | @Teacher |
+      | @ClassParentParentParent |                          |          |
+      | @ClassParentParent       | @ClassParentParentParent |          |
+      | @ClassParent             | @ClassParentParent       |          |
+      | @Class                   | @ClassParent             |          |
     And @Teacher is a manager of the group @Class and can grant group access
     And there are the following tasks:
       | item  |
@@ -65,19 +66,20 @@ Feature: Get permissions can_request_help_to for a group
   Scenario: Should return can_request_help_to arrays when permissions with specific origins are defined
     Given I am @Teacher
     And there are the following item permissions:
-      | item  | group              | source_group | origin           | is_owner | can_request_help_to          | comment                          |
-      | @Item | @Class             | @Class       | self             | false    | @HelperGroupSelf1            |                                  |
-      | @Item | @ClassParent       | @Class       | self             | false    | @AllUsers                    |                                  |
-      | @Item | @ClassParentParent | @Class       | self             | false    |                              | check we don't get empty groups  |
-      | @Item | @Class             | @Class       | group_membership | false    | @HelperGroupGroupMembership1 | granted                          |
-      | @Item | @ClassParent       | @Class       | group_membership | false    | @HelperGroupGroupMembership2 | group_membership but not granted |
-      | @Item | @ClassParentParent | @Class       | group_membership | false    | @AllUsers                    | group_membership but not granted |
-      | @Item | @ClassParent       | @Class       | item_unlocking   | false    | @HelperGroupItemUnlocking    |                                  |
-      | @Item | @Class             | @Class       | item_unlocking   | false    | @AllUsers                    |                                  |
-      | @Item | @ClassParentParent | @Class       | item_unlocking   | false    | @HelperGroupNotVisible       | not visible                      |
-      | @Item | @Class             | @Class       | other            | false    | @AllUsers                    |                                  |
-      | @Item | @ClassParentParent | @Class       | other            | false    | @HelperGroupOther1           |                                  |
-      | @Item | @ClassParent       | @Class       | other            | false    | @HelperGroupOther2           |                                  |
+      | item  | group                    | source_group | origin           | is_owner | can_request_help_to          | comment                                     |
+      | @Item | @Class                   | @Class       | self             | false    | @HelperGroupSelf1            |                                             |
+      | @Item | @ClassParentParentParent | @Class       | self             | false    | @HelperGroupSelf1            | shouldn't contain duplicate of previous one |
+      | @Item | @ClassParent             | @Class       | self             | false    | @AllUsers                    |                                             |
+      | @Item | @ClassParentParent       | @Class       | self             | false    |                              | check we don't get empty groups             |
+      | @Item | @Class                   | @Class       | group_membership | false    | @HelperGroupGroupMembership1 | granted                                     |
+      | @Item | @ClassParent             | @Class       | group_membership | false    | @HelperGroupGroupMembership2 | group_membership but not granted            |
+      | @Item | @ClassParentParent       | @Class       | group_membership | false    | @AllUsers                    | group_membership but not granted            |
+      | @Item | @ClassParent             | @Class       | item_unlocking   | false    | @HelperGroupItemUnlocking    |                                             |
+      | @Item | @Class                   | @Class       | item_unlocking   | false    | @AllUsers                    |                                             |
+      | @Item | @ClassParentParent       | @Class       | item_unlocking   | false    | @HelperGroupNotVisible       | not visible                                 |
+      | @Item | @Class                   | @Class       | other            | false    | @AllUsers                    |                                             |
+      | @Item | @ClassParentParent       | @Class       | other            | false    | @HelperGroupOther1           |                                             |
+      | @Item | @ClassParent             | @Class       | other            | false    | @HelperGroupOther2           |                                             |
   # The following lines are to make the groups visible by @Teacher
   And the group @Teacher is a descendant of the group @HelperGroupSelf1
   And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
@@ -108,3 +110,13 @@ Feature: Get permissions can_request_help_to for a group
     | @AllUsers          | AllUsers                | true               |
     | @HelperGroupOther1 | Group HelperGroupOther1 | false              |
     | @HelperGroupOther2 | Group HelperGroupOther2 | false              |
+  And the response at $.computed.can_request_help_to[*] should be:
+    | id                           | name                              | is_all_users_group |
+    | @AllUsers                    | AllUsers                          | true               |
+    | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
+    | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
+    | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
+    | @HelperGroupItemUnlocking    | Group HelperGroupItemUnlocking    | false              |
+    | @HelperGroupNotVisible       |                                   | false              |
+    | @HelperGroupOther1           | Group HelperGroupOther1           | false              |
+    | @HelperGroupOther2           | Group HelperGroupOther2           | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -11,10 +11,12 @@ Feature: Get permissions can_request_help_to for a group
   Background:
     Given allUsersGroup is defined as the group @AllUsers
     And there are the following groups:
-      | group     | parent | members  |
-      | @AllUsers |        |          |
-      | @School   |        | @Teacher |
-      | @Class    |        |          |
+      | group              | parent             | members  |
+      | @AllUsers          |                    |          |
+      | @School            |                    | @Teacher |
+      | @ClassParentParent |                    |          |
+      | @ClassParent       | @ClassParentParent |          |
+      | @Class             | @ClassParent       |          |
     And @Teacher is a manager of the group @Class and can grant group access
     And there are the following tasks:
       | item  |
@@ -34,10 +36,10 @@ Feature: Get permissions can_request_help_to for a group
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
     And the response at $.granted.can_request_help_to should be:
-      | id           | name              |
-      | @HelperGroup | Group HelperGroup |
+      | id           | name              | is_all_users_group |
+      | @HelperGroup | Group HelperGroup | false              |
 
-  Scenario: Should not return helper group when set and not visible by the current user
+  Scenario: Should return helper group without the name when set and not visible by the current user
     Given I am @Teacher
     And there is a group @HelperGroup
     And there are the following item permissions:
@@ -45,7 +47,9 @@ Feature: Get permissions can_request_help_to for a group
       | @Item | @Class | false    | @HelperGroup        |
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted.can_request_help_to should be "null"
+    And the response at $.granted.can_request_help_to should be:
+      | id           | name | is_all_users_group |
+      | @HelperGroup |      | false              |
 
   Scenario: Should return helper group as "AllUsers" group when set to its value
     Given I am @Teacher
@@ -55,5 +59,52 @@ Feature: Get permissions can_request_help_to for a group
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
     And the response at $.granted.can_request_help_to should be:
-      | is_all_users_group |
-      | true               |
+      | id        | name     | is_all_users_group |
+      | @AllUsers | AllUsers | true               |
+
+  Scenario: Should return can_request_help_to arrays when permissions with specific origins are defined
+    Given I am @Teacher
+    And there are the following item permissions:
+      | item  | group              | source_group | origin           | is_owner | can_request_help_to          | comment                          |
+      | @Item | @Class             | @Class       | self             | false    | @HelperGroupSelf1            |                                  |
+      | @Item | @ClassParent       | @Class       | self             | false    | @AllUsers                    |                                  |
+      | @Item | @ClassParentParent | @Class       | self             | false    |                              | check we don't get empty groups  |
+      | @Item | @Class             | @Class       | group_membership | false    | @HelperGroupGroupMembership1 | granted                          |
+      | @Item | @ClassParent       | @Class       | group_membership | false    | @HelperGroupGroupMembership2 | group_membership but not granted |
+      | @Item | @ClassParentParent | @Class       | group_membership | false    | @AllUsers                    | group_membership but not granted |
+      | @Item | @ClassParent       | @Class       | item_unlocking   | false    | @HelperGroupItemUnlocking    |                                  |
+      | @Item | @Class             | @Class       | item_unlocking   | false    | @AllUsers                    |                                  |
+      | @Item | @ClassParentParent | @Class       | item_unlocking   | false    | @HelperGroupNotVisible       | not visible                      |
+      | @Item | @Class             | @Class       | other            | false    | @AllUsers                    |                                  |
+      | @Item | @ClassParentParent | @Class       | other            | false    | @HelperGroupOther1           |                                  |
+      | @Item | @ClassParent       | @Class       | other            | false    | @HelperGroupOther2           |                                  |
+  # The following lines are to make the groups visible by @Teacher
+  And the group @Teacher is a descendant of the group @HelperGroupSelf1
+  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
+  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2
+  And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking
+  And the group @Teacher is a descendant of the group @HelperGroupOther1
+  And the group @Teacher is a descendant of the group @HelperGroupOther2
+  When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
+  Then the response code should be 200
+  And the response at $.granted_via_self.can_request_help_to[*] should be:
+    | id                | name                   | is_all_users_group |
+    | @AllUsers         | AllUsers               | true               |
+    | @HelperGroupSelf1 | Group HelperGroupSelf1 | false              |
+  And the response at $.granted.can_request_help_to should be:
+    | id                           | name                              |
+    | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 |
+  And the response at $.granted_via_group_membership.can_request_help_to[*] should be:
+    | id                           | name                              | is_all_users_group |
+    | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
+    | @AllUsers                    | AllUsers                          | true               |
+  And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be:
+    | id                        | name                           | is_all_users_group |
+    | @HelperGroupItemUnlocking | Group HelperGroupItemUnlocking | false              |
+    | @AllUsers                 | AllUsers                       | true               |
+    | @HelperGroupNotVisible    |                                | false              |
+  And the response at $.granted_via_other.can_request_help_to[*] should be:
+    | id                 | name                    | is_all_users_group |
+    | @AllUsers          | AllUsers                | true               |
+    | @HelperGroupOther1 | Group HelperGroupOther1 | false              |
+    | @HelperGroupOther2 | Group HelperGroupOther2 | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -45,9 +45,14 @@ Feature: Get permissions can_request_help_to for a group
       | @Item | @Class | false    | @HelperGroup        |
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted.can_request_help_to should be:
-      | id           | name              | is_all_users_group |
-      | @HelperGroup | Group HelperGroup | false              |
+    And the response at $.granted.can_request_help_to in JSON should be:
+      """
+        {
+          "id": "@HelperGroup",
+          "name": "Group HelperGroup",
+          "is_all_users_group": false
+        }
+      """
 
   Scenario: Should return helper group without the name when set and not visible by the current user
     Given I am @Teacher
@@ -57,10 +62,13 @@ Feature: Get permissions can_request_help_to for a group
       | @Item | @Class | false    | @HelperGroup        |
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted.can_request_help_to should be:
-      | id           | is_all_users_group |
-      | @HelperGroup | false              |
-    And the response at $.granted.can_request_help_to.name should be "<undefined>"
+    And the response at $.granted.can_request_help_to in JSON should be:
+      """
+        {
+          "id": "@HelperGroup",
+          "is_all_users_group": false
+        }
+      """
 
   Scenario: Should return helper group as "AllUsers" group when set to its value
     Given I am @Teacher
@@ -69,9 +77,14 @@ Feature: Get permissions can_request_help_to for a group
       | @Item | @Class | false    | @AllUsers           |
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted.can_request_help_to should be:
-      | id        | name     | is_all_users_group |
-      | @AllUsers | AllUsers | true               |
+    And the response at $.granted.can_request_help_to in JSON should be:
+      """
+        {
+          "id": "@AllUsers",
+          "name": "AllUsers",
+          "is_all_users_group": true
+        }
+      """
 
   Scenario: Should return can_request_help_to arrays when permissions with specific origins are defined
     Given I am @Teacher
@@ -113,9 +126,14 @@ Feature: Get permissions can_request_help_to for a group
     | @AllUsers                | AllUsers                      | true               |
     | @HelperGroupSelf1        | Group HelperGroupSelf1        | false              |
     | @HelperOtherSourceGroup1 | Group HelperOtherSourceGroup1 | false              |
-  And the response at $.granted.can_request_help_to should be:
-    | id                           | name                              |
-    | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 |
+  And the response at $.granted.can_request_help_to in JSON should be:
+    """
+      {
+        "id": "@HelperGroupGroupMembership1",
+        "name": "Group HelperGroupGroupMembership1",
+        "is_all_users_group": false
+      }
+    """
   And the response at $.granted_via_group_membership.can_request_help_to[*] should be:
     | id                           | name                              | is_all_users_group |
     | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
@@ -176,11 +194,11 @@ Feature: Get permissions can_request_help_to for a group
     And the group @Teacher is a descendant of the group @HelperGroupOther2
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted_via_self.can_request_help_to[*] should be "[]"
+    And the response at $.granted_via_self.can_request_help_to should be "[]"
     And the response at $.granted.can_request_help_to should be "<null>"
-    And the response at $.granted_via_group_membership.can_request_help_to[*] should be "[]"
-    And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be "[]"
-    And the response at $.granted_via_other.can_request_help_to[*] should be "[]"
+    And the response at $.granted_via_group_membership.can_request_help_to should be "[]"
+    And the response at $.granted_via_item_unlocking.can_request_help_to should be "[]"
+    And the response at $.granted_via_other.can_request_help_to should be "[]"
     And the response at $.computed.can_request_help_to[*] should be:
       | id                           | name                              | is_all_users_group |
       | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -18,6 +18,7 @@ Feature: Get permissions can_request_help_to for a group
       | @ClassParentParent       | @ClassParentParentParent |          |
       | @ClassParent             | @ClassParentParent       |          |
       | @Class                   | @ClassParent             |          |
+      | @OtherSourceGroup        |                          |          |
     And @Teacher is a manager of the group @Class and can grant group access
     And there are the following tasks:
       | item  |
@@ -66,20 +67,25 @@ Feature: Get permissions can_request_help_to for a group
   Scenario: Should return can_request_help_to arrays when permissions with specific origins are defined
     Given I am @Teacher
     And there are the following item permissions:
-      | item  | group                    | source_group | origin           | is_owner | can_request_help_to          | comment                                     |
-      | @Item | @Class                   | @Class       | self             | false    | @HelperGroupSelf1            |                                             |
-      | @Item | @ClassParentParentParent | @Class       | self             | false    | @HelperGroupSelf1            | shouldn't contain duplicate of previous one |
-      | @Item | @ClassParent             | @Class       | self             | false    | @AllUsers                    |                                             |
-      | @Item | @ClassParentParent       | @Class       | self             | false    |                              | check we don't get empty groups             |
-      | @Item | @Class                   | @Class       | group_membership | false    | @HelperGroupGroupMembership1 | granted                                     |
-      | @Item | @ClassParent             | @Class       | group_membership | false    | @HelperGroupGroupMembership2 | group_membership but not granted            |
-      | @Item | @ClassParentParent       | @Class       | group_membership | false    | @AllUsers                    | group_membership but not granted            |
-      | @Item | @ClassParent             | @Class       | item_unlocking   | false    | @HelperGroupItemUnlocking    |                                             |
-      | @Item | @Class                   | @Class       | item_unlocking   | false    | @AllUsers                    |                                             |
-      | @Item | @ClassParentParent       | @Class       | item_unlocking   | false    | @HelperGroupNotVisible       | not visible                                 |
-      | @Item | @Class                   | @Class       | other            | false    | @AllUsers                    |                                             |
-      | @Item | @ClassParentParent       | @Class       | other            | false    | @HelperGroupOther1           |                                             |
-      | @Item | @ClassParent             | @Class       | other            | false    | @HelperGroupOther2           |                                             |
+      | item  | group                    | source_group      | origin           | is_owner | can_request_help_to               | comment                                           |
+      | @Item | @Class                   | @Class            | self             | false    | @HelperGroupSelf1                 |                                                   |
+      | @Item | @ClassParentParentParent | @Class            | self             | false    | @HelperGroupSelf1                 | shouldn't contain duplicate of previous one       |
+      | @Item | @ClassParent             | @Class            | self             | false    | @AllUsers                         |                                                   |
+      | @Item | @ClassParentParent       | @Class            | self             | false    |                                   | check we don't get empty groups                   |
+      | @Item | @ClassParentParent       | @OtherSourceGroup | self             | false    | @HelperOtherSourceGroup1          | other source group                                |
+      | @Item | @Class                   | @Class            | group_membership | false    | @HelperGroupGroupMembership1      | in granted and computed, but not group_membership |
+      | @Item | @ClassParent             | @Class            | group_membership | false    | @HelperGroupGroupMembership2      | group_membership but not granted                  |
+      | @Item | @ClassParentParent       | @Class            | group_membership | false    | @AllUsers                         | group_membership but not granted                  |
+      | @Item | @ClassParentParent       | @OtherSourceGroup | group_membership | false    | @HelperOtherSourceGroup2          | other source group                                |
+      | @Item | @ClassParent             | @Class            | item_unlocking   | false    | @HelperGroupItemUnlocking         |                                                   |
+      | @Item | @Class                   | @Class            | item_unlocking   | false    | @AllUsers                         |                                                   |
+      | @Item | @ClassParentParent       | @Class            | item_unlocking   | false    | @HelperGroupNotVisible            | not visible                                       |
+      | @Item | @ClassParentParent       | @OtherSourceGroup | item_unlocking   | false    | @HelperOtherSourceGroup3          | other source group                                |
+      | @Item | @Class                   | @Class            | other            | false    | @AllUsers                         |                                                   |
+      | @Item | @ClassParentParent       | @Class            | other            | false    | @HelperGroupOther1                |                                                   |
+      | @Item | @ClassParent             | @Class            | other            | false    | @HelperGroupOther2                |                                                   |
+      | @Item | @ClassParent             | @OtherSourceGroup | other            | false    | @HelperOtherSourceGroup4          | other source group                                |
+      | @Item | @ClassParentParent       | @OtherSourceGroup | other            | false    | @HelperOtherSourceGroupNotVisible | other source group, not visible                   |
   # The following lines are to make the groups visible by @Teacher
   And the group @Teacher is a descendant of the group @HelperGroupSelf1
   And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
@@ -87,12 +93,17 @@ Feature: Get permissions can_request_help_to for a group
   And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking
   And the group @Teacher is a descendant of the group @HelperGroupOther1
   And the group @Teacher is a descendant of the group @HelperGroupOther2
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup1
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup2
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup3
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup4
   When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
   Then the response code should be 200
   And the response at $.granted_via_self.can_request_help_to[*] should be:
-    | id                | name                   | is_all_users_group |
-    | @AllUsers         | AllUsers               | true               |
-    | @HelperGroupSelf1 | Group HelperGroupSelf1 | false              |
+    | id                       | name                          | is_all_users_group |
+    | @AllUsers                | AllUsers                      | true               |
+    | @HelperGroupSelf1        | Group HelperGroupSelf1        | false              |
+    | @HelperOtherSourceGroup1 | Group HelperOtherSourceGroup1 | false              |
   And the response at $.granted.can_request_help_to should be:
     | id                           | name                              |
     | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 |
@@ -100,23 +111,32 @@ Feature: Get permissions can_request_help_to for a group
     | id                           | name                              | is_all_users_group |
     | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
     | @AllUsers                    | AllUsers                          | true               |
+    | @HelperOtherSourceGroup2     | Group HelperOtherSourceGroup2     | false              |
   And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be:
     | id                        | name                           | is_all_users_group |
     | @HelperGroupItemUnlocking | Group HelperGroupItemUnlocking | false              |
     | @AllUsers                 | AllUsers                       | true               |
     | @HelperGroupNotVisible    |                                | false              |
+    | @HelperOtherSourceGroup3  | Group HelperOtherSourceGroup3  | false              |
   And the response at $.granted_via_other.can_request_help_to[*] should be:
-    | id                 | name                    | is_all_users_group |
-    | @AllUsers          | AllUsers                | true               |
-    | @HelperGroupOther1 | Group HelperGroupOther1 | false              |
-    | @HelperGroupOther2 | Group HelperGroupOther2 | false              |
+    | id                                | name                          | is_all_users_group |
+    | @AllUsers                         | AllUsers                      | true               |
+    | @HelperGroupOther1                | Group HelperGroupOther1       | false              |
+    | @HelperGroupOther2                | Group HelperGroupOther2       | false              |
+    | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4 | false              |
+    | @HelperOtherSourceGroupNotVisible |                               | false              |
   And the response at $.computed.can_request_help_to[*] should be:
-    | id                           | name                              | is_all_users_group |
-    | @AllUsers                    | AllUsers                          | true               |
-    | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
-    | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
-    | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
-    | @HelperGroupItemUnlocking    | Group HelperGroupItemUnlocking    | false              |
-    | @HelperGroupNotVisible       |                                   | false              |
-    | @HelperGroupOther1           | Group HelperGroupOther1           | false              |
-    | @HelperGroupOther2           | Group HelperGroupOther2           | false              |
+    | id                                | name                              | is_all_users_group |
+    | @AllUsers                         | AllUsers                          | true               |
+    | @HelperGroupSelf1                 | Group HelperGroupSelf1            | false              |
+    | @HelperGroupGroupMembership1      | Group HelperGroupGroupMembership1 | false              |
+    | @HelperGroupGroupMembership2      | Group HelperGroupGroupMembership2 | false              |
+    | @HelperGroupItemUnlocking         | Group HelperGroupItemUnlocking    | false              |
+    | @HelperGroupNotVisible            |                                   | false              |
+    | @HelperGroupOther1                | Group HelperGroupOther1           | false              |
+    | @HelperGroupOther2                | Group HelperGroupOther2           | false              |
+    | @HelperOtherSourceGroup1          | Group HelperOtherSourceGroup1     | false              |
+    | @HelperOtherSourceGroup2          | Group HelperOtherSourceGroup2     | false              |
+    | @HelperOtherSourceGroup3          | Group HelperOtherSourceGroup3     | false              |
+    | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4     | false              |
+    | @HelperOtherSourceGroupNotVisible |                                   | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -20,9 +20,17 @@ Feature: Get permissions can_request_help_to for a group
       | @Class                   | @ClassParent             |          |
       | @OtherSourceGroup        |                          |          |
     And @Teacher is a manager of the group @Class and can grant group access
-    And there are the following tasks:
-      | item  |
-      | @Item |
+    And there are the following items:
+      | item                        | type    |
+      | @ChapterParent              | Chapter |
+      | @ChapterParentNoPropagation | Chapter |
+      | @Chapter                    | Chapter |
+      | @Item                       | Task    |
+    And there are the following item relations:
+      | item     | parent                      | request_help_propagation |
+      | @Item    | @Chapter                    | true                     |
+      | @Chapter | @ChapterParent              | true                     |
+      | @Chapter | @ChapterParentNoPropagation | false                    |
     And there are the following item permissions:
       | item  | group    | is_owner | can_request_help_to |
       | @Item | @Teacher | true     |                     |
@@ -140,3 +148,45 @@ Feature: Get permissions can_request_help_to for a group
     | @HelperOtherSourceGroup3          | Group HelperOtherSourceGroup3     | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4     | false              |
     | @HelperOtherSourceGroupNotVisible |                                   | false              |
+
+  Scenario: Should return can_request_help_to from parent items only into computed and only when it propagates
+    Given I am @Teacher
+    And there are the following item permissions:
+      | item                        | group                    | source_group      | origin           | is_owner | can_request_help_to                      | comment            |
+      | @Chapter                    | @Class                   | @Class            | self             | false    | @HelperGroupSelf1                        |                    |
+      | @ChapterParent              | @ClassParentParentParent | @Class            | self             | false    | @HelperGroupSelfNotVisible               | without name       |
+      | @ChapterParentNoPropagation | @ClassParent             | @Class            | self             | false    | @HelperGroupSelfNoPropagation            | shouldn't appear   |
+      | @Chapter                    | @Class                   | @Class            | group_membership | false    | @HelperGroupGroupMembership1             |                    |
+      | @ChapterParent              | @ClassParent             | @Class            | group_membership | false    | @AllUsers                                |                    |
+      | @ChapterParentNoPropagation | @ClassParentParent       | @Class            | group_membership | false    | @HelperGroupGroupMembershipNoPropagation | shouldn't appear   |
+      | @Chapter                    | @ClassParent             | @Class            | item_unlocking   | false    | @HelperGroupItemUnlocking1               |                    |
+      | @ChapterParent              | @Class                   | @Class            | item_unlocking   | false    | @HelperGroupItemUnlocking2               |                    |
+      | @ChapterParentNoPropagation | @ClassParentParent       | @Class            | item_unlocking   | false    | @HelperGroupItemUnlockingNoPropagation   | shouldn't appear   |
+      | @Chapter                    | @Class                   | @Class            | other            | false    | @HelperGroupOther1                       |                    |
+      | @ChapterParent              | @ClassParentParent       | @Class            | other            | false    | @HelperGroupOther2                       |                    |
+      | @ChapterParentNoPropagation | @ClassParent             | @OtherSourceGroup | other            | false    | @HelperGroupOtherNoPropagation           | other source group |
+  # The following lines are to make the groups visible by @Teacher
+    And the group @Teacher is a descendant of the group @HelperGroupSelf1
+    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
+    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2
+    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking1
+    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking2
+    And the group @Teacher is a descendant of the group @HelperGroupOther1
+    And the group @Teacher is a descendant of the group @HelperGroupOther2
+    When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
+    Then the response code should be 200
+    And the response at $.granted_via_self.can_request_help_to[*] should be ""
+    And the response at $.granted.can_request_help_to should be "null"
+    And the response at $.granted_via_group_membership.can_request_help_to[*] should be ""
+    And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be ""
+    And the response at $.granted_via_other.can_request_help_to[*] should be ""
+    And the response at $.computed.can_request_help_to[*] should be:
+      | id                           | name                              | is_all_users_group |
+      | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
+      | @HelperGroupSelfNotVisible   |                                   | false              |
+      | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
+      | @AllUsers                    | AllUsers                          | true               |
+      | @HelperGroupItemUnlocking1   | Group HelperGroupItemUnlocking1   | false              |
+      | @HelperGroupItemUnlocking2   | Group HelperGroupItemUnlocking2   | false              |
+      | @HelperGroupOther1           | Group HelperGroupOther1           | false              |
+      | @HelperGroupOther2           | Group HelperGroupOther2           | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -58,8 +58,8 @@ Feature: Get permissions can_request_help_to for a group
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
     And the response at $.granted.can_request_help_to should be:
-      | id           | name | is_all_users_group |
-      | @HelperGroup |      | false              |
+      | id           | name   | is_all_users_group |
+      | @HelperGroup | <null> | false              |
 
   Scenario: Should return helper group as "AllUsers" group when set to its value
     Given I am @Teacher
@@ -124,7 +124,7 @@ Feature: Get permissions can_request_help_to for a group
     | id                        | name                           | is_all_users_group |
     | @HelperGroupItemUnlocking | Group HelperGroupItemUnlocking | false              |
     | @AllUsers                 | AllUsers                       | true               |
-    | @HelperGroupNotVisible    |                                | false              |
+    | @HelperGroupNotVisible    | <null>                         | false              |
     | @HelperOtherSourceGroup3  | Group HelperOtherSourceGroup3  | false              |
   And the response at $.granted_via_other.can_request_help_to[*] should be:
     | id                                | name                          | is_all_users_group |
@@ -132,7 +132,7 @@ Feature: Get permissions can_request_help_to for a group
     | @HelperGroupOther1                | Group HelperGroupOther1       | false              |
     | @HelperGroupOther2                | Group HelperGroupOther2       | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4 | false              |
-    | @HelperOtherSourceGroupNotVisible |                               | false              |
+    | @HelperOtherSourceGroupNotVisible | <null>                        | false              |
   And the response at $.computed.can_request_help_to[*] should be:
     | id                                | name                              | is_all_users_group |
     | @AllUsers                         | AllUsers                          | true               |
@@ -140,14 +140,14 @@ Feature: Get permissions can_request_help_to for a group
     | @HelperGroupGroupMembership1      | Group HelperGroupGroupMembership1 | false              |
     | @HelperGroupGroupMembership2      | Group HelperGroupGroupMembership2 | false              |
     | @HelperGroupItemUnlocking         | Group HelperGroupItemUnlocking    | false              |
-    | @HelperGroupNotVisible            |                                   | false              |
+    | @HelperGroupNotVisible            | <null>                            | false              |
     | @HelperGroupOther1                | Group HelperGroupOther1           | false              |
     | @HelperGroupOther2                | Group HelperGroupOther2           | false              |
     | @HelperOtherSourceGroup1          | Group HelperOtherSourceGroup1     | false              |
     | @HelperOtherSourceGroup2          | Group HelperOtherSourceGroup2     | false              |
     | @HelperOtherSourceGroup3          | Group HelperOtherSourceGroup3     | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4     | false              |
-    | @HelperOtherSourceGroupNotVisible |                                   | false              |
+    | @HelperOtherSourceGroupNotVisible | <null>                            | false              |
 
   Scenario: Should return can_request_help_to from parent items only into computed and only when it propagates
     Given I am @Teacher
@@ -175,15 +175,15 @@ Feature: Get permissions can_request_help_to for a group
     And the group @Teacher is a descendant of the group @HelperGroupOther2
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
-    And the response at $.granted_via_self.can_request_help_to[*] should be ""
-    And the response at $.granted.can_request_help_to should be "null"
-    And the response at $.granted_via_group_membership.can_request_help_to[*] should be ""
-    And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be ""
-    And the response at $.granted_via_other.can_request_help_to[*] should be ""
+    And the response at $.granted_via_self.can_request_help_to[*] should be "[]"
+    And the response at $.granted.can_request_help_to should be "<null>"
+    And the response at $.granted_via_group_membership.can_request_help_to[*] should be "[]"
+    And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be "[]"
+    And the response at $.granted_via_other.can_request_help_to[*] should be "[]"
     And the response at $.computed.can_request_help_to[*] should be:
       | id                           | name                              | is_all_users_group |
       | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
-      | @HelperGroupSelfNotVisible   |                                   | false              |
+      | @HelperGroupSelfNotVisible   | <null>                            | false              |
       | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
       | @AllUsers                    | AllUsers                          | true               |
       | @HelperGroupItemUnlocking1   | Group HelperGroupItemUnlocking1   | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -58,8 +58,9 @@ Feature: Get permissions can_request_help_to for a group
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
     And the response at $.granted.can_request_help_to should be:
-      | id           | name   | is_all_users_group |
-      | @HelperGroup | <null> | false              |
+      | id           | is_all_users_group |
+      | @HelperGroup | false              |
+    And the response should not be defined at $.granted.can_request_help_to.name
 
   Scenario: Should return helper group as "AllUsers" group when set to its value
     Given I am @Teacher
@@ -124,7 +125,7 @@ Feature: Get permissions can_request_help_to for a group
     | id                        | name                           | is_all_users_group |
     | @HelperGroupItemUnlocking | Group HelperGroupItemUnlocking | false              |
     | @AllUsers                 | AllUsers                       | true               |
-    | @HelperGroupNotVisible    | <null>                         | false              |
+    | @HelperGroupNotVisible    | <undefined>                    | false              |
     | @HelperOtherSourceGroup3  | Group HelperOtherSourceGroup3  | false              |
   And the response at $.granted_via_other.can_request_help_to[*] should be:
     | id                                | name                          | is_all_users_group |
@@ -132,7 +133,7 @@ Feature: Get permissions can_request_help_to for a group
     | @HelperGroupOther1                | Group HelperGroupOther1       | false              |
     | @HelperGroupOther2                | Group HelperGroupOther2       | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4 | false              |
-    | @HelperOtherSourceGroupNotVisible | <null>                        | false              |
+    | @HelperOtherSourceGroupNotVisible | <undefined>                   | false              |
   And the response at $.computed.can_request_help_to[*] should be:
     | id                                | name                              | is_all_users_group |
     | @AllUsers                         | AllUsers                          | true               |
@@ -140,14 +141,14 @@ Feature: Get permissions can_request_help_to for a group
     | @HelperGroupGroupMembership1      | Group HelperGroupGroupMembership1 | false              |
     | @HelperGroupGroupMembership2      | Group HelperGroupGroupMembership2 | false              |
     | @HelperGroupItemUnlocking         | Group HelperGroupItemUnlocking    | false              |
-    | @HelperGroupNotVisible            | <null>                            | false              |
+    | @HelperGroupNotVisible            | <undefined>                       | false              |
     | @HelperGroupOther1                | Group HelperGroupOther1           | false              |
     | @HelperGroupOther2                | Group HelperGroupOther2           | false              |
     | @HelperOtherSourceGroup1          | Group HelperOtherSourceGroup1     | false              |
     | @HelperOtherSourceGroup2          | Group HelperOtherSourceGroup2     | false              |
     | @HelperOtherSourceGroup3          | Group HelperOtherSourceGroup3     | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4     | false              |
-    | @HelperOtherSourceGroupNotVisible | <null>                            | false              |
+    | @HelperOtherSourceGroupNotVisible | <undefined>                       | false              |
 
   Scenario: Should return can_request_help_to from parent items only into computed and only when it propagates
     Given I am @Teacher
@@ -183,7 +184,7 @@ Feature: Get permissions can_request_help_to for a group
     And the response at $.computed.can_request_help_to[*] should be:
       | id                           | name                              | is_all_users_group |
       | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
-      | @HelperGroupSelfNotVisible   | <null>                            | false              |
+      | @HelperGroupSelfNotVisible   | <undefined>                       | false              |
       | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
       | @AllUsers                    | AllUsers                          | true               |
       | @HelperGroupItemUnlocking1   | Group HelperGroupItemUnlocking1   | false              |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -60,7 +60,7 @@ Feature: Get permissions can_request_help_to for a group
     And the response at $.granted.can_request_help_to should be:
       | id           | is_all_users_group |
       | @HelperGroup | false              |
-    And the response should not be defined at $.granted.can_request_help_to.name
+    And the response at $.granted.can_request_help_to.name should be "<undefined>"
 
   Scenario: Should return helper group as "AllUsers" group when set to its value
     Given I am @Teacher

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -322,8 +322,8 @@ func (s *ItemStore) DeleteItem(itemID int64) (err error) {
 	})
 }
 
-// getAncestorsRequestHelpPropagationQuery gets all ancestors of an itemID while request_help_propagation = 1.
-func (s *ItemStore) getAncestorsRequestHelpPropagationQuery(itemID int64) *DB {
+// GetAncestorsRequestHelpPropagatedQuery gets all ancestors of an itemID while request_help_propagation = 1.
+func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
 	return s.Raw(`
 		WITH RECURSIVE items_ancestors_request_help_propagation(item_id) AS
 		(

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -69,7 +69,7 @@ func (u *User) CanRequestHelpTo(s *DataStore, itemID, helperGroupID int64) bool 
 	// one of the ancestors (including himself) of User has the can_request_help_to(Group) on Item,
 	// recursively on Item’s ancestors while request_help_propagation=1, for each Group being a descendant of Group.
 
-	itemAncestorsRequestHelpPropagationQuery := s.Items().getAncestorsRequestHelpPropagationQuery(itemID)
+	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
 
 	canRequestHelpTo, err := s.Users().
 		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", u.GroupID).

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -52,6 +52,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^there are the following items:$`, ctx.ThereAreTheFollowingItems)
 	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
+	s.Step(`^there are the following item relations:$`, ctx.ThereAreTheFollowingItemRelations)
 	s.Step(`^I can watch the group (@\w+)$`, ctx.ICanWatchGroup)
 	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -84,6 +84,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
 	s.Step(`^the response at ([^ ]+) should be "([^"]*)"$`, ctx.TheResponseAtShouldBeTheValue)
 	s.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
+	s.Step("^the response at ([^ ]+) in JSON should be:$", ctx.TheResponseAtInJSONShouldBe)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)
 	s.Step(`^the table "([^"]*)" should be empty$`, ctx.TableShouldBeEmpty)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -84,7 +84,6 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the response should be a JSON array with (\d+) entr(ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
 	s.Step(`^the response at ([^ ]+) should be "([^"]*)"$`, ctx.TheResponseAtShouldBeTheValue)
 	s.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
-	s.Step("^the response should not be defined at ([^ ]+)$", ctx.TheResponseShouldNotBeDefinedAt)
 
 	s.Step(`^the table "([^"]*)" should be:$`, ctx.TableShouldBe)
 	s.Step(`^the table "([^"]*)" should be empty$`, ctx.TableShouldBeEmpty)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -278,7 +278,13 @@ func (ctx *TestContext) addPermissionGranted(group, item, sourceGroup, origin, p
 	}
 
 	if permission == "can_request_help_to" {
-		permissionValue = strconv.FormatInt(ctx.getReference(permissionValue), 10)
+		canRequestHelpToGroupID := strconv.FormatInt(ctx.getReference(permissionValue), 10)
+
+		if !ctx.isInDatabase("groups", canRequestHelpToGroupID) {
+			ctx.addGroup(permissionValue, "Group "+referenceToName(permissionValue), "Class")
+		}
+
+		permissionValue = canRequestHelpToGroupID
 	}
 
 	if permission == "is_owner" {

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -20,7 +20,10 @@ const (
 	strTrue         = "true"
 )
 
-var itemPermissionKeys = []string{"can_view", "can_grant_view", "can_watch", "can_edit", "is_owner", "can_request_help_to"}
+var (
+	itemPermissionKeys  = []string{"can_view", "can_grant_view", "can_watch", "can_edit", "is_owner", "can_request_help_to"}
+	itemPropagationKeys = []string{"grant_view_propagation", "watch_propagation", "edit_propagation", "request_help_propagation"}
+)
 
 // ctx.getParameterMap parses parameters in format key1=val1,key2=val2,... into a map.
 func (ctx *TestContext) getParameterMap(parameters string) map[string]string {
@@ -331,6 +334,10 @@ func (ctx *TestContext) addResult(attemptID, participant, item string, validated
 	)
 }
 
+func (ctx *TestContext) getItemItemKey(parentItemID, childItemID int64) string {
+	return strconv.FormatInt(parentItemID, 10) + "," + strconv.FormatInt(childItemID, 10)
+}
+
 // addItemItem adds an item-item in the database.
 func (ctx *TestContext) addItemItem(parentItem, childItem string) {
 	parentItemID := ctx.getReference(parentItem)
@@ -338,13 +345,19 @@ func (ctx *TestContext) addItemItem(parentItem, childItem string) {
 
 	ctx.addInDatabase(
 		"items_items",
-		strconv.FormatInt(parentItemID, 10)+","+strconv.FormatInt(childItemID, 10),
+		ctx.getItemItemKey(parentItemID, childItemID),
 		map[string]interface{}{
 			"parent_item_id": parentItemID,
 			"child_item_id":  childItemID,
 			"child_order":    rand.Int31n(1000),
 		},
 	)
+}
+
+func (ctx *TestContext) addItemItemPropagation(parent, child, propagation, propagationValue string) {
+	key := ctx.getItemItemKey(ctx.getReference(parent), ctx.getReference(child))
+
+	ctx.dbTables["items_items"][key][propagation] = propagationValue
 }
 
 // addItem adds an item in the database.
@@ -733,6 +746,48 @@ func (ctx *TestContext) applyUserPermissionsOnItem(itemPermission map[string]str
 	return nil
 }
 
+// ThereAreTheFollowingItemRelations defines item relations, in items_items table.
+func (ctx *TestContext) ThereAreTheFollowingItemRelations(itemPermissions *messages.PickleStepArgument_PickleTable) error {
+	for i := 1; i < len(itemPermissions.Rows); i++ {
+		itemRelation := ctx.getRowMap(i, itemPermissions)
+
+		err := ctx.applyItemRelation(itemRelation)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ctx *TestContext) applyItemRelation(itemRelation map[string]string) error {
+	ctx.addItemItem(itemRelation["parent"], itemRelation["item"])
+
+	for _, propagationKey := range itemPropagationKeys {
+		if propagationValue, ok := itemRelation[propagationKey]; ok {
+			boolValue, err := strconv.ParseBool(propagationValue)
+			if err != nil {
+				panic(fmt.Sprintf("applyItemRelation: %v cannot be parsed as a boolean", boolValue))
+			}
+
+			if boolValue {
+				propagationValue = "1"
+			} else {
+				propagationValue = "0"
+			}
+
+			ctx.addItemItemPropagation(
+				itemRelation["parent"],
+				itemRelation["item"],
+				propagationKey,
+				propagationValue,
+			)
+		}
+	}
+
+	return nil
+}
+
 // ICanWatchGroup adds the permission for the user to watch a group.
 func (ctx *TestContext) ICanWatchGroup(groupName string) error {
 	return ctx.UserIsAManagerOfTheGroupWith(getParameterString(map[string]string{
@@ -842,6 +897,13 @@ domains:
 // IAmAMemberOfTheGroup puts a user in a group.
 func (ctx *TestContext) IAmAMemberOfTheGroup(name string) error {
 	return ctx.IAmAMemberOfTheGroupWithID(name)
+}
+
+// ItemRelationSetPropagation adds a propagation on an item relation.
+func (ctx *TestContext) ItemRelationSetPropagation(propagation, value, parent, item string) error {
+	ctx.addItemItemPropagation(parent, item, propagation, value)
+
+	return nil
 }
 
 // UserSetPermissionExtendedOnItemWithID gives a user a permission on an item with a specific source_group and origin.

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -259,8 +259,9 @@ func stringifyJSONPathResultValue(value interface{}) string {
 		// Convert boolean results to strings because the values we check are coming from Gherkin as strings.
 		return strconv.FormatBool(typedValue)
 	default:
+		// The value is nil when the JSONPath is not defined.
 		if value == nil {
-			return nullValue
+			return undefinedValue
 		}
 
 		return typedValue.(string)
@@ -377,6 +378,7 @@ func compareStrings(expected, actual string) error {
 const (
 	nullHeaderValue = "[NULL]"
 	nullValue       = "<null>"
+	undefinedValue  = "<undefined>"
 )
 
 // TheResponseHeaderShouldBe checks that the response header matches the provided value.

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -55,11 +55,6 @@ func (ctx *TestContext) getJSONPathOnResponse(jsonPath string) (interface{}, err
 func (ctx *TestContext) TheResponseAtShouldBeTheValue(jsonPath, value string) error {
 	jsonPathRes, err := ctx.getJSONPathOnResponse(jsonPath)
 	if err != nil {
-		// When an empty value is provided, not finding the jsonPath because it doesn't exist is a success.
-		if value == "" {
-			return nil
-		}
-
 		return err
 	}
 
@@ -87,8 +82,8 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 	case float64:
 		expected, _ = strconv.ParseFloat(value, 64)
 	case []interface{}:
-		// When the result is an empty array, matches if we're looking for an empty value.
-		if len(jsonPathResultTyped) == 0 && value == "" {
+		// When the result is an empty array, matches if we're looking for "[]".
+		if len(jsonPathResultTyped) == 0 && value == "[]" {
 			return true
 		}
 	case interface{}:
@@ -102,7 +97,7 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 }
 
 func jsonPathValueConsideredNil(value string) bool {
-	return value == "null" || value == ""
+	return value == nullValue
 }
 
 // TheResponseAtShouldBe checks that the response at a JSONPath matches multiple values.
@@ -265,7 +260,7 @@ func stringifyJSONPathResultValue(value interface{}) string {
 		return strconv.FormatBool(typedValue)
 	default:
 		if value == nil {
-			return ""
+			return nullValue
 		}
 
 		return typedValue.(string)
@@ -379,7 +374,10 @@ func compareStrings(expected, actual string) error {
 	return nil
 }
 
-const nullHeaderValue = "[NULL]"
+const (
+	nullHeaderValue = "[NULL]"
+	nullValue       = "<null>"
+)
 
 // TheResponseHeaderShouldBe checks that the response header matches the provided value.
 func (ctx *TestContext) TheResponseHeaderShouldBe(headerName, headerValue string) (err error) {

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -43,19 +43,19 @@ func (ctx *TestContext) getJSONPathOnResponse(jsonPath string) (interface{}, err
 		return nil, fmt.Errorf("getJSONPathOnResponse: Unmarshal response: %v", err)
 	}
 
-	jsonPathRes, err := jsonpath.Get(jsonPath, JSONResponse)
-	if err != nil {
-		return nil, fmt.Errorf("getJSONPathOnResponse: Cannot get JsonPath: %v", err)
-	}
-
-	return jsonPathRes, nil
+	return jsonpath.Get(jsonPath, JSONResponse)
 }
 
 // TheResponseAtShouldBeTheValue checks that the response at a JSONPath is a certain value.
 func (ctx *TestContext) TheResponseAtShouldBeTheValue(jsonPath, value string) error {
 	jsonPathRes, err := ctx.getJSONPathOnResponse(jsonPath)
 	if err != nil {
-		return err
+		// The JSONPath is not defined.
+		if value == undefinedValue {
+			return nil
+		}
+
+		return fmt.Errorf("TheResponseAtShouldBeTheValue: JSONPath %v doesn't match value %v: %v", jsonPath, value, err)
 	}
 
 	value = ctx.replaceReferencesByIDs(value)
@@ -266,23 +266,6 @@ func stringifyJSONPathResultValue(value interface{}) string {
 
 		return typedValue.(string)
 	}
-}
-
-// TheResponseShouldNotBeDefinedAt checks that the provided jsonPath doesn't exist.
-func (ctx *TestContext) TheResponseShouldNotBeDefinedAt(jsonPath string) error {
-	var JSONResponse interface{}
-	err := json.Unmarshal([]byte(ctx.lastResponseBody), &JSONResponse)
-	if err != nil {
-		return fmt.Errorf("TheResponseShouldNotBeDefinedAt: Unmarshal response: %v", err)
-	}
-
-	jsonPathRes, err := jsonpath.Get(jsonPath, JSONResponse)
-	if err != nil {
-		//nolint:nilerr // We want jsonpath.Get to return an error.
-		return nil
-	}
-
-	return fmt.Errorf("TheResponseShouldNotBeDefinedAt: JsonPath: %v is defined with value %v", jsonPath, jsonPathRes)
 }
 
 func (ctx *TestContext) TheResponseCodeShouldBe(code int) error { //nolint

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -94,7 +94,7 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 	case interface{}:
 	}
 
-q	if jsonPathRes == nil && (value == "null" || value == "") {
+	if jsonPathRes == nil && (value == "null" || value == "") {
 		return true
 	}
 

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -94,7 +94,7 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 	case interface{}:
 	}
 
-	if jsonPathRes == nil && value == "null" {
+q	if jsonPathRes == nil && (value == "null" || value == "") {
 		return true
 	}
 
@@ -135,9 +135,13 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *messages.P
 	case map[string]interface{}:
 		// The result is an object (eg. "element": {"a": 0, "b": 0})
 		return ctx.wantValuesMatchesJSONPathResultObject(wants, typedJSONRes)
+	default:
+		if typedJSONRes == nil {
+			return fmt.Errorf("TheResponseAtShouldBe: The JsonPath result at the path %v is %v", jsonPath, typedJSONRes)
+		}
 	}
 
-	panic(fmt.Sprintf("TheResponseAtShouldBe: Unhandled case for %v", jsonPathRes))
+	panic(fmt.Sprintf("TheResponseAtShouldBe: Unhandled case for result found at JSON Path %v: %v", jsonPath, jsonPathRes))
 }
 
 func (ctx *TestContext) wantRowsMatchesJSONPathResultArr(
@@ -256,6 +260,10 @@ func stringifyJSONPathResultValue(value interface{}) string {
 		// Convert boolean results to strings because the values we check are coming from Gherkin as strings.
 		return strconv.FormatBool(typedValue)
 	default:
+		if value == nil {
+			return ""
+		}
+
 		return typedValue.(string)
 	}
 }

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -131,16 +131,13 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *messages.P
 		}
 
 		return ctx.wantValuesMatchesJSONPathResultArr(wants, typedJSONRes)
-	case map[string]interface{}:
-		// The result is an object (eg. "element": {"a": 0, "b": 0})
-		return ctx.wantValuesMatchesJSONPathResultObject(wants, typedJSONRes)
 	default:
 		if typedJSONRes == nil {
 			return fmt.Errorf("TheResponseAtShouldBe: The JsonPath result at the path %v is %v", jsonPath, typedJSONRes)
 		}
 	}
 
-	panic(fmt.Sprintf("TheResponseAtShouldBe: Unhandled case for result found at JSON Path %v: %v", jsonPath, jsonPathRes))
+	panic(fmt.Sprintf("TheResponseAtShouldBe: Result found at JSON Path %v should be an array but is: %v", jsonPath, jsonPathRes))
 }
 
 // TheResponseAtInJSONShouldBe checks that the response in JSON at a JSONPath matches.
@@ -270,26 +267,6 @@ func (ctx *TestContext) wantValuesMatchesJSONPathResultArr(
 
 	if !cmp.Equal(sortedResults, sortedWants) {
 		return fmt.Errorf("wantValuesMatchesJSONPathResult: The values (sorted) are %v but should have been: %v", sortedResults, sortedWants)
-	}
-
-	return nil
-}
-
-func (ctx *TestContext) wantValuesMatchesJSONPathResultObject(
-	wants *messages.PickleStepArgument_PickleTable,
-	jsonPathResObject map[string]interface{},
-) error {
-	headerCells := wants.Rows[0].Cells
-	objectCells := wants.Rows[1].Cells
-
-	for i := 0; i < len(headerCells); i++ {
-		key := headerCells[i].Value
-		wantedValue := ctx.replaceReferencesByIDs(objectCells[i].Value)
-		actualValue := jsonPathResObject[key]
-
-		if !jsonPathResultMatchesValue(actualValue, wantedValue) {
-			return fmt.Errorf("wantValuesMatchesJSONPathResultObject: [%v] should be %v but is %v", key, wantedValue, actualValue)
-		}
 	}
 
 	return nil

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -94,11 +94,15 @@ func jsonPathResultMatchesValue(jsonPathRes interface{}, value string) bool {
 	case interface{}:
 	}
 
-	if jsonPathRes == nil && (value == "null" || value == "") {
+	if jsonPathRes == nil && jsonPathValueConsideredNil(value) {
 		return true
 	}
 
 	return jsonPathRes == expected
+}
+
+func jsonPathValueConsideredNil(value string) bool {
+	return value == "null" || value == ""
 }
 
 // TheResponseAtShouldBe checks that the response at a JSONPath matches multiple values.


### PR DESCRIPTION
fixes #1004 

We now return an array of all groups with `can_request_help_to` permissions set in all `granted_via_*`.

In `computed`, we also return all permissions coming from parent items while `request_help_propagation` is set. The uses a recursive query that is only called once, `GetAncestorsRequestHelpPropagatedQuery()`.


### Format of `can_request_help_to` in response

- `id` always set
- `name` present only if it is visible
- `is_all_users_group` to `true` or `false` depending on the case 


### Performance notice:
- We use  the query `IsVisibleForGroup()` once for each group we find. So it might be expensive if we have cases where we have many groups `can_request_help_to` permissions set.

The typical query is the following:
```
SELECT 1 FROM `groups` 
WHERE (groups.is_public OR groups.id IN(
    SELECT groups_ancestors_active.ancestor_group_id
    FROM `groups_groups_active`
    JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id
    JOIN `groups` AS ancestor_group ON ancestor_group.id = groups_ancestors_active.ancestor_group_id
    WHERE (groups_groups_active.child_group_id = 5549855599337303585)
    AND (ancestor_group.type != 'ContestParticipants'
))
OR groups.id IN(
    SELECT ancestors_of_managed.ancestor_group_id FROM `groups_ancestors_active` 
    JOIN group_managers ON group_managers.group_id = `groups_ancestors_active`.ancestor_group_id 
    JOIN groups_ancestors_active AS group_ancestors ON group_ancestors.ancestor_group_id = group_managers.manager_id
        AND group_ancestors.child_group_id = 5549855599337303585
    JOIN `groups` ON groups.id = groups_ancestors_active.child_group_id 
    JOIN groups_ancestors_active AS ancestors_of_managed ON ancestors_of_managed.child_group_id = groups_ancestors_active.child_group_id
        AND (groups.type != 'User' OR ancestors_of_managed.is_self)
    JOIN `groups` AS ancestor_group ON ancestor_group.id = ancestors_of_managed.ancestor_group_id
    WHERE (ancestor_group.type != 'ContestParticipants')
))
AND (groups.id = 2646504854435585587)
LIMIT 1
```

**Note:** It might be easier to review commit by commit. Notes about choices are present in commit messages.