### PR TITLE
Introduce an in-memory MySQL in docker-compose.yml for running tests

### DIFF
--- a/conf/config.test.sample.yaml
+++ b/conf/config.test.sample.yaml
@@ -19,7 +19,7 @@ token:
 database:
   user: algorea
   passwd: a_db_password
-  addr: localhost # TEST CONFIG WARNING: Running the tests erases the database, DO NOT USE A LIVE DATABASE
+  addr: localhost:3307 # TEST CONFIG WARNING: Running the tests erases the database, DO NOT USE A LIVE DATABASE
   net: tcp
   #dbname: algorea_db
   allownativepasswords: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,26 @@ services:
       MYSQL_ROOT_HOST: "%"
     security_opt:
       - seccomp:unconfined
+  db_test:
+    image: mysql:8.0.28
+    command: --default-authentication-plugin=mysql_native_password --innodb_lock_wait_timeout=1
+    restart: always
+    ports:
+      - "3307:3306"
+      - "33070:33060"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/mysql
+        tmpfs:
+          size: 314572800 # Size in bytes, 300MB
+    environment:
+      MYSQL_ROOT_PASSWORD: a_root_db_password
+      MYSQL_USER: algorea
+      MYSQL_PASSWORD: a_db_password
+      MYSQL_DATABASE: algorea_db
+      MYSQL_ROOT_HOST: "%"
+    security_opt:
+      - seccomp:unconfined
   backend:
     build: .
     ports:


### PR DESCRIPTION
Introduce an in-memory MySQL in docker-compose.yml for running tests and use it by default in conf/config.test.sample.yaml.

On my computer it noticeably speeds up tests (11m42s vs 14m08s).