### PR TITLE
createAccessTokenToken: Limit number of session at 10 / users to avoid session spamming

### DIFF
--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -42,6 +42,11 @@ const parsedRequestData ctxKey = iota
 //				on launch whether the user is logged or not.
 //				If the user is not already logged, a temporary user is created.
 //
+//
+//		To avoid the spamming of the sessions table with session creation, we store a maximum of 10 sessions per user.
+//		When we reach this limit, we delete the oldest session of the user.
+//
+//
 //		The `{code}` parameter is an output of the login-module after a successful login.
 //
 //		* If the `{code}` is given and the "Authorization" header is not given.
@@ -272,6 +277,9 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) se
 			token.AccessToken,
 			int32(time.Until(token.Expiry)/time.Second),
 		))
+
+		// Delete the oldest sessions of the user to keep a maximum of 10 sessions.
+		store.Sessions().DeleteOldSessionsToKeepMaximum(userID, 10)
 
 		return nil
 	}))

--- a/app/api/auth/create_access_token_avoid_session_spamming.feature
+++ b/app/api/auth/create_access_token_avoid_session_spamming.feature
@@ -16,80 +16,99 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
     And the DB time now is "2020-01-01 01:00:00"
     # login_id is used to match with the "id" returned by the login module
     And there are the following users:
-      | user                | login_id |
-      | @UserWith11Sessions | 11       |
-      | @UserWith10Sessions | 10       |
-      | @UserWith9Sessions  | 9        |
+      | user                  | login_id |
+      | @UserWith11Sessions   | 11       |
+      | @UserWith10Sessions   | 10       |
+      | @UserWith10Sessions_2 | 102      |
+      | @UserWith9Sessions    | 9        |
     And there are the following groups:
-      | group      | members                                                    |
-      | @AllUsers  | @UserWith9Sessions,@UserWith10Sessions,@UserWith11Sessions |
-      | @TempUsers |                                                            |
+      | group      | members                                                                          |
+      | @AllUsers  | @UserWith9Sessions,@UserWith10Sessions,@UserWith10Sessions_2,@UserWith11Sessions |
+      | @TempUsers |                                                                                  |
     And there are the following sessions:
-      | session                        | user                | refresh_token         |
-      | @Session_UserWith11Sessions_1  | @UserWith11Sessions | rt_user_11_session_1  | # shouldn't be deleted because it's the newest one
-      | @Session_UserWith11Sessions_2  | @UserWith11Sessions | rt_user_11_session_2  | # should be deleted
-      | @Session_UserWith11Sessions_3  | @UserWith11Sessions | rt_user_11_session_3  | # should be deleted
-      | @Session_UserWith11Sessions_4  | @UserWith11Sessions | rt_user_11_session_4  |
-      | @Session_UserWith11Sessions_5  | @UserWith11Sessions | rt_user_11_session_5  |
-      | @Session_UserWith11Sessions_6  | @UserWith11Sessions | rt_user_11_session_6  |
-      | @Session_UserWith11Sessions_7  | @UserWith11Sessions | rt_user_11_session_7  |
-      | @Session_UserWith11Sessions_8  | @UserWith11Sessions | rt_user_11_session_8  |
-      | @Session_UserWith11Sessions_9  | @UserWith11Sessions | rt_user_11_session_9  |
-      | @Session_UserWith11Sessions_10 | @UserWith11Sessions | rt_user_11_session_10 |
-      | @Session_UserWith11Sessions_11 | @UserWith11Sessions | rt_user_11_session_11 |
-      | @Session_UserWith10Sessions_1  | @UserWith10Sessions | rt_user_10_session_1  | # should be deleted
-      | @Session_UserWith10Sessions_2  | @UserWith10Sessions | rt_user_10_session_2  |
-      | @Session_UserWith10Sessions_3  | @UserWith10Sessions | rt_user_10_session_3  |
-      | @Session_UserWith10Sessions_4  | @UserWith10Sessions | rt_user_10_session_4  |
-      | @Session_UserWith10Sessions_5  | @UserWith10Sessions | rt_user_10_session_5  |
-      | @Session_UserWith10Sessions_6  | @UserWith10Sessions | rt_user_10_session_6  |
-      | @Session_UserWith10Sessions_7  | @UserWith10Sessions | rt_user_10_session_7  |
-      | @Session_UserWith10Sessions_8  | @UserWith10Sessions | rt_user_10_session_8  |
-      | @Session_UserWith10Sessions_9  | @UserWith10Sessions | rt_user_10_session_9  |
-      | @Session_UserWith10Sessions_10 | @UserWith10Sessions | rt_user_10_session_10 |
-      | @Session_UserWith9Sessions_1   | @UserWith9Sessions  | rt_user_9_session_1   |
-      | @Session_UserWith9Sessions_2   | @UserWith9Sessions  | rt_user_9_session_2   |
-      | @Session_UserWith9Sessions_3   | @UserWith9Sessions  | rt_user_9_session_3   |
-      | @Session_UserWith9Sessions_4   | @UserWith9Sessions  | rt_user_9_session_4   |
-      | @Session_UserWith9Sessions_5   | @UserWith9Sessions  | rt_user_9_session_5   |
-      | @Session_UserWith9Sessions_6   | @UserWith9Sessions  | rt_user_9_session_6   |
-      | @Session_UserWith9Sessions_7   | @UserWith9Sessions  | rt_user_9_session_7   |
-      | @Session_UserWith9Sessions_8   | @UserWith9Sessions  | rt_user_9_session_8   |
-      | @Session_UserWith9Sessions_9   | @UserWith9Sessions  | rt_user_9_session_9   |
+      | session                          | user                  | refresh_token           |
+      | @Session_UserWith11Sessions_1    | @UserWith11Sessions   | rt_user_11_session_1    | # shouldn't be deleted because it's the newest one
+      | @Session_UserWith11Sessions_2    | @UserWith11Sessions   | rt_user_11_session_2    | # should be deleted
+      | @Session_UserWith11Sessions_3    | @UserWith11Sessions   | rt_user_11_session_3    | # should be deleted
+      | @Session_UserWith11Sessions_4    | @UserWith11Sessions   | rt_user_11_session_4    |
+      | @Session_UserWith11Sessions_5    | @UserWith11Sessions   | rt_user_11_session_5    |
+      | @Session_UserWith11Sessions_6    | @UserWith11Sessions   | rt_user_11_session_6    |
+      | @Session_UserWith11Sessions_7    | @UserWith11Sessions   | rt_user_11_session_7    |
+      | @Session_UserWith11Sessions_8    | @UserWith11Sessions   | rt_user_11_session_8    |
+      | @Session_UserWith11Sessions_9    | @UserWith11Sessions   | rt_user_11_session_9    |
+      | @Session_UserWith11Sessions_10   | @UserWith11Sessions   | rt_user_11_session_10   |
+      | @Session_UserWith11Sessions_11   | @UserWith11Sessions   | rt_user_11_session_11   |
+      | @Session_UserWith10Sessions_1    | @UserWith10Sessions   | rt_user_10_session_1    | # should be deleted
+      | @Session_UserWith10Sessions_2    | @UserWith10Sessions   | rt_user_10_session_2    |
+      | @Session_UserWith10Sessions_3    | @UserWith10Sessions   | rt_user_10_session_3    |
+      | @Session_UserWith10Sessions_4    | @UserWith10Sessions   | rt_user_10_session_4    |
+      | @Session_UserWith10Sessions_5    | @UserWith10Sessions   | rt_user_10_session_5    |
+      | @Session_UserWith10Sessions_6    | @UserWith10Sessions   | rt_user_10_session_6    |
+      | @Session_UserWith10Sessions_7    | @UserWith10Sessions   | rt_user_10_session_7    |
+      | @Session_UserWith10Sessions_8    | @UserWith10Sessions   | rt_user_10_session_8    |
+      | @Session_UserWith10Sessions_9    | @UserWith10Sessions   | rt_user_10_session_9    |
+      | @Session_UserWith10Sessions_10   | @UserWith10Sessions   | rt_user_10_session_10   |
+      | @Session_UserWith10Sessions_2_1  | @UserWith10Sessions_2 | rt_user_10_session_2_1  | # without access token, should be deleted
+      | @Session_UserWith10Sessions_2_2  | @UserWith10Sessions_2 | rt_user_10_session_2_2  |
+      | @Session_UserWith10Sessions_2_3  | @UserWith10Sessions_2 | rt_user_10_session_2_3  |
+      | @Session_UserWith10Sessions_2_4  | @UserWith10Sessions_2 | rt_user_10_session_2_4  |
+      | @Session_UserWith10Sessions_2_5  | @UserWith10Sessions_2 | rt_user_10_session_2_5  |
+      | @Session_UserWith10Sessions_2_6  | @UserWith10Sessions_2 | rt_user_10_session_2_6  |
+      | @Session_UserWith10Sessions_2_7  | @UserWith10Sessions_2 | rt_user_10_session_2_7  |
+      | @Session_UserWith10Sessions_2_8  | @UserWith10Sessions_2 | rt_user_10_session_2_8  |
+      | @Session_UserWith10Sessions_2_9  | @UserWith10Sessions_2 | rt_user_10_session_2_9  |
+      | @Session_UserWith10Sessions_2_10 | @UserWith10Sessions_2 | rt_user_10_session_2_10 |
+      | @Session_UserWith9Sessions_1     | @UserWith9Sessions    | rt_user_9_session_1     |
+      | @Session_UserWith9Sessions_2     | @UserWith9Sessions    | rt_user_9_session_2     |
+      | @Session_UserWith9Sessions_3     | @UserWith9Sessions    | rt_user_9_session_3     |
+      | @Session_UserWith9Sessions_4     | @UserWith9Sessions    | rt_user_9_session_4     |
+      | @Session_UserWith9Sessions_5     | @UserWith9Sessions    | rt_user_9_session_5     |
+      | @Session_UserWith9Sessions_6     | @UserWith9Sessions    | rt_user_9_session_6     |
+      | @Session_UserWith9Sessions_7     | @UserWith9Sessions    | rt_user_9_session_7     |
+      | @Session_UserWith9Sessions_8     | @UserWith9Sessions    | rt_user_9_session_8     |
+      | @Session_UserWith9Sessions_9     | @UserWith9Sessions    | rt_user_9_session_9     |
     And there are the following access tokens:
-      | session                        | token                  | issued_at           | expires_at          |
-      | @Session_UserWith11Sessions_1  | rt_user_11_session_1a  | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # has a more recent issued_at, shouldn't be deleted
-      | @Session_UserWith11Sessions_1  | rt_user_11_session_1b  | 2020-01-01 00:01:01 | 2020-01-01 02:01:01 | # newest one
-      | @Session_UserWith11Sessions_2  | rt_user_11_session_2   | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 | # oldest
-      | @Session_UserWith11Sessions_3  | rt_user_11_session_3   | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 | #second oldest, should be deleted
-      | @Session_UserWith11Sessions_4  | rt_user_11_session_4   | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
-      | @Session_UserWith11Sessions_5  | rt_user_11_session_5   | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
-      | @Session_UserWith11Sessions_6  | rt_user_11_session_6   | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
-      | @Session_UserWith11Sessions_7  | rt_user_11_session_7   | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
-      | @Session_UserWith11Sessions_8  | rt_user_11_session_8   | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
-      | @Session_UserWith11Sessions_9  | rt_user_11_session_9   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
-      | @Session_UserWith11Sessions_10 | rt_user_11_session_10  | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
-      | @Session_UserWith11Sessions_11 | rt_user_11_session_11  | 2020-01-01 00:00:11 | 2020-01-01 02:00:11 |
-      | @Session_UserWith10Sessions_1  | rt_user_10_session_1   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # oldest one
-      | @Session_UserWith10Sessions_2  | rt_user_10_session_2   | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 |
-      | @Session_UserWith10Sessions_3  | rt_user_10_session_3   | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
-      | @Session_UserWith10Sessions_4  | rt_user_10_session_4   | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
-      | @Session_UserWith10Sessions_5  | rt_user_10_session_5   | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
-      | @Session_UserWith10Sessions_6  | rt_user_10_session_6   | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
-      | @Session_UserWith10Sessions_7  | rt_user_10_session_7   | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
-      | @Session_UserWith10Sessions_8  | rt_user_10_session_8   | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
-      | @Session_UserWith10Sessions_9  | rt_user_10_session_9   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
-      | @Session_UserWith10Sessions_10 | rt_user_10_session_10a | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
-      | @Session_UserWith10Sessions_10 | rt_user_10_session_10b | 2020-01-01 00:01:10 | 2020-01-01 02:01:10 |
-      | @Session_UserWith9Sessions_1   | rt_user_9_session_1a   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 |
-      | @Session_UserWith9Sessions_3   | rt_user_9_session_3    | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
-      | @Session_UserWith9Sessions_4   | rt_user_9_session_4    | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
-      | @Session_UserWith9Sessions_5   | rt_user_9_session_5    | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
-      | @Session_UserWith9Sessions_6   | rt_user_9_session_6    | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
-      | @Session_UserWith9Sessions_7   | rt_user_9_session_7    | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
-      | @Session_UserWith9Sessions_8   | rt_user_9_session_8    | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
-      | @Session_UserWith9Sessions_9   | rt_user_9_session_9a   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
-      | @Session_UserWith9Sessions_9   | rt_user_9_session_9b   | 2020-01-01 00:01:09 | 2020-01-01 02:01:09 | # verify we count the number of sessions and not access tokens.
+      | session                          | token                    | issued_at           | expires_at          |
+      | @Session_UserWith11Sessions_1    | rt_user_11_session_1a    | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # has a more recent issued_at, shouldn't be deleted
+      | @Session_UserWith11Sessions_1    | rt_user_11_session_1b    | 2020-01-01 00:01:01 | 2020-01-01 02:01:01 | # newest one
+      | @Session_UserWith11Sessions_2    | rt_user_11_session_2     | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 | # oldest
+      | @Session_UserWith11Sessions_3    | rt_user_11_session_3     | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 | #second oldest, should be deleted
+      | @Session_UserWith11Sessions_4    | rt_user_11_session_4     | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith11Sessions_5    | rt_user_11_session_5     | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith11Sessions_6    | rt_user_11_session_6     | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith11Sessions_7    | rt_user_11_session_7     | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith11Sessions_8    | rt_user_11_session_8     | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith11Sessions_9    | rt_user_11_session_9     | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith11Sessions_10   | rt_user_11_session_10    | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
+      | @Session_UserWith11Sessions_11   | rt_user_11_session_11    | 2020-01-01 00:00:11 | 2020-01-01 02:00:11 |
+      | @Session_UserWith10Sessions_1    | rt_user_10_session_1     | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # oldest one
+      | @Session_UserWith10Sessions_2    | rt_user_10_session_2     | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 |
+      | @Session_UserWith10Sessions_3    | rt_user_10_session_3     | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
+      | @Session_UserWith10Sessions_4    | rt_user_10_session_4     | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith10Sessions_5    | rt_user_10_session_5     | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith10Sessions_6    | rt_user_10_session_6     | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith10Sessions_7    | rt_user_10_session_7     | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith10Sessions_8    | rt_user_10_session_8     | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith10Sessions_9    | rt_user_10_session_9     | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith10Sessions_10   | rt_user_10_session_10a   | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
+      | @Session_UserWith10Sessions_2_2  | rt_user_10_session_2_2   | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 |
+      | @Session_UserWith10Sessions_2_3  | rt_user_10_session_2_3   | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
+      | @Session_UserWith10Sessions_2_4  | rt_user_10_session_2_4   | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith10Sessions_2_5  | rt_user_10_session_2_5   | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith10Sessions_2_6  | rt_user_10_session_2_6   | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith10Sessions_2_7  | rt_user_10_session_2_7   | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith10Sessions_2_8  | rt_user_10_session_2_8   | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith10Sessions_2_9  | rt_user_10_session_2_9   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith10Sessions_2_10 | rt_user_10_session_2_10a | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
+      | @Session_UserWith9Sessions_1     | rt_user_9_session_1a     | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 |
+      | @Session_UserWith9Sessions_3     | rt_user_9_session_3      | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
+      | @Session_UserWith9Sessions_4     | rt_user_9_session_4      | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith9Sessions_5     | rt_user_9_session_5      | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith9Sessions_6     | rt_user_9_session_6      | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith9Sessions_7     | rt_user_9_session_7      | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith9Sessions_8     | rt_user_9_session_8      | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith9Sessions_9     | rt_user_9_session_9a     | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith9Sessions_9     | rt_user_9_session_9b     | 2020-01-01 00:01:09 | 2020-01-01 02:01:09 | # verify we count the number of sessions and not access tokens.
 
   Scenario: Should just add the new session when the user have 9 sessions
     Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
