### PR TITLE
Parallel session refresh

### DIFF
--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -59,17 +59,23 @@ const parsedRequestData ctxKey = iota
 //			and if the authentication is valid.
 //			This happens when the frontend app loads and the user is already logged-in.
 //			Then,
-//			if the access token used isn't the most recent access token of the user, we return the most recent access token.
-//			If the access token used is the most recent access token of the user, and it has been refreshed LESS than 5 minutes ago,
-//			we just return it.
-//			If the access token used is the most recent access token of the user, and it has been refreshed MORE than 5 minutes ago,
-//			we refresh the access token and return the new access token
-//			(locally for temporary users or via the login module for normal users) and
-//			saves it into the DB keeping only the input token and the new token.
-//			Since the login module responds with both access and refresh tokens, the service updates the user's
-//			refresh token in this case as well.
-//			If there is no refresh token for the user in the DB,
-//			the 'not found' error is returned.
+//
+//
+//			1. If the access token used isn't the most recent access token of the user, we return the most recent access token.
+//
+//
+//			2. If the access token used is the most recent access token of the user, and it has been refreshed AFTER 5 minutes ago,
+//				we just return it.
+//
+//
+//			3. If the access token used is the most recent access token of the user, and it has been refreshed BEFORE 5 minutes ago,
+//				we refresh the access token and return the new access token
+//				(locally for temporary users or via the login module for normal users) and
+//				saves it into the DB keeping only the input token and the new token.
+//				Since the login module responds with both access and refresh tokens, the service updates the user's
+//				refresh token in this case as well.
+//				If there is no refresh token for the user in the DB,
+//				the 'not found' error is returned.
 //
 //
 //		* If the `{code}` is not given,

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -60,7 +60,9 @@ const parsedRequestData ctxKey = iota
 //			This happens when the frontend app loads and the user is already logged-in.
 //			Then,
 //			if the access token used isn't the most recent access token of the user, we return the most recent access token.
-//			If the access token used is the most recent access token of the user,
+//			If the access token used is the most recent access token of the user, and it has been refreshed LESS than 5 minutes ago,
+//			we just return it.
+//			If the access token used is the most recent access token of the user, and it has been refreshed MORE than 5 minutes ago,
 //			we refresh the access token and return the new access token
 //			(locally for temporary users or via the login module for normal users) and
 //			saves it into the DB keeping only the input token and the new token.

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -59,7 +59,9 @@ const parsedRequestData ctxKey = iota
 //			and if the authentication is valid.
 //			This happens when the frontend app loads and the user is already logged-in.
 //			Then,
-//			the service refreshes the access token
+//			if the access token used isn't the most recent access token of the user, we return the most recent access token.
+//			If the access token used is the most recent access token of the user,
+//			we refresh the access token and return the new access token
 //			(locally for temporary users or via the login module for normal users) and
 //			saves it into the DB keeping only the input token and the new token.
 //			Since the login module responds with both access and refresh tokens, the service updates the user's

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -10,20 +10,20 @@ Feature: Create a new access token
       | 12       | tmp-1234567 | true      |
       | 13       | jane        | false     |
       | 14       | john        | false     |
-    And the time now is "2020-01-01T01:00:00Z"
-    And the DB time now is "2020-01-01 01:00:00"
+    And the time now is "2020-01-01T02:00:00Z"
+    And the DB time now is "2020-01-01 02:00:00"
     And the database has the following table 'sessions':
       | session_id | user_id | refresh_token             |
       | 1          | 12      |                           |
       | 2          | 13      | jane_current_refreshtoken |
       | 3          | 14      | john_current_refreshtoken |
     And the database has the following table 'access_tokens':
