### PR TITLE
`startResultPath` and `startResult`: the `results propagation` is now async

### DIFF
--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -109,7 +109,7 @@ func (srv *Service) submit(rw http.ResponseWriter, httpReq *http.Request) servic
 			}).Error())
 		service.MustNotBeError(resultStore.MarkAsToBePropagated(
 			requestData.TaskToken.Converted.ParticipantID, requestData.TaskToken.Converted.AttemptID,
-			requestData.TaskToken.Converted.LocalItemID))
+			requestData.TaskToken.Converted.LocalItemID, true))
 		return nil
 	})
 

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -147,7 +147,7 @@ func (srv *Service) askHint(w http.ResponseWriter, r *http.Request) service.APIE
 			}).Error())
 		service.MustNotBeError(resultStore.MarkAsToBePropagated(
 			requestData.TaskToken.Converted.ParticipantID, requestData.TaskToken.Converted.AttemptID,
-			requestData.TaskToken.Converted.LocalItemID))
+			requestData.TaskToken.Converted.LocalItemID, true))
 
 		return nil
 	})

--- a/app/api/items/generate_task_token.go
+++ b/app/api/items/generate_task_token.go
@@ -154,7 +154,7 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 
 		// update results
 		service.MustNotBeError(resultScope.UpdateColumn("latest_activity_at", database.Now()).Error())
-		service.MustNotBeError(store.Results().MarkAsToBePropagated(participantID, attemptID, itemID))
+		service.MustNotBeError(store.Results().MarkAsToBePropagated(participantID, attemptID, itemID, true))
 
 		return nil
 	})

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -191,7 +191,7 @@ func saveGradingResultsIntoDB(store *database.DataStore, user *database.User,
 	resultStore := store.Results()
 	service.MustNotBeError(resultStore.MarkAsToBePropagated(
 		requestData.TaskToken.Converted.ParticipantID, requestData.TaskToken.Converted.AttemptID,
-		requestData.TaskToken.Converted.LocalItemID))
+		requestData.TaskToken.Converted.LocalItemID, true))
 	return validated, true
 }
 

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -101,7 +101,9 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 		if result.RowsAffected() != 0 {
 			resultStore := store.Results()
-			service.MustNotBeError(resultStore.MarkAsToBePropagated(participantID, attemptID, itemID))
+			service.MustNotBeError(resultStore.MarkAsToBePropagated(participantID, attemptID, itemID, false))
+
+			service.SchedulePropagation(store, srv.GetPropagationEndpoint(), []string{"results"})
 		}
 		return nil
 	})

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -122,7 +122,8 @@ func (srv *Service) startResultPath(w http.ResponseWriter, r *http.Request) serv
 			resultStore := store.Results()
 			service.MustNotBeError(resultStore.InsertOrUpdateMaps(rowsToInsert, []string{"started_at", "latest_activity_at"}))
 			service.MustNotBeError(resultStore.InsertIgnoreMaps("results_propagate", rowsToInsertPropagate))
-			resultStore.ScheduleResultsPropagation()
+
+			service.SchedulePropagation(store, srv.GetPropagationEndpoint(), []string{"results"})
 		}
 
 		return nil

--- a/app/database/attempt_store.go
+++ b/app/database/attempt_store.go
@@ -27,6 +27,6 @@ func (s *AttemptStore) CreateNew(participantID, parentAttemptID, itemID, creator
 		"participant_id": participantID, "attempt_id": attemptID, "item_id": itemID,
 		"started_at": Now(), "latest_activity_at": Now(),
 	}))
-	mustNotBeError(s.Results().MarkAsToBePropagated(participantID, attemptID, itemID))
+	mustNotBeError(s.Results().MarkAsToBePropagated(participantID, attemptID, itemID, true))
 	return attemptID, nil
 }

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -262,6 +262,10 @@ func (s *DataStore) WithForeignKeyChecksDisabled(blockFunc func(*DataStore) erro
 	})
 }
 
+func (s *DataStore) IsInTransaction() bool {
+	return s.DB.isInTransaction()
+}
+
 // WithNamedLock wraps the given function in GET_LOCK/RELEASE_LOCK.
 func (s *DataStore) WithNamedLock(lockName string, timeout time.Duration, txFunc func(*DataStore) error) error {
 	return s.withNamedLock(lockName, timeout, func(db *DB) error {

--- a/app/database/result_store.go
+++ b/app/database/result_store.go
@@ -34,11 +34,11 @@ func (s *ResultStore) GetHintsInfoForActiveAttempt(participantID, attemptID, ite
 }
 
 // MarkAsToBePropagated marks a given result as 'to_be_propagated'.
-func (s *ResultStore) MarkAsToBePropagated(participantID, attemptID, itemID int64) error {
+func (s *ResultStore) MarkAsToBePropagated(participantID, attemptID, itemID int64, propagateNow bool) error {
 	err := s.Exec(`
 		INSERT IGNORE INTO results_propagate (participant_id, attempt_id, item_id, state)
 		VALUES(?, ?, ?, 'to_be_propagated')`, participantID, attemptID, itemID).Error()
-	if err == nil {
+	if err == nil && propagateNow {
 		s.ScheduleResultsPropagation()
 	}
 	return err

--- a/app/service/propagation.go
+++ b/app/service/propagation.go
@@ -44,13 +44,19 @@ func SchedulePropagation(store *database.DataStore, endpoint string, types []str
 
 	if endpoint == "" || endpointFailed {
 		// Sync.
-		err := store.InTransaction(func(store *database.DataStore) error {
+		if store.IsInTransaction() {
 			store.ScheduleItemsAncestorsPropagation()
 			store.SchedulePermissionsPropagation()
 			store.ScheduleResultsPropagation()
+		} else {
+			err := store.InTransaction(func(store *database.DataStore) error {
+				store.ScheduleItemsAncestorsPropagation()
+				store.SchedulePermissionsPropagation()
+				store.ScheduleResultsPropagation()
 
-			return nil
-		})
-		MustNotBeError(err)
+				return nil
+			})
+			MustNotBeError(err)
+		}
 	}
 }


### PR DESCRIPTION
Needed to add a boolean in `MarkAsToBePropagated` to make it compatible with the other places it's used, but it's temporary: the propagation will be async everywhere in a further commit.