### PR TITLE
Do not store the logger inside DBLogger & StructuredDBLogger

### DIFF
--- a/app/logging/db_logger.go
+++ b/app/logging/db_logger.go
@@ -9,20 +9,26 @@ type DBLogger interface {
 	Print(v ...interface{})
 }
 
+type sharedLoggerWriter struct{}
+
+func (l *sharedLoggerWriter) Println(v ...interface{}) {
+	SharedLogger.Println(v...)
+}
+
 // NewDBLogger returns a logger for the database and the `logMode` as well as the 'rawLogMode', according to the config.
 func (l *Logger) NewDBLogger() (DBLogger, bool, bool) {
 	if l.config == nil {
 		// if cannot parse config, log on error to stdout
-		return gorm.Logger{LogWriter: l}, false, false
+		return gorm.Logger{LogWriter: &sharedLoggerWriter{}}, false, false
 	}
 
 	logMode := l.config.GetBool("LogSQLQueries")
 	rawLogMode := l.config.GetBool("LogRawSQLQueries")
 	switch l.config.GetString("format") {
 	case formatText:
-		return gorm.Logger{LogWriter: l}, logMode, rawLogMode
+		return gorm.Logger{LogWriter: &sharedLoggerWriter{}}, logMode, rawLogMode
 	case formatJSON:
-		return NewStructuredDBLogger(l.Logger), logMode, rawLogMode
+		return NewStructuredDBLogger(), logMode, rawLogMode
 	default:
 		panic("Logging format must be either 'text' or 'json'. Got: " + l.config.GetString("format"))
 	}

--- a/app/logging/raw_db_logger_test.go
+++ b/app/logging/raw_db_logger_test.go
@@ -12,11 +12,13 @@ import (
 )
 
 func TestNewRawDBLogger_TextLog(t *testing.T) {
-	nulllogger, hook := loggingtest.NewNullLogger()
+	var hook *loggingtest.Hook
+	SharedLogger.Logger, hook = loggingtest.NewNullLogger()
+	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "text")
 	config.Set("LogRawSQLQueries", true)
-	logger := &Logger{nulllogger, config}
+	logger := &Logger{SharedLogger.Logger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
@@ -25,11 +27,13 @@ func TestNewRawDBLogger_TextLog(t *testing.T) {
 }
 
 func TestNewRawDBLogger_HonoursLogMode(t *testing.T) {
-	nulllogger, hook := loggingtest.NewNullLogger()
+	var hook *loggingtest.Hook
+	SharedLogger.Logger, hook = loggingtest.NewNullLogger()
+	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "text")
 	config.Set("LogRawSQLQueries", false)
-	logger := &Logger{nulllogger, config}
+	logger := &Logger{SharedLogger.Logger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
 	rawLogger.Log(context.TODO(), "some message", "err", nil)
@@ -37,11 +41,13 @@ func TestNewRawDBLogger_HonoursLogMode(t *testing.T) {
 }
 
 func TestNewRawDBLogger_JSONLog(t *testing.T) {
-	nulllogger, hook := loggingtest.NewNullLogger()
+	var hook *loggingtest.Hook
+	SharedLogger.Logger, hook = loggingtest.NewNullLogger()
+	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "json")
 	config.Set("LogRawSQLQueries", true)
-	logger := &Logger{nulllogger, config}
+	logger := &Logger{SharedLogger.Logger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
 	rawLogger.Log(context.TODO(), "some message", "err", nil)
@@ -50,11 +56,13 @@ func TestNewRawDBLogger_JSONLog(t *testing.T) {
 }
 
 func TestRawDBLogger_ShouldSkipSkippedActions(t *testing.T) {
-	nulllogger, hook := loggingtest.NewNullLogger()
+	var hook *loggingtest.Hook
+	SharedLogger.Logger, hook = loggingtest.NewNullLogger()
+	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "json")
 	config.Set("LogRawSQLQueries", true)
-	logger := &Logger{nulllogger, config}
+	logger := &Logger{SharedLogger.Logger, config}
 	dbLogger, _, rawLogMode := logger.NewDBLogger()
 	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
 	rawLogger.Log(context.TODO(), "sql-stmt-exec", "err", driver.ErrSkip)

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -6,18 +6,14 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/sirupsen/logrus" //nolint:depguard
 )
 
 // StructuredDBLogger is a database structured logger.
-type StructuredDBLogger struct {
-	logger *logrus.Logger
-}
+type StructuredDBLogger struct{}
 
 // NewStructuredDBLogger created a database structured logger.
-func NewStructuredDBLogger(logger *logrus.Logger) *StructuredDBLogger {
-	return &StructuredDBLogger{logger}
+func NewStructuredDBLogger() *StructuredDBLogger {
+	return &StructuredDBLogger{}
 }
 
 var (
@@ -29,7 +25,7 @@ var (
 // values: 0: level, 1: source file, 2: duration in ns, 3: query, 4: slice of parameters, 5: rows affected or returned
 func (l *StructuredDBLogger) Print(values ...interface{}) {
 	level := values[0]
-	logger := l.logger.WithField("type", "db")
+	logger := SharedLogger.WithField("type", "db")
 
 	switch level {
 	case "sql":

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -98,8 +98,10 @@ func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 
 func TestStructuredDBLogger_Print_RawSQLWithDuration(t *testing.T) {
 	assert := assertlib.New(t)
-	logger, hook := test.NewNullLogger()
-	structuredLogger := logging.NewStructuredDBLogger(logger)
+	var hook *test.Hook
+	logging.SharedLogger.Logger, hook = test.NewNullLogger()
+	defer logging.ResetShared()
+	structuredLogger := logging.NewStructuredDBLogger()
 	structuredLogger.Print("rawsql", nil, "sql-stmt-exec",
 		map[string]interface{}{
 			"query":    "SELECT 1",


### PR DESCRIPTION
Currently (historically) DBLogger & StructuredDBLogger store their own pointers to logger instances. So each of them writes logs using its own logger. The loggers are stored at time of DBLogger/StructuredDBLogger construction. For StructuredDBLogger which is constructed only once on registering 'instrumented-mysql' driver, this means that it continues using the same old logger even for new DB connections, even if the SharedLogger has been reconfigured/recreated. For the DBLogger, the situation is a bit better: it is recreated for each new DB connection.

Although it works well in prod, it breaks isolation of tests. Anyway, there is no real need behind storing a logger inside DBLogger/StructuredDBLogger. It was done this way in order to be independent from SharedLogger global variable, but this variable is forever with us and it is used everywhere. Even if we hadn't had this global variable, it would be better to construct a new logger each time than storing an old outdated one.

For the above reasons, as DBLogger & StructuredDBLogger can simply use the SharedLogger, here we abandon the idea of storing loggers inside DBLogger & StructuredDBLogger.