### PR TITLE
Allow not providing the access token when the task token is provided

### DIFF
--- a/app/api/answers/answers.go
+++ b/app/api/answers/answers.go
@@ -25,14 +25,15 @@ type answerData struct {
 // SetRoutes defines the routes for this package in a route answers.
 func (srv *Service) SetRoutes(router chi.Router) {
 	router.Use(render.SetContentType(render.ContentTypeJSON))
-	router.Use(auth.UserMiddleware(srv.Base))
-	router.Get("/items/{item_id}/answers", service.AppHandler(srv.listAnswers).ServeHTTP)
-	router.Get("/items/{item_id}/best-answer", service.AppHandler(srv.getBestAnswer).ServeHTTP)
-	router.Get("/answers/{answer_id}", service.AppHandler(srv.getAnswer).ServeHTTP)
 	router.Post("/answers", service.AppHandler(srv.submit).ServeHTTP)
-	router.Post("/answers/{answer_id}/generate-task-token", service.AppHandler(srv.generateTaskToken).ServeHTTP)
 
-	routerWithParticipant := router.With(service.ParticipantMiddleware(srv.Base))
+	routerWithAuth := router.With(auth.UserMiddleware(srv.Base))
+	routerWithAuth.Get("/items/{item_id}/answers", service.AppHandler(srv.listAnswers).ServeHTTP)
+	routerWithAuth.Get("/items/{item_id}/best-answer", service.AppHandler(srv.getBestAnswer).ServeHTTP)
+	routerWithAuth.Get("/answers/{answer_id}", service.AppHandler(srv.getAnswer).ServeHTTP)
+	routerWithAuth.Post("/answers/{answer_id}/generate-task-token", service.AppHandler(srv.generateTaskToken).ServeHTTP)
+
+	routerWithParticipant := routerWithAuth.With(service.ParticipantMiddleware(srv.Base))
 	routerWithParticipant.Get("/items/{item_id}/current-answer", service.AppHandler(srv.getCurrentAnswer).ServeHTTP)
 	routerWithParticipant.Post("/items/{item_id}/attempts/{attempt_id}/answers", service.AppHandler(srv.answerCreate).ServeHTTP)
 	routerWithParticipant.Put("/items/{item_id}/attempts/{attempt_id}/answers/current", service.AppHandler(srv.updateCurrentAnswer).ServeHTTP)

--- a/app/api/answers/submit.feature
+++ b/app/api/answers/submit.feature
@@ -3,9 +3,13 @@ Feature: Submit a new answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
+    And the database has the following table 'groups':
+      | id  | name | type |
+      | 201 | team | Team |
     And the database has the following table 'groups_groups':
       | parent_group_id | child_group_id |
       | 22              | 13             |
+      | 201             | 101            |
     And the groups ancestors are computed
     And the database has the following table 'items':
       | id | default_language_tag |
@@ -20,13 +24,16 @@ Feature: Submit a new answer
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
+      | 201      | 50      | content            |
     And the database has the following table 'attempts':
       | id | participant_id |
       | 1  | 101            |
+      | 1  | 201            |
     And the database has the following table 'results':
       | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | latest_activity_at  | started_at          |
       | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 2           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
       | 1          | 101            | 10      | null                            | 0            | 0           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+      | 1          | 201            | 50      | [{"rotorIndex":0,"cellRank":0}] | 2            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
 
   Scenario: User is able to submit a new answer
     Given time is frozen
@@ -77,7 +84,60 @@ Feature: Submit a new answer
       | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 |
       | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        |
       | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           |
+      | 1          | 201            | 50      | [{"rotorIndex":0,"cellRank":0}] | 2            | 1           | 0                                                         | null                                                           |
     And the table "results_propagate" should be empty
+
+  Scenario: User is able to submit a new answer for his team (participant_id is the first integer in the idAttempt in the task token)
+    Given time is frozen
+    And "userTaskToken" is a token signed by the app with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idItemLocal": "50",
+        "idAttempt": "201/1",
+        "platformName": "{{app().Config.GetString("token.platformName")}}"
+      }
+      """
+    When I send a POST request to "/answers" with the following body:
+      """
+      {
+        "task_token": "{{userTaskToken}}",
+        "answer": "print 1"
+      }
+      """
+    Then the response code should be 201
+    And the response body decoded as "AnswersSubmitResponse" should be, in JSON:
+      """
+      {
+        "data": {
+          "answer_token": {
+            "date": "{{currentTimeInFormat("02-01-2006")}}",
+            "idUser": "101",
+            "idItem": null,
+            "idAttempt": "201/1",
+            "itemUrl": "",
+            "idItemLocal": "50",
+            "platformName": "algrorea_backend",
+            "randomSeed": "",
+            "sHintsRequested": "[{\"rotorIndex\":0,\"cellRank\":0}]",
+            "nbHintsGiven": "2",
+            "sAnswer": "print 1",
+            "idUserAnswer": "5577006791947779410"
+          }
+        },
+        "message": "created",
+        "success": true
+      }
+      """
+    And the table "answers" should be:
+      | author_id | participant_id | attempt_id | item_id | type       | answer  | ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 |
+      | 101       | 201            | 1          | 50      | Submission | print 1 | 1                                                 |
+    And the table "results" should be:
+      | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 |
+      | 1          | 101            | 10      | null                            | 0            | 0           | 0                                                         | null                                                        |
+      | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 2           | 0                                                         | null                                                        |
+      | 1          | 201            | 50      | [{"rotorIndex":0,"cellRank":0}] | 2            | 2           | 1                                                         | 1                                                           |
+  And the table "results_propagate" should be empty
 
   Scenario: User is able to submit a new answer (with all fields filled in the token)
     Given time is frozen
@@ -132,4 +192,5 @@ Feature: Submit a new answer
       | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_submission_at, NOW())) < 3 |
       | 1          | 101            | 10      | null                            | 0            | 0           | 1                                                         | null                                                        |
       | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 3           | 1                                                         | 1                                                           |
+      | 1          | 201            | 50      | [{"rotorIndex":0,"cellRank":0}] | 2            | 1           | 0                                                         | null                                                           |
     And the table "results_propagate" should be empty

--- a/app/api/answers/submit.feature
+++ b/app/api/answers/submit.feature
@@ -29,8 +29,7 @@ Feature: Submit a new answer
       | 1          | 101            | 10      | null                            | 0            | 0           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
   Scenario: User is able to submit a new answer
-    Given I am the user with id "101"
-    And time is frozen
+    Given time is frozen
     And "userTaskToken" is a token signed by the app with the following payload:
       """
       {
@@ -81,8 +80,7 @@ Feature: Submit a new answer
     And the table "results_propagate" should be empty
 
   Scenario: User is able to submit a new answer (with all fields filled in the token)
-    Given I am the user with id "101"
-    And time is frozen
+    Given time is frozen
     And "userTaskToken" is a token signed by the app with the following payload:
       """
       {

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -8,14 +8,44 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/France-ioi/AlgoreaBackend/app/doc"
+
 	"github.com/go-chi/render"
 	"github.com/jinzhu/gorm"
 
 	"github.com/France-ioi/AlgoreaBackend/app/database"
-	"github.com/France-ioi/AlgoreaBackend/app/doc"
 	"github.com/France-ioi/AlgoreaBackend/app/service"
 	"github.com/France-ioi/AlgoreaBackend/app/token"
 )
+
+// SubmitRequest represents a JSON request body format needed by answers.submit()
+// swagger:ignore
+type SubmitRequest struct {
+	TaskToken *token.Task `json:"task_token"`
+	Answer    *string     `json:"answer"`
+
+	PublicKey *rsa.PublicKey
+}
+
+// swagger:model
+type submitRequestWrapper struct {
+	// required:true
+	TaskToken *string `json:"task_token"`
+	// required:true
+	Answer *string `json:"answer"`
+}
+
+// Created. Success response with answer_token
+// swagger:model answerSubmitResponse
+type answerSubmitResponse struct {
+	// description
+	// swagger:allOf
+	doc.CreatedResponse
+	// required:true
+	Data struct {
+		AnswerToken string `json:"answer_token"`
+	} `json:"data"`
+}
 
 // swagger:operation POST /answers answers itemGetAnswerToken
 //
@@ -139,23 +169,6 @@ func (srv *Service) submit(rw http.ResponseWriter, httpReq *http.Request) servic
 	return service.NoError
 }
 
-// SubmitRequest represents a JSON request body format needed by answers.submit()
-// swagger:ignore
-type SubmitRequest struct {
-	TaskToken *token.Task `json:"task_token"`
-	Answer    *string     `json:"answer"`
-
-	PublicKey *rsa.PublicKey
-}
-
-// swagger:model
-type submitRequestWrapper struct {
-	// required:true
-	TaskToken *string `json:"task_token"`
-	// required:true
-	Answer *string `json:"answer"`
-}
-
 // UnmarshalJSON loads SubmitRequest from JSON passing a public key into TaskToken.
 func (requestData *SubmitRequest) UnmarshalJSON(raw []byte) error {
 	var wrapper submitRequestWrapper
@@ -187,15 +200,3 @@ func (requestData *SubmitRequest) Bind(r *http.Request) error {
 }
 
 var _ render.Binder = (*SubmitRequest)(nil)
-
-// Created. Success response with answer_token
-// swagger:model answerSubmitResponse
-type answerSubmitResponse struct {
-	// description
-	// swagger:allOf
-	doc.CreatedResponse
-	// required:true
-	Data struct {
-		AnswerToken string `json:"answer_token"`
-	} `json:"data"`
-}

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -55,9 +55,11 @@ type answerSubmitResponse struct {
 //		Generate and return an answer token from user's answer and task token.
 //		It is used to bind an answer with task parameters so that the TaskGrader can check if they have not been altered.
 //
-//		* task_token.idUser should be the current user.
 //
-//		* The user should have submission rights on `task_token.idItemLocal`.
+//		This service doesn't require authentication. The user is identified by the task token.
+//
+//
+//		* The task token's user should have submission rights on `task_token.idItemLocal`.
 //
 //		* The attempt should allow submission (`attempts.allows_submissions_until` should be a time in the future).
 //

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -90,14 +90,6 @@ func (srv *Service) submit(rw http.ResponseWriter, httpReq *http.Request) servic
 		return service.ErrInvalidRequest(err)
 	}
 
-	user := srv.GetUser(httpReq)
-
-	if user.GroupID != requestData.TaskToken.Converted.UserID {
-		return service.ErrInvalidRequest(fmt.Errorf(
-			"token doesn't correspond to user session: got idUser=%d, expected %d",
-			requestData.TaskToken.Converted.UserID, user.GroupID))
-	}
-
 	var answerID int64
 	var hintsInfo *database.HintsInfo
 	apiError := service.NoError
@@ -124,7 +116,7 @@ func (srv *Service) submit(rw http.ResponseWriter, httpReq *http.Request) servic
 		service.MustNotBeError(err)
 
 		answerID, err = store.Answers().SubmitNewAnswer(
-			user.GroupID, requestData.TaskToken.Converted.ParticipantID, requestData.TaskToken.Converted.AttemptID,
+			requestData.TaskToken.Converted.UserID, requestData.TaskToken.Converted.ParticipantID, requestData.TaskToken.Converted.AttemptID,
 			requestData.TaskToken.Converted.LocalItemID, *requestData.Answer)
 		service.MustNotBeError(err)
 

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -78,8 +78,6 @@ type answerSubmitResponse struct {
 //				"$ref": "#/definitions/answerSubmitResponse"
 //		"400":
 //			"$ref": "#/responses/badRequestResponse"
-//		"401":
-//			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
 //		"500":

--- a/app/api/answers/submit.robustness.feature
+++ b/app/api/answers/submit.robustness.feature
@@ -76,6 +76,26 @@ Feature: Submit a new answer - robustness
     And the response error message should contain "Invalid task_token: the token has expired"
     And the table "answers" should stay unchanged
 
+  Scenario: Falsified task_token with non-matching signature
+    Given "userTaskToken" is a falsified token signed by the app with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idAttempt": "100/2",
+        "idItemLocal": "50",
+        "platformName": "{{app().Config.GetString("token.platformName")}}"
+      }
+      """
+    When I send a POST request to "/answers" with the following body:
+      """
+      {
+        "task_token": "{{userTaskToken}}"
+      }
+      """
+    Then the response code should be 400
+    And the response error message should contain "Invalid task_token: invalid token: crypto/rsa: verification error"
+    And the table "answers" should stay unchanged
+
   Scenario: Missing answer
     Given "userTaskToken" is a token signed by the app with the following payload:
       """

--- a/app/api/answers/submit.robustness.feature
+++ b/app/api/answers/submit.robustness.feature
@@ -23,8 +23,7 @@ Feature: Submit a new answer - robustness
       | 101            | 1          | 60      |
 
   Scenario: Wrong JSON in request
-    Given I am the user with id "101"
-    When I send a POST request to "/answers" with the following body:
+    Given I send a POST request to "/answers" with the following body:
       """
       []
       """
@@ -33,8 +32,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: No task_token
-    Given I am the user with id "101"
-    When I send a POST request to "/answers" with the following body:
+    Given I send a POST request to "/answers" with the following body:
       """
       {
         "answer": "print 1"
@@ -45,8 +43,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: Wrong task_token
-    Given I am the user with id "101"
-    When I send a POST request to "/answers" with the following body:
+    Given I send a POST request to "/answers" with the following body:
       """
       {
         "task_token": "ADSFADQER.ASFDAS.ASDFSDA",
@@ -58,8 +55,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: Missing answer
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -79,8 +75,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: Wrong idUser
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "",
@@ -101,8 +96,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: Wrong idItemLocal
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -122,8 +116,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: Wrong idAttempt
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -143,31 +136,8 @@ Feature: Submit a new answer - robustness
     And the response error message should contain "Invalid task_token: wrong idAttempt"
     And the table "answers" should stay unchanged
 
-  Scenario: idUser doesn't match the user's group id
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
-      """
-      {
-        "idUser": "20",
-        "idItemLocal": "50",
-        "idAttempt": "100/1",
-        "platformName": "{{app().Config.GetString("token.platformName")}}"
-      }
-      """
-    When I send a POST request to "/answers" with the following body:
-      """
-      {
-        "task_token": "{{userTaskToken}}",
-        "answer": "print(1)"
-      }
-      """
-    Then the response code should be 400
-    And the response error message should contain "Token doesn't correspond to user session: got idUser=20, expected 101"
-    And the table "answers" should stay unchanged
-
   Scenario: User not found
-    Given I am the user with id "404"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "404",
@@ -183,13 +153,12 @@ Feature: Submit a new answer - robustness
         "answer": "print(1)"
       }
       """
-    Then the response code should be 401
-    And the response error message should contain "Invalid access token"
+    Then the response code should be 403
+    And the response error message should contain "No access to the task item"
     And the table "answers" should stay unchanged
 
   Scenario: No submission rights
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -210,8 +179,7 @@ Feature: Submit a new answer - robustness
     And the table "answers" should stay unchanged
 
   Scenario: The attempt is expired (doesn't allow submissions anymore)
-    Given I am the user with id "101"
-    And "userTaskToken" is a token signed by the app with the following payload:
+    Given "userTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",

--- a/app/api/answers/submit.robustness.feature
+++ b/app/api/answers/submit.robustness.feature
@@ -54,6 +54,28 @@ Feature: Submit a new answer - robustness
     And the response error message should contain "Invalid task_token: illegal base64 data at input byte 8"
     And the table "answers" should stay unchanged
 
+  Scenario: Expired task_token
+    Given the time now is "2020-01-01T00:00:00Z"
+    And "userTaskToken" is a token signed by the app with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idAttempt": "100/2",
+        "idItemLocal": "50",
+        "platformName": "{{app().Config.GetString("token.platformName")}}"
+      }
+      """
+    Then the time now is "2020-01-03T00:00:00Z"
+    When I send a POST request to "/answers" with the following body:
+      """
+      {
+        "task_token": "{{userTaskToken}}"
+      }
+      """
+    Then the response code should be 400
+    And the response error message should contain "Invalid task_token: the token has expired"
+    And the table "answers" should stay unchanged
+
   Scenario: Missing answer
     Given "userTaskToken" is a token signed by the app with the following payload:
       """

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -26,8 +26,7 @@ Feature: Ask for a hint
     And time is frozen
 
   Scenario: User is able to ask for a hint
-    Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    Given the database has the following table 'attempts':
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
@@ -90,8 +89,7 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for a hint with a minimal hint token
-    Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    Given the database has the following table 'attempts':
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
@@ -154,8 +152,7 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for an already given hint
-    Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    Given the database has the following table 'attempts':
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':
@@ -218,8 +215,7 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: Can't parse hints_requested
-    Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    Given the database has the following table 'attempts':
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table 'results':

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -101,7 +101,7 @@ Feature: Ask for a hint
       | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          |
       | 0          | 201            | 50      | [0,  1, "hint" , null] | 4            | 2020-01-01 00:00:00 |
       | 0          | 201            | 10      | null                   | 0            | 2020-01-01 00:00:00 |
-  And "priorUserTaskToken" is a token signed by the app with the following payload:
+    And "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -3,9 +3,13 @@ Feature: Ask for a hint
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
+    And the database has the following table 'groups':
+      | id  | name | type |
+      | 201 | team | Team |
     And the database has the following table 'groups_groups':
       | parent_group_id | child_group_id |
       | 22              | 13             |
+      | 201             | 101            |
     And the groups ancestors are computed
     And the database has the following table 'platforms':
       | id | regexp                                            | public_key                |
@@ -23,6 +27,7 @@ Feature: Ask for a hint
     And the database has the following table 'permissions_generated':
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
+      | 201      | 50      | content            |
     And time is frozen
 
   Scenario: User is able to ask for a hint
@@ -86,6 +91,69 @@ Feature: Ask for a hint
       | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
       | 0          | 101            | 10      | 1               | 0            | null                               | 1                                                         | null                                                  |
       | 0          | 101            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | 1                                                         | 1                                                     |
+    And the table "results_propagate" should be empty
+
+  Scenario: User is able to ask for a hint for a team (participant_id is the first integer in idAttempt in the task token)
+    Given the database has the following table 'attempts':
+      | id | participant_id |
+      | 0  | 201            |
+    And the database has the following table 'results':
+      | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          |
+      | 0          | 201            | 50      | [0,  1, "hint" , null] | 4            | 2020-01-01 00:00:00 |
+      | 0          | 201            | 10      | null                   | 0            | 2020-01-01 00:00:00 |
+  And "priorUserTaskToken" is a token signed by the app with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idItemLocal": "50",
+        "idAttempt": "201/0",
+        "itemURL": "http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936",
+        "platformName": "{{app().Config.GetString("token.platformName")}}"
+      }
+      """
+    And "hintRequestToken" is a token signed by the task platform with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idItemLocal": "50",
+        "idAttempt": "201/0",
+        "itemUrl": "http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936",
+        "askedHint": {"rotorIndex":1}
+      }
+      """
+    When I send a POST request to "/items/ask-hint" with the following body:
+      """
+      {
+        "task_token": "{{priorUserTaskToken}}",
+        "hint_requested": "{{hintRequestToken}}"
+      }
+      """
+    Then the response code should be 201
+    And the response body decoded as "AskHintResponse" should be, in JSON:
+      """
+      {
+        "data": {
+          "task_token": {
+            "date": "{{currentTimeInFormat("02-01-2006")}}",
+            "idUser": "101",
+            "idItemLocal": "50",
+            "idAttempt": "201/0",
+            "itemUrl": "http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936",
+            "randomSeed": "",
+            "platformName": "{{app().Config.GetString("token.platformName")}}",
+            "sHintsRequested": "[0,1,\"hint\",null,{\"rotorIndex\":1}]",
+            "nbHintsGiven": "5"
+          }
+        },
+        "message": "created",
+        "success": true
+      }
+      """
+    And the table "attempts" should stay unchanged
+    And the table "results" should be:
+      | attempt_id | participant_id | item_id | tasks_with_help | hints_cached | hints_requested                    | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | ABS(TIMESTAMPDIFF(SECOND, latest_hint_at, NOW())) < 3 |
+      | 0          | 201            | 10      | 1               | 0            | null                               | 1                                                         | null                                                  |
+      | 0          | 201            | 50      | 1               | 5            | [0,1,"hint",null,{"rotorIndex":1}] | 1                                                         | 1                                                     |
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for a hint with a minimal hint token

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -28,10 +28,12 @@ import (
 //		Saves the hint request into `results` and generates a new task token.
 //
 //
+//		This service doesn't require authentication. The user is identified by the task token.
+//
+//
 //		Restrictions:
 //
-//			* `task_token` should belong to the current user, otherwise the "bad request" response is returned.
-//			* The current user should have submission rights to the `task_token`'s item,
+//			* The task token's user should have submission rights to the `task_token`'s item,
 //				otherwise the "forbidden" response is returned.
 //			* There should be a row in the `results` with `participant_id`, `attempt_id`, and `item_id` matching the tokens
 //				and `attempts.allows_submissions_until` should be equal to time in the future,

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -91,10 +91,9 @@ func (srv *Service) askHint(w http.ResponseWriter, r *http.Request) service.APIE
 		return service.ErrInvalidRequest(err)
 	}
 
-	user := srv.GetUser(r)
-
 	var apiError service.APIError
-	if apiError = checkHintOrScoreTokenRequiredFields(user, requestData.TaskToken, "hint_requested",
+	if apiError = checkHintOrScoreTokenRequiredFields(requestData.TaskToken.Converted.UserID, requestData.TaskToken,
+		"hint_requested",
 		requestData.HintToken.Converted.UserID, requestData.HintToken.LocalItemID,
 		requestData.HintToken.ItemURL, requestData.HintToken.AttemptID); apiError != service.NoError {
 		return apiError

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -76,8 +76,6 @@ import (
 //								type: string
 //		"400":
 //			"$ref": "#/responses/badRequestResponse"
-//		"401":
-//			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":

--- a/app/api/items/ask_hint.robustness.feature
+++ b/app/api/items/ask_hint.robustness.feature
@@ -144,7 +144,7 @@ Feature: Ask for a hint - robustness
     And the response error message should contain "Wrong itemUrl in hint_requested token"
     And the table "attempts" should stay unchanged
 
-  Scenario: idUser in hint_requested doesn't match the user's id
+  Scenario: idUser in hint_requested token doesn't match the idUser in the task token
     Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {

--- a/app/api/items/ask_hint.robustness.feature
+++ b/app/api/items/ask_hint.robustness.feature
@@ -40,8 +40,7 @@ Feature: Ask for a hint - robustness
     And time is frozen
 
   Scenario: Wrong JSON in request
-    Given I am the user with id "101"
-    When I send a POST request to "/items/ask-hint" with the following body:
+    Given I send a POST request to "/items/ask-hint" with the following body:
       """
       []
       """
@@ -49,75 +48,8 @@ Feature: Ask for a hint - robustness
     And the response error message should contain "Json: cannot unmarshal array into Go value of type items.askHintRequestWrapper"
     And the table "attempts" should stay unchanged
 
-  Scenario: User not found
-    Given I am the user with id "404"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
-      """
-      {
-        "idUser": "404",
-        "idItemLocal": "50",
-        "idAttempt": "101/0",
-        "itemURL": "https://platformwithkey/50",
-        "platformName": "{{app().Config.GetString("token.platformName")}}"
-      }
-      """
-    And "hintRequestToken" is a token signed by the task platform with the following payload:
-      """
-      {
-        "idUser": "404",
-        "idItemLocal": "50",
-        "idAttempt": "101/0",
-        "itemUrl": "https://platformwithkey/50",
-        "askedHint": {"rotorIndex":1}
-      }
-      """
-    When I send a POST request to "/items/ask-hint" with the following body:
-      """
-      {
-        "task_token": "{{priorUserTaskToken}}",
-        "hint_requested": "{{hintRequestToken}}"
-      }
-      """
-    Then the response code should be 401
-    And the response error message should contain "Invalid access token"
-    And the table "attempts" should stay unchanged
-
-  Scenario: idUser in task_token doesn't match the user's id
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
-      """
-      {
-        "idUser": "20",
-        "idItemLocal": "50",
-        "idAttempt": "101/0",
-        "itemURL": "https://platformwithkey/50",
-        "platformName": "{{app().Config.GetString("token.platformName")}}"
-      }
-      """
-    And "hintRequestToken" is a token signed by the task platform with the following payload:
-      """
-      {
-        "idUser": "101",
-        "idItemLocal": "50",
-        "idAttempt": "101/0",
-        "itemUrl": "https://platformwithkey/50",
-        "askedHint": {"rotorIndex":1}
-      }
-      """
-    When I send a POST request to "/items/ask-hint" with the following body:
-      """
-      {
-        "task_token": "{{priorUserTaskToken}}",
-        "hint_requested": "{{hintRequestToken}}"
-      }
-      """
-    Then the response code should be 400
-    And the response error message should contain "Token in task_token doesn't correspond to user session: got idUser=20, expected 10"
-    And the table "attempts" should stay unchanged
-
   Scenario: itemUrls of task_token and hint_requested don't match
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -149,8 +81,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: idUser in hint_requested doesn't match the user's id
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -182,8 +113,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: idAttempt in hint_requested & task_token don't match
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -215,8 +145,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: idItemLocal in hint_requested & task_token don't match
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -248,8 +177,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: No submission rights
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -281,8 +209,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: idAttempt not found
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -314,8 +241,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: missing askedHint
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -346,8 +272,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: The attempt is expired (doesn't allow submissions anymore)
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -379,8 +304,7 @@ Feature: Ask for a hint - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: Should return an error if there is a public key and the hint token's content is sent in clear JSON
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",
@@ -407,8 +331,7 @@ Feature: Ask for a hint - robustness
     And the response error message should contain "Invalid hint_requested: json: cannot unmarshal object into Go value of type string"
 
   Scenario: Should return an error if there is no public key and the hint token's content is sent in clear JSON
-    Given I am the user with id "101"
-    And "priorUserTaskToken" is a token signed by the app with the following payload:
+    Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
         "idUser": "101",

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -71,8 +71,8 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}start-result", service.AppHandler(srv.startResult).ServeHTTP)
 	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}start-result-path", service.AppHandler(srv.startResultPath).ServeHTTP)
 	routerWithAuthAndParticipant.Get("/items/{item_id}/path-from-root", service.AppHandler(srv.getPathFromRoot).ServeHTTP)
-	router.Get("/items/{item_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByItemID).ServeHTTP)
-	router.Get("/items/by-text-id/{text_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByTextID).ServeHTTP)
+	routerWithAuth.Get("/items/{item_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByItemID).ServeHTTP)
+	routerWithAuth.Get("/items/by-text-id/{text_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByTextID).ServeHTTP)
 }
 
 func checkHintOrScoreTokenRequiredFields(userID int64, taskToken *token.Task, otherTokenFieldName string,

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -29,64 +29,65 @@ const (
 // SetRoutes defines the routes for this package in a route group.
 func (srv *Service) SetRoutes(router chi.Router) {
 	router.Use(render.SetContentType(render.ContentTypeJSON))
-	router.Use(auth.UserMiddleware(srv.Base))
-	routerWithParticipant := router.With(service.ParticipantMiddleware(srv.Base))
-
-	router.Post("/items", service.AppHandler(srv.createItem).ServeHTTP)
-	routerWithParticipant.Get(`/items/{ids:(\d+/)+}breadcrumbs`, service.AppHandler(srv.getBreadcrumbs).ServeHTTP)
-	router.Put("/items/{item_id}", service.AppHandler(srv.updateItem).ServeHTTP)
-	router.Delete("/items/{item_id}", service.AppHandler(srv.deleteItem).ServeHTTP)
-
-	routerWithParticipant.Get("/items/{item_id}/children", service.AppHandler(srv.getItemChildren).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/parents", service.AppHandler(srv.getItemParents).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}", service.AppHandler(srv.getItem).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/navigation", service.AppHandler(srv.getItemNavigation).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/prerequisites", service.AppHandler(srv.getItemPrerequisites).ServeHTTP)
-	routerWithParticipant.Post("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}",
-		service.AppHandler(srv.createDependency).ServeHTTP)
-	routerWithParticipant.Delete("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}",
-		service.AppHandler(srv.deleteDependency).ServeHTTP)
-	routerWithParticipant.Post("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}/apply",
-		service.AppHandler(srv.applyDependency).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/dependencies", service.AppHandler(srv.getItemDependencies).ServeHTTP)
-	router.Get("/items/search", service.AppHandler(srv.searchForItems).ServeHTTP)
-
-	routerWithParticipant.Post("/items/{item_id}/attempts/{attempt_id}/generate-task-token",
-		service.AppHandler(srv.generateTaskToken).ServeHTTP)
-	routerWithParticipant.Post("/items/{item_id}/attempts/{attempt_id}/publish", service.AppHandler(srv.publishResult).ServeHTTP)
-	routerWithParticipant.Put("/items/{item_id}/attempts/{attempt_id}", service.AppHandler(srv.updateResult).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/attempts", service.AppHandler(srv.listAttempts).ServeHTTP)
-	routerWithParticipant.Post("/items/{ids:(\\d+/)+}attempts", service.AppHandler(srv.createAttempt).ServeHTTP)
-	routerWithParticipant.Get("/items/{ancestor_item_id}/log", service.AppHandler(srv.getActivityLogForItem).ServeHTTP)
-	routerWithParticipant.Get("/items/log", service.AppHandler(srv.getActivityLogForAllItems).ServeHTTP)
-	router.Get("/items/{item_id}/official-sessions", service.AppHandler(srv.listOfficialSessions).ServeHTTP)
-	router.Put("/items/{item_id}/strings/{language_tag}", service.AppHandler(srv.updateItemString).ServeHTTP)
 	router.Post("/items/ask-hint", service.AppHandler(srv.askHint).ServeHTTP)
-	router.Post("/items/save-grade", service.AppHandler(srv.saveGrade).ServeHTTP)
-	router.Get("/items/{item_id}/entry-state",
+
+	routerWithAuth := router.With(auth.UserMiddleware(srv.Base))
+	routerWithAuthAndParticipant := routerWithAuth.With(service.ParticipantMiddleware(srv.Base))
+
+	routerWithAuth.Post("/items", service.AppHandler(srv.createItem).ServeHTTP)
+	routerWithAuthAndParticipant.Get(`/items/{ids:(\d+/)+}breadcrumbs`, service.AppHandler(srv.getBreadcrumbs).ServeHTTP)
+	routerWithAuth.Put("/items/{item_id}", service.AppHandler(srv.updateItem).ServeHTTP)
+	routerWithAuth.Delete("/items/{item_id}", service.AppHandler(srv.deleteItem).ServeHTTP)
+
+	routerWithAuthAndParticipant.Get("/items/{item_id}/children", service.AppHandler(srv.getItemChildren).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/parents", service.AppHandler(srv.getItemParents).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}", service.AppHandler(srv.getItem).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/navigation", service.AppHandler(srv.getItemNavigation).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/prerequisites", service.AppHandler(srv.getItemPrerequisites).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}",
+		service.AppHandler(srv.createDependency).ServeHTTP)
+	routerWithAuthAndParticipant.Delete("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}",
+		service.AppHandler(srv.deleteDependency).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{dependent_item_id}/prerequisites/{prerequisite_item_id}/apply",
+		service.AppHandler(srv.applyDependency).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/dependencies", service.AppHandler(srv.getItemDependencies).ServeHTTP)
+	routerWithAuth.Get("/items/search", service.AppHandler(srv.searchForItems).ServeHTTP)
+
+	routerWithAuthAndParticipant.Post("/items/{item_id}/attempts/{attempt_id}/generate-task-token",
+		service.AppHandler(srv.generateTaskToken).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{item_id}/attempts/{attempt_id}/publish", service.AppHandler(srv.publishResult).ServeHTTP)
+	routerWithAuthAndParticipant.Put("/items/{item_id}/attempts/{attempt_id}", service.AppHandler(srv.updateResult).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/attempts", service.AppHandler(srv.listAttempts).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}attempts", service.AppHandler(srv.createAttempt).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{ancestor_item_id}/log", service.AppHandler(srv.getActivityLogForItem).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/log", service.AppHandler(srv.getActivityLogForAllItems).ServeHTTP)
+	routerWithAuth.Get("/items/{item_id}/official-sessions", service.AppHandler(srv.listOfficialSessions).ServeHTTP)
+	routerWithAuth.Put("/items/{item_id}/strings/{language_tag}", service.AppHandler(srv.updateItemString).ServeHTTP)
+	routerWithAuth.Post("/items/save-grade", service.AppHandler(srv.saveGrade).ServeHTTP)
+	routerWithAuth.Get("/items/{item_id}/entry-state",
 		service.AppHandler(srv.getEntryState).ServeHTTP)
-	routerWithParticipant.Post("/items/{ids:(\\d+/)+}enter", service.AppHandler(srv.enter).ServeHTTP)
-	routerWithParticipant.Post("/attempts/{attempt_id}/end", service.AppHandler(srv.endAttempt).ServeHTTP)
-	routerWithParticipant.Post("/items/{ids:(\\d+/)+}start-result", service.AppHandler(srv.startResult).ServeHTTP)
-	routerWithParticipant.Post("/items/{ids:(\\d+/)+}start-result-path", service.AppHandler(srv.startResultPath).ServeHTTP)
-	routerWithParticipant.Get("/items/{item_id}/path-from-root", service.AppHandler(srv.getPathFromRoot).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}enter", service.AppHandler(srv.enter).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/attempts/{attempt_id}/end", service.AppHandler(srv.endAttempt).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}start-result", service.AppHandler(srv.startResult).ServeHTTP)
+	routerWithAuthAndParticipant.Post("/items/{ids:(\\d+/)+}start-result-path", service.AppHandler(srv.startResultPath).ServeHTTP)
+	routerWithAuthAndParticipant.Get("/items/{item_id}/path-from-root", service.AppHandler(srv.getPathFromRoot).ServeHTTP)
 	router.Get("/items/{item_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByItemID).ServeHTTP)
 	router.Get("/items/by-text-id/{text_id}/breadcrumbs-from-roots", service.AppHandler(srv.getBreadcrumbsFromRootsByTextID).ServeHTTP)
 }
 
-func checkHintOrScoreTokenRequiredFields(user *database.User, taskToken *token.Task, otherTokenFieldName string,
+func checkHintOrScoreTokenRequiredFields(userID int64, taskToken *token.Task, otherTokenFieldName string,
 	otherTokenConvertedUserID int64,
 	otherTokenLocalItemID, otherTokenItemURL, otherTokenAttemptID string,
 ) service.APIError {
-	if user.GroupID != taskToken.Converted.UserID {
+	if userID != taskToken.Converted.UserID {
 		return service.ErrInvalidRequest(fmt.Errorf(
 			"token in task_token doesn't correspond to user session: got idUser=%d, expected %d",
-			taskToken.Converted.UserID, user.GroupID))
+			taskToken.Converted.UserID, userID))
 	}
-	if user.GroupID != otherTokenConvertedUserID {
+	if userID != otherTokenConvertedUserID {
 		return service.ErrInvalidRequest(fmt.Errorf(
 			"token in %s doesn't correspond to user session: got idUser=%d, expected %d",
-			otherTokenFieldName, otherTokenConvertedUserID, user.GroupID))
+			otherTokenFieldName, otherTokenConvertedUserID, userID))
 	}
 	if taskToken.LocalItemID != otherTokenLocalItemID {
 		return service.ErrInvalidRequest(fmt.Errorf("wrong idItemLocal in %s token", otherTokenFieldName))

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -103,7 +103,7 @@ func (srv *Service) saveGrade(w http.ResponseWriter, r *http.Request) service.AP
 
 	user := srv.GetUser(r)
 
-	if apiError := checkHintOrScoreTokenRequiredFields(user, requestData.TaskToken, "score_token",
+	if apiError := checkHintOrScoreTokenRequiredFields(user.GroupID, requestData.TaskToken, "score_token",
 		requestData.ScoreToken.Converted.UserID, requestData.ScoreToken.LocalItemID,
 		requestData.ScoreToken.ItemURL, requestData.ScoreToken.AttemptID); apiError != service.NoError {
 		return apiError

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -100,6 +100,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the DB time now is "([^"]*)"$`, ctx.DbTimeNow)
 
 	s.Step(`^"([^"]+)" is a token signed by (.+) with the following payload:$`, ctx.SignedTokenIsDistributed)
+	s.Step(`^"([^"]+)" is a falsified token signed by (.+) with the following payload:$`, ctx.FalsifiedSignedTokenIsDistributed)
 	s.Step(`^logs should contain:$`, ctx.LogsShouldContain)
 
 	s.Step(`^the login module "token" endpoint for code "([^"]*)" returns (\d+) with body:$`, ctx.TheLoginModuleTokenEndpointForCodeReturns)


### PR DESCRIPTION
fixes #1057 

Update `itemGetAnswerToken` and `itemGetHintToken` services to be called without an access token.

Those services were removed from the auth middleware.


## Tests to check we don't accept falsified tokens

To simulate the falsification of a token, a single byte was changed in its payload. This way, the signature of the token isn't valid anymore. Details are in the specific commit.

## Tests for teams

Two tests were added for a team but I'm not really sure how teams are working. When a hint is asked, it's asked for the team? If so, the test is probably correct.

## Do we need more robustness tests for the teams?

There are no tests that specifically check that:
- The user is really in the participant team when a team is used
- The team has the right to submit / ask a hint

I'm not sure whether this should be added. Should we consider that since the token has been generated by the backend, we can trust everything in it? And what if some permissions changed since?

## Review

Easier to review commit by commit with the details in commit messages.