-      | session_id | expires_at          | token              |
-      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
-      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
-      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2          | 2020-01-01 03:00:00 | jane_current_token |
-      | 3          | 2020-01-01 03:00:00 | john_current_token |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
     And the application config is:
       """
       auth:
@@ -57,17 +57,17 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | expires_at          | token              |
-      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
-      | 3                   | 2020-01-01 03:00:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
+      | session_id          | issued_at           | expires_at          | token              |
+      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
   Examples:
     | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
     |                                  | [Header not defined]  | "access_token":"tmp_new_token", | [Header not defined]                                                                                                                                     |
-    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
-    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
+    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
+    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
+    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
 
   Scenario Outline: Request a new access token for a normal user
     Given the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
@@ -97,26 +97,26 @@ Feature: Create a new access token
       | 2          | 13      | jane_new_refreshtoken     |
       | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id | expires_at          | token              |
-      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
-      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
-      | 2          | 2020-01-01 03:00:00 | jane_current_token |
-      | 2          | 2021-01-01 01:00:00 | jane_new_token     | # the new token
-      | 3          | 2020-01-01 03:00:00 | john_current_token |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 2          | 2020-01-01 02:00:00 | 2021-01-01 02:00:00 | jane_new_token     | # the new token
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
     Examples:
       | query                            | token_in_data                     | expected_cookie                                                                                                                                               |
       |                                  | "access_token": "jane_new_token", | [Header not defined]                                                                                                                                          |
-      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
-      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
+      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 02:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
+      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 02:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
 
   Scenario Outline: >
       Accepts access_token cookie and removes it if cookie attributes differ for a normal user,
       since old tokens are used, the most recent one is returned
     Given the database table 'access_tokens' has also the following rows:
-      | session_id | expires_at          | token           |
-      | 2          | 2020-01-01 02:00:00 | jane_old1_token |
-      | 2          | 2020-01-01 02:00:00 | jane_old2_token |
-      | 2          | 2020-01-01 02:00:00 | jane_old3_token |
+      | session_id | issued_at           | expires_at          | token           |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old1_token |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old2_token |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old3_token |
     And the "Cookie" request header is "access_token=<token_cookie>"
     When I send a POST request to "/auth/token?use_cookie=1&cookie_secure=1"
     Then the response code should be 201
@@ -125,30 +125,30 @@ Feature: Create a new access token
       {
         "success": true,
         "message": "created",
-        "data": {"expires_in": 7200}
+        "data": {"expires_in": 6600}
       }
       """
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!jane_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
+        access_token=2!jane_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:50:00 GMT; Max-Age=6600; HttpOnly; Secure; SameSite=None
       """
   Examples:
     | token_cookie                    | cookie_removal                                                                                                                 |
-    | 1!jane_old_token!!              | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
+    | 1!jane_old_token!!              | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
     | 2!jane_old1_token!127.0.0.1!/   |                                                                                                                                |
-    | 2!jane_old2_token!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
-    | 3!jane_old3_token!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
+    | 2!jane_old2_token!!             | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
+    | 3!jane_old3_token!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
 
   Scenario Outline: >
       Accepts access_token cookie and removes it if cookie attributes differ for a temporary user.
       Since old tokens are used, the most recent one is returned.
     Given the generated auth key is "tmp_new_token"
     And the database table 'access_tokens' has also the following rows:
-      | session_id | expires_at          | token          |
-      | 1          | 2020-01-01 02:00:00 | tmp_old1_token |
-      | 1          | 2020-01-01 02:00:00 | tmp_old2_token |
-      | 1          | 2020-01-01 02:00:00 | tmp_old3_token |
+      | session_id | issued_at           | expires_at          | token          |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old1_token |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old2_token |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old3_token |
     And the "Cookie" request header is "access_token=<token_cookie>"
     When I send a POST request to "/auth/token?use_cookie=1&cookie_secure=1"
     Then the response code should be 201
@@ -157,20 +157,20 @@ Feature: Create a new access token
       {
         "success": true,
         "message": "created",
-        "data": {"expires_in": 86412}
+        "data": {"expires_in": 3612}
       }
       """
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!tmp_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Thu, 02 Jan 2020 01:00:12 GMT; Max-Age=86412; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:12 GMT; Max-Age=3612; HttpOnly; Secure; SameSite=None
       """
     Examples:
       | token_cookie                      | cookie_removal                                                                                                                   |
-      | 2!tmp_old_token!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
+      | 2!tmp_old_token!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
       | 2!tmp_old1_token!127.0.0.1!/      |                                                                                                                                  |
-      | 2!tmp_old2_token!!                | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
-      | 3!tmp_old3_token!a.127.0.0.1!/    | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
+      | 2!tmp_old2_token!!                | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
+      | 3!tmp_old3_token!a.127.0.0.1!/    | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
 
   Scenario Outline: Accepts cookie parameters from post data
     Given the generated auth key is "tmp_new_token"
@@ -200,16 +200,16 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | expires_at          | token              |
-      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
-      | 3                   | 2020-01-01 03:00:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
+      | session_id          | issued_at           | expires_at          | token              |
+      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
     Examples:
       | content-type                      | data                                                              | expected_cookie                                                                                                                                            |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
-      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -13,17 +13,17 @@ Feature: Create a new access token
     And the time now is "2020-01-01T01:00:00Z"
     And the DB time now is "2020-01-01 01:00:00"
     And the database has the following table 'sessions':
-      | session_id | user_id | refresh_token       |
-      | 1          | 12      |                     |
-      | 2          | 13      | refreshtokenforjane |
-      | 3          | 14      | refreshtokenforjohn |
+      | session_id | user_id | refresh_token             |
+      | 1          | 12      |                           |
+      | 2          | 13      | jane_current_refreshtoken |
+      | 3          | 14      | john_current_refreshtoken |
     And the database has the following table 'access_tokens':
-      | session_id | token                     | expires_at          |
-      | 1          | someaccesstoken           | 2020-01-01 01:00:01 |
-      | 1          | anotheraccesstoken        | 2020-01-02 01:00:12 |
-      | 2          | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2          | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3          | accesstokenjohn           | 2020-01-01 03:00:00 |
+      | session_id | expires_at          | token              |
+      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
+      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 03:00:00 | jane_current_token |
+      | 3          | 2020-01-01 03:00:00 | john_current_token |
     And the application config is:
       """
       auth:
@@ -33,8 +33,8 @@ Feature: Create a new access token
       """
 
   Scenario Outline: Request a new access token for a temporary user
-    Given the generated auth key is "newaccesstoken"
-    And the "Authorization" request header is "Bearer anotheraccesstoken"
+    Given the generated auth key is "tmp_new_token"
+    And the "Authorization" request header is "Bearer tmp_current_token"
     And the "Cookie" request header is "<current_cookie>"
     When I send a POST request to "/auth/token<query>"
     Then the response code should be 201
@@ -52,34 +52,34 @@ Feature: Create a new access token
       Generated a session token expiring in 7200 seconds for a temporary user with group_id = 12
       """
     And the table "sessions" should be:
