### PR TITLE
Search: do a "AND" on words

### DIFF
--- a/app/api/currentuser/search_for_available_groups.feature
+++ b/app/api/currentuser/search_for_available_groups.feature
@@ -65,6 +65,28 @@ Feature: Search for groups available to the current user
     ]
     """
 
+  Scenario: Should treat the words in the search string as "AND"
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/available-groups?search=the%20team"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "2",
+        "name": "(the) Our Team ___",
+        "description": null,
+        "type": "Team"
+      },
+      {
+        "id": "7",
+        "name": "Another %%%Team",
+        "description": "Another team group",
+        "type": "Team"
+      }
+    ]
+    """
+
   Scenario: Search for groups with "the", start from the second row
     Given I am the user with id "21"
     When I send a GET request to "/current-user/available-groups?search=the&from.id=2"

--- a/app/api/currentuser/search_for_available_groups.feature
+++ b/app/api/currentuser/search_for_available_groups.feature
@@ -1,20 +1,20 @@
 Feature: Search for groups available to the current user
   Background:
     Given the database has the following table 'groups':
-      | id | type                | name                                      | description            | is_public |
-      | 1  | Class               | (the) Our Class                           | Our class group        | 1         |
-      | 2  | Team                | (the) Our Team ___                        | null                   | 1         |
-      | 3  | Club                | (the) Our Club                            | Our club group         | 1         |
-      | 4  | Friends             | (the) \|\|\|Our Friends \\\\\\%\\\\%\\ :) | Group for our friends  | 1         |
-      | 5  | Other               | Other people                              | Group for other people | 1         |
-      | 6  | Class               | Another Class                             | Another class group    | 1         |
-      | 7  | Team                | Another %%%Team                           | Another team group     | 1         |
-      | 8  | Club                | Another %%%Club                           | Another club group     | 1         |
-      | 9  | Friends             | Some other friends                        | Another friends group  | 1         |
-      | 10 | Class               | The third class                           | The third class        | 1         |
-      | 11 | User                | Another %%%User                           | Another user group     | 1         |
-      | 21 | User                | (the) user self                           |                        | 0         |
-      | 22 | ContestParticipants | the                                       |                        | 1         |
+      | id | type                | name                                  | description            | is_public |
+      | 1  | Class               | amazing Class                         | Our class group        | 1         |
+      | 2  | Team                | amazing Team                          | null                   | 1         |
+      | 3  | Club                | amazing Club                          | Our club group         | 1         |
+      | 4  | Friends             | the amazing Friends \\\\\\%\\\\%\\ :) | Group for our friends  | 1         |
+      | 5  | Other               | Other people                          | Group for other people | 1         |
+      | 6  | Class               | Another amazing Class                 | Another class group    | 1         |
+      | 7  | Team                | Another amazing Team                  | Another team group     | 1         |
+      | 8  | Club                | Another amazing Club                  | Another club group     | 1         |
+      | 9  | Friends             | Some other friends                    | Another friends group  | 1         |
+      | 10 | Class               | amazing third class                   | The third class        | 1         |
+      | 11 | User                | Another amazing User                  | Another user group     | 1         |
+      | 21 | User                | amazing user self                     |                        | 0         |
+      | 22 | ContestParticipants | amazing                               |                        | 1         |
     And the database has the following table 'users':
       | login | temp_user | group_id | first_name  | last_name | grade |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
@@ -31,35 +31,35 @@ Feature: Search for groups available to the current user
       | 1        | 21        | invitation   |
       | 3        | 21        | join_request |
 
-  Scenario: Search for groups with "the"
+  Scenario: Search for groups with "amazing"
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=the"
+    When I send a GET request to "/current-user/available-groups?search=amazing"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
       },
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       },
       {
-        "id": "7",
-        "name": "Another %%%Team",
         "description": "Another team group",
+        "id": "7",
+        "name": "Another amazing Team",
         "type": "Team"
       },
       {
-        "id": "8",
-        "name": "Another %%%Club",
         "description": "Another club group",
+        "id": "8",
+        "name": "Another amazing Club",
         "type": "Club"
       }
     ]
@@ -67,140 +67,86 @@ Feature: Search for groups available to the current user
 
   Scenario: Should treat the words in the search string as "AND"
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=the%20team"
+    When I send a GET request to "/current-user/available-groups?search=amazing%20team"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
       },
       {
-        "id": "7",
-        "name": "Another %%%Team",
         "description": "Another team group",
-        "type": "Team"
-      }
+        "id": "7",
+        "name": "Another amazing Team",
+ 		    "type": "Team"
+ 		  }
     ]
     """
 
-  Scenario: Search for groups with "the", start from the second row
+  Scenario: Search for groups with "amazing", start from the second row
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=the&from.id=2"
+    When I send a GET request to "/current-user/available-groups?search=amazing&from.id=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       },
       {
-        "id": "7",
-        "name": "Another %%%Team",
         "description": "Another team group",
+        "id": "7",
+        "name": "Another amazing Team",
         "type": "Team"
       },
       {
-        "id": "8",
-        "name": "Another %%%Club",
         "description": "Another club group",
+        "id": "8",
+        "name": "Another amazing Club",
         "type": "Club"
       }
     ]
     """
 