@@ -180,7 +199,52 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
     And there are 10 sessions for user @UserWith10Sessions
     And there is no session @Session_UserWith10Sessions_1
 
-  Scenario: Should add the new session and delete the oldest one when the user have 10 sessions
+  Scenario: Should add the new session and delete the one without access token when the user have 10 sessions
+    Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
+      """
+      {
+        "token_type": "Bearer",
+        "expires_in": 31622420,
+        "access_token": "access_token_from_oauth",
+        "refresh_token": "refresh_token_from_oauth"
+      }
+      """
+    And the login module "account" endpoint for token "access_token_from_oauth" returns 200 with body:
+      """
+      {
+        "id":102, "login":"login","login_updated_at":null,"login_fixed":0,
+        "login_revalidate_required":0,"login_change_required":0,"language":null,"first_name":null,
+        "last_name":null,"real_name_visible":false,"timezone":null,"country_code":null,
+        "address":null,"city":null,"zipcode":null,"primary_phone":null,"secondary_phone":null,
+        "role":null,"school_grade":null,"student_id":null,"ministry_of_education":null,
+        "ministry_of_education_fr":false,"birthday":null,"presentation":null,
+        "website":null,"ip":null,"picture":null,
+        "gender":null,"graduation_year":null,"graduation_grade_expire_at":null,
+        "graduation_grade":null,"created_at":null,"last_login":null,
+        "logout_config":null,"last_password_recovery_at":null,"merge_group_id":null,
+        "origin_instance_id":null,"creator_client_id":null,"nationality":null,
+        "primary_email":null,"secondary_email":null,
+        "primary_email_verified":null,"secondary_email_verified":null,"has_picture":false,
+        "badges":null,"client_id":null,"verification":null,"subscription_news":false
+      }
+      """
+    When I send a POST request to "/auth/token?code=codefromauth"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "access_token_from_oauth",
+          "expires_in": 31622420
+        }
+      }
+      """
+    And there are 10 sessions for user @UserWith10Sessions_2
+    And there is no session @Session_UserWith10Sessions_2_1
+
+  Scenario: Should add the new session and delete the oldest one when the user have 11 sessions
     Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
       """
       {

--- a/app/api/auth/create_access_token_avoid_session_spamming.feature
+++ b/app/api/auth/create_access_token_avoid_session_spamming.feature
@@ -1,0 +1,227 @@
+Feature: To avoid session creation spamming, we allow a maximum of 10 sessions per user
+  Background:
+    Given the application config is:
+      """
+      auth:
+        loginModuleURL: "https://login.algorea.org"
+        clientID: "1"
+        clientSecret: "tzxsLyFtJiGnmD6sjZMqSEidVpVsL3hEoSxIXCpI"
+      domains:
+        -
+          domains: [127.0.0.1]
+          allUsersGroup: @AllUsers
+          TempUsersGroup: @TempUsers
+      """
+    And the time now is "2020-01-01T01:00:00Z"
+    And the DB time now is "2020-01-01 01:00:00"
+    # login_id is used to match with the "id" returned by the login module
+    And there are the following users:
+      | user                | login_id |
+      | @UserWith11Sessions | 11       |
+      | @UserWith10Sessions | 10       |
+      | @UserWith9Sessions  | 9        |
+    And there are the following groups:
+      | group      | members                                                    |
+      | @AllUsers  | @UserWith9Sessions,@UserWith10Sessions,@UserWith11Sessions |
+      | @TempUsers |                                                            |
+    And there are the following sessions:
+      | session                        | user                | refresh_token         |
+      | @Session_UserWith11Sessions_1  | @UserWith11Sessions | rt_user_11_session_1  | # shouldn't be deleted because it's the newest one
+      | @Session_UserWith11Sessions_2  | @UserWith11Sessions | rt_user_11_session_2  | # should be deleted
+      | @Session_UserWith11Sessions_3  | @UserWith11Sessions | rt_user_11_session_3  | # should be deleted
+      | @Session_UserWith11Sessions_4  | @UserWith11Sessions | rt_user_11_session_4  |
+      | @Session_UserWith11Sessions_5  | @UserWith11Sessions | rt_user_11_session_5  |
+      | @Session_UserWith11Sessions_6  | @UserWith11Sessions | rt_user_11_session_6  |
+      | @Session_UserWith11Sessions_7  | @UserWith11Sessions | rt_user_11_session_7  |
+      | @Session_UserWith11Sessions_8  | @UserWith11Sessions | rt_user_11_session_8  |
+      | @Session_UserWith11Sessions_9  | @UserWith11Sessions | rt_user_11_session_9  |
+      | @Session_UserWith11Sessions_10 | @UserWith11Sessions | rt_user_11_session_10 |
+      | @Session_UserWith11Sessions_11 | @UserWith11Sessions | rt_user_11_session_11 |
+      | @Session_UserWith10Sessions_1  | @UserWith10Sessions | rt_user_10_session_1  | # should be deleted
+      | @Session_UserWith10Sessions_2  | @UserWith10Sessions | rt_user_10_session_2  |
+      | @Session_UserWith10Sessions_3  | @UserWith10Sessions | rt_user_10_session_3  |
+      | @Session_UserWith10Sessions_4  | @UserWith10Sessions | rt_user_10_session_4  |
+      | @Session_UserWith10Sessions_5  | @UserWith10Sessions | rt_user_10_session_5  |
+      | @Session_UserWith10Sessions_6  | @UserWith10Sessions | rt_user_10_session_6  |
+      | @Session_UserWith10Sessions_7  | @UserWith10Sessions | rt_user_10_session_7  |
+      | @Session_UserWith10Sessions_8  | @UserWith10Sessions | rt_user_10_session_8  |
+      | @Session_UserWith10Sessions_9  | @UserWith10Sessions | rt_user_10_session_9  |
+      | @Session_UserWith10Sessions_10 | @UserWith10Sessions | rt_user_10_session_10 |
+      | @Session_UserWith9Sessions_1   | @UserWith9Sessions  | rt_user_9_session_1   |
+      | @Session_UserWith9Sessions_2   | @UserWith9Sessions  | rt_user_9_session_2   |
+      | @Session_UserWith9Sessions_3   | @UserWith9Sessions  | rt_user_9_session_3   |
+      | @Session_UserWith9Sessions_4   | @UserWith9Sessions  | rt_user_9_session_4   |
+      | @Session_UserWith9Sessions_5   | @UserWith9Sessions  | rt_user_9_session_5   |
+      | @Session_UserWith9Sessions_6   | @UserWith9Sessions  | rt_user_9_session_6   |
+      | @Session_UserWith9Sessions_7   | @UserWith9Sessions  | rt_user_9_session_7   |
+      | @Session_UserWith9Sessions_8   | @UserWith9Sessions  | rt_user_9_session_8   |
+      | @Session_UserWith9Sessions_9   | @UserWith9Sessions  | rt_user_9_session_9   |
+    And there are the following access tokens:
+      | session                        | token                  | issued_at           | expires_at          |
+      | @Session_UserWith11Sessions_1  | rt_user_11_session_1a  | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # has a more recent issued_at, shouldn't be deleted
+      | @Session_UserWith11Sessions_1  | rt_user_11_session_1b  | 2020-01-01 00:01:01 | 2020-01-01 02:01:01 | # newest one
+      | @Session_UserWith11Sessions_2  | rt_user_11_session_2   | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 | # oldest
+      | @Session_UserWith11Sessions_3  | rt_user_11_session_3   | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 | #second oldest, should be deleted
+      | @Session_UserWith11Sessions_4  | rt_user_11_session_4   | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith11Sessions_5  | rt_user_11_session_5   | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith11Sessions_6  | rt_user_11_session_6   | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith11Sessions_7  | rt_user_11_session_7   | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith11Sessions_8  | rt_user_11_session_8   | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith11Sessions_9  | rt_user_11_session_9   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith11Sessions_10 | rt_user_11_session_10  | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
+      | @Session_UserWith11Sessions_11 | rt_user_11_session_11  | 2020-01-01 00:00:11 | 2020-01-01 02:00:11 |
+      | @Session_UserWith10Sessions_1  | rt_user_10_session_1   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | # oldest one
+      | @Session_UserWith10Sessions_2  | rt_user_10_session_2   | 2020-01-01 00:00:02 | 2020-01-01 02:00:02 |
+      | @Session_UserWith10Sessions_3  | rt_user_10_session_3   | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
+      | @Session_UserWith10Sessions_4  | rt_user_10_session_4   | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith10Sessions_5  | rt_user_10_session_5   | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith10Sessions_6  | rt_user_10_session_6   | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith10Sessions_7  | rt_user_10_session_7   | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith10Sessions_8  | rt_user_10_session_8   | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith10Sessions_9  | rt_user_10_session_9   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith10Sessions_10 | rt_user_10_session_10a | 2020-01-01 00:00:10 | 2020-01-01 02:00:10 |
+      | @Session_UserWith10Sessions_10 | rt_user_10_session_10b | 2020-01-01 00:01:10 | 2020-01-01 02:01:10 |
+      | @Session_UserWith9Sessions_1   | rt_user_9_session_1a   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 |
+      | @Session_UserWith9Sessions_3   | rt_user_9_session_3    | 2020-01-01 00:00:03 | 2020-01-01 02:00:03 |
+      | @Session_UserWith9Sessions_4   | rt_user_9_session_4    | 2020-01-01 00:00:04 | 2020-01-01 02:00:04 |
+      | @Session_UserWith9Sessions_5   | rt_user_9_session_5    | 2020-01-01 00:00:05 | 2020-01-01 02:00:05 |
+      | @Session_UserWith9Sessions_6   | rt_user_9_session_6    | 2020-01-01 00:00:06 | 2020-01-01 02:00:06 |
+      | @Session_UserWith9Sessions_7   | rt_user_9_session_7    | 2020-01-01 00:00:07 | 2020-01-01 02:00:07 |
+      | @Session_UserWith9Sessions_8   | rt_user_9_session_8    | 2020-01-01 00:00:08 | 2020-01-01 02:00:08 |
+      | @Session_UserWith9Sessions_9   | rt_user_9_session_9a   | 2020-01-01 00:00:09 | 2020-01-01 02:00:09 |
+      | @Session_UserWith9Sessions_9   | rt_user_9_session_9b   | 2020-01-01 00:01:09 | 2020-01-01 02:01:09 | # verify we count the number of sessions and not access tokens.
+
+  Scenario: Should just add the new session when the user have 9 sessions
+    Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
+      """
+      {
+        "token_type": "Bearer",
+        "expires_in": 31622420,
+        "access_token": "access_token_from_oauth",
+        "refresh_token": "refresh_token_from_oauth"
+      }
+      """
+    And the login module "account" endpoint for token "access_token_from_oauth" returns 200 with body:
+      """
+      {
+        "id":9, "login":"login","login_updated_at":null,"login_fixed":0,
+        "login_revalidate_required":0,"login_change_required":0,"language":null,"first_name":null,
+        "last_name":null,"real_name_visible":false,"timezone":null,"country_code":null,
+        "address":null,"city":null,"zipcode":null,"primary_phone":null,"secondary_phone":null,
+        "role":null,"school_grade":null,"student_id":null,"ministry_of_education":null,
+        "ministry_of_education_fr":false,"birthday":null,"presentation":null,
+        "website":null,"ip":null,"picture":null,
+        "gender":null,"graduation_year":null,"graduation_grade_expire_at":null,
+        "graduation_grade":null,"created_at":null,"last_login":null,
+        "logout_config":null,"last_password_recovery_at":null,"merge_group_id":null,
+        "origin_instance_id":null,"creator_client_id":null,"nationality":null,
+        "primary_email":null,"secondary_email":null,
+        "primary_email_verified":null,"secondary_email_verified":null,"has_picture":false,
+        "badges":null,"client_id":null,"verification":null,"subscription_news":false
+      }
+      """
+    When I send a POST request to "/auth/token?code=codefromauth"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "access_token_from_oauth",
+          "expires_in": 31622420
+        }
+      }
+      """
+    And there are 10 sessions for user @UserWith9Sessions
+
+  Scenario: Should add the new session and delete the oldest one when the user have 10 sessions
+    Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
+      """
+      {
+        "token_type": "Bearer",
+        "expires_in": 31622420,
+        "access_token": "access_token_from_oauth",
+        "refresh_token": "refresh_token_from_oauth"
+      }
+      """
+    And the login module "account" endpoint for token "access_token_from_oauth" returns 200 with body:
+      """
+      {
+        "id":10, "login":"login","login_updated_at":null,"login_fixed":0,
+        "login_revalidate_required":0,"login_change_required":0,"language":null,"first_name":null,
+        "last_name":null,"real_name_visible":false,"timezone":null,"country_code":null,
+        "address":null,"city":null,"zipcode":null,"primary_phone":null,"secondary_phone":null,
+        "role":null,"school_grade":null,"student_id":null,"ministry_of_education":null,
+        "ministry_of_education_fr":false,"birthday":null,"presentation":null,
+        "website":null,"ip":null,"picture":null,
+        "gender":null,"graduation_year":null,"graduation_grade_expire_at":null,
+        "graduation_grade":null,"created_at":null,"last_login":null,
+        "logout_config":null,"last_password_recovery_at":null,"merge_group_id":null,
+        "origin_instance_id":null,"creator_client_id":null,"nationality":null,
+        "primary_email":null,"secondary_email":null,
+        "primary_email_verified":null,"secondary_email_verified":null,"has_picture":false,
+        "badges":null,"client_id":null,"verification":null,"subscription_news":false
+      }
+      """
+    When I send a POST request to "/auth/token?code=codefromauth"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "access_token_from_oauth",
+          "expires_in": 31622420
+        }
+      }
+      """
+    And there are 10 sessions for user @UserWith10Sessions
+    And there is no session @Session_UserWith10Sessions_1
+
+  Scenario: Should add the new session and delete the oldest one when the user have 10 sessions
+    Given  the login module "token" endpoint for code "codefromauth" returns 200 with body:
+      """
+      {
+        "token_type": "Bearer",
+        "expires_in": 31622420,
+        "access_token": "access_token_from_oauth",
+        "refresh_token": "refresh_token_from_oauth"
+      }
+      """
+    And the login module "account" endpoint for token "access_token_from_oauth" returns 200 with body:
+      """
+      {
+        "id":11, "login":"login","login_updated_at":null,"login_fixed":0,
+        "login_revalidate_required":0,"login_change_required":0,"language":null,"first_name":null,
+        "last_name":null,"real_name_visible":false,"timezone":null,"country_code":null,
+        "address":null,"city":null,"zipcode":null,"primary_phone":null,"secondary_phone":null,
+        "role":null,"school_grade":null,"student_id":null,"ministry_of_education":null,
+        "ministry_of_education_fr":false,"birthday":null,"presentation":null,
+        "website":null,"ip":null,"picture":null,
+        "gender":null,"graduation_year":null,"graduation_grade_expire_at":null,
+        "graduation_grade":null,"created_at":null,"last_login":null,
+        "logout_config":null,"last_password_recovery_at":null,"merge_group_id":null,
+        "origin_instance_id":null,"creator_client_id":null,"nationality":null,
+        "primary_email":null,"secondary_email":null,
+        "primary_email_verified":null,"secondary_email_verified":null,"has_picture":false,
+        "badges":null,"client_id":null,"verification":null,"subscription_news":false
+      }
+      """
+    When I send a POST request to "/auth/token?code=codefromauth"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "access_token": "access_token_from_oauth",
+          "expires_in": 31622420
+        }
+      }
+      """
+    And there are 10 sessions for user @UserWith10Sessions
+    And there is no session @Session_UserWith11Sessions_2
+    And there is no session @Session_UserWith11Sessions_3

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -75,11 +75,11 @@ Feature: Create a new access token
       {
         "token_type":"Bearer",
         "expires_in":31622400,
-        "access_token":"newaccesstokenforjane",
+        "access_token":"jane_new_token",
         "refresh_token":"jane_new_refreshtoken"
       }
       """