-      | session_id          | user_id | refresh_token       |
-      | 2                   | 13      | refreshtokenforjane |
-      | 3                   | 14      | refreshtokenforjohn |
-      | 5577006791947779410 | 12      | null                |
+      | session_id          | user_id | refresh_token             |
+      | 2                   | 13      | jane_current_refreshtoken |
+      | 3                   | 14      | john_current_refreshtoken |
+      | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
-      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
+      | session_id          | expires_at          | token              |
+      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
+      | 3                   | 2020-01-01 03:00:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
   Examples:
-    | query                            | current_cookie        | token_in_data                    | expected_cookie                                                                                                                                           |
-    |                                  | [Header not defined]  | "access_token":"newaccesstoken", | [Header not defined]                                                                                                                                      |
-    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                  | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                  | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
-    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"newaccesstoken", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                  |
+    | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
+    |                                  | [Header not defined]  | "access_token":"tmp_new_token", | [Header not defined]                                                                                                                                     |
+    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
+    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
+    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
 
   Scenario Outline: Request a new access token for a normal user
-    Given the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
+    Given the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
       """
       {
         "token_type":"Bearer",
         "expires_in":31622400,
         "access_token":"newaccesstokenforjane",
-        "refresh_token":"newrefreshtokenforjane"
+        "refresh_token":"jane_new_refreshtoken"
       }
       """
-    And the "Authorization" request header is "Bearer accesstokenforjane"
+    And the "Authorization" request header is "Bearer jane_old_token"
     When I send a POST request to "/auth/token<query>"
     Then the response code should be 201
     And the response body should be, in JSON:
@@ -92,22 +92,22 @@ Feature: Create a new access token
       """
     And the response header "Set-Cookie" should be "<expected_cookie>"
     And the table "sessions" should be:
-      | session_id | user_id | refresh_token          |
-      | 1          | 12      |                        |
-      | 2          | 13      | newrefreshtokenforjane |
-      | 3          | 14      | refreshtokenforjohn    |
+      | session_id | user_id | refresh_token             |
+      | 1          | 12      |                           |
+      | 2          | 13      | jane_new_refreshtoken     |
+      | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id | token                 | expires_at          |
-      | 1          | anotheraccesstoken    | 2020-01-02 01:00:12 |
-      | 1          | someaccesstoken       | 2020-01-01 01:00:01 |
-      | 2          | accesstokenforjane    | 2020-01-01 01:00:01 |
-      | 2          | newaccesstokenforjane | 2021-01-01 01:00:00 |
-      | 3          | accesstokenjohn       | 2020-01-01 03:00:00 |
+      | session_id | expires_at          | token              |
+      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
+      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
+      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2          | 2021-01-01 01:00:00 | jane_new_token     |
+      | 3          | 2020-01-01 03:00:00 | john_current_token |
     Examples:
-      | query                            | token_in_data                            | expected_cookie                                                                                                                                                      |
-      |                                  | "access_token": "newaccesstokenforjane", | [Header not defined]                                                                                                                                                               |
-      | ?use_cookie=1&cookie_secure=1    |                                          | access_token=2!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
-      | ?use_cookie=1&cookie_same_site=1 |                                          | access_token=1!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
+      | query                            | token_in_data                     | expected_cookie                                                                                                                                               |
+      |                                  | "access_token": "jane_new_token", | [Header not defined]                                                                                                                                          |
+      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
+      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a normal user
     Given the database table 'access_tokens' has also the following rows:
@@ -115,12 +115,12 @@ Feature: Create a new access token
       | 2          | 2020-01-01 03:00:00 | onemoreaccesstokenforjane |
       | 2          | 2020-01-01 03:00:00 | andmoreaccesstokenforjane |
       | 2          | 2020-01-01 03:00:00 | moremoraccesstokenforjane |
-    And the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
+    And the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
       """
       {
         "token_type":"Bearer",
         "expires_in":31622400,
-        "access_token":"newaccesstoken",
+        "access_token":"tmp_new_token",
         "refresh_token":"newrefreshtoken"
       }
       """
@@ -138,17 +138,17 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
       """
   Examples:
     | token_cookie                              | cookie_removal                                                                                                                 |
-    | 1!accesstokenforjane!!                    | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
+    | 1!jane_old_token!!                        | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
     | 2!onemoreaccesstokenforjane!127.0.0.1!/   |                                                                                                                                |
     | 2!andmoreaccesstokenforjane!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
     | 3!moremoraccesstokenforjane!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a temporary user
-    Given the generated auth key is "newaccesstoken"
+    Given the generated auth key is "tmp_new_token"
     And the database table 'access_tokens' has also the following rows:
       | session_id | expires_at          | token              |
       | 1          | 2020-01-01 03:00:00 | onemoreaccesstoken |