-  Scenario: Search for groups with "the" (limit=2)
+  Scenario: Search for groups with "amazing" (limit=2)
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=the&limit=2"
+    When I send a GET request to "/current-user/available-groups?search=amazing&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
       },
       {
-        "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
+        "id": "4",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "type": "Friends"
       }
     ]
     """
 
-  Scenario: Search for groups with percent signs ("%%%")
+  Scenario: Search for groups which begins with the search word
     Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=%25%25%25"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "7",
-        "name": "Another %%%Team",
-        "description": "Another team group",
-        "type": "Team"
-      },
-      {
-        "id": "8",
-        "name": "Another %%%Club",
-        "description": "Another club group",
-        "type": "Club"
-      }
-    ]
-    """
-
-  Scenario: Search for groups with underscore signs
-    Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=___"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "2",
-        "name": "(the) Our Team ___",
-        "description": null,
-        "type": "Team"
-      }
-    ]
-    """
-
-  Scenario: Search for groups with pipe signs ("|||")
-    Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=%7C%7C%7C"
+    When I send a GET request to "/current-user/available-groups?search=friend"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
-        "description": "Group for our friends",
-        "type": "Friends"
-      }
-    ]
-    """
-
-  Scenario: Search with percent sign and slashes ("\\\%\\%\")
-    Given I am the user with id "21"
-    When I send a GET request to "/current-user/available-groups?search=%5C%5C%5C%25%5C%5C%25%5C"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       }

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -26,10 +26,8 @@ const minSearchStringLength = 3
 //		All the words of the search query must appear in the name for the group to be returned.
 //
 //
-//		Note: The current implementation may be very slow because it uses `LIKE` with a percentage wildcard
-//		at the beginning. This causes MySQL to explore every row having `is_public`=1. Moreover, actually
-//		it has to examine every row of the `groups` table since there is no index for the `is_public` column.
-//		But since there are not too many groups and the result rows count is limited, the search works almost well.
+//		Note: MySQL Full-Text Search IN BOOLEAN MODE is used for the search, "amazing team" is transformed to "+amazing* +team*",
+//		so the words must all appear, as a prefix of a word.
 //	parameters:
 //		- name: search
 //			in: query

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -23,6 +23,9 @@ const minSearchStringLength = 3
 //		and for that the current user is not already a member and don’t have pending requests/invitations.
 //
 //
+//		All the words of the search query must appear in the name for the group to be returned.
+//
+//
 //		Note: The current implementation may be very slow because it uses `LIKE` with a percentage wildcard
 //		at the beginning. This causes MySQL to explore every row having `is_public`=1. Moreover, actually
 //		it has to examine every row of the `groups` table since there is no index for the `is_public` column.

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-chi/render"
 
-	"github.com/France-ioi/AlgoreaBackend/app/database"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 )
 
