### PR TITLE
Add "isEmpty" info to group member services

### DIFF
--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Get group children (groupChildrenView)
   Background:
     Given the database has the following table 'groups':
@@ -63,25 +64,25 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -94,31 +95,31 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -131,31 +132,31 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -168,19 +169,19 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -193,25 +194,25 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -224,25 +225,25 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -255,7 +256,7 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -268,7 +269,7 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 
@@ -281,31 +282,31 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
     ]
     """
 

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Get group children (groupChildrenView)
   Background:
     Given the database has the following table 'groups':
@@ -36,6 +35,10 @@ Feature: Get group children (groupChildrenView)
       | 23       | 21         | none                  | true                   | true              |
       | 28       | 21         | memberships_and_group | false                  | true              |
       | 30       | 21         | memberships           | true                   | false             |
+    # The group AllUsers should contain all users.
+    # But in this test file, this behavior is not implemented.
+    # Because this test file doesn't use the new Gherkin test system (steps_app_language).
+    # That's why we return "is_empty": false for this group.
     And the database has the following table 'groups_groups':
       | parent_group_id | child_group_id |
       | 11              | 29             |
@@ -64,16 +67,16 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
@@ -82,7 +85,7 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -95,16 +98,16 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
@@ -113,13 +116,13 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -132,16 +135,16 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
@@ -150,13 +153,13 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -169,19 +172,19 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -197,22 +200,22 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "25", "name": "Our Team", "type": "Team", "is_public": false, "grade": -1, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -231,19 +234,19 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "none",
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": true, "is_empty": true},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -256,7 +259,7 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -269,7 +272,7 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "none",
-       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 
@@ -282,16 +285,16 @@ Feature: Get group children (groupChildrenView)
     [
       {"id": "30", "name": "AllUsers", "type": "Base", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "28", "name": "Other", "type": "Other", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "23", "name": "Our Class", "type": "Class", "is_public": false, "grade": -3, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "memberships",
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "26", "name": "Our Club", "type": "Club", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "27", "name": "Our Friends", "type": "Friends", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 1, "current_user_is_manager": true, "current_user_can_manage": "memberships",
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
@@ -300,13 +303,13 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
       {"id": "24", "name": "Root", "type": "Base", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "21", "name": "user", "type": "User", "is_public": false, "grade": -2, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false},
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true},
       {"id": "29", "name": "User", "type": "User", "is_public": false, "grade": 0, "is_open": true,
        "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships",
-       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": false}
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
 

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -1,33 +1,38 @@
 Feature: Get group children (groupChildrenView)
   Background:
     Given the database has the following table 'groups':
-      | id | name          | grade | type    | is_open | is_public | code       |
-      | 11 | Group A       | -3    | Class   | true    | true      | ybqybxnlyo |
-      | 13 | Group B       | -2    | Class   | true    | true      | ybabbxnlyo |
-      | 21 | user          | -2    | User    | true    | false     | null       |
-      | 23 | Our Class     | -3    | Class   | true    | false     | null       |
-      | 24 | Root          | -2    | Base    | true    | false     | 3456789abc |
-      | 25 | Our Team      | -1    | Team    | true    | false     | 456789abcd |
-      | 26 | Our Club      | 0     | Club    | true    | false     | null       |
-      | 27 | Our Friends   | 0     | Friends | true    | false     | 56789abcde |
-      | 28 | Other         | 0     | Other   | true    | false     | null       |
-      | 29 | User          | 0     | User    | true    | false     | null       |
-      | 30 | AllUsers      | 0     | Base    | true    | false     | null       |
-      | 42 | Their Class   | -3    | Class   | true    | false     | null       |
-      | 43 | Other Root    | -2    | Base    | true    | false     | 3567894abc |
-      | 44 | Other Team    | -1    | Team    | true    | false     | 678934abcd |
-      | 45 | Their Club    | 0     | Club    | true    | false     | null       |
-      | 46 | Their Friends | 0     | Friends | true    | false     | 98765abcde |
-      | 47 | Other         | 0     | Other   | true    | false     | null       |
-      | 51 | john          | 0     | User    | false   | false     | null       |
-      | 53 | jane          | 0     | User    | false   | false     | null       |
-      | 90 | Sub-Class     | 0     | Team    | false   | false     | null       |
+      | id  | name                | grade | type    | is_open | is_public | code       |
+      | 11  | Group A             | -3    | Class   | true    | true      | ybqybxnlyo |
+      | 13  | Group B             | -2    | Class   | true    | true      | ybabbxnlyo |
+      | 21  | user                | -2    | User    | true    | false     | null       |
+      | 23  | Our Class           | -3    | Class   | true    | false     | null       |
+      | 24  | Root                | -2    | Base    | true    | false     | 3456789abc |
+      | 25  | Our Team            | -1    | Team    | true    | false     | 456789abcd |
+      | 26  | Our Club            | 0     | Club    | true    | false     | null       |
+      | 27  | Our Friends         | 0     | Friends | true    | false     | 56789abcde |
+      | 28  | Other               | 0     | Other   | true    | false     | null       |
+      | 29  | User                | 0     | User    | true    | false     | null       |
+      | 30  | AllUsers            | 0     | Base    | true    | false     | null       |
+      | 42  | Their Class         | -3    | Class   | true    | false     | null       |
+      | 43  | Other Root          | -2    | Base    | true    | false     | 3567894abc |
+      | 44  | Other Team          | -1    | Team    | true    | false     | 678934abcd |
+      | 45  | Their Club          | 0     | Club    | true    | false     | null       |
+      | 46  | Their Friends       | 0     | Friends | true    | false     | 98765abcde |
+      | 47  | Other               | 0     | Other   | true    | false     | null       |
+      | 51  | john                | 0     | User    | false   | false     | null       |
+      | 53  | jane                | 0     | User    | false   | false     | null       |
+      | 90  | Sub-Class           | 0     | Team    | false   | false     | null       |
+      | 100 | manager             | 0     | User    | true    | false     | null       |
+      | 101 | Managed group       | 0     | Class   | true    | true      | managedgrp |
+      | 102 | Managed subgroup    | 0     | Class   | true    | true      | managedsub |
+      | 103 | Managed subsubgroup | 0     | Class   | true    | true      | managedssb |
     And the database has the following table 'users':
-      | login | group_id | first_name  | last_name |
-      | owner | 21       | Jean-Michel | Blanquer  |
-      | jack  | 29       | Jack        | Smith     |
-      | john  | 51       | John        | Doe       |
-      | jane  | 53       | Jane        | Doe       |
+      | login   | group_id | first_name  | last_name |
+      | owner   | 21       | Jean-Michel | Blanquer  |
+      | jack    | 29       | Jack        | Smith     |
+      | john    | 51       | John        | Doe       |
+      | jane    | 53       | Jane        | Doe       |
+      | manager | 100      | Manager     | Manager   |
     And the database has the following table 'group_managers':
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 13       | 11         | memberships           | true                   | false             |
@@ -35,6 +40,7 @@ Feature: Get group children (groupChildrenView)
       | 23       | 21         | none                  | true                   | true              |
       | 28       | 21         | memberships_and_group | false                  | true              |
       | 30       | 21         | memberships           | true                   | false             |
+      | 101      | 100        | memberships_and_group | true                   | true              |
     # The group AllUsers should contain all users.
     # But in this test file, this behavior is not implemented.
     # Because this test file doesn't use the new Gherkin test system (steps_app_language).
@@ -56,6 +62,8 @@ Feature: Get group children (groupChildrenView)
       | 25              | 53             |
       | 27              | 53             |
       | 90              | 51             |
+      | 101             | 102            |
+      | 102             | 103            |
     And the groups ancestors are computed
 
   Scenario: User is a manager of the parent group, rows are sorted by name by default, User is skipped
@@ -275,6 +283,20 @@ Feature: Get group children (groupChildrenView)
        "current_user_can_grant_group_access": false, "current_user_can_watch_members": false, "is_empty": true}
     ]
     """
