### PR TITLE
Wait for the db to start before running the app in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,19 @@ services:
       MYSQL_ROOT_HOST: "%"
     security_opt:
       - seccomp:unconfined
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
   backend:
     build: .
     ports:
       - "8080:8080"
     links:
       - db
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       ALGOREA_ENV: dev
       ALGOREA_DATABASE__ADDR: db


### PR DESCRIPTION
Otherwise, the app is run too early and fails to connect the DB.