### PR TITLE
Fix slow trigger before_delete_items_items

### DIFF
--- a/db/migrations/2405071119_results_propagate_mark_item_id.sql
+++ b/db/migrations/2405071119_results_propagate_mark_item_id.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+CREATE TABLE `results_propagate_items` (
+  `item_id` BIGINT(19) NOT NULL,
+  PRIMARY KEY (`item_id`),
+  CONSTRAINT `fk_results_propagate_items_to_items` FOREIGN KEY (`item_id`) REFERENCES `items` (`id`) ON DELETE CASCADE
+)
+  COMMENT='Used by the algorithm that computes results. All results for the item_id have to be recomputed when the item_id is in this table.'
+  COLLATE='utf8_general_ci'
+  ENGINE=InnoDB
+;
+
+-- +migrate Down
+DROP TABLE `results_propagate_items`;

--- a/db/migrations/2405071129_results_propagate_insert_item_id_in_table_instead_of_trigger.sql
+++ b/db/migrations/2405071129_results_propagate_insert_item_id_in_table_instead_of_trigger.sql
@@ -1,0 +1,42 @@
+-- +migrate Up
+
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT IGNORE INTO `results_propagate_items` (`item_id`) VALUES (OLD.`parent_item_id`);
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT INTO `results_propagate`
+  SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+  FROM `results`
+  WHERE `item_id` = OLD.`parent_item_id`
+  ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+END
+-- +migrate StatementEnd


### PR DESCRIPTION
The trigger `before_delete_items_items` can be very slow. It insert an entry in table `results_propagate` for each entry in `results` of a given `item_id`. This means the insertion of 50k rows when we remove a child of `694914435881177216`.

This PR extract the inserts in table `results_propagate` out of the `before_delete_items_items`, and put it at the beginning of the process of `results propagation`.

Instead of doing the insert in the trigger, we add the `item_id` in question in a new table (`results_propagate_items`). Then, when we do the `results propagation`, we first retrieve the `item_id` in the new table, and do the inserts at this moment.

We do one transaction for each `item_id`, because we know it can take a long time, and we want to keep transactions as small as possible.