@@ -97,29 +96,7 @@ func (srv *Service) searchForAvailableGroups(w http.ResponseWriter, r *http.Requ
 	user := srv.GetUser(r)
 	store := srv.GetStore(r)
 
-	skipGroups := store.ActiveGroupGroups().
-		Select("groups_groups_active.parent_group_id").
-		Where("groups_groups_active.child_group_id = ?", user.GroupID).
-		SubQuery()
-
-	skipPending := store.GroupPendingRequests().
-		Select("group_pending_requests.group_id").
-		Where("group_pending_requests.member_id = ?", user.GroupID).
-		Where("group_pending_requests.type IN ('join_request', 'invitation')").
-		SubQuery()
-
-	escapedSearchString := database.EscapeLikeString(searchString, '|')
-	query := store.Groups().
-		Select(`
-			groups.id,
-			groups.name,
-			groups.type,
-			groups.description`).
-		Where("groups.is_public").
-		Where("type != 'User' AND type != 'ContestParticipants'").
-		Where("groups.id NOT IN ?", skipGroups).
-		Where("groups.id NOT IN ?", skipPending).
-		Where("groups.name LIKE CONCAT('%', ?, '%') ESCAPE '|'", escapedSearchString)
+	query := store.Groups().GetSearchForAvailableGroupsQuery(user, searchString)
 
 	query = service.NewQueryLimiter().Apply(r, query)
 	query, apiError := service.ApplySortingAndPaging(

--- a/app/api/groups/search_for_possible_subgroups.feature
+++ b/app/api/groups/search_for_possible_subgroups.feature
@@ -1,20 +1,20 @@
 Feature: Search for possible subgroups
   Background:
     Given the database has the following table 'groups':
-      | id | type    | name                                      | description            |
-      | 1  | Class   | (the) Our Class                           | Our class group        |
-      | 2  | Team    | (the) Our Team ___                        | null                   |
-      | 3  | Club    | (the) Our Club                            | Our club group         |
-      | 4  | Friends | (the) \|\|\|Our Friends \\\\\\%\\\\%\\ :) | Group for our friends  |
-      | 5  | Other   | Other people                              | Group for other people |
-      | 6  | Class   | Another Class                             | Another class group    |
-      | 7  | Team    | Another %%%Team                           | Another team group     |
-      | 8  | Club    | Another %%%Club                           | Another club group     |
-      | 9  | Friends | Some other friends                        | Another friends group  |
-      | 10 | Class   | The third class                           | The third class        |
-      | 11 | User    | Another %%%User                           | Another user group     |
-      | 12 | Club    | Club                                      | Parent group           |
-      | 21 | User    | (the) user self                           |                        |
+      | id | type    | name                                  | description            |
+      | 1  | Class   | amazing Class                         | Our class group        |
+      | 2  | Team    | amazing Team                          | null                   |
+      | 3  | Club    | amazing Club                          | Our club group         |
+      | 4  | Friends | the amazing Friends \\\\\\%\\\\%\\ :) | Group for our friends  |
+      | 5  | Other   | Other people                          | Group for other people |
+      | 6  | Class   | Another amazing Class                 | Another class group    |
+      | 7  | Team    | Another amazing Team                  | Another team group     |
+      | 8  | Club    | Another amazing Club                  | Another club group     |
+      | 9  | Friends | Some other friends                    | Another friends group  |
+      | 10 | Class   | amazing third class                   | The third class        |
+      | 11 | User    | Another amazing User                  | Another user group     |
+      | 12 | Club    | Club                                  | Parent group           |
+      | 21 | User    | amazing user self                     |                        |
     And the database has the following table 'users':
       | login | temp_user | group_id | first_name  | last_name | grade |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
@@ -40,164 +40,110 @@ Feature: Search for possible subgroups
       | 1        | 21        | invitation   |
       | 3        | 21        | join_request |
 
-  Scenario: Search for groups with "the"
+  Scenario: Search for groups with "amazing"
     Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=the"
+    When I send a GET request to "/groups/possible-subgroups?search=amazing"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
       },
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       },
       {
-        "id": "7",
-        "name": "Another %%%Team",
-        "description": "Another team group",
-        "type": "Team"
-      },
-      {
-        "id": "8",
-        "name": "Another %%%Club",
-        "description": "Another club group",
-        "type": "Club"
-      }
+          "description": "Another team group",
+          "id": "7",
+          "name": "Another amazing Team",
+          "type": "Team"
+        },
+        {
+          "description": "Another club group",
+          "id": "8",
+          "name": "Another amazing Club",
+          "type": "Club"
+        }
     ]
     """
 
   Scenario: Should treat the words in the search string as "AND"
     Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=the%20team"
+    When I send a GET request to "/groups/possible-subgroups?search=amazing%20team"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
       },
       {
-        "id": "7",
-        "name": "Another %%%Team",
         "description": "Another team group",
-        "type": "Team"
-      }
-    ]
-    """
-
-  Scenario: Search for groups with "the" (limit=2)
-    Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=the&limit=2"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "2",
-        "name": "(the) Our Team ___",
-        "description": null,
-        "type": "Team"
-      },
-      {
-        "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
-        "description": "Group for our friends",
-        "type": "Friends"
-      }
-    ]
-    """
-
-  Scenario: Search for groups with "the", get the third row
-    Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=the&limit=1&from.id=2"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
-        "description": "Group for our friends",
-        "type": "Friends"
-      }
-    ]
-    """
-
-  Scenario: Search for groups with percent signs ("%%%")
-    Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=%25%25%25"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
         "id": "7",
-        "name": "Another %%%Team",
-        "description": "Another team group",
+        "name": "Another amazing Team",
         "type": "Team"
-      },
-      {
-        "id": "8",
-        "name": "Another %%%Club",
-        "description": "Another club group",
-        "type": "Club"
       }
     ]
     """
 
-  Scenario: Search for groups with underscore signs
+  Scenario: Search for groups with "amazing" (limit=2)
     Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=___"
+    When I send a GET request to "/groups/possible-subgroups?search=amazing&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "name": "(the) Our Team ___",
+        "name": "amazing Team",
         "description": null,
         "type": "Team"
+      },
+      {
+        "description": "Group for our friends",
+        "id": "4",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
+        "type": "Friends"
       }
     ]
     """
 
