### PR TITLE
Refactor existing and temp user session processes

### DIFF
--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -49,21 +49,23 @@ Feature: Create a new access token
     And the response header "Set-Cookie" should be "<expected_cookie>"
     And logs should contain:
       """
-      Generated a session token expiring in 7200 seconds for a temporary user with group_id = 12
+      Refreshed a session token expiring in 7200 seconds for a temporary user with group_id = 12
       """
     And the table "sessions" should be:
-      | session_id          | user_id | refresh_token             |
-      | 2                   | 13      | jane_current_refreshtoken |
-      | 3                   | 14      | john_current_refreshtoken |
-      | 5577006791947779410 | 12      | null                      |
+      | session_id | user_id | refresh_token             |
+      | 1          | 12      |                           |
+      | 2          | 13      | jane_current_refreshtoken |
+      | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id          | issued_at           | expires_at          | token              |
-      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
-      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
-  Examples:
-    | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 1          | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
+      | 2          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
+    Examples:
+      | query                            | current_cookie        | token_in_data                   | expected_cookie                                                                                                                                          |
     |                                  | [Header not defined]  | "access_token":"tmp_new_token", | [Header not defined]                                                                                                                                     |
     | ?use_cookie=1&cookie_secure=1    | [Header not defined]  |                                 | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None |
     | ?use_cookie=1&cookie_same_site=1 | [Header not defined]  |                                 | access_token=1!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; SameSite=Strict       |
@@ -191,19 +193,21 @@ Feature: Create a new access token
     And the response header "Set-Cookie" should be "<expected_cookie>"
     And logs should contain:
       """
-      Generated a session token expiring in 7200 seconds for a temporary user with group_id = 12
+      Refreshed a session token expiring in 7200 seconds for a temporary user with group_id = 12
       """
     And the table "sessions" should be:
-      | session_id          | user_id | refresh_token             |
-      | 2                   | 13      | jane_current_refreshtoken |
-      | 3                   | 14      | john_current_refreshtoken |
-      | 5577006791947779410 | 12      | null                      |
+      | session_id | user_id | refresh_token             |
+      | 1          | 12      |                           |
+      | 2          | 13      | jane_current_refreshtoken |
+      | 3          | 14      | john_current_refreshtoken |
     And the table "access_tokens" should be:
