### PR TITLE
Update item slow and blocked by propagation

### DIFF
--- a/app/auth/middleware_test.go
+++ b/app/auth/middleware_test.go
@@ -247,9 +247,11 @@ func callAuthThroughMiddleware(expectedAccessToken string, authorizationHeaders,
 					"users.temp_user, users.notifications_read_at, users.default_language, sessions.session_id "+
 					"FROM `sessions` "+
 					"JOIN users ON users.group_id = sessions.user_id "+
-					"JOIN access_tokens ON access_tokens.session_id = sessions.session_id "+
-					"WHERE (access_tokens.token = ?) AND (access_tokens.expires_at > NOW()) LIMIT 1") +
+					"JOIN access_tokens "+
+					"  ON access_tokens.session_id = sessions.session_id AND access_tokens.token = ? AND access_tokens.expires_at > NOW() "+
+					"LIMIT 1") +
 			"$").WithArgs(expectedAccessToken)
+
 		if dbError != nil {
 			expectation.WillReturnError(dbError)
 		} else {

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -2,6 +2,9 @@ package database
 
 import (
 	"database/sql"
+	"time"
+
+	"github.com/France-ioi/AlgoreaBackend/app/logging"
 )
 
 const groups = "groups"
@@ -19,7 +22,11 @@ const groups = "groups"
 // - before_delete_items_items/groups_groups.
 func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /* #nosec */
 	mustNotBeError(s.InTransaction(func(s *DataStore) error {
+		initTransactionTime := time.Now()
+
 		s.createNewAncestorsInsideTransaction(objectName, singleObjectName)
+
+		logging.Debugf("Duration of %v_ancestors propagation: %v", objectName, time.Since(initTransactionTime))
 
 		return nil
 	}))

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -341,21 +341,21 @@ func (s *ResultStore) propagate() (err error) {
 			return nil
 		}))
 
+		// If items have been unlocked, need to recompute access
+		if groupsUnlocked > 0 {
+			mustNotBeError(s.InTransaction(func(s *DataStore) error {
+				// generate permissions_generated from permissions_granted
+				s.SchedulePermissionsPropagation()
+				// we should compute attempts again as new permissions were set and
+				// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
+				s.ScheduleResultsPropagation()
+
+				return nil
+			}))
+		}
+
 		return nil
 	}))
-
-	// If items have been unlocked, need to recompute access
-	if groupsUnlocked > 0 {
-		mustNotBeError(s.InTransaction(func(s *DataStore) error {
-			// generate permissions_generated from permissions_granted
-			s.SchedulePermissionsPropagation()
-			// we should compute attempts again as new permissions were set and
-			// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
-			s.ScheduleResultsPropagation()
-
-			return nil
-		}))
-	}
 
 	return nil
 }

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -150,7 +150,11 @@ func (s *ResultStore) propagate() (err error) {
 				ON DUPLICATE KEY UPDATE state = 'to_be_recomputed'`).Error())
 			}
 
-			logging.Debugf("Duration of step of results propagation: %d rows affected, took %v", result.RowsAffected, time.Since(initTransactionTime))
+			logging.Debugf(
+				"Duration of step of results propagation: %d rows affected, took %v",
+				result.RowsAffected,
+				time.Since(initTransactionTime),
+			)
 
 			return nil
 		}))
@@ -328,7 +332,11 @@ func (s *ResultStore) propagate() (err error) {
 			err = s.db.Exec(`DELETE FROM results_propagate WHERE state = 'to_be_propagated'`).Error
 			mustNotBeError(err)
 
-			logging.Debugf("Duration of final step of results propagation: %d rows affected, took %v", result.RowsAffected, time.Since(initTransactionTime))
+			logging.Debugf(
+				"Duration of final step of results propagation: %d rows affected, took %v",
+				result.RowsAffected,
+				time.Since(initTransactionTime),
+			)
 
 			return nil
 		}))

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"database/sql"
 	"time"
 )
 
@@ -32,11 +31,10 @@ const (
 // - before_delete_items_items.
 func (s *ResultStore) propagate() (err error) {
 	var groupsUnlocked int64
-	mustNotBeError(s.InTransaction(func(s *DataStore) error {
-		defer recoverPanics(&err)
-
-		// Use a lock so that we don't execute the listener multiple times in parallel
-		mustNotBeError(s.WithNamedLock(propagateLockName, propagateLockTimeout, func(s *DataStore) error {
+	defer recoverPanics(&err)
+	// Use a lock so that we don't execute the listener multiple times in parallel
+	mustNotBeError(s.WithNamedLock(propagateLockName, propagateLockTimeout, func(s *DataStore) error {
+		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			// We mark as 'to_be_recomputed' results of all ancestors of items marked as 'to_be_recomputed'/'to_be_propagated'
 			// with appropriate attempt_id.
 			// Also, we insert missing results for chapters having descendants with results marked as 'to_be_recomputed'/'to_be_propagated'.
@@ -147,11 +145,16 @@ func (s *ResultStore) propagate() (err error) {
 				FROM results_to_mark
 				ON DUPLICATE KEY UPDATE state = 'to_be_recomputed'`).Error())
 			}
