### PR TITLE
authMiddleware: explicitely disallow access if the token > max token size

### DIFF
--- a/app/auth/middleware.go
+++ b/app/auth/middleware.go
@@ -96,7 +96,9 @@ func ValidatesUserAuthentication(service GetStorer, w http.ResponseWriter, r *ht
 		return r.Context(), false, errors.New("no access token provided")
 	}
 
-	if len(accessToken) <= 2000 {
+	if len(accessToken) > database.AccessTokenMaxLength {
+		authorized = false
+	} else {
 		user, sessionID, err = service.GetStore(r).Sessions().GetUserAndSessionIDByValidAccessToken(accessToken)
 		authorized = err == nil
 		if err != nil && !gorm.IsRecordNotFoundError(err) {

--- a/app/database/access_token_store.go
+++ b/app/database/access_token_store.go
@@ -2,6 +2,8 @@ package database
 
 import "github.com/jinzhu/gorm"
 
+const AccessTokenMaxLength = 2000
+
 // AccessTokenStore implements database operations on `access_tokens`.
 type AccessTokenStore struct {
 	*DataStore


### PR DESCRIPTION
Related to #1022 

It was already the case implicitly (default value of `authorized`=`false`), but the condition looked like a backdoor.