### PR TITLE
userViewById: add whether we can view/edit his personnal info

### DIFF
--- a/app/api/users/get_user.feature
+++ b/app/api/users/get_user.feature
@@ -95,7 +95,8 @@ Feature: Get user info
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "10", "name": "Some group"}],
       "current_user_can_grant_user_access": false,
-      "current_user_can_watch_user": false
+      "current_user_can_watch_user": false,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """
 
@@ -114,7 +115,8 @@ Feature: Get user info
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "12", "name": "Friends"}],
       "current_user_can_grant_user_access": false,
-      "current_user_can_watch_user": true
+      "current_user_can_watch_user": true,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """
 
@@ -133,6 +135,7 @@ Feature: Get user info
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "12", "name": "Friends"}],
       "current_user_can_grant_user_access": true,
-      "current_user_can_watch_user": false
+      "current_user_can_watch_user": false,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -153,7 +153,7 @@ func (srv *Service) getUser(w http.ResponseWriter, r *http.Request) service.APIE
 				Group("groups_ancestors.child_group_id").SubQuery()).
 		Scan(&userInfo).Error()
 
-	if err == gorm.ErrRecordNotFound {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return service.ErrNotFound(errors.New("no such user"))
 	}
 	service.MustNotBeError(err)

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -225,7 +225,8 @@ func computeHighestPersonalInfoAccessApproval(groupInfos []groupInfo) string {
 		if group.RequirePersonalInfoAccessApproval == personalInfoAccessApprovalEdit {
 			highestPersonalInfoAccessApproval = personalInfoAccessApprovalEdit
 			break
-		} else if group.RequirePersonalInfoAccessApproval == personalInfoAccessApprovalView && highestPersonalInfoAccessApproval == personalInfoAccessApprovalNone {
+		} else if group.RequirePersonalInfoAccessApproval == personalInfoAccessApprovalView &&
+			highestPersonalInfoAccessApproval == personalInfoAccessApprovalNone {
 			highestPersonalInfoAccessApproval = personalInfoAccessApprovalView
 		}
 	}

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -230,5 +230,6 @@ func computeHighestPersonalInfoAccessApproval(groupInfos []groupInfo) string {
 			highestPersonalInfoAccessApproval = personalInfoAccessApprovalView
 		}
 	}
+
 	return highestPersonalInfoAccessApproval
 }

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -13,9 +13,11 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/structures"
 )
 
-const personalInfoAccessApprovalNone = "none"
-const personalInfoAccessApprovalView = "view"
-const personalInfoAccessApprovalEdit = "edit"
+const (
+	personalInfoAccessApprovalNone = "none"
+	personalInfoAccessApprovalView = "view"
+	personalInfoAccessApprovalEdit = "edit"
+)
 
 // ManagerPermissionsPart contains fields related to permissions for managing the user.
 // These fields are only displayed if the current user is a manager of the user.
@@ -199,15 +201,21 @@ func setUserInfosForManager(store *database.DataStore, user *database.User, user
 		Select("groups.id, groups.name, groups.require_personal_info_access_approval").
 		Scan(&groupInfos).Error())
 
-	userInfo.AncestorsCurrentUserIsManagerOf = make([]structures.GroupShortInfo, len(groupInfos))
-	for i, groupInfo := range groupInfos {
-		userInfo.AncestorsCurrentUserIsManagerOf[i] = structures.GroupShortInfo{
-			ID:   groupInfo.ID,
-			Name: groupInfo.Name,
+	userInfo.AncestorsCurrentUserIsManagerOf = getGroupShortInfos(groupInfos)
+	userInfo.PersonalInfoAccessApprovalToCurrentUser = computeHighestPersonalInfoAccessApproval(groupInfos)
+}
+
+// getGroupShortInfos returns a list of GroupShortInfo from the given groupInfos.
+func getGroupShortInfos(groupInfos []groupInfo) []structures.GroupShortInfo {
+	ancestorsCurrentUserIsManagerOf := make([]structures.GroupShortInfo, len(groupInfos))
+	for i, groupInfoValue := range groupInfos {
+		ancestorsCurrentUserIsManagerOf[i] = structures.GroupShortInfo{
+			ID:   groupInfoValue.ID,
+			Name: groupInfoValue.Name,
 		}
 	}
 
-	userInfo.PersonalInfoAccessApprovalToCurrentUser = computeHighestPersonalInfoAccessApproval(groupInfos)
+	return ancestorsCurrentUserIsManagerOf
 }
 
 // computeHighestPersonalInfoAccessApproval computes the highest personal info access approval ("edit" > "view" > "none").

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -13,6 +13,10 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/app/structures"
 )
 
+const personalInfoAccessApprovalNone = "none"
+const personalInfoAccessApprovalView = "view"
+const personalInfoAccessApprovalEdit = "edit"
+
 // ManagerPermissionsPart contains fields related to permissions for managing the user.
 // These fields are only displayed if the current user is a manager of the user.
 // swagger:ignore
@@ -202,13 +206,13 @@ func setUserInfosForManager(store *database.DataStore, user *database.User, user
 	}
 
 	// Compute the higher required personal info access approval ("edit" > "view" > "none").
