### PR TITLE
Add a robustness test to verify that `refreshToken` returns an error with an expired token

### DIFF
--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -27,3 +27,8 @@ Feature: Refresh an access token - robustness
     And the table "sessions" should stay unchanged
     # The expired token has been removed
     And the table "access_tokens" should stay unchanged
+
+  Scenario: Should return an error when trying to refresh an expired token
+    Given the "Authorization" request header is "Bearer jane_expired_token"
+    When I send a POST request to "/auth/token"
+    Then the response code should be 401


### PR DESCRIPTION
It wasn't explicitly tested.