### PR TITLE
`refreshToken`: put the lock before the most recent token is retrieved

### DIFF
--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -42,18 +42,17 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 		response, mock, logs, err := servicetest.GetResponseForRouteWithMockedDBAndUser(
 			"POST", "/auth/token", "", &database.User{GroupID: 2},
 			func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("^" +
-					regexp.QuoteMeta(
-						"SELECT "+
-							"token, "+
-							"TIMESTAMPDIFF(SECOND, NOW(), expires_at) AS seconds_until_expiry, "+
-							"issued_at > (NOW() - INTERVAL 5 MINUTE) AS too_new_to_refresh "+
-							"FROM `access_tokens`  WHERE (session_id = ?) ORDER BY expires_at DESC LIMIT 1") + "$").
-					WithArgs(sqlmock.AnyArg()).
-					WillReturnRows(mock.NewRows([]string{"token", "seconds_until_expiry", "too_new_to_refresh"}).
-						AddRow("accesstoken", 600, false))
-
 				if !timeout {
+					mock.ExpectQuery("^" +
+						regexp.QuoteMeta(
+							"SELECT "+
+								"token, "+
+								"TIMESTAMPDIFF(SECOND, NOW(), expires_at) AS seconds_until_expiry, "+
+								"issued_at > (NOW() - INTERVAL 5 MINUTE) AS too_new_to_refresh "+
+								"FROM `access_tokens`  WHERE (session_id = ?) ORDER BY expires_at DESC LIMIT 1") + "$").
+						WithArgs(sqlmock.AnyArg()).
+						WillReturnRows(mock.NewRows([]string{"token", "seconds_until_expiry", "too_new_to_refresh"}).
+							AddRow("accesstoken", 600, false))
 					mock.ExpectQuery("^" +
 						regexp.QuoteMeta("SELECT refresh_token FROM `sessions` WHERE (session_id = ?) LIMIT 1") + "$").
 						WithArgs(sqlmock.AnyArg()).


### PR DESCRIPTION
If another refresh is already happening, the most recent token will have changed when the lock is released, and with the current code, it will be refreshed again.

The following process had an issue:
1. We start two refresh requests
2. The first one takes the lock and refreshes the token, while the second gets the most recent token of the session, then waits for the lock
3. The first request finishes, put the new token in the database, and release the lock
4. The second request gets the lock, refreshes the token again. But it shouldn't, because now there is a valid most recent token for the session!

With this change, 4. becomes: The second request acquires the lock, gets the most recent valid token for the session, notices it is too new to refresh, and simply returns it.