### PR TITLE
Add test-results folder into .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !db/schema/*
 !db/migrations/*
 log/
+test-results/


### PR DESCRIPTION
Just a bit less garbage in the app's Docker container.