### PR TITLE
Fix lock timeout when the `results propagation` leads to an unlocked groups

### DIFF
--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -343,21 +343,21 @@ func (s *ResultStore) propagate() (err error) {
 			return nil
 		}))
 
-		// If items have been unlocked, need to recompute access
-		if groupsUnlocked > 0 {
-			mustNotBeError(s.InTransaction(func(s *DataStore) error {
-				// generate permissions_generated from permissions_granted
-				s.SchedulePermissionsPropagation()
-				// we should compute attempts again as new permissions were set and
-				// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
-				s.ScheduleResultsPropagation()
-
-				return nil
-			}))
-		}
-
 		return nil
 	}))
+
+	// If items have been unlocked, need to recompute access
+	if groupsUnlocked > 0 {
+		mustNotBeError(s.InTransaction(func(s *DataStore) error {
+			// generate permissions_generated from permissions_granted
+			s.SchedulePermissionsPropagation()
+			// we should compute attempts again as new permissions were set and
+			// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
+			s.ScheduleResultsPropagation()
+
+			return nil
+		}))
+	}
 
 	return nil
 }


### PR DESCRIPTION
The named lock was asked again without releasing it first, leading to a lock timeout.

It's now out of the scope of the lock, so it'll be released before asking it again.