+
+  Scenario: Should return is_empty=false with user_count=0 when a subgroup contains a group and no user, with user being a manager of the parent group
+    Given I am the user with id "100"
+    When I send a GET request to "/groups/101/children"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "102", "name": "Managed subgroup", "type": "Class", "is_public": true, "grade": 0, "is_open": true,
+       "user_count": 0, "current_user_is_manager": true, "current_user_can_manage": "memberships_and_group",
+       "current_user_can_grant_group_access": true, "current_user_can_watch_members": true, "is_empty": false}
+    ]
+    """
+
 
   Scenario: User's ancestor is a manager of the parent group
     Given I am the user with id "29"

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -140,10 +140,14 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 			groups.id as id, groups.name, groups.type, groups.grade,
 			groups.is_open, groups.is_public,
 			IF(manager_permissions.found,
-				(SELECT COUNT(DISTINCT users.group_id) FROM users
-				JOIN groups_groups_active ON groups_groups_active.child_group_id = users.group_id
-				JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id
-				WHERE groups_ancestors_active.ancestor_group_id = groups.id),
+				(SELECT COUNT(DISTINCT users.group_id)
+					 FROM users
+					 JOIN groups_groups_active
+					   ON groups_groups_active.child_group_id = users.group_id
+					 JOIN groups_ancestors_active
+					   ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id
+					WHERE groups_ancestors_active.ancestor_group_id = groups.id
+				),
 				0
 			) AS user_count,
 			IF(manager_permissions.found,

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -32,6 +32,9 @@ type groupChildrenViewResponseRow struct {
 	IsOpen bool `json:"is_open"`
 	// required:true
 	IsPublic bool `json:"is_public"`
+	// Only returned if the current user is a manager of the group.
+	// For now, it is always `false` if the user is a manager.
+	IsEmpty *bool `json:"is_empty,omitempty"`
 	// required:true
 	CurrentUserIsManager bool `json:"current_user_is_manager"`
 	*ManagerPermissionsPart
@@ -144,6 +147,10 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 				WHERE groups_ancestors_active.ancestor_group_id = groups.id),
 				0
 			) AS user_count,
+			IF(manager_permissions.found,
+				FALSE,
+				NULL
+			) AS is_empty,
 			manager_permissions.found AS current_user_is_manager,
 			current_user_can_manage_value, current_user_can_grant_group_access, current_user_can_watch_members`).
 		Joins(`

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -33,7 +33,6 @@ type groupChildrenViewResponseRow struct {
 	// required:true
 	IsPublic bool `json:"is_public"`
 	// Only returned if the current user is a manager of the group.
-	// For now, it is always `false` if the user is a manager.
 	IsEmpty *bool `json:"is_empty,omitempty"`
 	// required:true
 	CurrentUserIsManager bool `json:"current_user_is_manager"`
@@ -148,7 +147,11 @@ func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.
 				0
 			) AS user_count,
 			IF(manager_permissions.found,
-				FALSE,
+				(SELECT COUNT(*) = 0
+				   FROM groups_groups_active
+				  WHERE groups_groups_active.parent_group_id = groups.id
+					  AND groups_groups_active.child_group_id != groups.id
+				),
 				NULL
 			) AS is_empty,
 			manager_permissions.found AS current_user_is_manager,

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -32,6 +32,7 @@ type groupChildrenViewResponseRow struct {
 	IsOpen bool `json:"is_open"`
 	// required:true
 	IsPublic bool `json:"is_public"`
+	// Whether the group has no child group (incl. users).
 	// Only returned if the current user is a manager of the group.
 	IsEmpty *bool `json:"is_empty,omitempty"`
 	// required:true


### PR DESCRIPTION
fixes #1026 

Didn't add tests because the different cases were already covered:
* When the user is not a manager of the group, `is_empty` isn't in the response
* When the user is a manager and the group is empty: `is_empty=true`,
* When the user is a manager and the group is not empty: `is_empty=false`

Improved the indentation of the query to make the indent clearer, specifically the use of `IF()`.

In the response, `IsEmpty` is a pointer to allow us to have 3 values:
* `null` -> don't include it in the response, when the user is not a manager of the group
* `true/false` -> when the user is a manager

The SQL query uses `IF()` to compute `is_empty` only when the user is a manager.