-  Scenario: Search for groups with pipe signs ("|||")
+  Scenario: Search for groups with "amazing", get the second row
     Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=%7C%7C%7C"
+    When I send a GET request to "/groups/possible-subgroups?search=amazing&limit=1&from.id=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       }
     ]
     """
 
-  Scenario: Search with percent sign and slashes ("\\\%\\%\")
+  Scenario: Search for groups which begins with the search word
     Given I am the user with id "21"
-    When I send a GET request to "/groups/possible-subgroups?search=%5C%5C%5C%25%5C%5C%25%5C"
+    When I send a GET request to "/groups/possible-subgroups?search=friend"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "name": "(the) |||Our Friends \\\\\\%\\\\%\\ :)",
+        "name": "the amazing Friends \\\\\\%\\\\%\\ :)",
         "description": "Group for our friends",
         "type": "Friends"
       }

--- a/app/api/groups/search_for_possible_subgroups.feature
+++ b/app/api/groups/search_for_possible_subgroups.feature
@@ -74,6 +74,28 @@ Feature: Search for possible subgroups
     ]
     """
 
+  Scenario: Should treat the words in the search string as "AND"
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/possible-subgroups?search=the%20team"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "2",
+        "name": "(the) Our Team ___",
+        "description": null,
+        "type": "Team"
+      },
+      {
+        "id": "7",
+        "name": "Another %%%Team",
+        "description": "Another team group",
+        "type": "Team"
+      }
+    ]
+    """
+
   Scenario: Search for groups with "the" (limit=2)
     Given I am the user with id "21"
     When I send a GET request to "/groups/possible-subgroups?search=the&limit=2"

--- a/app/api/groups/search_for_possible_subgroups.go
+++ b/app/api/groups/search_for_possible_subgroups.go
@@ -21,6 +21,9 @@ const minSearchStringLength = 3
 //		Searches for groups that can be added as subgroups, based on a substring of their name.
 //		Returns groups for which the user is a manager with `can_manage` = 'memberships_and_group',
 //		whose `name` has `{search}` as a substring.
+//
+//
+//		All the words of the search query must appear in the name for the group to be returned.
 //	parameters:
 //		- name: search
 //			in: query

--- a/app/api/groups/search_for_possible_subgroups.go
+++ b/app/api/groups/search_for_possible_subgroups.go
@@ -24,6 +24,10 @@ const minSearchStringLength = 3
 //
 //
 //		All the words of the search query must appear in the name for the group to be returned.
+//
+//
+//		Note: MySQL Full-Text Search IN BOOLEAN MODE is used for the search, "amazing team" is transformed to "+amazing* +team*",
+//		so the words must all appear, as a prefix of a word.
 //	parameters:
 //		- name: search
 //			in: query

--- a/app/api/items/search_for_items.feature
+++ b/app/api/items/search_for_items.feature
@@ -126,6 +126,22 @@ Feature: Search for items
     ]
     """
 
+  Scenario: Should treat the words in the search string as "AND"
+    Given I am the user with id "21"
+    When I send a GET request to "/items/search?search=Le%20chapitre"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "10",
+        "title": "Le troisième chapitre",
+        "type": "Chapter",
+        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false}
+      }
+    ]
+    """
+
   Scenario: Search for items with "the" (limit=2)
     Given I am the user with id "21"
     When I send a GET request to "/items/search?search=the&limit=2"

--- a/app/api/items/search_for_items.feature
+++ b/app/api/items/search_for_items.feature
@@ -1,5 +1,4 @@
 Feature: Search for items
-
   Background:
     Given the database has the following table 'items':
       | id | type    | default_language_tag |
@@ -126,9 +125,25 @@ Feature: Search for items
     ]
     """
 