@@ -168,18 +168,18 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
       """
     Examples:
-      | token_cookie                        | cookie_removal                                                                                                                   |
-      | 2!someaccesstoken!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
-      | 2!onemoreaccesstoken!127.0.0.1!/    |                                                                                                                                  |
-      | 2!andmoreaccesstoken!!              | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
-      | 3!moremoraccesstoken!a.127.0.0.1!/  | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict    |
+      | token_cookie                       | cookie_removal                                                                                                                   |
+      | 2!tmp_old_token!a.127.0.0.1!/api/  | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
+      | 2!onemoreaccesstoken!127.0.0.1!/   |                                                                                                                                  |
+      | 2!andmoreaccesstoken!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
+      | 3!moremoraccesstoken!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
 
   Scenario Outline: Accepts cookie parameters from post data
-    Given the generated auth key is "newaccesstoken"
-    And the "Authorization" request header is "Bearer anotheraccesstoken"
+    Given the generated auth key is "tmp_new_token"
+    And the "Authorization" request header is "Bearer tmp_current_token"
     And the "Content-Type" request header is "<content-type>"
     When I send a POST request to "/auth/token" with the following body:
       """
@@ -200,21 +200,21 @@ Feature: Create a new access token
       Generated a session token expiring in 7200 seconds for a temporary user with group_id = 12
       """
     And the table "sessions" should be:
-      | session_id          | user_id | refresh_token       |
-      | 2                   | 13      | refreshtokenforjane |
-      | 3                   | 14      | refreshtokenforjohn |
-      | 5577006791947779410 | 12      | null                |
+      | session_id          | user_id | refresh_token             |
+      | 2                   | 13      | jane_current_refreshtoken |
+      | 3                   | 14      | john_current_refreshtoken |
+      | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
-      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
+      | session_id          | expires_at          | token              |
+      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
+      | 3                   | 2020-01-01 03:00:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
     Examples:
-      | content-type                      | data                                                              | expected_cookie                                                                                                                                             |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict          |
-      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | content-type                      | data                                                              | expected_cookie                                                                                                                                            |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -10,8 +10,8 @@ Feature: Create a new access token
       | 12       | tmp-1234567 | true      |
       | 13       | jane        | false     |
       | 14       | john        | false     |
-    And the time now is "2019-07-16T22:02:28Z"
-    And the DB time now is "2019-07-16 22:02:28"
+    And the time now is "2020-01-01T01:00:00Z"
+    And the DB time now is "2020-01-01 01:00:00"
     And the database has the following table 'sessions':
       | session_id | user_id | refresh_token       |
       | 1          | 12      |                     |
@@ -19,11 +19,11 @@ Feature: Create a new access token
       | 3          | 14      | refreshtokenforjohn |
     And the database has the following table 'access_tokens':
       | session_id | token                     | expires_at          |
-      | 1          | someaccesstoken           | 2019-07-16 22:02:29 |
-      | 1          | anotheraccesstoken        | 2019-07-16 22:02:40 |
-      | 2          | accesstokenforjane        | 2019-07-16 22:02:29 |
-      | 2          | anotheraccesstokenforjane | 2019-07-16 22:02:31 |
-      | 3          | accesstokenjohn           | 2019-07-16 22:02:31 |
+      | 1          | someaccesstoken           | 2020-01-01 01:00:01 |
+      | 1          | anotheraccesstoken        | 2020-01-02 01:00:12 |
+      | 2          | accesstokenforjane        | 2020-01-01 01:00:01 |
+      | 2          | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
+      | 3          | accesstokenjohn           | 2020-01-01 03:00:00 |
     And the application config is:
       """
       auth:
@@ -58,16 +58,16 @@ Feature: Create a new access token
       | 5577006791947779410 | 12      | null                |
     And the table "access_tokens" should be:
       | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2019-07-16 22:02:29 |
-      | 2                   | anotheraccesstokenforjane | 2019-07-16 22:02:31 |
-      | 3                   | accesstokenjohn           | 2019-07-16 22:02:31 |
-      | 5577006791947779410 | newaccesstoken            | 2019-07-17 00:02:28 |
+      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
+      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
+      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
+      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
   Examples:
     | query                            | current_cookie        | token_in_data                    | expected_cookie                                                                                                                                           |
     |                                  | [Header not defined]  | "access_token":"newaccesstoken", | [Header not defined]                                                                                                                                      |
-    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                  | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                  | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
-    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"newaccesstoken", | access_token=; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                  |
+    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                  | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
+    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                  | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
+    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"newaccesstoken", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                  |
 
   Scenario Outline: Request a new access token for a normal user
     Given the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
@@ -98,24 +98,24 @@ Feature: Create a new access token
       | 3          | 14      | refreshtokenforjohn    |
     And the table "access_tokens" should be:
       | session_id | token                 | expires_at          |
-      | 1          | anotheraccesstoken    | 2019-07-16 22:02:40 |
-      | 1          | someaccesstoken       | 2019-07-16 22:02:29 |
-      | 2          | accesstokenforjane    | 2019-07-16 22:02:29 |
-      | 2          | newaccesstokenforjane | 2020-07-16 22:02:28 |
-      | 3          | accesstokenjohn       | 2019-07-16 22:02:31 |
-  Examples:
-    | query                            | token_in_data                            | expected_cookie                                                                                                                                                      |
-    |                                  | "access_token": "newaccesstokenforjane", | [Header not defined]                                                                                                                                                 |
-    | ?use_cookie=1&cookie_secure=1    |                                          | access_token=2!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Thu, 16 Jul 2020 22:02:28 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 |                                          | access_token=1!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Thu, 16 Jul 2020 22:02:28 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
+      | 1          | anotheraccesstoken    | 2020-01-02 01:00:12 |
+      | 1          | someaccesstoken       | 2020-01-01 01:00:01 |
+      | 2          | accesstokenforjane    | 2020-01-01 01:00:01 |
+      | 2          | newaccesstokenforjane | 2021-01-01 01:00:00 |
+      | 3          | accesstokenjohn       | 2020-01-01 03:00:00 |
+    Examples:
+      | query                            | token_in_data                            | expected_cookie                                                                                                                                                      |
+      |                                  | "access_token": "newaccesstokenforjane", | [Header not defined]                                                                                                                                                               |
+      | ?use_cookie=1&cookie_secure=1    |                                          | access_token=2!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
+      | ?use_cookie=1&cookie_same_site=1 |                                          | access_token=1!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a normal user
     Given the database table 'access_tokens' has also the following rows:
       | session_id | expires_at          | token                     |
