### PR TITLE
Suppress output of passed BDD scenarios and suites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/testify v1.8.2
 	github.com/thingful/httpmock v0.0.0-20171102191412-cfb4c64b7d81
+	github.com/zenovich/flowmingo v1.0.4
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/thingful/httpmock v0.0.0-20171102191412-cfb4c64b7d81/go.mod h1:7l+awG
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zenovich/flowmingo v1.0.4 h1:o91AVw8OcHgM+D3OGjJzdoZZxlU5TK3F/wu5eSwLYk8=
+github.com/zenovich/flowmingo v1.0.4/go.mod h1:P+S7uJahGneGBFcndKOxuy2rrVfFhpQ5au+pLQc0Sxs=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
As a subtask of #1105, we suppress output of passed BDD scenarios and suites.
Depends on #1107 