### PR TITLE
Make all propagations async

### DIFF
--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -231,6 +231,6 @@ func setAdditionalTimeForGroupInContest(
 	service.MustNotBeError(store.Exec("DROP TEMPORARY TABLE new_expires_at").Error())
 	if groupsGroupsModified {
 		store.ScheduleGroupsAncestorsPropagation()
-		store.ScheduleResultsPropagation()
+		store.SchedulePropagation([]string{"results"})
 	}
 }

--- a/app/api/groups/update_permissions.feature
+++ b/app/api/groups/update_permissions.feature
@@ -54,7 +54,7 @@ Feature: Change item access rights for a group
       | attempt_id | participant_id | item_id |
       | 0          | 21             | 103     |
 
-  Scenario Outline: Create a new permissions_granted row (with results propagation)
+  Scenario Outline: Create a new permissions_granted row
     Given I am the user with id "21"
     And the database table 'permissions_generated' has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
@@ -99,7 +99,7 @@ Feature: Change item access rights for a group
     | {"can_view":"info","can_make_session_official":true} | info     | none           | none      | none     | false    | true                      | info               | none                     | none                | none               | none                | none                      | none                 | none                |
     | {"is_owner":true}                                    | none     | none           | none      | none     | true     | false                     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | content             | solution                  | answer               | all                 |
 
-  Scenario Outline: Create a new permissions_granted row (without results propagation)
+  Scenario Outline: Create a new permissions_granted row (more)
     Given I am the user with id "21"
     And the database table 'permissions_generated' has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
@@ -129,9 +129,10 @@ Feature: Change item access rights for a group
       | 23       | 102     | none               | none                     | none                | none               | false              |
       | 23       | 103     | none               | none                     | none                | none               | false              |
     And the table "attempts" should stay unchanged
-    And the table "results_propagate" should be:
-      | attempt_id | participant_id | item_id | state            |
-      | 0          | 21             | 103     | to_be_propagated |
+    And the table "results" should be:
+      | attempt_id | participant_id | item_id |
+      | 0          | 21             | 102     |
+      | 0          | 21             | 103     |
   Examples:
     | json                                       | can_enter_from      | can_enter_until     |
     | {"can_enter_from":"2019-05-30T11:00:00Z"}  | 2019-05-30 11:00:00 | 9999-12-31 23:59:59 |

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -728,10 +728,10 @@ func savePermissionsIntoDB(groupID, itemID, sourceGroupID int64, dbMap map[strin
 
 	permissionGrantedStore := s.PermissionsGranted()
 	service.MustNotBeError(permissionGrantedStore.InsertOrUpdateMap(dbMap, columnsToUpdate))
-	s.SchedulePermissionsPropagation()
+	s.SchedulePropagation([]string{"permissions"})
 	if dbMap["can_view"] != nil && dbMap["can_view"] != none || dbMap["is_owner"] != nil && dbMap["is_owner"].(bool) {
 		// permissionGrantedStore.After() implicitly (via triggers) marks some attempts as to_be_propagated
 		// when an item becomes visible, so we should propagate attempts here
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 	}
 }

--- a/app/api/items/apply_dependency.go
+++ b/app/api/items/apply_dependency.go
@@ -114,10 +114,10 @@ func (srv *Service) applyDependency(rw http.ResponseWriter, httpReq *http.Reques
 		// If items have been unlocked, need to recompute access
 		if groupsUnlocked > 0 {
 			// generate permissions_generated from permissions_granted
-			store.SchedulePermissionsPropagation()
+			store.SchedulePropagation([]string{"permissions"})
 			// we should compute attempts again as new permissions were set and
 			// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
-			store.ScheduleResultsPropagation()
+			store.SchedulePropagation([]string{"results"})
 		}
 		return err
 	})

--- a/app/api/items/create_attempt.go
+++ b/app/api/items/create_attempt.go
@@ -101,7 +101,7 @@ func (srv *Service) createAttempt(w http.ResponseWriter, r *http.Request) servic
 		attemptID, err = store.Attempts().CreateNew(participantID, parentAttemptID, itemID, user.GroupID)
 		service.MustNotBeError(err)
 