-    And the "Authorization" request header is "Bearer jane_old_token"
+    And the "Authorization" request header is "Bearer jane_current_token"
     When I send a POST request to "/auth/token<query>"
     Then the response code should be 201
     And the response body should be, in JSON:

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -10,20 +10,20 @@ Feature: Create a new access token
       | 12       | tmp-1234567 | true      |
       | 13       | jane        | false     |
       | 14       | john        | false     |
-    And the time now is "2020-01-01T01:00:00Z"
-    And the DB time now is "2020-01-01 01:00:00"
+    And the time now is "2020-01-01T02:00:00Z"
+    And the DB time now is "2020-01-01 02:00:00"
     And the database has the following table 'sessions':
       | session_id | user_id | refresh_token             |
       | 1          | 12      |                           |
       | 2          | 13      | jane_current_refreshtoken |
       | 3          | 14      | john_current_refreshtoken |
     And the database has the following table 'access_tokens':
-      | session_id | expires_at          | token              |
-      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
-      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
-      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2          | 2020-01-01 03:00:00 | jane_current_token |
-      | 3          | 2020-01-01 03:00:00 | john_current_token |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
     And the application config is:
       """
       auth:
@@ -57,17 +57,17 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | expires_at          | token              |
-      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
-      | 3                   | 2020-01-01 03:00:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
+      | session_id          | issued_at           | expires_at          | token              |
+      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
   Examples:
     | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
     |                                  | [Header not defined]  | "access_token":"tmp_new_token", | [Header not defined]                                                                                                                                     |
-    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
-    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
+    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
+    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
+    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
 
   Scenario Outline: Request a new access token for a normal user
     Given the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
@@ -97,35 +97,26 @@ Feature: Create a new access token
       | 2          | 13      | jane_new_refreshtoken     |
       | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id | expires_at          | token              |
-      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
-      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
-      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2          | 2021-01-01 01:00:00 | jane_new_token     |
-      | 3          | 2020-01-01 03:00:00 | john_current_token |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 2          | 2020-01-01 02:00:00 | 2021-01-01 02:00:00 | jane_new_token     | # the new token
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
     Examples:
       | query                            | token_in_data                     | expected_cookie                                                                                                                                               |
       |                                  | "access_token": "jane_new_token", | [Header not defined]                                                                                                                                          |
-      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
-      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
+      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 02:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
+      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 02:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
 
   Scenario Outline: >
       Accepts access_token cookie and removes it if cookie attributes differ for a normal user,
       since old tokens are used, the most recent one is returned
     Given the database table 'access_tokens' has also the following rows:
-      | session_id | expires_at          | token                     |
-      | 2          | 2020-01-01 03:00:00 | onemoreaccesstokenforjane |
-      | 2          | 2020-01-01 03:00:00 | andmoreaccesstokenforjane |
-      | 2          | 2020-01-01 03:00:00 | moremoraccesstokenforjane |
-    And the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
-      """
-      {
-        "token_type":"Bearer",
-        "expires_in":31622400,
-        "access_token":"tmp_new_token",
-        "refresh_token":"newrefreshtoken"
-      }
-      """
+      | session_id | issued_at           | expires_at          | token           |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old1_token |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old2_token |
+      | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old3_token |
     And the "Cookie" request header is "access_token=<token_cookie>"
     When I send a POST request to "/auth/token?use_cookie=1&cookie_secure=1"
     Then the response code should be 201
@@ -140,22 +131,22 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
+        access_token=2!jane_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:50:00 GMT; Max-Age=6600; HttpOnly; Secure; SameSite=None
       """
   Examples:
