### PR TITLE
Makefile: make test-bdd work and check for races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-unit:
 	$(GOTEST) -gcflags=all=-l -race -cover -v -tags=unit $(TEST_DIR) $(TEST_FILTER)
 test-bdd:
 	# to pass args: make TAGS=wip test-bdd
-	$(Q)$(GOTEST) -v -tags=!unit -run TestBDD $(TEST_DIR) -p 1 -parallel 1 $(TEST_TAGS)
+	$(Q)$(GOTEST) -gcflags=all=-l -race -v -tags=!unit -run TestBDD $(TEST_DIR) -p 1 -parallel 1 $(TEST_TAGS)
 lint:
 	@[ -e $(GOLANGCILINT) ] && \
 		($(GOLANGCILINT) --version | grep -F "version $(GOLANGCILINT_VERSION) built" > /dev/null || rm $(GOLANGCILINT)) || true


### PR DESCRIPTION
Currently in Makefile the 'test-bdd' target doesn't contain the '-gcflags=all=-l' flag which is required by 'monkey' package to work fine.

Here we add. Also, the '-race' flag is added to check for data races while running BDD tests.