-      | session_id          | issued_at           | expires_at          | token              |
-      | 2                   | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
-      | 2                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
-      | 3                   | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
-      | 5577006791947779410 | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
+      | session_id | issued_at           | expires_at          | token              |
+      | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
+      | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
+      | 1          | 2020-01-01 02:00:00 | 2020-01-01 04:00:00 | tmp_new_token      |
+      | 2          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | jane_old_token     |
+      | 2          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | jane_current_token |
+      | 3          | 2020-01-01 01:50:00 | 2020-01-01 03:50:00 | john_current_token |
     Examples:
       | content-type                      | data                                                              | expected_cookie                                                                                                                                            |
       | Application/x-www-form-urlencoded | use_cookie=1&cookie_secure=1                                      | access_token=2!tmp_new_token!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Wed, 01 Jan 2020 04:00:00 GMT; Max-Age=7200; HttpOnly; Secure; SameSite=None   |

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -61,8 +61,8 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 	} else {
 		if user.IsTempUser {
 			service.MustNotBeError(store.InTransaction(func(store *database.DataStore) error {
-				// delete all the user's access tokens keeping the input token only
-				service.MustNotBeError(store.Sessions().Delete("session_id = ?", sessionID).Error())
+				store.AccessTokens().DeleteExpiredTokensOfUser(user.GroupID)
+
 				var err error
 				newToken, expiresIn, err = auth.CreateNewTempSession(store, user.GroupID)
 				return err

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -61,10 +61,8 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 	} else {
 		if user.IsTempUser {
 			service.MustNotBeError(store.InTransaction(func(store *database.DataStore) error {
-				store.AccessTokens().DeleteExpiredTokensOfUser(user.GroupID)
-
 				var err error
-				newToken, expiresIn, err = auth.CreateNewTempSession(store, user.GroupID)
+				newToken, expiresIn, err = auth.RefreshTempUserSession(store, user.GroupID, sessionID)
 				return err
 			}))
 		} else {

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -78,6 +78,8 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 		if apiError != service.NoError {
 			return apiError
 		}
+
+		store.AccessTokens().DeleteExpiredTokensOfUser(user.GroupID)
 	}
 
 	srv.respondWithNewAccessToken(r, w, service.CreationSuccess, newToken, time.Now().Add(time.Duration(expiresIn)*time.Second),
@@ -118,7 +120,6 @@ func (srv *Service) refreshTokens(
 				Error(),
 			)
 		}
-		store.AccessTokens().DeleteExpiredTokensOfUser(user.GroupID)
 
 		newToken = token.AccessToken
 		expiresIn = int32(time.Until(token.Expiry).Round(time.Second) / time.Second)

--- a/app/api/auth/refresh_access_token_remove_expired_of_user_on_refresh.feature
+++ b/app/api/auth/refresh_access_token_remove_expired_of_user_on_refresh.feature
@@ -52,6 +52,21 @@ Feature: Support for parallel sessions
     # UserUntouched's access tokens shouldn't be touched.
     And there are 2 access tokens for user @UserUntouched
 
+  Scenario: Should remove the expired access tokens of the user when refreshing a token, when the user is a temp user
+    Given there are the following users:
+      | user                     | groups    | temp_user |
+      | @User1                   | @AllUsers | true      |
+      | @UserUntouched           | @AllUsers | true      |
+      | @UserWithoutExpiredToken | @AllUsers | true      |
+    And the "Authorization" request header is "Bearer t_user_1_session_1_most_recent"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 201
+    And there are 7 access tokens for user @User1
+    And there is no access token "t_user_1_session_1_expired"
+    And there is no access token "t_user_1_session_2_expired"
+    # UserUntouched's access tokens shouldn't be touched.
+    And there are 2 access tokens for user @UserUntouched
+
   Scenario: Should not remove any access token if there's no expired one for the user
     Given the login module "token" endpoint for refresh token "rt_user_without_expired_token" returns 200 with body:
       """
@@ -62,6 +77,17 @@ Feature: Support for parallel sessions
         "refresh_token":"t_user_without_expired_token_new"
       }
       """
+    And the "Authorization" request header is "Bearer t_user_without_expired_token"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 201
+    And there are 2 access tokens for user @UserWithoutExpiredToken
+
+  Scenario: Should not remove any access token if there's no expired one for the user, when the user is a temp user
+    Given there are the following users:
+      | user                     | groups    | temp_user |
+      | @User1                   | @AllUsers | true      |
+      | @UserUntouched           | @AllUsers | true      |
+      | @UserWithoutExpiredToken | @AllUsers | true      |
     And the "Authorization" request header is "Bearer t_user_without_expired_token"
     When I send a POST request to "/auth/token"
     Then the response code should be 201

--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -67,6 +67,8 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 					mock.ExpectExec("^"+regexp.QuoteMeta("UPDATE `sessions` SET `refresh_token` = ? WHERE (session_id = ?)")+"$").
 						WithArgs("newfirstrefreshtoken", sqlmock.AnyArg()).
 						WillReturnResult(sqlmock.NewResult(-1, 1))
+					mock.ExpectCommit()
+					mock.ExpectBegin()
 					mock.ExpectExec("^" + regexp.QuoteMeta(
 						"DELETE FROM `access_tokens`  WHERE "+
 							"(session_id IN ((SELECT session_id FROM `sessions`  WHERE (user_id = ?)))) AND (expires_at < NOW())",

--- a/app/auth/temp_sessions.go
+++ b/app/auth/temp_sessions.go
@@ -48,8 +48,6 @@ func RefreshTempUserSession(s *database.DataStore, userID, sessionID int64) (acc
 	logging.Infof("Refreshed a session token expiring in %d seconds for a temporary user with group_id = %d",
 		expiresIn, userID)
 
-	s.AccessTokens().DeleteExpiredTokensOfUser(userID)
-
 	return
 }
 

--- a/app/auth/temp_sessions.go
+++ b/app/auth/temp_sessions.go
@@ -36,6 +36,23 @@ func CreateNewTempSession(s *database.DataStore, userID int64) (
 	return
 }
 
+// RefreshTempUserSession refreshes the session of a temporary user.
+func RefreshTempUserSession(s *database.DataStore, userID, sessionID int64) (accessToken string, expiresIn int32, err error) {
+	expiresIn = TemporaryUserSessionLifetimeInSeconds
+
+	accessToken, err = GenerateKey()
+	mustNotBeError(err)
+
+	mustNotBeError(s.AccessTokens().InsertNewToken(sessionID, accessToken, expiresIn))
+
+	logging.Infof("Refreshed a session token expiring in %d seconds for a temporary user with group_id = %d",
+		expiresIn, userID)
+
+	s.AccessTokens().DeleteExpiredTokensOfUser(userID)
+
+	return
+}
+
 // mustNotBeError panics if the error is not nil.
 func mustNotBeError(err error) {
 	if err != nil {

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -169,10 +169,7 @@ func (ctx *TestContext) GroupIsAChildOfTheGroup(childGroup, parentGroup string) 
 
 // UserIsAMemberOfTheGroup puts a user in a group.
 func (ctx *TestContext) UserIsAMemberOfTheGroup(user, group string) error {
-	err := ctx.ThereIsAUserWith(getParameterString(map[string]string{
-		"group_id": user,
-		"user":     user,
-	}))
+	err := ctx.ThereIsAUser(user)
 	if err != nil {
 		return err
 	}

--- a/testhelpers/app_language_users.go
+++ b/testhelpers/app_language_users.go
@@ -108,8 +108,8 @@ func (ctx *TestContext) ThereAreTheFollowingUsers(users *messages.PickleStepArgu
 		if _, ok := user["temp_user"]; ok {
 			ctx.setUserFieldInDatabase(
 				ctx.getUserPrimaryKey(groupID),
-				"last_name",
-				user["last_name"],
+				"temp_user",
+				user["temp_user"],
 			)
 		}
 		if _, ok := user["login_id"]; ok {

--- a/testhelpers/app_language_users.go
+++ b/testhelpers/app_language_users.go
@@ -1,0 +1,125 @@
+//go:build !prod
+
+package testhelpers
+
+import (
+	"strconv"
+
+	"github.com/cucumber/godog"
+	"github.com/cucumber/messages-go/v10"
+)
+
+// registerFeaturesForUsers registers the Gherkin features related to users.
+func (ctx *TestContext) registerFeaturesForUsers(s *godog.Suite) {
+	s.Step(`^there is a user (@\w+)$`, ctx.ThereIsAUser)
+	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
+}
+
+// addUsersIntoAllUsersGroup adds all users in the AllUsers group if it is defined.
+func (ctx *TestContext) addUsersIntoAllUsersGroup() error {
+	if ctx.allUsersGroup == "" {
+		return nil
+	}
+
+	for userID := range ctx.dbTables["users"] {
+		err := ctx.UserIsAMemberOfTheGroup(userID, ctx.allUsersGroup)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getUserPrimaryKey returns the primary key of a group.
+func (ctx *TestContext) getUserPrimaryKey(groupID int64) string {
+	return strconv.FormatInt(groupID, 10)
+}
+
+// addUser adds a user in database.
+func (ctx *TestContext) addUser(user string) {
+	primaryKey := ctx.getUserPrimaryKey(ctx.getReference(user))
+
+	if !ctx.isInDatabase("users", primaryKey) {
+		ctx.addInDatabase("users", primaryKey, map[string]interface{}{
+			"group_id": ctx.getReference(user),
+			"login":    referenceToName(user),
+			// All the other fields are set to default values.
+			"login_id":   nil,
+			"temp_user":  false,
+			"first_name": nil,
+			"last_name":  nil,
+		})
+	}
+}
+
+// setUserFieldInDatabase sets a specific field of a user in the database.
+func (ctx *TestContext) setUserFieldInDatabase(primaryKey, field string, value interface{}) {
+	if value == tableValueNull {
+		value = nil
+	}
+	if value == tableValueFalse {
+		value = false
+	}
+	if value == tableValueTrue {
+		value = true
+	}
+
+	ctx.dbTables["users"][primaryKey][field] = value
+}
+
+// ThereIsAUser create a user.
+func (ctx *TestContext) ThereIsAUser(name string) error {
+	ctx.addUser(name)
+
+	err := ctx.ThereIsAGroup(name)
+	mustNotBeError(err)
+
+	groupPrimaryKey := ctx.getGroupPrimaryKey(ctx.getReference(name))
+	ctx.setGroupFieldInDatabase(groupPrimaryKey, "type", "User")
+
+	return nil
+}
+
+// ThereAreTheFollowingUsers defines users.
+func (ctx *TestContext) ThereAreTheFollowingUsers(users *messages.PickleStepArgument_PickleTable) error {
+	for i := 1; i < len(users.Rows); i++ {
+		user := ctx.getRowMap(i, users)
+
+		groupID := ctx.getReference(user["user"])
+
+		err := ctx.ThereIsAUser(user["user"])
+		mustNotBeError(err)
+
+		if _, ok := user["first_name"]; ok {
+			ctx.setUserFieldInDatabase(
+				ctx.getUserPrimaryKey(groupID),
+				"first_name",
+				user["first_name"],
+			)
+		}
+		if _, ok := user["last_name"]; ok {
+			ctx.setUserFieldInDatabase(
+				ctx.getUserPrimaryKey(groupID),
+				"last_name",
+				user["last_name"],
+			)
+		}
+		if _, ok := user["temp_user"]; ok {
+			ctx.setUserFieldInDatabase(
+				ctx.getUserPrimaryKey(groupID),
+				"last_name",
+				user["last_name"],
+			)
+		}
+		if _, ok := user["login_id"]; ok {
+			ctx.setUserFieldInDatabase(
+				ctx.getUserPrimaryKey(groupID),
+				"login_id",
+				user["login_id"],
+			)
+		}
+	}
+
+	return nil
+}

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -20,9 +20,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 
 	ctx.registerFeaturesForSessions(s)
+	ctx.registerFeaturesForUsers(s)
 
-	s.Step(`^there is a user (@\w+)$`, ctx.ThereIsAUser)
-	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
 	s.Step(`^the time now is "([^"]*)"$`, ctx.TimeNow)
 	s.Step(`^time is frozen$`, ctx.TimeIsFrozen)
 	s.Step(`^the generated group code is "([^"]*)"$`, ctx.TheGeneratedGroupCodeIs)


### PR DESCRIPTION
fixes #1022 

We now have the same behavior of `refreshToken` for temp user and normal user:
- For temp users, refresh used to create a new session, we now keep the same session and only create a new access token
- For temp users, refresh used to delete the old access token, we now delete only the expired tokens of the user

This is the last PR for the parallel sessions.

Also refactors what's related to testing users into a new file to simplify `testhelpers/steps_app_language.go`.

Easier to review everything at once. Details of the steps in the commit messages.