### PR TITLE
Make sure the tests cannot be run on live database as it empties the database

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -136,6 +136,11 @@ func DBConfig(globalConfig *viper.Viper) (config *mysql.Config, err error) {
 	vConfig.SetEnvPrefix(fmt.Sprintf("%s_%s_", envPrefix, databaseConfigKey))
 	vConfig.AutomaticEnv()
 	err = vConfig.Unmarshal(&config)
+
+	if appenv.IsEnvTest() && strings.HasSuffix(config.Addr, "amazonaws.com") {
+		err = fmt.Errorf("cannot connect to AWS RDS in tests as it empties the database")
+	}
+
 	return
 }
 


### PR DESCRIPTION
An error is thrown if the test environment uses a database on AWS.

So the issue that happened last time wont happen anymore.