### PR TITLE
Print errors and other messages related to config loading to os.Stderr instead of SharedLogger in app/config.go

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -62,20 +61,20 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 	// because it might contain the credentials to a live database, and running the tests will erase the database
 	if !appenv.IsEnvTest() {
 		if err = config.ReadInConfig(); err != nil {
-			log.Print("Cannot read the main config file, ignoring it: ", err)
+			fmt.Fprint(os.Stderr, "Cannot read the main config file, ignoring it: ", err)
 		}
 	}
 
 	environment := appenv.Env()
-	log.Printf("Loading environment: %s\n", environment)
+	fmt.Fprintf(os.Stderr, "Loading environment: %s\n", environment)
 
 	config.SetConfigName(filename + "." + environment)
 	if err = config.MergeInConfig(); err != nil {
 		if appenv.IsEnvTest() {
-			log.Printf("Cannot read the %q config file: %s", environment, err)
+			fmt.Fprintf(os.Stderr, "Cannot read the %q config file: %s", environment, err)
 			panic("Cannot read the test config file")
 		} else {
-			log.Printf("Cannot merge %q config file, ignoring it: %s", environment, err)
+			fmt.Fprintf(os.Stderr, "Cannot merge %q config file, ignoring it: %s", environment, err)
 		}
 	}
 

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -3,8 +3,8 @@ package app
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -70,10 +70,13 @@ func TestLoadConfigFrom(t *testing.T) {
 func TestLoadConfigFrom_ShouldLogWarningWhenNonTestEnvAndNoMainConfigFile(t *testing.T) {
 	assert := assertlib.New(t)
 
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
+	origStdErr := os.Stderr
+	stdErrReader, stdErrWriter, _ := os.Pipe()
+	os.Stderr = stdErrWriter
 	defer func() {
-		log.SetOutput(os.Stderr)
+		os.Stderr = origStdErr
+		_ = stdErrWriter.Close()
+		_ = stdErrReader.Close()
 	}()
 
 	monkey.Patch(appenv.Env, func() string { return devEnv })
@@ -89,6 +92,11 @@ func TestLoadConfigFrom_ShouldLogWarningWhenNonTestEnvAndNoMainConfigFile(t *tes
 
 	conf := loadConfigFrom(configName, os.TempDir())
 	assert.NotNil(conf)
+
+	_ = stdErrWriter.Close()
+	buf := new(bytes.Buffer)
+	_, _ = io.Copy(buf, stdErrReader)
+
 	assert.Contains(buf.String(), "Cannot read the main config file, ignoring it")
 }
 


### PR DESCRIPTION
Messages related to config loading are printed at the time when the config hasn't been loaded yet. This means the SharedLogger hasn't been configured yet too, so we should not use it.

Mostly the effect of this is that our BDD and other integration tests write messages like 'Loading environment: test' to a logger initialized by a previous test which make the tests not isolated.