### PR TITLE
1. Rename 'ok' meaning 'watched_group_id is set' into 'watchedGroupIDSet', then 2. Rename 'watchedGroupIDSet' into 'watchedGroupIDIsSet'

### DIFF
--- a/app/api/answers/get_best.go
+++ b/app/api/answers/get_best.go
@@ -56,7 +56,7 @@ func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request)
 		return service.ErrInvalidRequest(err)
 	}
 
-	watchedGroupID, watchedGroupOK, apiError := srv.ResolveWatchedGroupID(httpReq)
+	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(httpReq)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -69,7 +69,7 @@ func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request)
 		WithGradings().
 		DB
 
-	if watchedGroupOK {
+	if watchedGroupIDSet {
 		// the following checks were made by ResolveWatchedGroupID:
 		// - watched_group_id must be a participant
 		// - the current user is able to watch the participant

--- a/app/api/answers/get_best.go
+++ b/app/api/answers/get_best.go
@@ -56,7 +56,7 @@ func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request)
 		return service.ErrInvalidRequest(err)
 	}
 
-	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(httpReq)
+	watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(httpReq)
 	if apiError != service.NoError {
 		return apiError
 	}
@@ -69,7 +69,7 @@ func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request)
 		WithGradings().
 		DB
 
-	if watchedGroupIDSet {
+	if watchedGroupIDIsSet {
 		// the following checks were made by ResolveWatchedGroupID:
 		// - watched_group_id must be a participant
 		// - the current user is able to watch the participant

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -321,12 +321,12 @@ func (srv *Service) parseParticipantProgressParameters(r *http.Request, store *d
 	}
 	params.CheckPermissionsForGroupID = params.ParticipantID
 
-	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(r)
+	watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
 		return params, apiError
 	}
 
-	if watchedGroupIDSet {
+	if watchedGroupIDIsSet {
 		if len(r.URL.Query()["as_team_id"]) != 0 {
 			return params, service.ErrInvalidRequest(errors.New("only one of as_team_id and watched_group_id can be given"))
 		}

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -321,12 +321,12 @@ func (srv *Service) parseParticipantProgressParameters(r *http.Request, store *d
 	}
 	params.CheckPermissionsForGroupID = params.ParticipantID
 
-	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
+	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
 		return params, apiError
 	}
 
-	if ok {
+	if watchedGroupIDSet {
 		if len(r.URL.Query()["as_team_id"]) != 0 {
 			return params, service.ErrInvalidRequest(errors.New("only one of as_team_id and watched_group_id can be given"))
 		}

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -308,7 +308,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 	user *database.User, fromValues map[string]interface{},
 ) (*database.DB, service.APIError) {
 	participantID := service.ParticipantIDFromContext(r.Context())
-	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(r)
+	watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
 		return nil, apiError
 	}
@@ -319,7 +319,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 		Group("item_id").
 		HavingMaxPermissionAtLeast("view", "info")
 
-	if watchedGroupIDSet {
+	if watchedGroupIDIsSet {
 		if len(r.URL.Query()["as_team_id"]) != 0 {
 			return nil, service.ErrInvalidRequest(errors.New("only one of as_team_id and watched_group_id can be given"))
 		}

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -308,7 +308,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 	user *database.User, fromValues map[string]interface{},
 ) (*database.DB, service.APIError) {
 	participantID := service.ParticipantIDFromContext(r.Context())
-	watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(r)
+	watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(r)
 	if apiError != service.NoError {
 		return nil, apiError
 	}
@@ -319,7 +319,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 		Group("item_id").
 		HavingMaxPermissionAtLeast("view", "info")
 
-	if ok {
+	if watchedGroupIDSet {
 		if len(r.URL.Query()["as_team_id"]) != 0 {
 			return nil, service.ErrInvalidRequest(errors.New("only one of as_team_id and watched_group_id can be given"))
 		}

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -35,7 +35,7 @@ type rawNavigationItem struct {
 
 // getRawNavigationData reads a navigation subtree from the DB and returns an array of rawNavigationItem's.
 func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemptID int64,
-	user *database.User, watchedGroupID int64, watchedGroupIDSet bool,
+	user *database.User, watchedGroupID int64, watchedGroupIDIsSet bool,
 ) []rawNavigationItem {
 	var result []rawNavigationItem
 	items := dataStore.Items()
@@ -82,7 +82,7 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 		groupID,
 		"info",
 		attemptID,
-		watchedGroupIDSet,
+		watchedGroupIDIsSet,
 		watchedGroupID,
 		commonAttributes+
 			`, items.requires_explicit_entry, parent_item_id, items.entry_participant_type, items.no_score,
@@ -129,12 +129,12 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 }
 
 func constructItemListWithoutResultsQuery(dataStore *database.DataStore, groupID int64, requiredViewPermissionOnItems string,
-	watchedGroupIDSet bool, watchedGroupID int64, columnList string, columnListValues []interface{},
+	watchedGroupIDIsSet bool, watchedGroupID int64, columnList string, columnListValues []interface{},
 	joinItemRelationsToItemsFunc, joinItemRelationsToPermissionsFunc func(*database.DB) *database.DB,
 ) *database.DB {
 	watchedGroupCanViewQuery := interface{}(gorm.Expr("NULL"))
 	watchedGroupAvgScoreQuery := interface{}(gorm.Expr("(SELECT NULL AS avg_score, NULL AS all_validated)"))
-	if watchedGroupIDSet {
+	if watchedGroupIDIsSet {
 		watchedGroupCanViewQuery = dataStore.Permissions().
 			Joins("JOIN groups_ancestors_active ON groups_ancestors_active.ancestor_group_id = permissions.group_id").
 			Where("groups_ancestors_active.child_group_id = ?", watchedGroupID).
@@ -182,12 +182,12 @@ func constructItemListWithoutResultsQuery(dataStore *database.DataStore, groupID
 }
 
 func constructItemListQuery(dataStore *database.DataStore, groupID int64, requiredViewPermissionOnItems string,
-	watchedGroupIDSet bool, watchedGroupID int64, columnList string, columnListValues []interface{},
+	watchedGroupIDIsSet bool, watchedGroupID int64, columnList string, columnListValues []interface{},
 	externalColumnList string,
 	joinItemRelationsToItemsFunc, joinItemRelationsToPermissionsFunc, filterAttemptsFunc func(*database.DB) *database.DB,
 ) *database.DB {
 	itemsWithoutResultsQuery := constructItemListWithoutResultsQuery(dataStore, groupID, requiredViewPermissionOnItems,
-		watchedGroupIDSet, watchedGroupID, columnList, columnListValues, joinItemRelationsToItemsFunc, joinItemRelationsToPermissionsFunc)
+		watchedGroupIDIsSet, watchedGroupID, columnList, columnListValues, joinItemRelationsToItemsFunc, joinItemRelationsToPermissionsFunc)
 
 	if externalColumnList != "" {
 		externalColumnList += ", "

--- a/app/api/items/raw_watched_group_stat_fields.go
+++ b/app/api/items/raw_watched_group_stat_fields.go
@@ -13,9 +13,9 @@ type RawWatchedGroupStatFields struct {
 }
 
 func (stat *RawWatchedGroupStatFields) asItemWatchedGroupStat(
-	watchedGroupIDSet bool, permissionGrantedStore *database.PermissionGrantedStore,
+	watchedGroupIDIsSet bool, permissionGrantedStore *database.PermissionGrantedStore,
 ) *itemWatchedGroupStat {
-	if !watchedGroupIDSet {
+	if !watchedGroupIDIsSet {
 		return nil
 	}
 	result := &itemWatchedGroupStat{

--- a/app/service/watched_group.go
+++ b/app/service/watched_group.go
@@ -7,7 +7,7 @@ import (
 
 // ResolveWatchedGroupID returns the watched_group_id parameter (if given) and checks if the current user has rights
 // to watch for its members.
-func (srv *Base) ResolveWatchedGroupID(httpReq *http.Request) (watchedGroupID int64, watchedGroupIDSet bool, apiError APIError) {
+func (srv *Base) ResolveWatchedGroupID(httpReq *http.Request) (watchedGroupID int64, watchedGroupIDIsSet bool, apiError APIError) {
 	if len(httpReq.URL.Query()["watched_group_id"]) == 0 {
 		return 0, false, NoError
 	}

--- a/app/service/watched_group.go
+++ b/app/service/watched_group.go
@@ -7,7 +7,7 @@ import (
 
 // ResolveWatchedGroupID returns the watched_group_id parameter (if given) and checks if the current user has rights
 // to watch for its members.
-func (srv *Base) ResolveWatchedGroupID(httpReq *http.Request) (watchedGroupID int64, ok bool, apiError APIError) {
+func (srv *Base) ResolveWatchedGroupID(httpReq *http.Request) (watchedGroupID int64, watchedGroupIDSet bool, apiError APIError) {
 	if len(httpReq.URL.Query()["watched_group_id"]) == 0 {
 		return 0, false, NoError
 	}

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -44,26 +44,26 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	forbiddenError := service.ErrForbidden(errors.New("no rights to watch for watched_group_id"))
 
 	tests := []struct {
-		name                  string
-		url                   string
-		wantWatchedGroupID    int64
-		wantWatchedGroupIDSet bool
-		wantAPIError          service.APIError
+		name                    string
+		url                     string
+		wantWatchedGroupID      int64
+		wantWatchedGroupIDIsSet bool
+		wantAPIError            service.APIError
 	}{
 		{name: "watched_group_id is not managed by the user", url: "?watched_group_id=4", wantAPIError: forbiddenError},
 		{name: "no can_watch_members permission", url: "?watched_group_id=2", wantAPIError: forbiddenError},
-		{name: "managed by an ancestor", url: "?watched_group_id=3", wantWatchedGroupID: 3, wantWatchedGroupIDSet: true},
-		{name: "managed by the user", url: "?watched_group_id=5", wantWatchedGroupID: 5, wantWatchedGroupIDSet: true},
-		{name: "an ancestor is managed", url: "?watched_group_id=6", wantWatchedGroupID: 6, wantWatchedGroupIDSet: true},
+		{name: "managed by an ancestor", url: "?watched_group_id=3", wantWatchedGroupID: 3, wantWatchedGroupIDIsSet: true},
+		{name: "managed by the user", url: "?watched_group_id=5", wantWatchedGroupID: 5, wantWatchedGroupIDIsSet: true},
+		{name: "an ancestor is managed", url: "?watched_group_id=6", wantWatchedGroupID: 6, wantWatchedGroupIDIsSet: true},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
-			watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(req)
+			watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(req)
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)
-			assert.Equal(t, tt.wantWatchedGroupIDSet, watchedGroupIDSet)
+			assert.Equal(t, tt.wantWatchedGroupIDIsSet, watchedGroupIDIsSet)
 			assert.Equal(t, tt.wantAPIError, apiError)
 		})
 	}

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -44,26 +44,26 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	forbiddenError := service.ErrForbidden(errors.New("no rights to watch for watched_group_id"))
 
 	tests := []struct {
-		name               string
-		url                string
-		wantWatchedGroupID int64
-		wantOk             bool
-		wantAPIError       service.APIError
+		name                  string
+		url                   string
+		wantWatchedGroupID    int64
+		wantWatchedGroupIDSet bool
+		wantAPIError          service.APIError
 	}{
 		{name: "watched_group_id is not managed by the user", url: "?watched_group_id=4", wantAPIError: forbiddenError},
 		{name: "no can_watch_members permission", url: "?watched_group_id=2", wantAPIError: forbiddenError},
-		{name: "managed by an ancestor", url: "?watched_group_id=3", wantWatchedGroupID: 3, wantOk: true},
-		{name: "managed by the user", url: "?watched_group_id=5", wantWatchedGroupID: 5, wantOk: true},
-		{name: "an ancestor is managed", url: "?watched_group_id=6", wantWatchedGroupID: 6, wantOk: true},
+		{name: "managed by an ancestor", url: "?watched_group_id=3", wantWatchedGroupID: 3, wantWatchedGroupIDSet: true},
+		{name: "managed by the user", url: "?watched_group_id=5", wantWatchedGroupID: 5, wantWatchedGroupIDSet: true},
+		{name: "an ancestor is managed", url: "?watched_group_id=6", wantWatchedGroupID: 6, wantWatchedGroupIDSet: true},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
-			watchedGroupID, ok, apiError := srv.ResolveWatchedGroupID(req)
+			watchedGroupID, watchedGroupIDSet, apiError := srv.ResolveWatchedGroupID(req)
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)
-			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantWatchedGroupIDSet, watchedGroupIDSet)
 			assert.Equal(t, tt.wantAPIError, apiError)
 		})
 	}

--- a/app/service/watched_group_test.go
+++ b/app/service/watched_group_test.go
@@ -10,19 +10,19 @@ import (
 
 func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	tests := []struct {
-		name               string
-		url                string
-		wantWatchedGroupID int64
-		wantOk             bool
-		wantAPIError       APIError
+		name                  string
+		url                   string
+		wantWatchedGroupID    int64
+		wantWatchedGroupIDSet bool
+		wantAPIError          APIError
 	}{
-		{name: "no watched_group_id", url: "/dummy", wantWatchedGroupID: 0, wantOk: false, wantAPIError: NoError},
+		{name: "no watched_group_id", url: "/dummy", wantWatchedGroupID: 0, wantWatchedGroupIDSet: false, wantAPIError: NoError},
 		{
-			name:               "invalid watched_group_id",
-			url:                "/dummy?watched_group_id=abc",
-			wantWatchedGroupID: 0,
-			wantOk:             false,
-			wantAPIError:       ErrInvalidRequest(errors.New("wrong value for watched_group_id (should be int64)")),
+			name:                  "invalid watched_group_id",
+			url:                   "/dummy?watched_group_id=abc",
+			wantWatchedGroupID:    0,
+			wantWatchedGroupIDSet: false,
+			wantAPIError:          ErrInvalidRequest(errors.New("wrong value for watched_group_id (should be int64)")),
 		},
 	}
 
@@ -30,10 +30,10 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
-			watchedGroupID, ok, apiError := (&Base{}).ResolveWatchedGroupID(req)
+			watchedGroupID, watchedGroupIDSet, apiError := (&Base{}).ResolveWatchedGroupID(req)
 
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)
-			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantWatchedGroupIDSet, watchedGroupIDSet)
 			assert.Equal(t, tt.wantAPIError, apiError)
 		})
 	}

--- a/app/service/watched_group_test.go
+++ b/app/service/watched_group_test.go
@@ -10,19 +10,19 @@ import (
 
 func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	tests := []struct {
-		name                  string
-		url                   string
-		wantWatchedGroupID    int64
-		wantWatchedGroupIDSet bool
-		wantAPIError          APIError
+		name                    string
+		url                     string
+		wantWatchedGroupID      int64
+		wantWatchedGroupIDIsSet bool
+		wantAPIError            APIError
 	}{
-		{name: "no watched_group_id", url: "/dummy", wantWatchedGroupID: 0, wantWatchedGroupIDSet: false, wantAPIError: NoError},
+		{name: "no watched_group_id", url: "/dummy", wantWatchedGroupID: 0, wantWatchedGroupIDIsSet: false, wantAPIError: NoError},
 		{
-			name:                  "invalid watched_group_id",
-			url:                   "/dummy?watched_group_id=abc",
-			wantWatchedGroupID:    0,
-			wantWatchedGroupIDSet: false,
-			wantAPIError:          ErrInvalidRequest(errors.New("wrong value for watched_group_id (should be int64)")),
+			name:                    "invalid watched_group_id",
+			url:                     "/dummy?watched_group_id=abc",
+			wantWatchedGroupID:      0,
+			wantWatchedGroupIDIsSet: false,
+			wantAPIError:            ErrInvalidRequest(errors.New("wrong value for watched_group_id (should be int64)")),
 		},
 	}
 
@@ -30,10 +30,10 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
-			watchedGroupID, watchedGroupIDSet, apiError := (&Base{}).ResolveWatchedGroupID(req)
+			watchedGroupID, watchedGroupIDIsSet, apiError := (&Base{}).ResolveWatchedGroupID(req)
 
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)
-			assert.Equal(t, tt.wantWatchedGroupIDSet, watchedGroupIDSet)
+			assert.Equal(t, tt.wantWatchedGroupIDIsSet, watchedGroupIDIsSet)
 			assert.Equal(t, tt.wantAPIError, apiError)
 		})
 	}


### PR DESCRIPTION
Since constructs like 'if ok {', where 'ok' actually means 'watched_group_id is set' especially when they are located far from the definition of 'ok' variable are not very meaningful, it's been decided to get rid of 'ok' meaning 'watched_group_id is set'.

In this change, 'ok' meaning 'watched_group_id is set' gets renamed into 'watchedGroupIDSet' first.
Then, 'watchedGroupIDSet' gets renamed into 'watchedGroupIDIsSet' to improve readability even beyond.