### PR TITLE
updateThread: when the user owns an item, he can request help to any visible group, including himself

### DIFF
--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -232,6 +232,10 @@ func (s *GroupStore) PickVisibleGroups(db *DB, user *User) *DB {
 
 // IsVisibleForGroup checks whether a group is visible to a group.
 func (s *GroupStore) IsVisibleForGroup(groupID, visibleForGroupID int64) bool {
+	if groupID == visibleForGroupID {
+		return true
+	}
+
 	isVisible, err := s.PickVisibleGroupsForGroup(s.Groups().DB, visibleForGroupID).
 		Where("groups.id = ?", groupID).
 		Select("1").

--- a/app/database/group_store_test.go
+++ b/app/database/group_store_test.go
@@ -131,3 +131,12 @@ func TestGroupStore_DeleteGroup_HandlesErrorOfInnerMethod(t *testing.T) {
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestGroupStore_GroupIsVisibleToHimself(t *testing.T) {
+	db, _ := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	store := NewDataStore(db)
+
+	assert.True(t, store.Groups().IsVisibleForGroup(1, 1))
+}


### PR DESCRIPTION
fixes #1011 

A change has been made to `IsVisibleForGroup`: a group can now see himself. This wasn't the case before, it could only see its ancestors, but I assume it should have been.

No update required for `getThread`.