-      | 2          | 2019-07-16 22:02:31 | onemoreaccesstokenforjane |
-      | 2          | 2019-07-16 22:02:31 | andmoreaccesstokenforjane |
-      | 2          | 2019-07-16 22:02:31 | moremoraccesstokenforjane |
-  And the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
+      | 2          | 2020-01-01 03:00:00 | onemoreaccesstokenforjane |
+      | 2          | 2020-01-01 03:00:00 | andmoreaccesstokenforjane |
+      | 2          | 2020-01-01 03:00:00 | moremoraccesstokenforjane |
+    And the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
       """
       {
         "token_type":"Bearer",
@@ -138,22 +138,22 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Thu, 16 Jul 2020 22:02:28 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
+        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
       """
   Examples:
     | token_cookie                              | cookie_removal                                                                                                                 |
-    | 1!accesstokenforjane!!                    | access_token=; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
+    | 1!accesstokenforjane!!                    | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
     | 2!onemoreaccesstokenforjane!127.0.0.1!/   |                                                                                                                                |
-    | 2!andmoreaccesstokenforjane!!             | access_token=; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
-    | 3!moremoraccesstokenforjane!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
+    | 2!andmoreaccesstokenforjane!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
+    | 3!moremoraccesstokenforjane!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a temporary user
     Given the generated auth key is "newaccesstoken"
     And the database table 'access_tokens' has also the following rows:
       | session_id | expires_at          | token              |
-      | 1          | 2019-07-16 22:02:31 | onemoreaccesstoken |
-      | 1          | 2019-07-16 22:02:31 | andmoreaccesstoken |
-      | 1          | 2019-07-16 22:02:31 | moremoraccesstoken |
+      | 1          | 2020-01-01 03:00:00 | onemoreaccesstoken |
+      | 1          | 2020-01-01 03:00:00 | andmoreaccesstoken |
+      | 1          | 2020-01-01 03:00:00 | moremoraccesstoken |
     And the "Cookie" request header is "access_token=<token_cookie>"
     When I send a POST request to "/auth/token?use_cookie=1&cookie_secure=1"
     Then the response code should be 201
