### PR TITLE
Use a named volume for the 'db' service in docker-complose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "3306:3306"
       - "33060:33060"
+    volumes:
+      - mysql-volume:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: a_root_db_password
       MYSQL_USER: algorea
@@ -40,3 +42,5 @@ services:
         sleep 2;
         AlgoreaBackend serve;
       "
+volumes:
+  mysql-volume:


### PR DESCRIPTION
Currently the DB storage (/var/lib/mysql) of the 'db' service (the database container) in docker-compose.yml is stored inside the container. Because of this, the database (and the data inside it) gets removed each time we recreate the container (to upgrade MySQL or by accident).

Here I suggest using a named volume for /var/lib/mysql which will be persistently stored outside of the container.

Note, like on any update before, running `docker compose down` and `docker compose up -d` to upgrade the configuration will delete the previously configured container (with all the db data) as we haven't used the named volume before.