### PR TITLE
Suppress output of items-related integration tests if they pass

### DIFF
--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -811,6 +811,8 @@ func Test_FindItemPath(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -438,6 +438,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)

--- a/testhelpers/suppress_output.go
+++ b/testhelpers/suppress_output.go
@@ -17,7 +17,7 @@ import (
 // After the output is suppressed, t.Parallel() for the test will panic.
 //
 // Note: This function does nothing if the test is run in verbose mode.
-func SuppressOutputIfPasses(t *testing.T) {
+func SuppressOutputIfPasses(t *testing.T) { //nolint:gocritic
 	if testing.Verbose() {
 		return
 	}

--- a/testhelpers/suppress_output.go
+++ b/testhelpers/suppress_output.go
@@ -1,0 +1,32 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/zenovich/flowmingo"
+)
+
+// SuppressOutputIfPasses immediately mutes output (to both STDOUT and STDERR) of the test
+// so that the output will only be shown if the test fails.
+// The cleanup part is scheduled to be run automatically,
+// no need to clean up manually.
+//
+// Note: This function will only work when the test is not run in parallel within the test binary,
+// i.e. when the test (or its parents) haven't called t.Parallel(),
+// otherwise it will panic.
+// After the output is suppressed, t.Parallel() for the test will panic.
+//
+// Note: This function does nothing if the test is run in verbose mode.
+func SuppressOutputIfPasses(t *testing.T) {
+	if testing.Verbose() {
+		return
+	}
+
+	// panics if t.Parallel() has been called before, prevents future calls to t.Parallel()
+	t.Setenv("OUTPUT_CAPTURED", "1")
+
+	restoreFunc := flowmingo.CaptureStdoutAndStderr()
+	t.Cleanup(func() {
+		restoreFunc(t.Failed())
+	})
+}


### PR DESCRIPTION
As a subtask of #1105, we suppress output of some Go test (items-related integration tests) if they pass.
Depends on #1108 