-    | token_cookie                              | cookie_removal                                                                                                                 |
-    | 1!jane_old_token!!                        | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
-    | 2!onemoreaccesstokenforjane!127.0.0.1!/   |                                                                                                                                |
-    | 2!andmoreaccesstokenforjane!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
-    | 3!moremoraccesstokenforjane!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
+    | token_cookie                    | cookie_removal                                                                                                                 |
+    | 1!jane_old_token!!              | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
+    | 2!jane_old1_token!127.0.0.1!/   |                                                                                                                                |
+    | 2!jane_old2_token!!             | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
+    | 3!jane_old3_token!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a temporary user
     Given the generated auth key is "tmp_new_token"
     And the database table 'access_tokens' has also the following rows:
-      | session_id | expires_at          | token              |
-      | 1          | 2020-01-01 03:00:00 | onemoreaccesstoken |
-      | 1          | 2020-01-01 03:00:00 | andmoreaccesstoken |
-      | 1          | 2020-01-01 03:00:00 | moremoraccesstoken |
+      | session_id | issued_at           | expires_at          | token          |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old1_token |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old2_token |
+      | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old3_token |
     And the "Cookie" request header is "access_token=<token_cookie>"
     When I send a POST request to "/auth/token?use_cookie=1&cookie_secure=1"
     Then the response code should be 201
