### PR TITLE
Add index to sleed up permissions propagation

### DIFF
--- a/db/migrations/2405061508_add_index_permissions_propagate.sql
+++ b/db/migrations/2405061508_add_index_permissions_propagate.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+ALTER TABLE `permissions_propagate`
+  ADD INDEX `propagate_to_group_id_item_id`
+    (`propagate_to`,`group_id`,`item_id`)
+;
+
+ALTER TABLE `permissions_propagate`
+  DROP INDEX `propagate_to`;
+
+-- +migrate Down
+ALTER TABLE `permissions_propagate`
+  DROP INDEX `propagate_to_group_id_item_id`;
+
+ALTER TABLE `permissions_propagate`
+  ADD INDEX `propagate_to`
+    (`propagate_to`)
+;


### PR DESCRIPTION
Add index in table `permissions_propagate` on (`propagate_to`,`group_id`,`item_id`).

The first query of the `permissions propagation` step was very slow, because of the filter on `propagate_to`.
There was an index on `propagate_to`, but it wasn't used because the rows also had to be filtered by `group_id`+`item_id`.

We also remove the old index containing only `propagate_to`, because the new index can also be used as this (the first column is `propagate_to`).