-  Scenario: Should treat the words in the search string as "AND"
+  Scenario: Should treat the words in the search string as "AND", and work with accents
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=Le%20chapitre"
+    When I send a GET request to "/items/search?search=chapitre%20troisième"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "10",
+        "title": "Le troisième chapitre",
+        "type": "Chapter",
+        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false}
+      }
+    ]
+    """
+
+  Scenario: Should treat the words in the search string as "AND", and work without accents
+    Given I am the user with id "21"
+    When I send a GET request to "/items/search?search=chapitre%20troisieme"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
@@ -173,7 +188,7 @@ Feature: Search for items
     [
       {
         "id": "2",
-        "title": "amazing Our Task",
+        "title": "amazing Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false}
       },

--- a/app/api/items/search_for_items.feature
+++ b/app/api/items/search_for_items.feature
@@ -32,37 +32,37 @@ Feature: Search for items
       | 30 | Chapter | en                   |
       | 31 | Chapter | en                   |
     And the database has the following table 'items_strings':
-      | item_id | language_tag | title                                   |
-      | 1       | fr           | (the) Our Chapter                       |
-      | 2       | fr           | (the) Our Task ___                      |
-      | 3       | en           | (the) Our Task                          |
-      | 4       | fr           | (the) \|\|\|Our Skill \\\\\\%\\\\%\\ :) |
-      | 6       | en           | Another Chapter                         |
-      | 6       | fr           | Un autre chapitre                       |
-      | 7       | en           | Another %%%Task                         |
-      | 10      | en           | The third chapter                       |
-      | 10      | fr           | Le troisième chapitre                   |
-      | 11      | en           | chapter                                 |
-      | 12      | en           | chapter                                 |
-      | 13      | en           | chapter                                 |
-      | 14      | en           | chapter                                 |
-      | 15      | en           | chapter                                 |
-      | 16      | en           | chapter                                 |
-      | 17      | en           | chapter                                 |
-      | 18      | en           | chapter                                 |
-      | 19      | en           | chapter                                 |
-      | 20      | en           | chapter                                 |
-      | 21      | en           | chapter                                 |
-      | 22      | en           | chapter                                 |
-      | 23      | en           | chapter                                 |
-      | 24      | en           | chapter                                 |
-      | 25      | en           | chapter                                 |
-      | 26      | en           | chapter                                 |
-      | 27      | en           | chapter                                 |
-      | 28      | en           | chapter                                 |
-      | 29      | en           | chapter                                 |
-      | 30      | en           | chapter                                 |
-      | 31      | en           | chapter                                 |
+      | item_id | language_tag | title                                     |
+      | 1       | fr           | amazing Chapter                           |
+      | 2       | fr           | amazing Task                              |
+      | 3       | en           | amazing Task                              |
+      | 4       | fr           | amazing \|\|\|Our Skill \\\\\\%\\\\%\\ :) |
+      | 6       | en           | Another amazing Chapter                   |
+      | 6       | fr           | Un autre chapitre                         |
+      | 7       | en           | Another amazing Task                      |
+      | 10      | en           | amazing third chapter                     |
+      | 10      | fr           | Le troisième chapitre                     |
+      | 11      | en           | chapter                                   |
+      | 12      | en           | chapter                                   |
+      | 13      | en           | chapter                                   |
+      | 14      | en           | chapter                                   |
+      | 15      | en           | chapter                                   |
+      | 16      | en           | chapter                                   |
+      | 17      | en           | chapter                                   |
+      | 18      | en           | chapter                                   |
+      | 19      | en           | chapter                                   |
+      | 20      | en           | chapter                                   |
+      | 21      | en           | chapter                                   |
+      | 22      | en           | chapter                                   |
+      | 23      | en           | chapter                                   |
+      | 24      | en           | chapter                                   |
+      | 25      | en           | chapter                                   |
+      | 26      | en           | chapter                                   |
+      | 27      | en           | chapter                                   |
+      | 28      | en           | chapter                                   |
+      | 29      | en           | chapter                                   |
+      | 30      | en           | chapter                                   |
+      | 31      | en           | chapter                                   |
     And the database has the following users:
       | login | default_language | temp_user | group_id | first_name  | last_name | grade |
       | owner | fr               | 0         | 21       | Jean-Michel | Blanquer  | 3     |
@@ -98,28 +98,28 @@ Feature: Search for items
       | 21       | 30      | content_with_descendants |
       | 21       | 31      | content_with_descendants |
 
-  Scenario: Search for items with "the"
+  Scenario: Search for items with "amazing"
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=the"
+    When I send a GET request to "/items/search?search=amazing"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "title": "(the) Our Task ___",
+        "title": "amazing Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false}
       },
       {
         "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
+        "title": "amazing |||Our Skill \\\\\\%\\\\%\\ :)",
         "type": "Skill",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       },
       {
         "id": "7",
-        "title": "Another %%%Task",
+        "title": "Another amazing Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       }
@@ -142,140 +142,76 @@ Feature: Search for items
     ]
     """
 