@@ -168,14 +168,14 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
+        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
       """
     Examples:
       | token_cookie                        | cookie_removal                                                                                                                   |
-      | 2!someaccesstoken!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
+      | 2!someaccesstoken!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
       | 2!onemoreaccesstoken!127.0.0.1!/    |                                                                                                                                  |
-      | 2!andmoreaccesstoken!!              | access_token=; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
-      | 3!moremoraccesstoken!a.127.0.0.1!/  | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Tue, 16 Jul 2019 21:45:48 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
+      | 2!andmoreaccesstoken!!              | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
+      | 3!moremoraccesstoken!a.127.0.0.1!/  | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict    |
 
   Scenario Outline: Accepts cookie parameters from post data
     Given the generated auth key is "newaccesstoken"
@@ -206,15 +206,15 @@ Feature: Create a new access token
       | 5577006791947779410 | 12      | null                |
     And the table "access_tokens" should be:
       | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2019-07-16 22:02:29 |
-      | 2                   | anotheraccesstokenforjane | 2019-07-16 22:02:31 |
-      | 3                   | accesstokenjohn           | 2019-07-16 22:02:31 |
-      | 5577006791947779410 | newaccesstoken            | 2019-07-17 00:02:28 |
+      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
+      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
+      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
+      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
     Examples:
-    | content-type                      | data                                                              | expected_cookie                                                                                                                                             |
-    | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-    | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-    | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
-    | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-    | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-    | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 17 Jul 2019 00:02:28 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | content-type                      | data                                                              | expected_cookie                                                                                                                                             |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict          |
+      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -1,7 +1,7 @@
 Feature: Refresh an access token - robustness
   Background:
-    Given the DB time is "2020-01-01 00:00:00"
-    Given the database has the following table 'groups':
+    Given the DB time now is "2020-01-01 00:00:00"
+    And the database has the following table 'groups':
       | id | name        | type |
       | 13 | jane        | User |
     And the database has the following table 'users':
@@ -14,10 +14,9 @@ Feature: Refresh an access token - robustness
       | session_id | expires_at          | token              |
       | 1          | 2019-01-01 00:00:00 | jane_expired_token |
       | 1          | 2021-01-01 00:00:00 | jane_current_token |
-
-
+    @wop
   Scenario: No refresh token in the DB
-    Given the "Authorization" request header is "Bearer accesstokenforjane"
+    Given the "Authorization" request header is "Bearer jane_current_token"
     When I send a POST request to "/auth/token"
     Then the response code should be 404
     And the response error message should contain "No refresh token found in the DB for the authenticated user"

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -1,5 +1,6 @@
 Feature: Refresh an access token - robustness
   Background:
+    Given the DB time is "2020-01-01 00:00:00"
     Given the database has the following table 'groups':
       | id | name        | type |
       | 13 | jane        | User |
@@ -10,9 +11,10 @@ Feature: Refresh an access token - robustness
       | session_id | user_id | refresh_token |
       | 1          | 13      |               |
     And the database has the following table 'access_tokens':
-      | session_id | token                     | expires_at          |
-      | 1          | accesstokenforjane        | 3019-07-16 22:02:29 |
-      | 1          | anotheraccesstokenforjane | 2019-07-16 22:02:31 |
+      | session_id | expires_at          | token              |
+      | 1          | 2019-01-01 00:00:00 | jane_expired_token |
+      | 1          | 2021-01-01 00:00:00 | jane_current_token |
+
 
   Scenario: No refresh token in the DB
     Given the "Authorization" request header is "Bearer accesstokenforjane"

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Refresh an access token - robustness
   Background:
-    Given the DB time now is "2020-01-01 00:00:00"
+    Given the DB time now is "2020-01-01 01:00:00"
     And the database has the following table 'groups':
       | id | name        | type |
       | 13 | jane        | User |
@@ -11,9 +11,9 @@ Feature: Refresh an access token - robustness
       | session_id | user_id | refresh_token |
       | 1          | 13      |               |
     And the database has the following table 'access_tokens':
-      | session_id | expires_at          | token              |
-      | 1          | 2019-01-01 00:00:00 | jane_expired_token |
-      | 1          | 2021-01-01 00:00:00 | jane_current_token |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 | jane_expired_token |
+      | 1          | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 | jane_current_token |
 
   Scenario: No refresh token in the DB
     Given the "Authorization" request header is "Bearer jane_current_token"

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -15,14 +15,14 @@ Feature: Refresh an access token - robustness
       | 1          | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 | jane_expired_token |
       | 1          | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 | jane_current_token |
 
-  Scenario: No refresh token in the DB
-    Given the "Authorization" request header is "Bearer jane_current_token"
-    When I send a POST request to "/auth/token"
-    Then the response code should be 404
-    And the response error message should contain "No refresh token found in the DB for the authenticated user"
-    And logs should contain:
-      """
-      No refresh token found in the DB for user 13
-      """
-    And the table "sessions" should stay unchanged
-    And the table "access_tokens" should stay unchanged
+#  Scenario: No refresh token in the DB
+#    Given the "Authorization" request header is "Bearer jane_current_token"
+#    When I send a POST request to "/auth/token"
+#    Then the response code should be 404
+#    And the response error message should contain "No refresh token found in the DB for the authenticated user"
+#    And logs should contain:
+#      """
+#      No refresh token found in the DB for user 13
+#      """
+#    And the table "sessions" should stay unchanged
+#    And the table "access_tokens" should stay unchanged

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -14,7 +14,7 @@ Feature: Refresh an access token - robustness
       | session_id | expires_at          | token              |
       | 1          | 2019-01-01 00:00:00 | jane_expired_token |
       | 1          | 2021-01-01 00:00:00 | jane_current_token |
-    @wop
+
   Scenario: No refresh token in the DB
     Given the "Authorization" request header is "Bearer jane_current_token"
     When I send a POST request to "/auth/token"

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -15,14 +15,14 @@ Feature: Refresh an access token - robustness
       | 1          | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 | jane_expired_token |
       | 1          | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 | jane_current_token |
 
-#  Scenario: No refresh token in the DB
-#    Given the "Authorization" request header is "Bearer jane_current_token"
-#    When I send a POST request to "/auth/token"
-#    Then the response code should be 404
-#    And the response error message should contain "No refresh token found in the DB for the authenticated user"
-#    And logs should contain:
-#      """
-#      No refresh token found in the DB for user 13
-#      """
-#    And the table "sessions" should stay unchanged
-#    And the table "access_tokens" should stay unchanged
+  Scenario: No refresh token in the DB
+    Given the "Authorization" request header is "Bearer jane_current_token"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 404
+    And the response error message should contain "No refresh token found in the DB for the authenticated user"
+    And logs should contain:
+      """
+      No refresh token found in the DB for user 13
+      """
+    And the table "sessions" should stay unchanged
+    And the table "access_tokens" should stay unchanged

--- a/app/api/auth/refresh_access_token_parallel_sessions.feature
+++ b/app/api/auth/refresh_access_token_parallel_sessions.feature
@@ -9,17 +9,20 @@ Feature: Support for parallel sessions
       | session                | user           | refresh_token       |
       | @Session_User1_1       | @User1         | rt_user_1_session_1 |
       | @Session_User1_2       | @User1         | rt_user_1_session_2 |
+      | @Session_User1_3       | @User1         | rt_user_1_session_3 |
       | @Session_UserUntouched | @UserUntouched | rt_user_untouched   |
     And there are the following access tokens:
