### PR TITLE
Fix CreateMissingData() when more than one domain is defined

### DIFF
--- a/app/database/configdb/config.go
+++ b/app/database/configdb/config.go
@@ -3,6 +3,7 @@ package configdb
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/domain"
@@ -118,14 +119,17 @@ func insertRootGroups(groupStore *database.GroupStore, domainConfig *domain.Conf
 			ByID(spec.id).
 			Where("type = 'Base'").
 			Where("name = ?", spec.name).
-			Where("text_id = ?", spec.name).
 			Limit(1).
 			HasRows()
 		mustNotBeError(err)
 
 		if !found {
 			err = groupStore.InsertMap(map[string]interface{}{
-				"id": spec.id, "type": "Base", "name": spec.name, "text_id": spec.name,
+				"id":   spec.id,
+				"type": "Base",
+				"name": spec.name,
+				// Append the id to the name because the text_id must be unique.
+				"text_id": spec.name + "-" + strconv.FormatInt(spec.id, 10),
 			})
 			mustNotBeError(err)
 

--- a/app/database/configdb/config_integration_test.go
+++ b/app/database/configdb/config_integration_test.go
@@ -156,6 +156,20 @@ propagations:
 			},
 			checkConfigPassBefore: false,
 		},
+		{
+			name: "create everything with two domains",
+			config: []domain.ConfigItem{
+				{
+					Domains:       []string{"127.0.0.1", "192.168.0.1"},
+					AllUsersGroup: 2, TempUsersGroup: 4,
+				},
+				{
+					Domains:       []string{"www.france-ioi.org"},
+					AllUsersGroup: 6, TempUsersGroup: 8,
+				},
+			},
+			checkConfigPassBefore: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fixes https://github.com/France-ioi/AlgoreaBackend/issues/1001

**Note: Merge after PR for async propagation.**

The problem was that multiple groups were created with text_id=AllUsers, and text_id now has a UNIQUE key.

The value is now text_id=AllUsers-{GROUP_ID}. Since the value is not used anywhere, it should have no impact. It would also have been possible to set it to NULL.