### PR TITLE
Run Godog tests in strict mode

### DIFF
--- a/testhelpers/loader.go
+++ b/testhelpers/loader.go
@@ -21,6 +21,7 @@ import (
 var defaultGodogOptions = godog.Options{
 	Output: colors.Colored(os.Stdout),
 	Format: "progress",
+	Strict: true,
 }
 
 var godogFlagsBound bool


### PR DESCRIPTION
Since the very beginning we have been running Godog tests in the lenient (non-strict) mode that allows to have not implemented test steps. For example, when a coder mistypes a test step (like 'And the response body should be in JSON' instead of 'And the response body should be, in JSON') Godog in the lenient mode silently skips this "undefined step" without failing. As it's too easy to mistype a step, especially because there is now IDE able to autocomplete test steps, it would be great to run Godog tests in the strict mode.