-		store.ScheduleResultsPropagation()
+		store.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	if apiError != service.NoError {

--- a/app/api/items/enter.go
+++ b/app/api/items/enter.go
@@ -144,7 +144,7 @@ func (srv *Service) enter(w http.ResponseWriter, r *http.Request) service.APIErr
 			store.ScheduleGroupsAncestorsPropagation()
 			// Upserting into groups_groups may mark some attempts as 'to_be_propagated',
 			// so we need to recompute them
-			store.ScheduleResultsPropagation()
+			store.SchedulePropagation([]string{"results"})
 		} else {
 			logging.GetLogEntry(r).Warnf("items.participants_group_id is not set for the item with id = %d", entryState.itemID)
 		}

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -817,9 +817,9 @@ func Test_FindItemPath(t *testing.T) {
 			var got []items.ItemPath
 			assert.NoError(t, store.InTransaction(func(s *database.DataStore) error {
 				s.ScheduleGroupsAncestorsPropagation()
-				s.ScheduleItemsAncestorsPropagation()
-				s.SchedulePermissionsPropagation()
-				s.ScheduleResultsPropagation()
+				s.SchedulePropagation([]string{"items_ancestors"})
+				s.SchedulePropagation([]string{"permissions"})
+				s.SchedulePropagation([]string{"results"})
 
 				return nil
 			}))

--- a/app/database/badges.go
+++ b/app/database/badges.go
@@ -53,7 +53,7 @@ func (s *GroupStore) StoreBadges(badges []Badge, userID int64, newUser bool) (er
 
 	if ancestorsCalculationNeeded {
 		s.ScheduleGroupsAncestorsPropagation()
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 	}
 
 	if len(managedBadgeGroups) > 0 {

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -209,7 +209,11 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
 		types := triggersToRun.SchedulePropagationTypes
 		triggersToRun.SchedulePropagationTypes = []string{}
 
-		StartAsyncPropagation(s, s.Context().Value("propagation_endpoint").(string), types)
+		propagationEndpoint := ""
+		if s.Context().Value("propagation_endpoint") != nil {
+			propagationEndpoint = s.Context().Value("propagation_endpoint").(string)
+		}
+		StartAsyncPropagation(s, propagationEndpoint, types)
 	}
 	if triggersToRun.GroupAncestors {
 		triggersToRun.GroupAncestors = false

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -205,6 +205,10 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
 
 	triggersToRun := s.ctx.Value(triggersContextKey).(*awaitingTriggers)
 
+	if triggersToRun.GroupAncestors {
+		triggersToRun.GroupAncestors = false
+		s.createNewAncestors("groups", "group")
+	}
 	if len(triggersToRun.SchedulePropagationTypes) > 0 {
 		types := triggersToRun.SchedulePropagationTypes
 		triggersToRun.SchedulePropagationTypes = []string{}
@@ -214,10 +218,6 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
 			propagationEndpoint = s.Context().Value("propagation_endpoint").(string)
 		}
 		StartAsyncPropagation(s, propagationEndpoint, types)
-	}
-	if triggersToRun.GroupAncestors {
-		triggersToRun.GroupAncestors = false
-		s.createNewAncestors("groups", "group")
 	}
 	if triggersToRun.ItemAncestors {
 		triggersToRun.ItemAncestors = false

--- a/app/database/group_group_store.go
+++ b/app/database/group_group_store.go
@@ -60,7 +60,7 @@ func (s *GroupGroupStore) CreateRelation(parentGroupID, childGroupID int64) (err
 		// and it might not work if we call CreateRelation again in this same transaction.
 		s.createNewAncestorsInsideTransaction("groups", "group")
 
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	}))
 	return err
@@ -119,7 +119,7 @@ func (s *GroupGroupStore) DeleteRelation(parentGroupID, childGroupID int64, shou
 			s.ScheduleGroupsAncestorsPropagation()
 
 			if shouldPropagatePermissions {
-				s.SchedulePermissionsPropagation()
+				s.SchedulePropagation([]string{"permissions"})
 			}
 		}
 
@@ -183,7 +183,7 @@ func (s *GroupGroupStore) deleteGroupAndOrphanedDescendants(groupID int64) {
 	// cascading deletes from many tables including groups_ancestors, groups_propagate, permission_granted & permissions_generated
 	mustNotBeError(s.Groups().Delete("id IN (?)", idsToDelete).Error())
 
-	s.SchedulePermissionsPropagation()
+	s.SchedulePropagation([]string{"permissions"})
 }
 
 func (s *GroupGroupStore) deleteObjectsLinkedToGroups(groupIDs []int64) *DB {

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -168,7 +168,7 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			assert.NoError(t, dataStore.Table("groups_propagate").UpdateColumn("ancestors_computation_state", "done").Error())
 
 			assert.NoError(t, dataStore.InTransaction(func(s *database.DataStore) error {
-				s.SchedulePermissionsPropagation()
+				s.SchedulePropagation([]string{"permissions"})
 				return nil
 			}))
 			err := dataStore.InTransaction(func(s *database.DataStore) error {

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -455,9 +455,9 @@ func (s *GroupGroupStore) Transition(action GroupGroupTransitionAction,
 		if shouldCreateNewAncestors {
 			dataStore.ScheduleGroupsAncestorsPropagation()
 			if shouldPropagatePermissions {
-				dataStore.SchedulePermissionsPropagation()
+				dataStore.SchedulePropagation([]string{"permissions"})
 			}
-			dataStore.ScheduleResultsPropagation()
+			dataStore.SchedulePropagation([]string{"results"})
 		}
 		return nil
 	}))

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -268,8 +268,9 @@ func testTransitionAcceptingNoRelationAndAnyPendingRequest(name string, action d
 			{GroupID: 20, MemberID: 6, Action: string(expectedGroupMembershipAction), At: currentTimePtr, InitiatorID: userIDPtr},
 			{GroupID: 20, MemberID: 7, Action: string(expectedGroupMembershipAction), At: currentTimePtr, InitiatorID: userIDPtr},
 		},
-		wantGrantedPermissions: grantedPermissionsUnchanged,
-		shouldRunListeners:     true,
+		wantGrantedPermissions:   grantedPermissionsUnchanged,
+		wantGeneratedPermissions: generatedPermissionsUnchanged,
+		shouldRunListeners:       true,
 	}
 }
 