-  Scenario: Search for items with "the" (limit=2)
+  Scenario: Search for items with "amazing" (limit=2)
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=the&limit=2"
+    When I send a GET request to "/items/search?search=amazing&limit=2"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "title": "(the) Our Task ___",
+        "title": "amazing Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false}
       },
       {
         "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
+        "title": "amazing |||Our Skill \\\\\\%\\\\%\\ :)",
         "type": "Skill",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       }
     ]
     """
 
-  Scenario: Search for items with percent signs ("%%%")
+  Scenario: Search for items with "amazing", include only items of specified types
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=%25%25%25"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "7",
-        "title": "Another %%%Task",
-        "type": "Task",
-        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
-      }
-    ]
-    """
-
-  Scenario: Search for items with underscore signs
-    Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=___"
+    When I send a GET request to "/items/search?search=amazing&types_include=Task"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "2",
-        "title": "(the) Our Task ___",
-        "type": "Task",
-        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false}
-      }
-    ]
-    """
-
-  Scenario: Search for items with pipe signs ("|||")
-    Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=%7C%7C%7C"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
-        "type": "Skill",
-        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
-      }
-    ]
-    """
-
-  Scenario: Search with percent sign and slashes ("\\\%\\%\")
-    Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=%5C%5C%5C%25%5C%5C%25%5C"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
-        "type": "Skill",
-        "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
-      }
-    ]
-    """
-
-  Scenario: Search for items with "the", include only items of specified types
-    Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=the&types_include=Task"
-    Then the response code should be 200
-    And the response body should be, in JSON:
-    """
-    [
-      {
-        "id": "2",
-        "title": "(the) Our Task ___",
+        "title": "amazing Our Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "content", "can_watch": "none", "is_owner": false}
       },
       {
         "id": "7",
-        "title": "Another %%%Task",
+        "title": "Another amazing Task",
         "type": "Task",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       }
     ]
     """
 
-  Scenario: Search for items with "the", exclude items of specified types
+  Scenario: Search for items with "amazing", exclude items of specified types
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=the&types_exclude=Task"
+    When I send a GET request to "/items/search?search=amazing&types_exclude=Task"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
+        "title": "amazing |||Our Skill \\\\\\%\\\\%\\ :)",
         "type": "Skill",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       }
     ]
     """
 
-  Scenario: Search for items with "the", combination of types_include & types_exclude
+  Scenario: Search for items with "amazing", combination of types_include & types_exclude
     Given I am the user with id "21"
