### PR TITLE
Correctly interpolate *database.Time and other pointers implementing driver.Valuer interface into SQL queries printed by Gorm logger

### DIFF
--- a/app/logging/gorm_log_formatter.go
+++ b/app/logging/gorm_log_formatter.go
@@ -1,0 +1,183 @@
+package logging
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"time"
+	"unicode"
+
+	"github.com/jinzhu/gorm"
+)
+
+/*
+	The code below is based on the original GORM log formatter from https://github.com/jinzhu/gorm under MIT License:
+
+	The MIT License (MIT)
+
+	Copyright (c) 2013-NOW  Jinzhu <wosmvp@gmail.com>
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+func isPrintable(s string) bool {
+	for _, r := range s {
+		if !unicode.IsPrint(r) {
+			return false
+		}
+	}
+	return true
+}
+
+const (
+	nullString = "NULL"
+	sqlString  = "sql"
+)
+
+func formatValue(value interface{}) string {
+	reflValue := reflect.ValueOf(value)
+	if !reflValue.IsValid() {
+		return nullString
+	}
+
+	switch v := value.(type) {
+	case time.Time:
+		return formatTime(v)
+	case []byte:
+		return formatBytes(v)
+	case driver.Valuer:
+		return formatValuer(v)
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+		return fmt.Sprintf("%v", value)
+	default:
+		// try if &value implements driver.Valuer
+		reflPtrToValue := reflect.New(reflValue.Type())
+		reflPtrToValue.Elem().Set(reflValue)
+		valuePtr := reflPtrToValue.Interface()
+		if valuer, ok := valuePtr.(driver.Valuer); ok {
+			return formatValuer(valuer)
+		}
+
+		if reflValue.Kind() == reflect.Ptr {
+			if reflValue.IsNil() {
+				return nullString
+			}
+			return formatValue(reflValue.Elem().Interface())
+		}
+		return fmt.Sprintf("'%v'", value)
+	}
+}
+
+func formatValuer(v driver.Valuer) string {
+	if value, err := v.Value(); err == nil && value != nil {
+		return fmt.Sprintf("'%v'", value)
+	}
+	return nullString
+}
+
+func formatBytes(v []byte) string {
+	if str := string(v); isPrintable(str) {
+		return fmt.Sprintf("'%v'", str)
+	}
+
+	return "'<binary>'"
+}
+
+func formatTime(v time.Time) string {
+	if v.IsZero() {
+		return fmt.Sprintf("'%v'", "0000-00-00 00:00:00")
+	}
+
+	// Print fractions for time values
+	return fmt.Sprintf("'%v'", v.Format("2006-01-02 15:04:05.999999999"))
+}
+
+func formatGormDBLog(values ...interface{}) (messages []interface{}) {
+	if len(values) <= 1 {
+		return
+	}
+
+	var (
+		sql             string
+		formattedValues []string
+		level           = values[0]
+		currentTime     = "\n\033[33m[" + gorm.NowFunc().Format("2006-01-02 15:04:05") + "]\033[0m"
+		source          = fmt.Sprintf("\033[35m(%v)\033[0m", values[1])
+	)
+
+	if len(values) == 2 {
+		// remove the line break
+		currentTime = currentTime[1:]
+		// remove the brackets
+		source = fmt.Sprintf("\033[35m%v\033[0m", values[1])
+
+		return []interface{}{currentTime, source}
+	}
+
+	messages = []interface{}{source, currentTime}
+
+	if level == sqlString {
+		// duration
+		messages = append(messages,
+			fmt.Sprintf(" \033[36;1m[%.2fms]\033[0m ",
+				float64(values[2].(time.Duration).Nanoseconds()/1e4)/100.0))
+
+		// sql
+		for _, value := range values[4].([]interface{}) {
+			formattedValues = append(formattedValues, formatValue(value))
+		}
+
+		// differentiate between $n placeholders or else treat like ?
+		if numericPlaceHolderRegexp.MatchString(values[3].(string)) {
+			sql = values[3].(string)
+			for index, value := range formattedValues {
+				placeholder := fmt.Sprintf(`\$%d([^\d]|$)`, index+1)
+				sql = regexp.MustCompile(placeholder).ReplaceAllString(sql, value+"$1")
+			}
+		} else {
+			formattedValuesLength := len(formattedValues)
+			for index, value := range sqlRegexp.Split(values[3].(string), -1) {
+				sql += value
+				if index < formattedValuesLength {
+					sql += formattedValues[index]
+				}
+			}
+		}
+
+		messages = append(messages,
+			sql,
+			fmt.Sprintf(" \n\033[36;31m[%v]\033[0m ",
+				strconv.FormatInt(values[5].(int64), 10)+" rows affected or returned "),
+		)
+		return messages
+	}
+
+	messages = append(messages, "\033[31;1m")
+	messages = append(messages, values[2:]...)
+	messages = append(messages, "\033[0m")
+
+	return messages
+}
+
+// Override the default GORM log formatter to print values of pointer types correctly.
+func init() {
+	gorm.LogFormatter = formatGormDBLog
+}

--- a/app/logging/gorm_log_formatter_test.go
+++ b/app/logging/gorm_log_formatter_test.go
@@ -1,0 +1,162 @@
+package logging
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+)
+
+type timeType time.Time
+
+// Value returns a timeType Value (*time.Time).
+func (t *timeType) Value() (driver.Value, error) {
+	if t == nil {
+		return nil, nil
+	}
+	return (*time.Time)(t).UTC().Format("2006-01-02 15:04:05.999999"), nil
+}
+
+func Test_GormLogFormatter(t *testing.T) {
+	timeValue := time.Date(2022, 8, 2, 15, 4, 5, 123456789, time.UTC)
+	timeValuePtr := timeValue
+	timeTypeValue := timeType(timeValue)
+	timeTypeValuePtr := &timeTypeValue
+	int64Value := int64(12345)
+	int64Ptr := &int64Value
+	nilValue := (*int64)(nil)
+	nilValuePtr := &nilValue
+
+	tests := []struct {
+		name     string
+		args     []interface{}
+		expected []interface{}
+	}{
+		{
+			name: "scalar numbers and booleans",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`, `c7`, `c8`, `c9`, `c10`, `c11`, `c12`, `c13`) VALUES " +
+					"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				[]interface{}{
+					1, int8(2), int16(3), int32(4), int64(5), uint(6), uint8(7), uint16(8), uint32(9), uint64(10),
+					float32(0.11), float64(0.12), true,
+				},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`, `c7`, `c8`, `c9`, `c10`, `c11`, `c12`, `c13`) VALUES " +
+					"(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0.11, 0.12, true)",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name: "time values",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`) VALUES (?, ?, ?, ?, ?, ?)",
+				[]interface{}{timeValue, timeValuePtr, timeTypeValue, timeTypeValuePtr, (*timeType)(nil), time.Time{}},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`) VALUES " +
+					"('2022-08-02 15:04:05.123456789', '2022-08-02 15:04:05.123456789', " +
+					"'2022-08-02 15:04:05.123456', '2022-08-02 15:04:05.123456', NULL, '0000-00-00 00:00:00')",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name: "$n placeholders",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`) VALUES ($1, $2, $3, $3)",
+				[]interface{}{int64(123451234512345), "testsessiontestsessiontestsessio", int64(1), int64(2)},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`) VALUES (123451234512345, 'testsessiontestsessiontestsessio', 1, 1)",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name: "bytes values",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`, `c2`) VALUES ($1, $2)",
+				[]interface{}{[]byte("test"), []byte{0x01, 0x02, 0x03}},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`, `c2`) VALUES ('test', '<binary>')",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name: "pointer values",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`, `c2`) VALUES (?, ?)",
+				[]interface{}{int64Ptr, nilValuePtr},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`, `c2`) VALUES (12345, NULL)",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name: "nil value",
+			args: []interface{}{
+				"sql", "file:line", time.Duration(52739320000),
+				"INSERT INTO `t` (`c1`) VALUES (?)",
+				[]interface{}{nil},
+				int64(1),
+			},
+			expected: []interface{}{
+				"\033[35m(file:line)\033[0m",
+				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
+				" \033[36;1m[52739.32ms]\033[0m ",
+				"INSERT INTO `t` (`c1`) VALUES (NULL)",
+				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+			},
+		},
+		{
+			name:     "one argument",
+			args:     []interface{}{"sql"},
+			expected: nil,
+		},
+		{
+			name:     "two arguments",
+			args:     []interface{}{"sql", "file:line"},
+			expected: []interface{}{"\x1b[33m[2021-08-02 15:04:05]\x1b[0m", "\x1b[35mfile:line\x1b[0m"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			oldGormNowFunc := gorm.NowFunc
+			gorm.NowFunc = func() time.Time { return time.Date(2021, 8, 2, 15, 4, 5, 123456789, time.UTC) }
+			defer func() { gorm.NowFunc = oldGormNowFunc }()
+
+			assert.Equal(t, test.expected, gorm.LogFormatter(test.args...))
+		})
+	}
+}

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -28,7 +28,7 @@ func (l *StructuredDBLogger) Print(values ...interface{}) {
 	logger := SharedLogger.WithField("type", "db")
 
 	switch level {
-	case "sql":
+	case sqlString:
 		duration := float64(values[2].(time.Duration).Nanoseconds()) / float64(time.Second.Nanoseconds()) // to seconds
 		sql := fillSQLPlaceholders(values[3].(string), values[4].([]interface{}))
 		logger.WithFields(map[string]interface{}{
@@ -75,7 +75,7 @@ func fillSQLPlaceholders(query string, values []interface{}) string {
 				formattedValue = fmt.Sprintf("%v", typedValue)
 			}
 		} else {
-			formattedValue = "NULL"
+			formattedValue = nullString
 		}
 		formattedValues = append(formattedValues, formattedValue)
 	}


### PR DESCRIPTION
Currently, when the DB logger logs a query like ```db.Exec("SELECT ?", t)``` where t is *database.Time, it looks like 'SELECT &{13454110244426743808 1 0x538f20}'. Here I fix this this issue to make it log 'SELECT "2009-11-10 23:00:00"' instead.