@@ -328,8 +329,9 @@ func testTransitionAcceptingPendingRequest(name string, action database.GroupGro
 		wantGroupMembershipChanges: []groupMembershipChange{
 			{GroupID: 20, MemberID: acceptedID, Action: string(expectedGroupMembershipAction), At: currentTimePtr, InitiatorID: userIDPtr},
 		},
-		wantGrantedPermissions: grantedPermissionsUnchanged,
-		shouldRunListeners:     true,
+		wantGrantedPermissions:   grantedPermissionsUnchanged,
+		wantGeneratedPermissions: generatedPermissionsUnchanged,
+		shouldRunListeners:       true,
 	}
 }
 
@@ -425,8 +427,9 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 				{GroupID: 20, MemberID: 6, Action: "invitation_created", InitiatorID: userIDPtr, At: currentTimePtr},
 				{GroupID: 20, MemberID: 7, Action: "invitation_created", InitiatorID: userIDPtr, At: currentTimePtr},
 			},
-			wantGrantedPermissions: grantedPermissionsUnchanged,
-			shouldRunListeners:     true,
+			wantGrantedPermissions:   grantedPermissionsUnchanged,
+			wantGeneratedPermissions: generatedPermissionsUnchanged,
+			shouldRunListeners:       true,
 		},
 		{
 			name:                       "AdminCreatesInvitation (max participants limit is not exceeded)",
@@ -459,8 +462,9 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 				{GroupID: 20, MemberID: 6, Action: "invitation_created", InitiatorID: userIDPtr, At: currentTimePtr},
 				{GroupID: 20, MemberID: 7, Action: "invitation_created", InitiatorID: userIDPtr, At: currentTimePtr},
 			},
-			wantGrantedPermissions: grantedPermissionsUnchanged,
-			shouldRunListeners:     true,
+			wantGrantedPermissions:   grantedPermissionsUnchanged,
+			wantGeneratedPermissions: generatedPermissionsUnchanged,
+			shouldRunListeners:       true,
 		},
 		{
 			name:                       "AdminCreatesInvitation (enforce max participants)",

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -29,7 +29,7 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 	testhelpers.RunConcurrently(func() {
 		dataStore := database.NewDataStoreWithContext(context.Background(), db)
 		assert.NoError(t, dataStore.InTransaction(func(ds *database.DataStore) error {
-			ds.ScheduleItemsAncestorsPropagation()
+			ds.SchedulePropagation([]string{"items_ancestors"})
 			return nil
 		}))
 	}, 30)
@@ -63,7 +63,7 @@ func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
 
 	itemItemStore := database.NewDataStore(db).ItemItems()
 	assert.NoError(t, itemItemStore.InTransaction(func(ds *database.DataStore) error {
-		ds.ScheduleItemsAncestorsPropagation()
+		ds.SchedulePropagation([]string{"items_ancestors"})
 		return nil
 	}))
 
@@ -98,7 +98,7 @@ func TestItemItemStore_CreateNewAncestors_IgnoresDoneItems(t *testing.T) {
 	}
 
 	assert.NoError(t, itemItemStore.InTransaction(func(ds *database.DataStore) error {
-		ds.ScheduleItemsAncestorsPropagation()
+		ds.SchedulePropagation([]string{"items_ancestors"})
 		return nil
 	}))
 

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -318,9 +318,9 @@ func (s *ItemStore) DeleteItem(itemID int64) (err error) {
 		}))
 		mustNotBeError(s.Items().ByID(itemID).Delete().Error())
 
-		s.ScheduleItemsAncestorsPropagation()
-		s.SchedulePermissionsPropagation()
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"items_ancestors"})
+		s.SchedulePropagation([]string{"permissions"})
+		s.SchedulePropagation([]string{"results"})
 
 		return nil
 	})

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -43,7 +43,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *test
 	assert.NoError(t, permissionGrantedStore.Where("group_id=2 AND item_id=11").
 		UpdateColumn("can_view", "content").Error())
 	assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 
@@ -116,7 +116,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t
 		"content_view_propagation": "as_info",
 	}).Error())
 	assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 
@@ -189,7 +189,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 			assert.NoError(t, permissionGrantedStore.Where("group_id=2 AND item_id=11").
 				UpdateColumn("can_view", access).Error())
 			assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-				ds.SchedulePermissionsPropagation()
+				ds.SchedulePropagation([]string{"permissions"})
 				return nil
 			}))
 
@@ -334,7 +334,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 				permissions_granted: [{group_id: 1, item_id: 1, source_group_id: 1, can_view: ` + testcase.canView + `}]`)
 			permissionStore := database.NewDataStore(db).Permissions()
 			assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-				ds.SchedulePermissionsPropagation()
+				ds.SchedulePropagation([]string{"permissions"})
 				return nil
 			}))
 			var result string
@@ -363,7 +363,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanView(t
 			- {group_id: 1, item_id: 2, source_group_id: 1, can_view: content_with_descendants}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -385,7 +385,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 			- {group_id: 2, item_id: 2, source_group_id: 1, can_view: solution}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -403,7 +403,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanView(t
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_view: content_with_descendants}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -421,7 +421,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanViewAsSolutionForO
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_view: content_with_descendants, is_owner: 1}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -450,7 +450,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanGrantV
 			- {group_id: 1, item_id: 3, source_group_id: 1, can_grant_view: solution_with_grant}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -471,7 +471,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 			- {group_id: 2, item_id: 2, source_group_id: 1, can_grant_view: solution}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -489,7 +489,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanGrantV
 			- {group_id: 1, item_id: 1, source_group_id: 1, origin: group_membership, can_grant_view: content_with_descendants}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -508,7 +508,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanGrantViewAsSolutio
 			- {group_id: 3, item_id: 2, source_group_id: 3, can_grant_view: none, is_owner: 1}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -541,7 +541,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanWatch(
 			- {group_id: 1, item_id: 3, source_group_id: 1, can_watch: answer_with_grant}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -562,7 +562,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 			- {group_id: 2, item_id: 2, source_group_id: 1, can_watch: answer}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -580,7 +580,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanWatch(
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_watch: answer}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -598,7 +598,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanWatchAsAnswerWithG
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_watch: answer, is_owner: 1}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -627,7 +627,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanEdit(t
 			- {group_id: 1, item_id: 3, source_group_id: 1, can_edit: all_with_grant}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -648,7 +648,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 			- {group_id: 2, item_id: 2, source_group_id: 1, can_edit: all}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -666,7 +666,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanEdit(t
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_edit: all}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -684,7 +684,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanEditAsAllWithGrant
 			- {group_id: 1, item_id: 1, source_group_id: 1, can_edit: all, is_owner: 1}`)
 	permissionStore := database.NewDataStore(db).Permissions()
 	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
+		ds.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	var result string
@@ -768,7 +768,7 @@ func testPropagates(t *testing.T, column, propagationColumn, valueForParent stri
 				permissions_granted: [{group_id: 1, item_id: 1, source_group_id: 1, ` + column + `: ` + valueForParent + `}]`)
 		permissionStore := database.NewDataStore(db).Permissions()
 		assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-			ds.SchedulePermissionsPropagation()
+			ds.SchedulePropagation([]string{"permissions"})
 			return nil
 		}))
 		var result string

--- a/app/database/permission_granted_store_compute_all_access_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_integration_test.go
@@ -25,7 +25,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_Concurrency(t *testing.T) {
 	testhelpers.RunConcurrently(func() {
 		dataStore := database.NewDataStoreWithContext(context.Background(), db)
 		assert.NoError(t, dataStore.InTransaction(func(ds *database.DataStore) error {
-			ds.SchedulePermissionsPropagation()
+			ds.SchedulePropagation([]string{"permissions"})
 			return nil
 		}))
 	}, 30)

--- a/app/database/result_store.go
+++ b/app/database/result_store.go
@@ -39,7 +39,7 @@ func (s *ResultStore) MarkAsToBePropagated(participantID, attemptID, itemID int6
 		INSERT IGNORE INTO results_propagate (participant_id, attempt_id, item_id, state)
 		VALUES(?, ?, ?, 'to_be_propagated')`, participantID, attemptID, itemID).Error()
 	if err == nil && propagateNow {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 	}
 	return err
 }

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -75,7 +75,7 @@ func TestResultStore_Propagate(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := database.NewDataStore(db).InTransaction(func(s *database.DataStore) error {
-				s.ScheduleResultsPropagation()
+				s.SchedulePropagation([]string{"results"})
 				return nil
 			})
 			if (err != nil) != tt.wantErr {
@@ -94,7 +94,7 @@ func TestResultStore_Propagate(t *testing.T) {
 //	testhelpers.RunConcurrently(func() {
 //		s := database.NewDataStoreWithContext(context.Background(), db)
 //		err := s.InTransaction(func(st *database.DataStore) error {
-//			st.ScheduleResultsPropagation()
+//			st.SchedulePropagation([]string{"results"})
 //			return nil
 //		})
 //		assert.NoError(t, err)

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -350,10 +350,10 @@ func (s *ResultStore) propagate() (err error) {
 	if groupsUnlocked > 0 {
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			// generate permissions_generated from permissions_granted
-			s.SchedulePermissionsPropagation()
+			s.SchedulePropagation([]string{"permissions"})
 			// we should compute attempts again as new permissions were set and
 			// triggers on permissions_generated likely marked some attempts as 'to_be_propagated'
-			s.ScheduleResultsPropagation()
+			s.SchedulePropagation([]string{"results"})
 
 			return nil
 		}))

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -69,7 +69,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 			err := resultStore.InTransaction(func(s *database.DataStore) error {
 				assert.NoError(t, resultStore.Exec(
 					"INSERT IGNORE INTO results_propagate SELECT participant_id, attempt_id, item_id, 'to_be_propagated' AS state FROM results").Error())
-				s.ScheduleResultsPropagation()
+				s.SchedulePropagation([]string{"results"})
 				return nil
 			})
 			assert.NoError(t, err)
@@ -116,7 +116,7 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 
 	resultStore := database.NewDataStore(db).Results()
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -145,7 +145,7 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 	}).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -189,7 +189,7 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 				}).Error())
 
 			err := resultStore.InTransaction(func(s *database.DataStore) error {
-				s.ScheduleResultsPropagation()
+				s.SchedulePropagation([]string{"results"})
 				return nil
 			})
 			assert.NoError(t, err)

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -75,7 +75,7 @@ func testResultStorePropagateCreatesNew(t *testing.T, testCase *resultStorePropa
 	}
 	resultStore := database.NewDataStore(db).Results()
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/result_store_propagate_cyclic_graph_integration_test.go
+++ b/app/database/result_store_propagate_cyclic_graph_integration_test.go
@@ -25,7 +25,7 @@ func TestResultStore_Propagate_WithCyclicGraph(t *testing.T) {
 	resultStore := database.NewDataStore(db).Results()
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -59,7 +59,7 @@ func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
 	prepareDependencies(db, t)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -117,7 +117,7 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHas
 	prepareDependencies(db, t)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func testRegularUnlocks(db *database.DB, t *testing.T) {
 
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -208,7 +208,7 @@ func testExplicitEntryUnlocks(db *database.DB, t *testing.T) {
 	prepareDependencies(db, t)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		sSchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -208,7 +208,7 @@ func testExplicitEntryUnlocks(db *database.DB, t *testing.T) {
 	prepareDependencies(db, t)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		sSchedulePropagation([]string{"results"})
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -60,7 +60,7 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 		UpdateColumn("validated_at", skippedDate).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 			Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 		UpdateColumn("category", "Validation").Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -163,7 +163,7 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 		UpdateColumn("category", "Validation").Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)
@@ -207,7 +207,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	}).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -43,7 +43,7 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	}
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
+		s.SchedulePropagation([]string{"results"})
 		return nil
 	})
 	assert.NoError(t, err)

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -201,7 +201,7 @@ func setupDBForDeleteWithTrapsTests(t *testing.T, currentTime time.Time) *databa
 	store := database.NewDataStore(db)
 	assert.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
 		trStore.ScheduleGroupsAncestorsPropagation()