-      | session                | token                          | issued_at           | expires_at          |
-      | @Session_User1_1       | t_user_1_session_1_expired     | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
-      | @Session_User1_1       | t_user_1_session_1_old         | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
-      | @Session_User1_1       | t_user_1_session_1_most_recent | 2020-01-01 00:30:00 | 2020-01-01 02:30:00 |
-      | @Session_User1_2       | t_user_1_session_2_expired     | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
-      | @Session_User1_2       | t_user_1_session_2_old         | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
-      | @Session_User1_2       | t_user_1_session_2_most_recent | 2020-01-01 00:30:00 | 2020-01-01 02:30:00 |
-      | @Session_UserUntouched | t_user_untouched_expired       | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
-      | @Session_UserUntouched | t_user_untouched               | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | session                | token                                    | issued_at           | expires_at          |
+      | @Session_User1_1       | t_user_1_session_1_expired               | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_User1_1       | t_user_1_session_1_old                   | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | @Session_User1_1       | t_user_1_session_1_most_recent           | 2020-01-01 00:30:00 | 2020-01-01 02:30:00 |
+      | @Session_User1_2       | t_user_1_session_2_expired               | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_User1_2       | t_user_1_session_2_old                   | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | @Session_User1_2       | t_user_1_session_2_most_recent_less_5min | 2020-01-01 00:56:00 | 2020-01-01 02:56:00 |
+      | @Session_User1_3       | t_user_1_session_3_old                   | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | @Session_User1_3       | t_user_1_session_3_most_recent_more_5min | 2020-01-01 00:54:59 | 2020-01-01 02:54:59 |
+      | @Session_UserUntouched | t_user_untouched_expired                 | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_UserUntouched | t_user_untouched                         | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
     And the application config is:
       """
       auth:
@@ -41,6 +44,48 @@ Feature: Support for parallel sessions
         "data": {
           "access_token": "t_user_1_session_1_most_recent",
           "expires_in": 5400
+        }
+      }
+      """
+
+  Scenario: Should return the same access token if we try to refresh a token not older than 5 minutes
+    When the "Authorization" request header is "Bearer t_user_1_session_2_most_recent_less_5min"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 201
+    # expires_in is 6960 seconds = 1h56
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "t_user_1_session_2_most_recent_less_5min",
+          "expires_in": 6960
+        }
+      }
+      """
+
+  Scenario: Should return a new access token if we try to refresh a token older than 5 minutes
+    Given the login module "token" endpoint for refresh token "rt_user_1_session_3" returns 200 with body:
+      """
+      {
+        "token_type":"Bearer",
+        "expires_in":7200,
+        "access_token":"t_user_1_session_3_new",
+        "refresh_token":"rt_user_1_session_3_new"
+      }
+      """
+    When the "Authorization" request header is "Bearer t_user_1_session_3_most_recent_more_5min"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "t_user_1_session_3_new",
+          "expires_in": 7200
         }
       }
       """

