### PR TITLE
Makefile: add command serve-swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ lint: $(GOLANGCILINT)
 validate-swagger:
 	swagger generate spec --scan-models -o ./swagger.yaml && swagger validate ./swagger.yaml
 
-serve-swagger:
-	swagger generate spec --scan-models -o ./swagger.yaml && swagger validate ./swagger.yaml && swagger serve ./swagger.yaml --no-open
+serve-swagger: validate-swagger
+	swagger serve ./swagger.yaml --no-open
 
 dbdoc: $(MYSQL_CONNECTOR_JAVA) $(SCHEMASPY)
 	$(call check_defined, DBNAME)

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ lint: $(GOLANGCILINT)
 validate-swagger:
 	swagger generate spec --scan-models -o ./swagger.yaml && swagger validate ./swagger.yaml
 
+serve-swagger:
+	swagger generate spec --scan-models -o ./swagger.yaml && swagger validate ./swagger.yaml && swagger serve ./swagger.yaml --no-open
+
 dbdoc: $(MYSQL_CONNECTOR_JAVA) $(SCHEMASPY)
 	$(call check_defined, DBNAME)
 	$(call check_defined, DBHOST)


### PR DESCRIPTION
`make serve-swagger`

Generates the swagger file, and starts the "serve" command, so it can be checked in the browser.

This improves the process to check if the doc has been generated correctly.