-		trStore.SchedulePermissionsPropagation()
+		trStore.SchedulePropagation([]string{"permissions"})
 		return nil
 	}))
 	return db

--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -96,9 +96,9 @@ func recomputeDBCaches(gormDB *database.DB) error {
 	return database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
 		fmt.Print("Schedule the propagations\n")
 		store.ScheduleGroupsAncestorsPropagation()
-		store.ScheduleItemsAncestorsPropagation()
-		store.SchedulePermissionsPropagation()
-		store.ScheduleResultsPropagation()
+		store.SchedulePropagation([]string{"items_ancestors"})
+		store.SchedulePropagation([]string{"permissions"})
+		store.SchedulePropagation([]string{"results"})
 
 		return nil
 	})

--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -96,9 +96,9 @@ func recomputeDBCaches(gormDB *database.DB) error {
 	return database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
 		fmt.Print("Schedule the propagations\n")
 		store.ScheduleGroupsAncestorsPropagation()
-		store.SchedulePropagation([]string{"items_ancestors"})
-		store.SchedulePropagation([]string{"permissions"})
-		store.SchedulePropagation([]string{"results"})
+		store.ScheduleItemsAncestorsPropagation()
+		store.SchedulePermissionsPropagation()
+		store.ScheduleResultsPropagation()
 
 		return nil
 	})


### PR DESCRIPTION
Related to #1047 (First step of: Make sure async propagation does not block other requests).

The `async` propagation, when executed `async` or `sync` when there's no endpoint or an error during its call, always execute the following propagations:
- `items_ancestors`
- `permissions`
- `results`

There were tests that checked things like "verify that the `results` propagation has been run but not the `permissions` propagation. Those tests have been updated because it cannot happen anymore.

Note: The `groups ancestor`propagation is an exception. It is always executed in sync because there are cases where its results are used in intermediate computations. Since it's very fast compared to the others, it shouldn't be a problem.

### Review

Easier to review commit by commit as there are a few steps. Details in commit messages.