### PR TITLE
WIP: Fix the results propagation concurrent test

### DIFF
--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -3,6 +3,7 @@
 package database_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -85,18 +86,16 @@ func TestResultStore_Propagate(t *testing.T) {
 	}
 }
 
-// Works locally but fails twice for every run on CI, losing 20 minutes each time.
-// Comment for now until the current emergency is over.
-// func TestResultStore_Propagate_Concurrent(t *testing.T) {
-//	db := testhelpers.SetupDBWithFixture("results_propagation/main")
-//	defer func() { _ = db.Close() }()
-//
-//	testhelpers.RunConcurrently(func() {
-//		s := database.NewDataStoreWithContext(context.Background(), db)
-//		err := s.InTransaction(func(st *database.DataStore) error {
-//			st.ScheduleResultsPropagation()
-//			return nil
-//		})
-//		assert.NoError(t, err)
-//	}, 30)
-// }
+func TestResultStore_Propagate_Concurrent(t *testing.T) {
+	db := testhelpers.SetupDBWithFixture("results_propagation/main")
+	defer func() { _ = db.Close() }()
+
+	testhelpers.RunConcurrently(func() {
+		s := database.NewDataStoreWithContext(context.Background(), db)
+		err := s.InTransaction(func(st *database.DataStore) error {
+			st.ScheduleResultsPropagation()
+			return nil
+		})
+		assert.NoError(t, err)
+	}, 30)
+}


### PR DESCRIPTION
Issue: https://github.com/France-ioi/AlgoreaBackend/issues/1067

### What the test does

- Launch the result propagation concurrently 30 times
- Note: the result propagation takes a lock with `SELECT GET_LOCK("listener_propagate", 10 seconds)`, with a timeout of `10s`, to make sure it's never running concurrently.

### Problem

The whole test runs in 1s in my local environment, but on CircleCI, it takes longer than the timeout of 10s, so it fails.
![image](https://github.com/France-ioi/AlgoreaBackend/assets/5871762/bf1335be-c81d-4181-9bc4-42c323f5ff13)

```
Failed
result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    result_store_integration_test.go:99: 
    ... 
    result_store_integration_test.go:99:
```