-	highestPersonalInfoAccessApproval := "none"
+	highestPersonalInfoAccessApproval := personalInfoAccessApprovalNone
 	for _, group := range groupInfos {
-		if group.RequirePersonalInfoAccessApproval == "edit" {
-			highestPersonalInfoAccessApproval = "edit"
+		if group.RequirePersonalInfoAccessApproval == personalInfoAccessApprovalEdit {
+			highestPersonalInfoAccessApproval = personalInfoAccessApprovalEdit
 			break
-		} else if group.RequirePersonalInfoAccessApproval == "view" && highestPersonalInfoAccessApproval == "none" {
-			highestPersonalInfoAccessApproval = "view"
+		} else if group.RequirePersonalInfoAccessApproval == personalInfoAccessApprovalView && highestPersonalInfoAccessApproval == personalInfoAccessApprovalNone {
+			highestPersonalInfoAccessApproval = personalInfoAccessApprovalView
 		}
 	}
 	userInfo.PersonalInfoAccessApprovalToCurrentUser = highestPersonalInfoAccessApproval

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -186,7 +186,7 @@ type groupInfo struct {
 
 // setUserInfosForManager sets the following fields in the response:
 // - AncestorsCurrentUserIsManagerOf
-// - PersonalInfoAccessApprovalToCurrentUser
+// - PersonalInfoAccessApprovalToCurrentUser.
 func setUserInfosForManager(store *database.DataStore, user *database.User, userInfo *userViewResponse) {
 	var groupInfos []groupInfo
 

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -207,8 +207,7 @@ func setUserInfosForManager(store *database.DataStore, user *database.User, user
 		}
 	}
 
-	highestPersonalInfoAccessApproval := computeHighestPersonalInfoAccessApproval(groupInfos)
-	userInfo.PersonalInfoAccessApprovalToCurrentUser = highestPersonalInfoAccessApproval
+	userInfo.PersonalInfoAccessApprovalToCurrentUser = computeHighestPersonalInfoAccessApproval(groupInfos)
 }
 
 // computeHighestPersonalInfoAccessApproval computes the highest personal info access approval ("edit" > "view" > "none").

--- a/app/api/users/get_user_by_login.feature
+++ b/app/api/users/get_user_by_login.feature
@@ -95,7 +95,8 @@ Feature: Get user info by login
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "10", "name": "Some group"}],
       "current_user_can_grant_user_access": false,
-      "current_user_can_watch_user": false
+      "current_user_can_watch_user": false,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """
 
@@ -114,7 +115,8 @@ Feature: Get user info by login
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "12", "name": "Friends"}],
       "current_user_can_grant_user_access": false,
-      "current_user_can_watch_user": true
+      "current_user_can_watch_user": true,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """
 
@@ -133,6 +135,7 @@ Feature: Get user info by login
       "is_current_user": false,
       "ancestors_current_user_is_manager_of": [{"id": "12", "name": "Friends"}],
       "current_user_can_grant_user_access": true,
-      "current_user_can_watch_user": false
+      "current_user_can_watch_user": false,
+      "personal_info_access_approval_to_current_user": "none"
     }
     """

--- a/app/api/users/get_user_personal_info_access_approval_to_current_user.feature
+++ b/app/api/users/get_user_personal_info_access_approval_to_current_user.feature
@@ -1,0 +1,25 @@
+Feature: Manager of a user gets `personal_info_access_approval_to_current_user` in the response
+  Scenario Outline: Should return the max permission of all the groups the current-user manages and which the user is a descendant of
+    Given there are the following groups:
+      | group                         | parent  | members        | require_personal_info_access_approval |
+      | @AllUsers                     |         | @Manager,@User |                                       |
+      | @School                       |         |                | <school_permission>                   |
+      | @Class                        | @School | @User          | <class_permission>                    |
+      | @OtherManagedGroupWithoutUser |         |                | edit                                  |
+      | @OtherManagedGroupWithUser    |         | @User          | <other_permission>                    |
+      | @NonManagedGroupWithUser      |         | @User          | edit                                  |
+    And I am @Manager
+    And I am a manager of the group @School
+    And I am a manager of the group @OtherManagedGroupWithUser
+    When I send a GET request to "/users/@User"
+    Then the response code should be 200
+    And the response at $.personal_info_access_approval_to_current_user should be "<result>"
+  Examples:
+    | school_permission | class_permission | other_permission | result |
+    | none              | none             | none             | none   |
+    | view              | none             | none             | view   |
+    | none              | view             | none             | view   |
+    | none              | none             | view             | view   |
+    | edit              | none             | view             | edit   |
+    | none              | edit             | view             | edit   |
+    | view              | none             | edit             | edit   |


### PR DESCRIPTION
fixes #1090 

Add `personal_info_access_approval_to_current_user` in the response, which is the max value among the groups for which both the current user is implicitly manager of, and the user requested is descendant of.

Notes:
- The field is not present if the current user is not a manager of the user, to make it consistent with the other fields.
- The `userViewByLogin` service is affected in the same way (/users/by-login/{login}), as the same code serves the two services

## Implementation

We already get the list of groups of which the current-user is a manager and of which the user is a descendant of (for the field `ancestors_current_user_is_manager_of`). So to avoid doing another query for this, the values of `require_personal_info_access_approval` were added in the `select` of the existing query.

Then, with the result of the query, we fill the groups information and we compute the `max`.

Another way of doing would have been to create a query just for it, but since it requires to check the same groups as `ancestors_current_user_is_manager_of`, we would have done almost the same work twice.

## Query index

Only added a field in the `select`, so there's no need for a new index.

## Review

Probably easier all at once because there are a few refactoring to make the code clearer.