### PR TITLE
Introduce "test-dev" target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ test: $(TEST_REPORT_DIR)
 	$(Q)# add FILTER=functionToTest to only test a certain function. functionToTest is a Regex.
 
 	$(Q)$(GOTEST) -gcflags=all=-l -race -coverpkg=$(COVER_PACKAGES) -coverprofile=$(TEST_REPORT_DIR)/coverage.txt -covermode=atomic -v $(TEST_DIR) -p 1 -parallel 1 $(TEST_FILTER)
+test-dev:
+	$(Q)$(GOTEST) -gcflags=all=-l $(TEST_DIR) -p 1 -parallel 1 $(TEST_FILTER)
 test-unit:
 	$(GOTEST) -gcflags=all=-l -race -cover -v -tags=unit $(TEST_DIR) $(TEST_FILTER)
 test-bdd:

--- a/README.md
+++ b/README.md
@@ -85,23 +85,32 @@ in order to recompute DB caches.
 
 ## Testing
 
-Run all tests (unit, and bdd):
+### make test
+To execute all tests (unit and bdd) with race detection and collect the test code coverage you can run:
 ```
 make test
 ```
-You can filter with a certain directory and the name of the test function you want to run:
+
+This mode is the slowest one, it doesn't use the cache, and it always runs all tests. It is useful to run before pushing code to the repository.
+
+### make test-dev
+
+To get test results faster during development, you may want to run all tests without race detection and without collecting the test code coverage to get advantage of Golang per-package caching:
 ```
-make DIRECTORY=./app/database FILTER=TestItemStore_TriggerBeforeInsert_SetsPlatformID test
+make test-dev
 ```
-Only unit tests who are marked with the "unit" tag. For unit tests not marked, use `make test`:
+
+### make test-unit
+
+You may want to run only unit tests that are marked with the "unit" tag:
 ```
 make test-unit
 ```
-You can also use the filters:
-```
-make DIRECTORY=./app/database FILTER=TestItemStore_TriggerBeforeInsert_SetsPlatformID test-unit
-```
-Only Gherkin tests defined in *.feature files, using the database connection:
+`make test-unit` doesn't cache test results, all the matching tests will be run. For unit tests not marked as "unit", use `make test` or `make test-dev` instead.
+
+### make test-bdd
+
+It is possible to run only Gherkin tests defined in *.feature files:
 ```
 make test-bdd
 ```
@@ -112,9 +121,19 @@ DIRECTORY=./app/api/answers/ TAGS=wip make test-bdd
 ```
 To add a tag to a test, just precede it by @wip on the line above it in the *.feature file. This is useful to only execute appropriate tests.
 
+`make test-bdd` doesn't cache test results, all the matching tests will be run.
+
+### Tests filtering
+For all `make test*` it is possible to filter with a certain directory and the name of the test function you want to run:
+```
+make DIRECTORY=./app/database FILTER=TestItemStore_TriggerBeforeInsert_SetsPlatformID test
+```
+Note that `FILTER` is not currently supported for `make test-bdd`.
+
+
 ## Install the git hooks
 
-Copy `githooks/pre-commit` to `.git/hooks/pre-commit`. You may want to adapt the content in case you have personnal hooks.
+Copy `githooks/pre-commit` to `.git/hooks/pre-commit`. You may want to adapt the content in case you have personal hooks.
 
 ## Style
 


### PR DESCRIPTION
As a subtask of #1105 , here we introduce a new Makefile target named 'test-dev' which runs test without code coverage collecting and without verbose output in order to enable per-package caching.