### PR TITLE
Make inviting_user in invitationsView nullable

### DIFF
--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -18,6 +18,8 @@ Feature: Get group invitations for the current user
       | 21 | User    | owner self                    |                               | none                                  | null                                   | false                  |
       | 33 | Class   | Other group with invitation   | Other group with invitation   | view                                  | null                                   | false                  |
       | 34 | Class   | Other group with invitation 2 | Other group with invitation 2 | edit                                  | null                                   | false                  |
+      | 35 | Class   | Group with broken change log  | Group with broken change log  | edit                                  | null                                   | false                  |
+      | 36 | Class   | Group without inviting user   | Group without inviting user   | edit                                  | null                                   | false                  |
     And the database has the following table 'users':
       | login       | temp_user | group_id | first_name  | last_name | grade |
       | owner       | 0         | 21       | Jean-Michel | Blanquer  | 3     |
@@ -39,6 +41,8 @@ Feature: Get group invitations for the current user
       | 34       | 21        | invitation_created    | {{relativeTime("-190h")}} | 13           |
       | 34       | 21        | invitation_refused    | {{relativeTime("-180h")}} | 21           |
       | 34       | 21        | invitation_created    | {{relativeTime("-166h")}} | 12           |
+      | 35       | 21        | invitation_accepted   | {{relativeTime("-186h")}} | 12           |
+      | 36       | 21        | invitation_created    | {{relativeTime("-200h")}} | null         |
       | 5        | 21        | invitation_accepted   | {{relativeTime("-165h")}} | 12           |
       | 6        | 21        | join_request_accepted | {{relativeTime("-164h")}} | 12           |
       | 7        | 21        | removed               | {{relativeTime("-163h")}} | 21           |
@@ -48,12 +52,14 @@ Feature: Get group invitations for the current user
       | 10       | 21        | joined_by_code        | {{relativeTime("-180h")}} | null         |
       | 11       | 21        | joined_by_badge       | {{relativeTime("-190h")}} | null         |
     And the database has the following table 'group_pending_requests':
-      | group_id | member_id | type         |
-      | 1        | 21        | invitation   |
-      | 33       | 21        | invitation   |
-      | 34       | 21        | invitation   |
-      | 3        | 21        | join_request |
-      | 1        | 12        | invitation   |
+      | group_id | member_id | type         | at                                             |
+      | 1        | 21        | invitation   | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
+      | 33       | 21        | invitation   | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
+      | 34       | 21        | invitation   | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
+      | 35       | 21        | invitation   | {{relativeTime("-200h")}}                      |
+      | 36       | 21        | invitation   | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
+      | 3        | 21        | join_request | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
+      | 1        | 12        | invitation   | {{currentTimeInFormat("2006-01-02 15:04:05")}} |
 
   Scenario: Show all invitations
     Given I am the user with id "21"
@@ -118,6 +124,34 @@ Feature: Get group invitations for the current user
           "require_watch_approval": true
         },
         "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}"
+      },
+      {
+        "group_id": "35",
+        "inviting_user": null,
+        "group": {
+          "id": "35",
+          "name": "Group with broken change log",
+          "description": "Group with broken change log",
+          "type": "Class",
+          "require_personal_info_access_approval": "edit",
+          "require_lock_membership_approval_until": null,
+          "require_watch_approval": false
+        },
+        "at": "{{timeToRFC(db("group_pending_requests[4][at]"))}}"
+      },
+      {
+        "group_id": "36",
+        "inviting_user": null,
+        "group": {
+          "id": "36",
+          "name": "Group without inviting user",
+          "description": "Group without inviting user",
+          "type": "Class",
+          "require_personal_info_access_approval": "edit",
+          "require_lock_membership_approval_until": null,
+          "require_watch_approval": false
+        },
+        "at": "{{timeToRFC(db("group_membership_changes[10][at]"))}}"
       }
     ]
     """


### PR DESCRIPTION
The situation where inviting_user (group_membership_changes.initiator_id) is null even for pending invitations having a corresponding (latest, with action='invitation_created') group membership change is possible and real. Actually, it's what we have in our dev database (and possibly the prod database too).

```
mysql> select at, group_id, member_id, type, action from group_pending_requests JOIN LATERAL (SELECT initiator_id, action FROM group_membership_changes WHERE group_membership_changes.group_id=group_pending_requests.group_id AND group_membership_changes.member_id=group_pending_requests.member_id ORDER BY at DESC LIMIT 1) AS latest_change ON latest_change.action='invitation_created' where type='invitation' AND action IS NOT NULL AND initiator_id IS NULL ORDER BY at;
+---------------------+---------------------+---------------------+------------+--------------------+
| at                  | group_id            | member_id           | type       | action             |
+---------------------+---------------------+---------------------+------------+--------------------+
| 2016-05-30 08:47:52 | 1061441261823291025 |  395414163411905857 | invitation | invitation_created |
| 2016-06-09 10:22:58 |  524710592747926617 |  758424489137954341 | invitation | invitation_created |
| 2016-09-12 16:45:07 |  265634762887890771 |   43494452251133038 | invitation | invitation_created |
| 2016-09-12 16:47:28 |  265634762887890771 |   64106307088691560 | invitation | invitation_created |
| 2017-06-02 23:23:28 |  351088315787638674 |  127087297316779357 | invitation | invitation_created |
| 2017-12-21 17:13:32 |  281477260571403056 |  694708648158149243 | invitation | invitation_created |
| 2018-09-21 21:41:51 |  162115639603334619 |  205404017817317958 | invitation | invitation_created |
| 2018-09-27 12:14:16 |  162115639603334619 |  590538280986825160 | invitation | invitation_created |
| 2018-10-10 14:36:33 |  940836791310406061 |  851979882668439468 | invitation | invitation_created |
| 2019-03-02 10:58:31 |  860323942498157720 | 1909944900306129841 | invitation | invitation_created |
| 2019-05-01 21:03:39 |  474667219360029565 | 1909944900306129841 | invitation | invitation_created |
| 2019-07-07 16:10:50 |   95223015275745886 |  261728824945523043 | invitation | invitation_created |
| 2019-07-10 15:10:15 |  125310545739285762 |  131067918929082935 | invitation | invitation_created |
| 2019-08-01 18:29:04 |  306882785614785617 |  796451867380488914 | invitation | invitation_created |
+---------------------+---------------------+---------------------+------------+--------------------+
14 rows in set (0.23 sec)
```

Also, there are pending invitations that don't have corresponding (latest, with action='invitation_created') group membership changes (see #1123).

Here, in this PR, we address both situations. Also, when there is no corresponding group membership change, we use 'at' field from group_pending_requests instead of one from group_membership_changes.

Depends on #1122 