-    When I send a GET request to "/items/search?search=the&types_include=Task,Skill&types_exclude=Task"
+    When I send a GET request to "/items/search?search=amazing&types_include=Task,Skill&types_exclude=Task"
     Then the response code should be 200
     And the response body should be, in JSON:
     """
     [
       {
         "id": "4",
-        "title": "(the) |||Our Skill \\\\\\%\\\\%\\ :)",
+        "title": "amazing |||Our Skill \\\\\\%\\\\%\\ :)",
         "type": "Skill",
         "permissions": {"can_edit": "none", "can_grant_view": "none", "can_view": "info", "can_watch": "none", "is_owner": false}
       }

--- a/app/api/items/search_for_items.go
+++ b/app/api/items/search_for_items.go
@@ -45,6 +45,9 @@ type itemSearchResponseRowRaw struct {
 //	description: >
 //		Searches for visible (`can_view` >= 'info') items, basing on a substring of their titles
 //		in the current user's (if exists, otherwise default) language.
+//
+//
+//		All the words of the search query must appear in the title for the item to be returned.
 //	parameters:
 //		- name: search
 //			in: query

--- a/app/api/items/search_for_items.go
+++ b/app/api/items/search_for_items.go
@@ -48,6 +48,10 @@ type itemSearchResponseRowRaw struct {
 //
 //
 //		All the words of the search query must appear in the title for the item to be returned.
+//
+//
+//		Note: MySQL Full-Text Search IN BOOLEAN MODE is used for the search, "amazing team" is transformed to "+amazing* +team*",
+//		so the words must all appear, as a prefix of a word.
 //	parameters:
 //		- name: search
 //			in: query

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -287,7 +287,7 @@ func (s *GroupStore) GetSearchForPossibleSubgroupsQuery(user *User, searchString
 		Where("group_managers.can_manage = 'memberships_and_group'").
 		Group("groups.id").
 		Where("groups.type != 'User'").
-		WhereSearchStringMatches("groups.name", searchString).
+		WhereSearchStringMatches("groups.name", "", searchString).
 		Select(`
 			groups.id,
 			groups.name,
@@ -316,5 +316,5 @@ func (s *GroupStore) GetSearchForAvailableGroupsQuery(user *User, searchString s
 		Where("type != 'User' AND type != 'ContestParticipants'").
 		Where("groups.id NOT IN ?", skipGroups).
 		Where("groups.id NOT IN ?", skipPending).
-		WhereSearchStringMatches("groups.name", searchString)
+		WhereSearchStringMatches("groups.name", "", searchString)
 }

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"strings"
-
 	"github.com/jinzhu/gorm"
 )
 
@@ -285,23 +283,38 @@ func (s *GroupStore) HasParticipants(groupID int64) bool {
 
 // GetSearchForPossibleSubgroupsQuery returns a query for searching for possible subgroups of a user.
 func (s *GroupStore) GetSearchForPossibleSubgroupsQuery(user *User, searchString string) *DB {
-	escapedSearchString := EscapeLikeString(searchString, '|')
-
-	query := s.ManagedBy(user).
+	return s.ManagedBy(user).
 		Where("group_managers.can_manage = 'memberships_and_group'").
 		Group("groups.id").
 		Where("groups.type != 'User'").
+		WhereSearchStringMatches("groups.name", searchString).
 		Select(`
 			groups.id,
 			groups.name,
 			groups.type,
 			groups.description`)
+}
 
-	// For each word in searchString.
-	for _, word := range strings.Fields(escapedSearchString) {
-		// Add a condition to the query to match the word.
-		query = query.Where("groups.name LIKE CONCAT('%', ?, '%') ESCAPE '|'", word)
-	}
+func (s *GroupStore) GetSearchForAvailableGroupsQuery(user *User, searchString string) *DB {
+	skipGroups := s.ActiveGroupGroups().
+		Select("groups_groups_active.parent_group_id").
+		Where("groups_groups_active.child_group_id = ?", user.GroupID).
+		SubQuery()
 
-	return query
+	skipPending := s.GroupPendingRequests().
+		Select("group_pending_requests.group_id").
+		Where("group_pending_requests.member_id = ?", user.GroupID).
+		Where("group_pending_requests.type IN ('join_request', 'invitation')").
+		SubQuery()
+
+	return s.Select(`
+			groups.id,
+			groups.name,
+			groups.type,
+			groups.description`).
+		Where("groups.is_public").
+		Where("type != 'User' AND type != 'ContestParticipants'").
+		Where("groups.id NOT IN ?", skipGroups).
+		Where("groups.id NOT IN ?", skipPending).
+		WhereSearchStringMatches("groups.name", searchString)
 }

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -40,7 +40,7 @@ func (s *ItemStore) GetSearchQuery(user *User, searchString string, typesList []
 			items.type,
 			permissions.*`).
 		Where("items.type IN (?)", typesList).
-		WhereSearchStringMatches("COALESCE(user_strings.title, default_strings.title)", searchString).
+		WhereSearchStringMatches("user_strings.title", "default_strings.title", searchString).
 		JoinsPermissionsForGroupToItemsWherePermissionAtLeast(user.GroupID, "view", "info").
 		Order("items.id")
 }

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -33,25 +33,16 @@ func (conn *DB) WhereItemsAreSelfOrDescendantsOf(itemAncestorID int64) *DB {
 // GetSearchQuery returns a query for searching items by title.
 // It returns only items visible for the given user, which matches the given types.
 func (s *ItemStore) GetSearchQuery(user *User, searchString string, typesList []string) *DB {
-	escapedSearchString := EscapeLikeString(searchString, '|')
-
-	query := s.JoinsUserAndDefaultItemStrings(user).
+	return s.JoinsUserAndDefaultItemStrings(user).
 		Select(`
 			items.id,
 			COALESCE(user_strings.title, default_strings.title) AS title,
 			items.type,
 			permissions.*`).
 		Where("items.type IN (?)", typesList).
+		WhereSearchStringMatches("COALESCE(user_strings.title, default_strings.title)", searchString).
 		JoinsPermissionsForGroupToItemsWherePermissionAtLeast(user.GroupID, "view", "info").
 		Order("items.id")
-
-	// For each word in searchString.
-	for _, word := range strings.Fields(escapedSearchString) {
-		// Add a condition to the query to match the word.
-		query = query.Where("COALESCE(user_strings.title, default_strings.title) LIKE CONCAT('%', ?, '%') ESCAPE '|'", word)
-	}
-
-	return query
 }
 
 // IsValidParticipationHierarchyForParentAttempt checks if the given list of item ids is a valid participation hierarchy

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -4,32 +4,40 @@ import "strings"
 
 // WhereSearchStringMatches returns a composable query where {field} matches the search string {searchString}
 // All the words in the search string are matched with "AND".
-func (conn *DB) WhereSearchStringMatches(field, searchString string) *DB {
+// If fallbackField is not empty, it is used as a fallback if the field is NULL.
+func (conn *DB) WhereSearchStringMatches(field, fallbackField, searchString string) *DB {
 	query := conn.db
-
-	// Remove all the special characters from the search string.
-	searchString = strings.Map(func(r rune) rune {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
-			return r
-		}
-		return ' '
-	}, searchString)
-
-	// Remove consecutive spaces.
-	searchString = strings.Join(strings.Fields(searchString), " ")
 
 	words := strings.Fields(strings.Trim(searchString, " "))
 
-	// Search words than begin with.
 	for i := 0; i < len(words); i++ {
 		word := words[i]
+		if word == "" {
+			continue
+		}
 
 		// The "+" sign means that the word must be present in the result.
+		if word[0] != '+' {
+			word = "+" + word
+		}
+
 		// The "*" sign means that the word can be a prefix of a word in the result.
-		words[i] = "+" + word + "*"
+		if word[len(word)-1] != '*' {
+			word += "*"
+		}
+
+		words[i] = word
 	}
 
-	query = query.Where("MATCH ("+field+") AGAINST (? IN BOOLEAN MODE)", strings.Join(words, " "))
+	searchPattern := strings.Join(words, " ")
+
+	condition := "(" + field + " IS NOT NULL AND MATCH(" + field + ") AGAINST(? IN BOOLEAN MODE))"
+	if fallbackField == "" {
+		query = query.Where(condition, searchPattern)
+	} else {
+		condition += "OR (" + field + " IS NULL AND MATCH(" + fallbackField + ") AGAINST(? IN BOOLEAN MODE))"
+		query = query.Where(condition, searchPattern, searchPattern)
+	}
 
 	return newDB(conn.ctx, query)
 }

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -1,19 +1,11 @@
 package database
 
-import "strings"
-
 // WhereSearchStringMatches returns a composable query where {field} matches the search string {searchString}
 // All the words in the search string are matched with "AND".
 func (conn *DB) WhereSearchStringMatches(field, searchString string) *DB {
-	escapedSearchString := EscapeLikeString(searchString, '|')
-
 	query := conn.db
 
-	// For each word in the escaped search string.
-	for _, word := range strings.Fields(escapedSearchString) {
-		// Add a condition to the query to match the word.
-		query = query.Where(field+" LIKE CONCAT('%', ?, '%') ESCAPE '|'", word)
-	}
+	query = query.Where("MATCH ("+field+") AGAINST (? IN BOOLEAN MODE)", searchString)
 
 	return newDB(conn.ctx, query)
 }

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -1,0 +1,19 @@
+package database
+
+import "strings"
+
+// WhereSearchStringMatches returns a composable query where {field} matches the search string {searchString}
+// All the words in the search string are matched with "AND".
+func (conn *DB) WhereSearchStringMatches(field, searchString string) *DB {
+	escapedSearchString := EscapeLikeString(searchString, '|')
+
+	query := conn.db
+
+	// For each word in the escaped search string.
+	for _, word := range strings.Fields(escapedSearchString) {
+		// Add a condition to the query to match the word.
+		query = query.Where(field+" LIKE CONCAT('%', ?, '%') ESCAPE '|'", word)
+	}
+
+	return newDB(conn.ctx, query)
+}

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -12,9 +12,6 @@ func (conn *DB) WhereSearchStringMatches(field, fallbackField, searchString stri
 
 	for i := 0; i < len(words); i++ {
 		word := words[i]
-		if word == "" {
-			continue
-		}
 
 		// The "+" sign means that the word must be present in the result.
 		if word[0] != '+' {

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -1,11 +1,35 @@
 package database
 
+import "strings"
+
 // WhereSearchStringMatches returns a composable query where {field} matches the search string {searchString}
 // All the words in the search string are matched with "AND".
 func (conn *DB) WhereSearchStringMatches(field, searchString string) *DB {
 	query := conn.db
 
-	query = query.Where("MATCH ("+field+") AGAINST (? IN BOOLEAN MODE)", searchString)
+	// Remove all the special characters from the search string.
+	searchString = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return ' '
+	}, searchString)
+
+	// Remove consecutive spaces.
+	searchString = strings.Join(strings.Fields(searchString), " ")
+
+	words := strings.Fields(strings.Trim(searchString, " "))
+
+	// Search words than begin with.
+	for i := 0; i < len(words); i++ {
+		word := words[i]
+
+		// The "+" sign means that the word must be present in the result.
+		// The "*" sign means that the word can be a prefix of a word in the result.
+		words[i] = "+" + word + "*"
+	}
+
+	query = query.Where("MATCH ("+field+") AGAINST (? IN BOOLEAN MODE)", strings.Join(words, " "))
 
 	return newDB(conn.ctx, query)
 }

--- a/db/migrations/2406141532_add_full_text_indexes_for_search.sql
+++ b/db/migrations/2406141532_add_full_text_indexes_for_search.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
+CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
+
+-- +migrate Down
+
+ALTER TABLE `groups` DROP INDEX `fullTextName`;
+ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;


### PR DESCRIPTION
fixes #1023 

The following searching services have been updated.
- `itemSearch`
- `groupsJoinableSearch`
- `groupsPossibleSubgroupsSearch`

### Modifications

- The search string is now exploded into words, and each word has to be found for the item or group to be returned.

Note: we use `LIKE %?%`, so that the words has to be found in any place of the field (ie. "the" matches in "ano**the**r").

- The construction of the queries have been refactored to make the services easier to read.

- The conditions for the search have been refactored in the function `WhereSearchStringMatches` to make sure we use the same logic for all the search queries.