--- a/app/api/auth/refresh_access_token_parallel_sessions.feature
+++ b/app/api/auth/refresh_access_token_parallel_sessions.feature
@@ -1,0 +1,46 @@
+Feature: Support for parallel sessions
+  Background:
+    Given there are the following groups:
+      | group     | parent | members               |
+      | @AllUsers |        | @User1,@UserUntouched |
+    And the time now is "2020-01-01T01:00:00Z"
+    And the DB time now is "2020-01-01 01:00:00"
+    And there are the following sessions:
+      | session                | user           | refresh_token       |
+      | @Session_User1_1       | @User1         | rt_user_1_session_1 |
+      | @Session_User1_2       | @User1         | rt_user_1_session_2 |
+      | @Session_UserUntouched | @UserUntouched | rt_user_untouched   |
+    And there are the following access tokens:
+      | session                | token                          | issued_at           | expires_at          |
+      | @Session_User1_1       | t_user_1_session_1_expired     | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_User1_1       | t_user_1_session_1_old         | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | @Session_User1_1       | t_user_1_session_1_most_recent | 2020-01-01 00:30:00 | 2020-01-01 02:30:00 |
+      | @Session_User1_2       | t_user_1_session_2_expired     | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_User1_2       | t_user_1_session_2_old         | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+      | @Session_User1_2       | t_user_1_session_2_most_recent | 2020-01-01 00:30:00 | 2020-01-01 02:30:00 |
+      | @Session_UserUntouched | t_user_untouched_expired       | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 |
+      | @Session_UserUntouched | t_user_untouched               | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
+    And the application config is:
+      """
+      auth:
+        loginModuleURL: "https://login.algorea.org"
+        clientID: "1"
+        clientSecret: "tzxsLyFtJiGnmD6sjZMqSEidVpVsL3hEoSxIXCpI"
+      """
+
+  Scenario: Should return the most recent access token if the one used to refresh isn't the most recent one, along with the right expiration time
+    When the "Authorization" request header is "Bearer t_user_1_session_1_old"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 201
+    # expires_in is 5400 seconds = 1h30
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "t_user_1_session_1_most_recent",
+          "expires_in": 5400
+        }
+      }
+      """

--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -120,6 +120,8 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 	// check that the service timeouts if the user is locked for too long
 	mutexChannel = make(chan bool, 1)
 	(*sync.Map)(&sessionIDsInProgress).Store(auth.MockCtxSessionID, mutexChannel) // lock the session
+	// Remove the mutex once we're finished, otherwise it makes further tests block if they use the same session ID.
+	defer (*sync.Map)(&sessionIDsInProgress).Delete(auth.MockCtxSessionID)
 	mutexChannel <- true
 	go doRequest(true)
 	<-done // wait until the service finishes

--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -1,13 +1,14 @@
 package auth
 
 import (
-	"github.com/France-ioi/AlgoreaBackend/app/auth"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"sync"
 	"testing"
+
+	"github.com/France-ioi/AlgoreaBackend/app/auth"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-chi/chi"

--- a/app/auth/mocks.go
+++ b/app/auth/mocks.go
@@ -7,6 +7,8 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/database"
 )
 
+const MockCtxSessionID = int64(1)
+
 // MockUserMiddleware is a middleware to be used to mock a fixed user in the context.
 func MockUserMiddleware(user *database.User) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -14,7 +16,7 @@ func MockUserMiddleware(user *database.User) func(next http.Handler) http.Handle
 			ctx := context.WithValue(r.Context(), ctxBearer, "accesstoken")
 			ctx = context.WithValue(ctx, ctxSessionCookieAttributes, &SessionCookieAttributes{})
 			ctx = context.WithValue(ctx, ctxUser, user)
-			ctx = context.WithValue(ctx, ctxSessionID, int64(1))
+			ctx = context.WithValue(ctx, ctxSessionID, MockCtxSessionID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/app/database/access_token_store.go
+++ b/app/database/access_token_store.go
@@ -17,20 +17,29 @@ func (s *AccessTokenStore) InsertNewToken(sessionID int64, token string, seconds
 	})
 }
 
-// GetMostRecentValidTokenForSession returns the most recent valid token for the given sessionID.
-func (s *AccessTokenStore) GetMostRecentValidTokenForSession(sessionID int64) (token string, secondsUntilExpiry int32) {
-	var resultRow struct {
-		Token              string
-		SecondsUntilExpiry int32
-	}
+// MostRecentToken represents the most recent token for a session.
+type MostRecentToken struct {
+	Token              string
+	SecondsUntilExpiry int32
+	TooNewToRefresh    bool
+}
 
-	err := s.Select(`token, TIMESTAMPDIFF(SECOND, NOW(), expires_at) AS seconds_until_expiry`).
+// GetMostRecentValidTokenForSession returns the most recent valid token for the given sessionID.
+func (s *AccessTokenStore) GetMostRecentValidTokenForSession(sessionID int64) MostRecentToken {
+	var mostRecentToken MostRecentToken
+
+	// A token is considered too new to refresh if it was issued less than 5 minutes ago.
+	err := s.Select(`
+			token,
+			TIMESTAMPDIFF(SECOND, NOW(), expires_at) AS seconds_until_expiry,
+			issued_at > (NOW() - INTERVAL 5 MINUTE) AS too_new_to_refresh
+		`).
 		Where("session_id = ?", sessionID).
 		Order("expires_at DESC").
 		Limit(1).
-		Scan(&resultRow).
+		Scan(&mostRecentToken).
 		Error()
 	mustNotBeError(err)
 
-	return resultRow.Token, resultRow.SecondsUntilExpiry
+	return mostRecentToken
 }

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -69,6 +69,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^there is no thread with "([^"]*)"$`, ctx.ThereIsNoThreadWith)
 	s.Step(`^I am part of the helper group of the thread$`, ctx.IAmPartOfTheHelperGroupOfTheThread)
 
+	s.Step(`^there are the following sessions:$`, ctx.ThereAreTheFollowingSessions)
+	s.Step(`^there are the following access tokens:$`, ctx.ThereAreTheFollowingAccessTokens)
+
 	s.Step(`^the "([^"]*)" request header is "(.*)"$`, ctx.TheRequestHeaderIs)
 	s.Step(`^I send a (GET|POST|PUT|DELETE) request to "([^"]*)"$`, ctx.ISendrequestTo)
 	s.Step(`^I send a (GET|POST|PUT|DELETE) request to "([^"]*)" with the following body:$`, ctx.ISendrequestToWithBody)


### PR DESCRIPTION
Related to #1022 

This PR includes two changes:

1. When we call the service to refresh with a token that is **not** the most recent one for the session, we return the most recent one, with its expiration time
2. When we call the service to refresh with a token that is **the most recent** one, and if it has been issued **less than 5 minutes ago**, we just return the current token without refreshing, with the expiration time
3. (actual refresh) When we call the service to refresh with a token that is **the most recent one**, and if it as been issued **more than 5 minutes ago**, we refresh the token


- Added a new *.feature file for the new behavior that uses the new testing system
- The new testing system now handles sessions and access tokens
- Updated the older tests. The times have been updated to make it easier to read, and to make the old tests compliant with the new behaviors.
- Updated the service swagger doc

Easier to read commit by commit, with the details in commit descriptions.

## The lock `userID` have been changed to be on `sessionID`

There was a lock on `userID` to prevent multiple refresh concurrently. It was modified to be on the `sessionID` instead, because we don't want to have a lock waiting on one device because we coincidentally have a refresh on another device for the same user.

I had a bug with it (two last commits), because a test was using the lock manually without clearing it, a another test was blocked because it uses the same `sessionID`. It's weird to use the lock manually instead of using the implementation function `withLock`, which would have cleaned it automatically. Anyway, the test was updated to clear the lock, to fix the bug.