### PR TITLE
Fix a panic in DB.inTransactionWithCount() when it recovers an error that doesn't implenent error interface

### DIFF
--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -99,6 +99,23 @@ func TestDB_inTransaction_Panic(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestDB_inTransaction_PanicWithString(t *testing.T) {
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	expectedError := "some error"
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	assert.PanicsWithValue(t, expectedError, func() {
+		_ = db.inTransaction(func(db *DB) error {
+			panic(expectedError)
+		})
+	})
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDB_inTransaction_ErrorOnRollback(t *testing.T) {
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()


### PR DESCRIPTION
For instance, when DB.inTransactionWithCount() recovers a string it panics without re-throwing the caught error.
(This is a partial reversion of https://github.com/France-ioi/AlgoreaBackend/commit/9639e4420dbd95f2d4814be9b794176f89430917#diff-922f99fad48da0cadc4df22b0f8b52d267d1689e91ee413605ce5b741570adf6L116, fyi @GeoffreyHuck).

Here I fix the issue and add a test.