@@ -170,14 +161,14 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_current_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:12 GMT; Max-Age=3612; HttpOnly; Secure; SameSite=None
       """
     Examples:
-      | token_cookie                       | cookie_removal                                                                                                                   |
-      | 2!tmp_old_token!a.127.0.0.1!/api/  | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
-      | 2!onemoreaccesstoken!127.0.0.1!/   |                                                                                                                                  |
-      | 2!andmoreaccesstoken!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
-      | 3!moremoraccesstoken!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
+      | token_cookie                      | cookie_removal                                                                                                                   |
+      | 2!tmp_old_token!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
+      | 2!tmp_old1_token!127.0.0.1!/      |                                                                                                                                  |
+      | 2!tmp_old2_token!!                | access_token=; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
+      | 3!tmp_old3_token!a.127.0.0.1!/    | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 01:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
 
   Scenario Outline: Accepts cookie parameters from post data
     Given the generated auth key is "tmp_new_token"
@@ -207,16 +198,16 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | expires_at          | token              |
-      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
-      | 3                   | 2020-01-01 03:00:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
+      | session_id          | issued_at           | expires_at          | token              |
+      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
     Examples:
       | content-type                      | data                                                              | expected_cookie                                                                                                                                            |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
-      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -18,12 +18,12 @@ Feature: Create a new access token
       | 2          | 13      | jane_current_refreshtoken |
       | 3          | 14      | john_current_refreshtoken |
     And the database has the following table 'access_tokens':
-      | session_id | token                     | expires_at          |
-      | 1          | someaccesstoken           | 2020-01-01 01:00:01 |
-      | 1          | anotheraccesstoken        | 2020-01-02 01:00:12 |
-      | 2          | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2          | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3          | accesstokenjohn           | 2020-01-01 03:00:00 |
+      | session_id | expires_at          | token              |
+      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
+      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
+      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 03:00:00 | jane_current_token |
+      | 3          | 2020-01-01 03:00:00 | john_current_token |
     And the application config is:
       """
       auth:
@@ -57,17 +57,17 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
-      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
+      | session_id          | expires_at          | token              |
+      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
+      | 3                   | 2020-01-01 03:00:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
   Examples:
-    | query                            | current_cookie        | token_in_data                    | expected_cookie                                                                                                                                           |
-    |                                  | [Header not defined]  | "access_token":"newaccesstoken", | [Header not defined]                                                                                                                                      |
-    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                  | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
-    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                  | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
-    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"newaccesstoken", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                  |
+    | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
+    |                                  | [Header not defined]  | "access_token":"tmp_new_token", | [Header not defined]                                                                                                                                     |
+    | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
+    | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
+    | ?use_cookie=0                    | access_token=0!1234!! | "access_token":"tmp_new_token", | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=None                                                                 |
 
   Scenario Outline: Request a new access token for a normal user
     Given the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
@@ -75,11 +75,11 @@ Feature: Create a new access token
       {
         "token_type":"Bearer",
         "expires_in":31622400,
-        "access_token":"jane_new_token",
+        "access_token":"newaccesstokenforjane",
         "refresh_token":"jane_new_refreshtoken"
       }
       """
-    And the "Authorization" request header is "Bearer jane_current_token"
+    And the "Authorization" request header is "Bearer jane_old_token"
     When I send a POST request to "/auth/token<query>"
     Then the response code should be 201
     And the response body should be, in JSON:
@@ -97,17 +97,17 @@ Feature: Create a new access token
       | 2          | 13      | jane_new_refreshtoken     |
       | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id | token                 | expires_at          |
-      | 1          | anotheraccesstoken    | 2020-01-02 01:00:12 |
-      | 1          | someaccesstoken       | 2020-01-01 01:00:01 |
-      | 2          | accesstokenforjane    | 2020-01-01 01:00:01 |
-      | 2          | newaccesstokenforjane | 2021-01-01 01:00:00  |
-      | 3          | accesstokenjohn       | 2020-01-01 03:00:00 |
+      | session_id | expires_at          | token              |
+      | 1          | 2020-01-02 01:00:12 | tmp_current_token  |
+      | 1          | 2020-01-01 01:00:01 | tmp_old_token      |
+      | 2          | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2          | 2021-01-01 01:00:00 | jane_new_token     |
+      | 3          | 2020-01-01 03:00:00 | john_current_token |
     Examples:
-      | query                            | token_in_data                            | expected_cookie                                                                                                                                                      |
-      |                                  | "access_token": "newaccesstokenforjane", | [Header not defined]                                                                                                                                                 |
-      | ?use_cookie=1&cookie_secure=1    |                                          | access_token=2!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
-      | ?use_cookie=1&cookie_same_site=1 |                                          | access_token=1!newaccesstokenforjane!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
+      | query                            | token_in_data                     | expected_cookie                                                                                                                                               |
+      |                                  | "access_token": "jane_new_token", | [Header not defined]                                                                                                                                          |
+      | ?use_cookie=1&cookie_secure=1    |                                   | access_token=2!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None |
+      | ?use_cookie=1&cookie_same_site=1 |                                   | access_token=1!jane_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; SameSite=Strict       |
 
   Scenario Outline: >
       Accepts access_token cookie and removes it if cookie attributes differ for a normal user,
@@ -117,12 +117,12 @@ Feature: Create a new access token
       | 2          | 2020-01-01 03:00:00 | onemoreaccesstokenforjane |
       | 2          | 2020-01-01 03:00:00 | andmoreaccesstokenforjane |
       | 2          | 2020-01-01 03:00:00 | moremoraccesstokenforjane |
-    And the login module "token" endpoint for refresh token "refreshtokenforjane" returns 200 with body:
+    And the login module "token" endpoint for refresh token "jane_current_refreshtoken" returns 200 with body:
       """
       {
         "token_type":"Bearer",
         "expires_in":31622400,
-        "access_token":"newaccesstoken",
+        "access_token":"tmp_new_token",
         "refresh_token":"newrefreshtoken"
       }
       """
@@ -140,18 +140,16 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Fri, 01 Jan 2021 01:00:00 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
       """
   Examples:
     | token_cookie                              | cookie_removal                                                                                                                 |
-    | 1!accesstokenforjane!!                    | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
+    | 1!jane_old_token!!                        | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; SameSite=Strict                                     |
     | 2!onemoreaccesstokenforjane!127.0.0.1!/   |                                                                                                                                |
     | 2!andmoreaccesstokenforjane!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                               |
     | 3!moremoraccesstokenforjane!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict |
 
-  Scenario Outline: >
-      Accepts access_token cookie and removes it if cookie attributes differ for a temporary user.
-      Since old tokens are used, the most recent one is returned.
+  Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a temporary user
     Given the generated auth key is "tmp_new_token"
     And the database table 'access_tokens' has also the following rows:
       | session_id | expires_at          | token              |
@@ -172,14 +170,14 @@ Feature: Create a new access token
     And the response headers "Set-Cookie" should be:
       """
         <cookie_removal>
-        access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
+        access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None
       """
     Examples:
-      | token_cookie                        | cookie_removal                                                                                                                   |
-      | 2!someaccesstoken!a.127.0.0.1!/api/ | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
-      | 2!onemoreaccesstoken!127.0.0.1!/    |                                                                                                                                  |
-      | 2!andmoreaccesstoken!!              | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
-      | 3!moremoraccesstoken!a.127.0.0.1!/  | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
+      | token_cookie                       | cookie_removal                                                                                                                   |
+      | 2!tmp_old_token!a.127.0.0.1!/api/  | access_token=; Path=/api/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None |
+      | 2!onemoreaccesstoken!127.0.0.1!/   |                                                                                                                                  |
+      | 2!andmoreaccesstoken!!             | access_token=; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=None                                 |
+      | 3!moremoraccesstoken!a.127.0.0.1!/ | access_token=; Path=/; Domain=a.127.0.0.1; Expires=Wed, 01 Jan 2020 00:43:20 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Strict   |
 
   Scenario Outline: Accepts cookie parameters from post data
     Given the generated auth key is "tmp_new_token"
@@ -209,17 +207,16 @@ Feature: Create a new access token
       | 3                   | 14      | john_current_refreshtoken |
       | 5577006791947779410 | 12      | null                      |
     And the table "access_tokens" should be:
-      | session_id          | token                     | expires_at          |
-      | 2                   | accesstokenforjane        | 2020-01-01 01:00:01 |
-      | 2                   | anotheraccesstokenforjane | 2020-01-01 03:00:00 |
-      | 3                   | accesstokenjohn           | 2020-01-01 03:00:00 |
-      | 5577006791947779410 | newaccesstoken            | 2020-01-01 03:00:00 |
+      | session_id          | expires_at          | token              |
+      | 2                   | 2020-01-01 01:00:01 | jane_old_token     |
+      | 2                   | 2020-01-01 03:00:00 | jane_current_token |
+      | 3                   | 2020-01-01 03:00:00 | john_current_token |
+      | 5577006791947779410 | 2020-01-01 03:00:00 | tmp_new_token      |
     Examples:
-      | content-type                      | data                                                              | expected_cookie                                                                                                                                             |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict          |
-      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
-      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
-      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!newaccesstoken!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
-
+      | content-type                      | data                                                              | expected_cookie                                                                                                                                            |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1&cookie_same_site=1                   | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=0&cookie_same_site=1                   | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |
+      | application/jsoN; charset=utf8    | {"use_cookie":true,"cookie_secure":true}                          | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |
+      | application/json                  | {"use_cookie":true,"cookie_secure":true,"cookie_same_site":true}  | access_token=3!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=Strict |
+      | Application/json                  | {"use_cookie":true,"cookie_secure":false,"cookie_same_site":true} | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 03:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict         |

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -194,6 +194,9 @@ func (conn *DB) Limit(limit interface{}) *DB {
 	return newDB(conn.ctx, conn.db.Limit(limit))
 }
 
+// Offset specifies the offset of the records to be retrieved.
+func (conn *DB) Offset(offset interface{}) *DB { return newDB(conn.ctx, conn.db.Offset(offset)) }
+
 // Where returns a new relation, filters records with given conditions, accepts `map`,
 // `struct` or `string` as conditions, refer http://jinzhu.github.io/gorm/crud.html#query
 func (conn *DB) Where(query interface{}, args ...interface{}) *DB {

--- a/app/database/mysqldb/constants.go
+++ b/app/database/mysqldb/constants.go
@@ -1,0 +1,3 @@
+package mysqldb
+
+const MaxRowsReturned int = 1000000000

--- a/app/database/session_store.go
+++ b/app/database/session_store.go
@@ -53,7 +53,7 @@ func (s *SessionStore) GetUserSessionsSortedByMostRecentIssuedAt(userID int64) [
 		Joins("JOIN access_tokens ON access_tokens.session_id = sessions.session_id").
 		Where("sessions.user_id = ?", userID).
 		Group("access_tokens.session_id").
-		Order("issued_at DESC").
+		Order("issued_at DESC, sessions.session_id").
 		Scan(&sessions).
 		Error()
 	mustNotBeError(err)

--- a/testhelpers/app_language_db.go
+++ b/testhelpers/app_language_db.go
@@ -42,7 +42,7 @@ func (ctx *TestContext) buildDatabaseCountRowQuery(table string, datamap map[str
 // queryScalar returns a single value from the database as the result of the query.
 func (ctx *TestContext) queryScalar(query string, values []interface{}) int {
 	var resultCount int
-	err := db.
+	err := ctx.db.
 		QueryRow(query, values...).
 		Scan(&resultCount)
 	mustNotBeError(err)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -68,6 +68,8 @@ func FeatureContext(s *godog.Suite) {
 
 	s.Step(`^there are the following sessions:$`, ctx.ThereAreTheFollowingSessions)
 	s.Step(`^there are the following access tokens:$`, ctx.ThereAreTheFollowingAccessTokens)
+	s.Step(`^there are (\d+) sessions for user (@\w+)$`, ctx.ThereAreCountSessionsForUser)
+	s.Step(`^there is no session (@\w+)$`, ctx.ThereIsNoSessionID)
 
 	s.Step(`^the "([^"]*)" request header is "(.*)"$`, ctx.TheRequestHeaderIs)
 	s.Step(`^I send a (GET|POST|PUT|DELETE) request to "([^"]*)"$`, ctx.ISendrequestTo)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -92,7 +92,7 @@ func (ctx *TestContext) populateDatabase() error {
 		return nil
 	}
 
-	db, err := database.Open(ctx.db())
+	db, err := database.Open(ctx.db)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (ctx *TestContext) addUser(fields map[string]string) {
 		}
 
 		switch {
-		case "login_id" == key:
+		case key == "login_id":
 			dbFields["login_id"] = value
 		case strings.HasSuffix(key, "_id"):
 			dbFields[key] = ctx.getReference(value)
@@ -1012,7 +1012,7 @@ func (ctx *TestContext) ThereAreCountSessionsForUser(count int, user string) err
 	userID := ctx.getReference(user)
 
 	var sessionCount int
-	err := db.QueryRow("SELECT COUNT(*) as count FROM sessions WHERE user_id = ?", userID).
+	err := ctx.db.QueryRow("SELECT COUNT(*) as count FROM sessions WHERE user_id = ?", userID).
 		Scan(&sessionCount)
 	if err != nil {
 		return err
@@ -1029,7 +1029,7 @@ func (ctx *TestContext) ThereIsNoSessionID(session string) error {
 	sessionID := ctx.getReference(session)
 
 	var sessionCount int
-	err := db.QueryRow("SELECT COUNT(*) as count FROM sessions WHERE session_id = ?", sessionID).
+	err := ctx.db.QueryRow("SELECT COUNT(*) as count FROM sessions WHERE session_id = ?", sessionID).
 		Scan(&sessionCount)
 	if err != nil {
 		return err

--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -33,7 +33,7 @@ func (ctx *TestContext) IAmUserWithID(userID int64) error {
 	ctx.userID = userID
 	ctx.user = strconv.FormatInt(userID, 10)
 
-	db, err := database.Open(ctx.db())
+	db, err := database.Open(ctx.db)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related to #1022 

Limits the number of sessions to 10 for a user.

When a new session is created (user logs in), we count the number of sessions. If it's more than 10, we remove the oldest one(s).

We first retrieve the list of sessions along with the most recent `issued_at` access token, sorted by `issued_at DESC`. Then we delete the oldest.

Adds to new Gherkin features:
- `there are X sessions for user @Session`, checks the number of sessions for a user
- `there is no session @Session`, checks that a session doesn't exists (has been deleted)


### Do we need an index?

The query is executed every time a user logs in.

Here's an explain of the request :
![image](https://github.com/France-ioi/AlgoreaBackend/assets/5871762/ddaa0441-b32f-4539-9977-c27632a69d01)

`sessions` is filtered by `user_id`, which is a foreign key.
`access_tokens` needs to sort the matching `session_id` by `issued_at`. We will never have many access tokens for one session in the database because:
1. We'll remove the expired tokens (coming soon)
2. We can only refresh the token every 5 min

So, no index required.


### An unnecessary global variable was removed in the test package

Some lint tests were failing, which shown that we had a global variable `db` for the database in the test package. A refactoring was done to remove the global variable. Details are in the last commit message.


> Easier to review commit by commit.