### PR TITLE
CircleCI: Increase `no_output_timeout` of tests execution to 30min.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
       - run:
           when: on_fail
           name: On failure, run BDD tests with details
+          no_output_timeout: 30m
           command: make test-bdd
   migration-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
             go install github.com/jstemmer/go-junit-report
       - run:
           name: Run tests (make verbosity disabled)
+          no_output_timeout: 30m
           command: NOECHO=1 make test 2>&1 | go-junit-report > test-results/junit.xml
       - run:
           name: Upload test coverage results to Codecov


### PR DESCRIPTION
The default value was 10 min.

Currently, the whole test suite takes, sometimes ~7.5min to execute, and sometimes > 13min. In the second case, it fails with an error on circleci: `Too long with no output (exceeded 10m0s): context deadline exceeded`.

I'm not sure yet why we have those different times.

See https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded

