### PR TITLE
`updateGroup` with strengthened approvals: fix "reinvite" doesn't properly create invitations

### DIFF
--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -225,12 +225,14 @@ func (srv *Service) updateGroup(w http.ResponseWriter, r *http.Request) service.
 
 		if approvalChangeAction != "" {
 			participantIDs := s.Groups().GetDirectParticipantIDsOf(groupID)
-			s.GroupMembershipChanges().InsertEntries(user.GroupID, groupID, participantIDs, "removed_due_to_approval_change")
-			s.GroupGroups().RemoveMembersOfGroup(groupID, participantIDs)
 
 			// If the approval_change_action is 'reinvite', we need to reinvite the participants.
 			if approvalChangeAction == "reinvite" {
-				s.GroupPendingRequests().InviteParticipants(groupID, participantIDs)
+				_, _, err = s.GroupGroups().Transition(database.AdminStrengthensApprovalWithReinvite, groupID, participantIDs, nil, user.GroupID)
+				service.MustNotBeError(err)
+			} else {
+				_, _, err = s.GroupGroups().Transition(database.AdminStrengthensApprovalWithEmpty, groupID, participantIDs, nil, user.GroupID)
+				service.MustNotBeError(err)
 			}
 		}
 

--- a/app/api/groups/update_group_require_strengthened.feature
+++ b/app/api/groups/update_group_require_strengthened.feature
@@ -14,6 +14,7 @@ Feature:
       | @SubGroup | @Class | @Student3,@Student4 |                                             |                                              |                              |
     And @Teacher is a manager of the group @Class and can manage memberships and group
     And the time now is "2020-01-01T01:00:00Z"
+    And the DB time now is "2020-01-01 01:00:00"
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -125,10 +126,9 @@ Feature:
     Then the response should be "updated"
     And there should be no group pending requests for the group @Class with the type "join_request"
     And there should be the following group pending requests:
-      | group_id | member_id | type          |
-      | @Class   | @Student1 | leave_request |
-      | @Class   | @Student5 | invitation    |
-      | @Other   | @Student5 | join_request  |
+      | group_id | member_id | type         |
+      | @Class   | @Student5 | invitation   |
+      | @Other   | @Student5 | join_request |
 
   Scenario: Should reject all pending requests and send invitations to the past members when approval_change_action = 'reinvite'
     Given I am @Teacher
@@ -145,6 +145,8 @@ Feature:
       | @Class | @Student5 | invitation    |
       | @Other | @Student5 | join_request  |
     And @Teacher is a manager of the group @Class and can manage memberships and group
+    And the time now is "2020-01-01T01:00:00Z"
+    And the DB time now is "2020-01-01 01:00:00"
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -156,10 +158,15 @@ Feature:
     And there should be no group pending requests for the group @Class with the type "join_request"
     And there should be the following group pending requests:
       | group_id | member_id | type         |
-      | @Class   | @Student1 | invitation   |
       | @Class   | @Student2 | invitation   |
       | @Class   | @Student5 | invitation   |
       | @Other   | @Student5 | join_request |
+    And there should be the following group membership changes:
+      | group_id | member_id | action                         | at                  | initiator_id |
+      | @Class   | @Student1 | removed_due_to_approval_change | 2020-01-01 01:00:00 | @Teacher     |
+      | @Class   | @Student2 | invitation_created             | 2020-01-01 01:00:00 | @Teacher     |
+      | @Class   | @Student3 | join_request_refused           | 2020-01-01 01:00:00 | @Teacher     |
+      | @Class   | @Student4 | join_request_refused           | 2020-01-01 01:00:00 | @Teacher     |
 
   Scenario: Should empty the group when approval_change_action = "reinvite"
     Given I am @Teacher

--- a/app/database/group_group_store.go
+++ b/app/database/group_group_store.go
@@ -204,13 +204,3 @@ func (s *GroupGroupStore) deleteObjectsLinkedToGroups(groupIDs []int64) *DB {
 func (s *GroupGroupStore) WithGroupsRelationsLock(txFunc func(*DataStore) error) error {
 	return s.WithNamedLock(s.tableName, groupsRelationsLockTimeout, txFunc)
 }
-
-// RemoveMembersOfGroup removes members of a group.
-func (s *GroupGroupStore) RemoveMembersOfGroup(groupID int64, memberIDs []int64) {
-	err := s.
-		Where("groups_groups.parent_group_id = ?", groupID).
-		Where("groups_groups.child_group_id IN (?)", memberIDs).
-		Delete().
-		Error()
-	mustNotBeError(err)
-}

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -46,6 +46,8 @@ const (
 	LeaveRequestRefused GroupMembershipAction = "leave_request_refused"
 	// LeaveRequestWithdrawn means a user withdrew his request to leave a group.
 	LeaveRequestWithdrawn GroupMembershipAction = "leave_request_withdrawn"
+	// RemovedDueToApprovalChange means a user has been removed from a group because of approval changes.
+	RemovedDueToApprovalChange GroupMembershipAction = "removed_due_to_approval_change"
 	// NoRelation means there is no row for the group pair in the groups_groups/group_pending_requests tables.
 	NoRelation GroupMembershipAction = ""
 )
@@ -131,6 +133,10 @@ const (
 	// UserJoinsGroupByCode means a user joins a group using a group's code
 	// We don't check the code here (a calling service should check the code by itself).
 	UserJoinsGroupByCode
+	// AdminStrengthensApprovalWithEmpty means an admin strengthens the approval requirements for a group and empties it.
+	AdminStrengthensApprovalWithEmpty
+	// AdminStrengthensApprovalWithReinvite means an admin strengthens the approval requirements for a group, empties it and re-invites all the users.
+	AdminStrengthensApprovalWithReinvite
 )
 
 type groupGroupTransitionRule struct {
@@ -250,6 +256,26 @@ var groupGroupTransitionRules = map[GroupGroupTransitionAction]groupGroupTransit
 			IsMember:            NoRelation,
 			NoRelation:          NoRelation,
 			LeaveRequestCreated: NoRelation,
+		},
+	},
+	AdminStrengthensApprovalWithEmpty: {
+		Transitions: map[GroupMembershipAction]GroupMembershipAction{
+			IsMember:            RemovedDueToApprovalChange,
+			NoRelation:          NoRelation,
+			JoinRequestCreated:  NoRelation,
+			LeaveRequestCreated: RemovedDueToApprovalChange,
+			LeaveRequestExpired: RemovedDueToApprovalChange,
+			InvitationCreated:   NoRelation,
+		},
+	},
+	AdminStrengthensApprovalWithReinvite: {
+		Transitions: map[GroupMembershipAction]GroupMembershipAction{
+			IsMember:            InvitationCreated,
+			NoRelation:          NoRelation,
+			JoinRequestCreated:  NoRelation,
+			LeaveRequestCreated: RemovedDueToApprovalChange,
+			LeaveRequestExpired: RemovedDueToApprovalChange,
+			InvitationCreated:   InvitationCreated,
 		},
 	},
 }

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -135,7 +135,8 @@ const (
 	UserJoinsGroupByCode
 	// AdminStrengthensApprovalWithEmpty means an admin strengthens the approval requirements for a group and empties it.
 	AdminStrengthensApprovalWithEmpty
-	// AdminStrengthensApprovalWithReinvite means an admin strengthens the approval requirements for a group, empties it and re-invites all the users.
+	// AdminStrengthensApprovalWithReinvite means an admin strengthens the approval requirements for a group,
+	// empties it and re-invites all the users.
 	AdminStrengthensApprovalWithReinvite
 )
 

--- a/app/database/group_membership_change_store.go
+++ b/app/database/group_membership_change_store.go
@@ -1,26 +1,7 @@
 package database
 
-import "time"
-
 // GroupMembershipChangeStore implements database operations on `group_membership_changes`
 // (which stores the history of group membership changes).
 type GroupMembershipChangeStore struct {
 	*DataStore
-}
-
-// InsertEntries inserts multiple entries into the group_membership_changes table.
-func (s GroupMembershipChangeStore) InsertEntries(initiatorID, groupID int64, memberIDs []int64, action string) {
-	var groupMembershipChangesEntries []map[string]interface{}
-	for _, memberID := range memberIDs {
-		groupMembershipChangesEntries = append(groupMembershipChangesEntries, map[string]interface{}{
-			"group_id":     groupID,
-			"member_id":    memberID,
-			"at":           time.Now(),
-			"action":       action,
-			"initiator_id": initiatorID,
-		})
-	}
-
-	err := s.InsertMaps(groupMembershipChangesEntries)
-	mustNotBeError(err)
 }

--- a/app/database/group_pending_request_store.go
+++ b/app/database/group_pending_request_store.go
@@ -1,25 +1,7 @@
 package database
 
-import "time"
-
 // GroupPendingRequestStore implements database operations on `group_pending_requests`
 // (which stores requests that require an action from a user).
 type GroupPendingRequestStore struct {
 	*DataStore
-}
-
-// InviteParticipants add pending requests of invitation to participants to a group.
-func (s GroupPendingRequestStore) InviteParticipants(groupID int64, participantIDs []int64) {
-	invitationMaps := make([]map[string]interface{}, 0, len(participantIDs))
-	for _, participantID := range participantIDs {
-		invitationMaps = append(invitationMaps, map[string]interface{}{
-			"group_id":  groupID,
-			"member_id": participantID,
-			"type":      "invitation",
-			"at":        time.Now(),
-		})
-	}
-
-	err := s.InsertOrUpdateMaps(invitationMaps, []string{"type", "at"})
-	mustNotBeError(err)
 }


### PR DESCRIPTION
`reinvite` didn't work, because we didn't add the entries in table `group_membership_changes`.

I also realized a "transition" system was developed to handle those kind of changes. So the service was updated to use this transition system. For consistence and to make sure we don't end up with inconsistent states that messes up with the transition system.

Now the invitations should work as expected because the transition system takes care of it.

Two slight changes from before when the approval are strengthened:
- with `empty`:  `leave_request` doesn't stay `leave_request` but leaves the group
- with `reinvite`: `leave_request` leaves the group and doesn't get re-invited

I think those are the expected behaviors.