-			hasChanges := true
 
-			var updateStatement *sql.Stmt
+			// TODO: Log time: initialization step of results propagation
 
-			for hasChanges {
+			return nil
+		}))
+
+		hasChanges := true
+
+		for hasChanges {
+			mustNotBeError(s.InTransaction(func(s *DataStore) error {
 				// We process only those objects that were marked as 'to_be_recomputed' and
 				// that have no children (within the attempt or child attempts) marked as 'to_be_recomputed'.
 				// This way we prevent infinite looping as we never process items that are ancestors of themselves
@@ -162,11 +165,10 @@ func (s *ResultStore) propagate() (err error) {
 				//  - children_validated as the number of children items with validated == 1
 				//  - validated, depending on the items_items.category and items.validation_type
 				//    (an item should have at least one validated child to become validated itself by the propagation)
-				if updateStatement == nil {
-					const updateQuery = `
+				const updateQuery = `
 					UPDATE results_propagate AS target_propagate ` +
-						// process only those results marked as 'to_be_recomputed' that do not have child results marked as 'to_be_recomputed'
-						`JOIN (
+					// process only those results marked as 'to_be_recomputed' that do not have child results marked as 'to_be_recomputed'
+					`JOIN (
 						SELECT *
 						FROM (
 							WITH marked_to_be_recomputed AS (SELECT participant_id, attempt_id, item_id FROM results_propagate WHERE state='to_be_recomputed')
@@ -215,10 +217,10 @@ func (s *ResultStore) propagate() (err error) {
 							SUM(IFNULL(aggregated_children_results.score_computed, 0) * items_items.score_weight) /
 								COALESCE(NULLIF(SUM(items_items.score_weight), 0), 1) AS average_score
 						FROM items_items ` +
-						// We use LEFT JOIN LATERAL to aggregate results grouped by target_results.participant_id & items_items.child_item_id.
-						// The usual LEFT JOIN conditions in the ON clause would group results before joining which would produce
-						// wrong results.
-						`	LEFT JOIN LATERAL (
+					// We use LEFT JOIN LATERAL to aggregate results grouped by target_results.participant_id & items_items.child_item_id.
+					// The usual LEFT JOIN conditions in the ON clause would group results before joining which would produce
+					// wrong results.
+					`	LEFT JOIN LATERAL (
 							SELECT
 								MAX(validated) AS validated,
 								MIN(validated_at) AS validated_at,
@@ -270,21 +272,20 @@ func (s *ResultStore) propagate() (err error) {
 								ELSE children_stats.average_score
 							END, 0), 100)), 0),
 						target_propagate.state = 'to_be_propagated'`
-					updateStatement, err = s.db.CommonDB().Prepare(updateQuery)
-					mustNotBeError(err)
-					defer func() { mustNotBeError(updateStatement.Close()) }() //nolint:gocritic defer in for loop, possible resource leak.
-				}
 
-				result, err := updateStatement.Exec()
-				mustNotBeError(err)
+				rowsAffected := s.Exec(updateQuery).RowsAffected()
 
-				rowsAffected, err := result.RowsAffected()
-				mustNotBeError(err)
+				// TODO: Log time: step of results propagation
+
 				hasChanges = rowsAffected > 0
-			}
 
+				return nil
+			}))
+		}
+
+		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			canViewContentIndex := s.PermissionsGranted().ViewIndexByName("content")
-			result = s.db.Exec(`
+			result := s.db.Exec(`
 			INSERT INTO permissions_granted
 				(group_id, item_id, source_group_id, origin, can_view, can_enter_from, latest_update_at)
 				SELECT
@@ -316,11 +317,20 @@ func (s *ResultStore) propagate() (err error) {
 			mustNotBeError(result.Error)
 			groupsUnlocked += result.RowsAffected
 
-			return s.db.Exec(`DELETE FROM results_propagate WHERE state = 'to_be_propagated'`).Error
+			err = s.db.Exec(`DELETE FROM results_propagate WHERE state = 'to_be_propagated'`).Error
+			mustNotBeError(err)
+
+			// TODO: Log time: ending step of results propagation
+
+			return nil
 		}))
 
-		// If items have been unlocked, need to recompute access
-		if groupsUnlocked > 0 {
+		return nil
+	}))
+
+	// If items have been unlocked, need to recompute access
+	if groupsUnlocked > 0 {
+		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			// generate permissions_generated from permissions_granted
 			s.SchedulePermissionsPropagation()
 			// we should compute attempts again as new permissions were set and
@@ -328,10 +338,8 @@ func (s *ResultStore) propagate() (err error) {
 			s.ScheduleResultsPropagation()
 
 			return nil
-		}
-
-		return nil
-	}))
+		}))
+	}
 
 	return nil
 }

--- a/app/database/session_store.go
+++ b/app/database/session_store.go
@@ -24,9 +24,12 @@ func (s *SessionStore) GetUserAndSessionIDByValidAccessToken(token string) (user
 			sessions.session_id
 		`).
 		Joins("JOIN users ON users.group_id = sessions.user_id").
-		Joins("JOIN access_tokens ON access_tokens.session_id = sessions.session_id").
-		Where("access_tokens.token = ?", token).
-		Where("access_tokens.expires_at > NOW()").
+		Joins(`
+			JOIN access_tokens
+			  ON access_tokens.session_id = sessions.session_id
+			 AND access_tokens.token = ?
+			 AND access_tokens.expires_at > NOW()
+		`, token).
 		Take(&result).
 		Error()
 


### PR DESCRIPTION
A few things to speed up things and get more info.

## Optimize query to authenticate the user

The query took ~1.2s in preprod, now it takes ~0.2s.

This will speed up all service calls.

## Results propagation now has step by step transactions

1. A step for the initialization
2. The main steps
3. A step for the ending

## Add logs for propagation

Add logs for how long the propagation steps take.

Log level: DEBUG

## Add logs for database lock acquisition

Add logs for how long it takes to acquire a database lock.

Log level: DEBUG

## `LOW_PRIORITY` MySQL

We cannot use `LOW_PRIORITY` as it doesn't work for `InnoDB`, which uses row-level locking.

From the manuel "With the LOW_PRIORITY modifier, execution of the [UPDATE](https://dev.mysql.com/doc/refman/8.0/en/update.html) is delayed until no other clients are reading from the table. **This affects only storage engines that use only table-level locking (such as MyISAM, MEMORY, and MERGE).**"

## Review

Easier to review commit by commit.