### PR TITLE
Make ids of references in cucumber tests definite with the same sorting order as the references

### DIFF
--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -19,7 +19,8 @@ Feature: Get permissions can_request_help_to for a group
       | @ClassParent             | @ClassParentParent       |          |
       | @Class                   | @ClassParent             |          |
       | @OtherSourceGroup        |                          |          |
-    And @Teacher is a manager of the group @Class and can grant group access
+    And @Teacher is a manager of the group @ClassAnotherParent and can grant group access
+    And @Class is a child of the group @ClassAnotherParent
     And there are the following items:
       | item                        | type    |
       | @ChapterParent              | Chapter |
@@ -39,7 +40,7 @@ Feature: Get permissions can_request_help_to for a group
     Given I am @Teacher
     And there is a group @HelperGroup
     # @HelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroup
+    And the group @Teacher is a descendant of the group @HelperGroup via @HelperGroupChild
     And there are the following item permissions:
       | item  | group  | is_owner | can_request_help_to |
       | @Item | @Class | false    | @HelperGroup        |
@@ -109,16 +110,16 @@ Feature: Get permissions can_request_help_to for a group
       | @Item | @ClassParent             | @OtherSourceGroup | other            | false    | @HelperOtherSourceGroup4          | other source group                                |
       | @Item | @ClassParentParent       | @OtherSourceGroup | other            | false    | @HelperOtherSourceGroupNotVisible | other source group, not visible                   |
   # The following lines are to make the groups visible by @Teacher
-  And the group @Teacher is a descendant of the group @HelperGroupSelf1
-  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
-  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2
-  And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking
-  And the group @Teacher is a descendant of the group @HelperGroupOther1
-  And the group @Teacher is a descendant of the group @HelperGroupOther2
-  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup1
-  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup2
-  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup3
-  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup4
+  And the group @Teacher is a descendant of the group @HelperGroupSelf1 via @HelperGroupSelf1Child
+  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1 via @HelperGroupGroupMembership1Child
+  And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2 via @HelperGroupGroupMembership2Child
+  And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking via @HelperGroupItemUnlockingChild
+  And the group @Teacher is a descendant of the group @HelperGroupOther1 via @HelperGroupOther1Child
+  And the group @Teacher is a descendant of the group @HelperGroupOther2 via @HelperGroupOther2Child
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup1 via @HelperOtherSourceGroup1Child
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup2 via @HelperOtherSourceGroup2Child
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup3 via @HelperOtherSourceGroup3Child
+  And the group @Teacher is a descendant of the group @HelperOtherSourceGroup4 via @HelperOtherSourceGroup4Child
   When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
   Then the response code should be 200
   And the response at $.granted_via_self.can_request_help_to[*] should be:
@@ -185,13 +186,13 @@ Feature: Get permissions can_request_help_to for a group
       | @ChapterParent              | @ClassParentParent       | @Class            | other            | false    | @HelperGroupOther2                       |                    |
       | @ChapterParentNoPropagation | @ClassParent             | @OtherSourceGroup | other            | false    | @HelperGroupOtherNoPropagation           | other source group |
   # The following lines are to make the groups visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroupSelf1
-    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1
-    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2
-    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking1
-    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking2
-    And the group @Teacher is a descendant of the group @HelperGroupOther1
-    And the group @Teacher is a descendant of the group @HelperGroupOther2
+    And the group @Teacher is a descendant of the group @HelperGroupSelf1 via @HelperGroupSelf1Child
+    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership1 via @HelperGroupGroupMembership1Child
+    And the group @Teacher is a descendant of the group @HelperGroupGroupMembership2 via @HelperGroupGroupMembership2Child
+    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking1 via @HelperGroupItemUnlocking1Child
+    And the group @Teacher is a descendant of the group @HelperGroupItemUnlocking2 via @HelperGroupItemUnlocking2Child
+    And the group @Teacher is a descendant of the group @HelperGroupOther1 via @HelperGroupOther1Child
+    And the group @Teacher is a descendant of the group @HelperGroupOther2 via @HelperGroupOther2Child
     When I send a GET request to "/groups/@Class/permissions/@Class/@Item"
     Then the response code should be 200
     And the response at $.granted_via_self.can_request_help_to should be "[]"

--- a/app/api/groups/update_group_require_strengthened.feature
+++ b/app/api/groups/update_group_require_strengthened.feature
@@ -8,11 +8,11 @@ Feature:
       a require_* field is strengthened, and approval_change_action is set to "empty"
     Given I am @Teacher
     And there are the following groups:
-      | group     | parent | members             | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       |
-      | @School   |        | @Teacher            |                                             |                                              |                              |
-      | @Class    |        | @Student1,@Student2 | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
-      | @SubGroup | @Class | @Student3,@Student4 |                                             |                                              |                              |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+      | group     | parent       | members             | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       |
+      | @School   |              | @Teacher            |                                             |                                              |                              |
+      | @Class    | @ClassParent | @Student1,@Student2 | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
+      | @SubGroup | @Class       | @Student3,@Student4 |                                             |                                              |                              |
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     And the time now is "2020-01-01T01:00:00Z"
     And the DB time now is "2020-01-01 01:00:00"
     When I send a PUT request to "/groups/@Class" with the following body:
@@ -47,10 +47,10 @@ Feature:
       Should be able to update the require_* fields without approval_change_action when they are not strengthened
     Given I am @Teacher
     And there are the following groups:
-      | group   | members         | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       |
-      | @School | @Teacher        |                                             |                                              |                              |
-      | @Class  | <group_members> | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+      | group   | parent       | members         | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       |
+      | @School |              | @Teacher        |                                             |                                              |                              |
+      | @Class  | @ClassParent | <group_members> | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     And the time now is "2020-01-01T01:00:00Z"
     When I send a PUT request to "/groups/@Class" with the following body:
     """
@@ -88,10 +88,10 @@ Feature:
   Scenario: Should be able to set require_lock_membership_approval_until to null when it is already set
     Given I am @Teacher
     And there are the following groups:
-      | group   | members   | require_lock_membership_approval_until |
-      | @School | @Teacher  |                                        |
-      | @Class  | @Student1 | 2020-01-01 12:00:00                    |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+      | group   | parent       | members   | require_lock_membership_approval_until |
+      | @School |              | @Teacher  |                                        |
+      | @Class  | @ClassParent | @Student1 | 2020-01-01 12:00:00                    |
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -104,10 +104,10 @@ Feature:
   Scenario: Should reject all pending requests when approval_change_action = 'empty'
     Given I am @Teacher
     And there are the following groups:
-      | group   | members                       | require_watch_approval |
-      | @School | @Teacher                      |                        |
-      | @Class  | @Student1,@Student2           | false                  |
-      | @Other  | @Student3,@Student4,@Student5 |                        |
+      | group   | parent       | members                       | require_watch_approval |
+      | @School |              | @Teacher                      |                        |
+      | @Class  | @ClassParent | @Student1,@Student2           | false                  |
+      | @Other  |              | @Student3,@Student4,@Student5 |                        |
     And there are the following group pending requests:
       | group  | member    | type          |
       | @Class | @Student1 | leave_request |
@@ -115,7 +115,7 @@ Feature:
       | @Class | @Student4 | join_request  |
       | @Class | @Student5 | invitation    |
       | @Other | @Student5 | join_request  |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -133,10 +133,10 @@ Feature:
   Scenario: Should reject all pending requests and send invitations to the past members when approval_change_action = 'reinvite'
     Given I am @Teacher
     And there are the following groups:
-      | group   | members                       | require_watch_approval |
-      | @School | @Teacher                      |                        |
-      | @Class  | @Student1,@Student2           | false                  |
-      | @Other  | @Student3,@Student4,@Student5 |                        |
+      | group   | parent       | members                       | require_watch_approval |
+      | @School |              | @Teacher                      |                        |
+      | @Class  | @ClassParent | @Student1,@Student2           | false                  |
+      | @Other  |              | @Student3,@Student4,@Student5 |                        |
     And there are the following group pending requests:
       | group  | member    | type          |
       | @Class | @Student1 | leave_request |
@@ -144,7 +144,7 @@ Feature:
       | @Class | @Student4 | join_request  |
       | @Class | @Student5 | invitation    |
       | @Other | @Student5 | join_request  |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     And the time now is "2020-01-01T01:00:00Z"
     And the DB time now is "2020-01-01 01:00:00"
     When I send a PUT request to "/groups/@Class" with the following body:
@@ -171,11 +171,11 @@ Feature:
   Scenario: Should empty the group when approval_change_action = "reinvite"
     Given I am @Teacher
     And there are the following groups:
-      | group     | parent | members             | require_watch_approval |
-      | @School   |        | @Teacher            |                        |
-      | @Class    |        | @Student1,@Student2 | false                  |
-      | @SubGroup | @Class | @Student3,@Student4 |                        |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+      | group     | parent       | members             | require_watch_approval |
+      | @School   |              | @Teacher            |                        |
+      | @Class    | @ClassParent | @Student1,@Student2 | false                  |
+      | @SubGroup | @Class       | @Student3,@Student4 |                        |
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -191,14 +191,16 @@ Feature:
   # If approval_change_action = "reinvite", the leave requests are transformed into invitations,
   # because the primary key of the group_pending_requests table is (group_id, member_id).
   # This was already tested in a test above.
+
+
   Scenario: Should reject all pending leave requests when require_lock_membership_approval_until is strengthened and approval_change_action = 'empty'
     Given I am @Teacher
     And the time now is "2020-01-01T01:00:00Z"
     And there are the following groups:
-      | group   | members                       | require_lock_membership_approval_until |
-      | @School | @Teacher                      |                                        |
-      | @Class  | @Student1,@Student2,@Student3 | 2020-01-01 12:00:00                    |
-      | @Other  | @Student4,@Student5,@Student6 |                                        |
+      | group   | parent       | members                       | require_lock_membership_approval_until |
+      | @School |              | @Teacher                      |                                        |
+      | @Class  | @ClassParent | @Student1,@Student2,@Student3 | 2020-01-01 12:00:00                    |
+      | @Other  |              | @Student4,@Student5,@Student6 |                                        |
     And there are the following group pending requests:
       | group  | member    | type          |
       | @Class | @Student1 | leave_request |
@@ -208,7 +210,7 @@ Feature:
       | @Class | @Student6 | invitation    |
       | @Other | @Student5 | leave_request |
       | @Other | @Student6 | join_request  |
-    And @Teacher is a manager of the group @Class and can manage memberships and group
+    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {

--- a/app/api/groups/update_permissions_can_request_help_to.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.feature
@@ -11,13 +11,13 @@ Feature: Change item access rights for a group - can_request_help_to
   Background:
     Given allUsersGroup is defined as the group @AllUsers
     And there are the following groups:
-      | group           | parent | members  |
-      | @AllUsers       |        |          |
-      | @School         |        | @Teacher |
-      | @Class          |        |          |
-      | @OldHelperGroup |        |          |
-      | @NewHelperGroup |        |          |
-    And @Teacher is a manager of the group @Class and can grant group access
+      | group           | parent       | members  |
+      | @AllUsers       |              |          |
+      | @School         |              | @Teacher |
+      | @Class          | @ClassParent |          |
+      | @OldHelperGroup |              |          |
+      | @NewHelperGroup |              |          |
+    And @Teacher is a manager of the group @ClassParent and can grant group access
     And there are the following tasks:
       | item  |
       | @Item |
@@ -28,13 +28,13 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario Outline: Should update can_request_help_to to the desired value when rights are appropriate
     Given I am @Teacher
     # @OldHelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @OldHelperGroup
+    And the group @Teacher is a descendant of the group @OldHelperGroup via @OldHelperGroupChild1
     # @OldHelperGroup is visible by @Class
-    And the group @Class is a descendant of the group @OldHelperGroup
+    And the group @Class is a descendant of the group @OldHelperGroup via @OldHelperGroupChild2
     # @NewHelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @NewHelperGroup
+    And the group @Teacher is a descendant of the group @NewHelperGroup via @NewHelperGroupChild1
     # @NewHelperGroup is visible by @Class
-    And the group @Class is a descendant of the group @NewHelperGroup
+    And the group @Class is a descendant of the group @NewHelperGroup via @NewHelperGroupChild2
     And there are the following item permissions:
       | item  | group  | can_view | can_request_help_to           |
       | @Item | @Class | info     | <initial_can_request_help_to> |
@@ -81,7 +81,8 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should work when trying to set can_request_help_to to a group not visible by the giver (current-user) if it was already set at the same value previously
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
-    And @Class is a manager of the group @HelperGroup and can watch its members
+    And @Class is a manager of the group @HelperGroupParent and can watch its members
+    And @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_view | can_grant_view | can_request_help_to |
       | @Item | @Teacher |          | content        |                     |
@@ -100,7 +101,7 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should work when trying to set can_request_help_to to a group no visible by the receiver if it was already set at the same value previously
     Given I am @Teacher
     # @HelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroup
+    And the group @Teacher is a descendant of the group @HelperGroup via @HelperGroupChild
     And there are the following item permissions:
       | item  | group    | can_view | can_grant_view | can_request_help_to |
       | @Item | @Teacher |          | content        |                     |

--- a/app/api/groups/update_permissions_can_request_help_to.robustness.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.robustness.feature
@@ -11,12 +11,12 @@ Feature: Change item access rights for a group - can_request_help_to
   Background:
     Given allUsersGroup is defined as the group @AllUsers
     And there are the following groups:
-      | group        | parent | members  |
-      | @AllUsers    |        |          |
-      | @School      |        | @Teacher |
-      | @Class       |        |          |
-      | @HelperGroup |        |          |
-    And @Teacher is a manager of the group @Class and can grant group access
+      | group        | parent       | members  |
+      | @AllUsers    |              |          |
+      | @School      |              | @Teacher |
+      | @Class       | @ClassParent |          |
+      | @HelperGroup |              |          |
+    And @Teacher is a manager of the group @ClassParent and can grant group access
     And there are the following tasks:
       | item  |
       | @Item |
@@ -51,7 +51,7 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should be an exception when trying to set can_request_help_to and can_request_help_to_all_users at the same time
     Given I am @Teacher
     # @HelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroup
+    And the group @Teacher is a descendant of the group @HelperGroup via @HelperGroupChild
     When I send a PUT request to "/groups/@Class/permissions/@Class/@Item" with the following body:
       """
         {
@@ -77,9 +77,9 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario Outline: Should be access denied when the user doesn't have can_grant_view>=content but group is visible by both the current user and the receiver
     Given I am @Teacher
     # @HelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroup
+    And the group @Teacher is a descendant of the group @HelperGroup via @HelperGroupChild
     # @HelperGroup is visible by @Class
-    And the group @Class is a descendant of the group @HelperGroup
+    And the group @Class is a descendant of the group @HelperGroup via @HelperGroupAnotherChild
     And there is a group @OldHelperGroup
     And there are the following item permissions:
       | item  | group    | can_grant_view | can_view | can_request_help_to |
@@ -114,7 +114,8 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should be access denied when trying to set can_request_help_to to a group not visible by the giver (current-user)
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
-    And @Class is a manager of the group @HelperGroup and can watch its members
+    And @Class is a manager of the group @HelperGroupParent and can watch its members
+    And @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_grant_view |
       | @Item | @Teacher | content        |
@@ -142,7 +143,7 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should be access denied when trying to set can_request_help_to to a group no visible by the receiver
     Given I am @Teacher
     # @HelperGroup is visible by @Teacher
-    And the group @Teacher is a descendant of the group @HelperGroup
+    And the group @Teacher is a descendant of the group @HelperGroup via @HelperGroupChild
     And there are the following item permissions:
       | item  | group    | can_grant_view |
       | @Item | @Teacher | content        |

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -6,8 +6,9 @@ Feature: Get permissions can_request_help for an item
       | @School             |         | @TeacherGroup         |
       | @TeacherGroup       |         | @Teacher              |
       | @ClassParent        |         | @Class                |
+      | @ClassAnotherParent |         | @Class                |
       | @Class              | @School | @Student,@HelperGroup |
-    And @Teacher is a manager of the group @Class and can watch its members
+    And @Teacher is a manager of the group @ClassAnotherParent and can watch its members
     And there are the following items:
       | item                          | type    |
       | @Chapter1                     | Chapter |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -10,7 +10,8 @@ Feature: List threads
       | @A_Class      | @A_Section    | @A_ClassMember1,@A_ClassMember2                       |
       | @B_Class      | @B_Section    |                                                       |
       | @OtherGroup   |               | @OtherGroupMember                                     |
-    And @A_UniversityManagerCanWatch is a manager of the group @A_University and can watch its members
+    And @A_UniversityManagerCanWatch is a manager of the group @A_UniversityParent and can watch its members
+    And @A_University is a child of the group @A_UniversityParent
     And there are the following tasks:
       | item                                            |
       | @B_SectionMember2_CanViewInfo                   |
@@ -95,7 +96,8 @@ Feature: List threads
 
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am @LaboratoryManagerCanWatch
-    And I am a manager of the group @Laboratory and can watch its members
+    And I am a manager of the group @LaboratoryParent and can watch its members
+    And @Laboratory is a child of the group @LaboratoryParent
     And there are the following users:
       | user                                                | first_name            | last_name            |
       | @LaboratoryMember_WithApprovedAccessPersonalInfo    | FirstName_Approved    | LastName_Approved    |

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -27,7 +27,8 @@ Feature: List threads - robustness
   Scenario: The user should be able to watch the watched_group_id group
     Given I am @John
     And there is a group @Classroom
-    And I am a manager of the group @Classroom
+    And I am a manager of the group @ClassroomParent
+    And @Classroom is a child of the group @ClassroomParent
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"
@@ -41,7 +42,8 @@ Feature: List threads - robustness
   Scenario Outline: Should not have watched_group_id and is_mine set a the same time
     Given I am @John
     And there is a group @Classroom
-    And I am a manager of the group @Classroom and can watch its members
+    And I am a manager of the group @ClassroomParent and can watch its members
+    And @Classroom is a child of the group @ClassroomParent
     When I send a GET request to "/threads?watched_group_id=@Classroom&is_mine=<is_mine>"
     Then the response code should be 400
     And the response error message should contain "Must not provide watched_group_id and is_mine at the same time"

--- a/app/api/users/generate_profile_edit_token.feature
+++ b/app/api/users/generate_profile_edit_token.feature
@@ -1,12 +1,12 @@
 Feature: Generate Profile Edit Token
   Scenario: Should return a token when the requester is a manager of the target group
     Given there are the following groups:
-      | group     | parent | members        | require_personal_info_access_approval |
-      | @AllUsers |        | @Manager,@User |                                       |
-      | @Class    |        | @User          | edit                                  |
+      | group     | parent       | members        | require_personal_info_access_approval |
+      | @AllUsers |              | @Manager,@User |                                       |
+      | @Class    | @ClassParent | @User          | edit                                  |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
-    And I am a manager of the group @Class
+    And I am a manager of the group @ClassParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 200
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:
@@ -21,13 +21,13 @@ Feature: Generate Profile Edit Token
 
   Scenario: Should return a token when the requester is a manager of the target group's parent group
     Given there are the following groups:
-      | group     | parent  | members        | require_personal_info_access_approval |
-      | @AllUsers |         | @Manager,@User |                                       |
-      | @School   |         |                |                                       |
-      | @Class    | @School | @User          | edit                                  |
+      | group     | parent        | members        | require_personal_info_access_approval |
+      | @AllUsers |               | @Manager,@User |                                       |
+      | @School   | @SchoolParent |                |                                       |
+      | @Class    | @School       | @User          | edit                                  |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
-    And I am a manager of the group @School
+    And I am a manager of the group @SchoolParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 200
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:
@@ -50,7 +50,8 @@ Feature: Generate Profile Edit Token
       | @Class    | @School | @User          |                                       |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
-    And I am a manager of the group @City
+    And I am a manager of the group @CityParent
+    And @City is a child of the group @CityParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 200
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:

--- a/app/api/users/generate_profile_edit_token.robustness.feature
+++ b/app/api/users/generate_profile_edit_token.robustness.feature
@@ -29,11 +29,11 @@ Feature: Generate Profile Edit Token - robustness
 
   Scenario Outline: Should be forbidden when the group managed by the current-user doesn't have `require_personal_info_access_approval` === 'edit'
     Given there are the following groups:
-      | group     | parent | members        | require_personal_info_access_approval   |
-      | @AllUsers |        | @Manager,@User |                                         |
-      | @Class    |        | @User          | <require_personal_info_access_approval> |
+      | group     | parent       | members        | require_personal_info_access_approval   |
+      | @AllUsers |              | @Manager,@User |                                         |
+      | @Class    | @ClassParent | @User          | <require_personal_info_access_approval> |
     And I am @Manager
-    And I am a manager of the group @Class
+    And I am a manager of the group @ClassParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"

--- a/app/api/users/get_user_personal_info_access_approval_to_current_user.feature
+++ b/app/api/users/get_user_personal_info_access_approval_to_current_user.feature
@@ -1,16 +1,16 @@
 Feature: Manager of a user gets `personal_info_access_approval_to_current_user` in the response
   Scenario Outline: Should return the max permission of all the groups the current-user manages and which the user is a descendant of
     Given there are the following groups:
-      | group                         | parent  | members        | require_personal_info_access_approval |
-      | @AllUsers                     |         | @Manager,@User |                                       |
-      | @School                       |         |                | <school_permission>                   |
-      | @Class                        | @School | @User          | <class_permission>                    |
-      | @OtherManagedGroupWithoutUser |         |                | edit                                  |
-      | @OtherManagedGroupWithUser    |         | @User          | <other_permission>                    |
-      | @NonManagedGroupWithUser      |         | @User          | edit                                  |
+      | group                         | parent                           | members        | require_personal_info_access_approval |
+      | @AllUsers                     |                                  | @Manager,@User |                                       |
+      | @School                       | @SchoolParent                    |                | <school_permission>                   |
+      | @Class                        | @School                          | @User          | <class_permission>                    |
+      | @OtherManagedGroupWithoutUser |                                  |                | edit                                  |
+      | @OtherManagedGroupWithUser    | @OtherManagedGroupWithUserParent | @User          | <other_permission>                    |
+      | @NonManagedGroupWithUser      |                                  | @User          | edit                                  |
     And I am @Manager
-    And I am a manager of the group @School
-    And I am a manager of the group @OtherManagedGroupWithUser
+    And I am a manager of the group @SchoolParent
+    And I am a manager of the group @OtherManagedGroupWithUserParent
     When I send a GET request to "/users/@User"
     Then the response code should be 200
     And the response at $.personal_info_access_approval_to_current_user should be "<result>"

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -17,6 +17,7 @@ func (ctx *TestContext) registerFeaturesForGroups(s *godog.ScenarioContext) {
 	s.Step(`^I am a member of the group (@\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^(@\w+) is a member of the group (@\w+)$`, ctx.UserIsAMemberOfTheGroup)
+	s.Step(`^(@\w+) is a child of the group (@\w+)$`, ctx.GroupIsAChildOfTheGroup)
 	s.Step(
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
@@ -27,7 +28,7 @@ func (ctx *TestContext) registerFeaturesForGroups(s *godog.ScenarioContext) {
 	s.Step(`^(@\w+) should not be a member of the group (@\w+)$`, ctx.UserShouldNotBeAMemberOfTheGroup)
 	s.Step(`^(@\w+) should be a member of the group (@\w+)$`, ctx.UserShouldBeAMemberOfTheGroup)
 
-	s.Step(`^the group (@\w+) is a descendant of the group (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
+	s.Step(`^the group (@\w+) is a descendant of the group (@\w+) via (@\w+)$`, ctx.theGroupIsADescendantOfTheGroup)
 }
 
 // getGroupPrimaryKey returns the primary key of a group.
@@ -257,11 +258,8 @@ func (ctx *TestContext) UserShouldBeAMemberOfTheGroup(user, group string) error 
 	return nil
 }
 
-// theGroupIsADescendantOfTheGroup sets a group as a descendant of another.
-func (ctx *TestContext) theGroupIsADescendantOfTheGroup(descendant, parent string) error {
-	// we add another group in between to increase the robustness of the tests.
-	middle := parent + " -> X -> " + referenceToName(descendant)
-
+// theGroupIsADescendantOfTheGroup sets a group as a descendant of another via a third group.
+func (ctx *TestContext) theGroupIsADescendantOfTheGroup(descendant, parent, middle string) error {
 	groups := []string{descendant, middle, parent}
 	for _, group := range groups {
 		err := ctx.ThereIsAGroup(group)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -383,30 +383,18 @@ func (ctx *TestContext) UserIsAManagerOfTheGroupWith(parameters string) error {
 	canWatchMembers := "0"
 	canGrantGroupAccess := "0"
 	canManage := "none"
-	watchedGroupName := group["user_id"] + " manages " + referenceToName(group["name"])
 
 	if group["can_watch_members"] == strTrue {
 		canWatchMembers = "1"
-		watchedGroupName += " with can_watch_members"
 	}
 	if group["can_grant_group_access"] == strTrue {
 		canGrantGroupAccess = "1"
-		watchedGroupName += " with can_grant_group_access"
 	}
 	if _, ok := group["can_manage"]; ok {
 		canManage = group["can_manage"]
-		watchedGroupName += " with can_manage_memberships_and_groups"
 	}
 
-	// We create a parent group of which the user is the manager.
-	err = ctx.ThereIsAGroup(watchedGroupName)
-	if err != nil {
-		return err
-	}
-
-	ctx.IsAMemberOfTheGroup(group["id"], watchedGroupName)
-
-	ctx.addGroupManager(group["user_id"], watchedGroupName, canWatchMembers, canGrantGroupAccess, canManage)
+	ctx.addGroupManager(group["user_id"], group["id"], canWatchMembers, canGrantGroupAccess, canManage)
 
 	return nil
 }


### PR DESCRIPTION
Currently IDs for the references in cucumber tests are generated by rand.Int63() which has some disadvantages:
1. It's very hard to use `the table "*" should be` step when a column contains references, because the order of random ids is unpredictable, it requires trial and error method, such tests would be hard to support.
2. As the sorting order of random IDs changes randomly every time we add a new reference, we cannot rely on ordering table in `the table "*" should be` step by a column with references, such tests become fragile.

Here we introduce definite (not random) IDs for references. These definite IDs have the same sorting order as the references, so it becomes easy to use test steps depending on DB tables ordering with references like here:
```
    And the table "group_membership_changes" should be:
      | group_id | member_id | action                         | at                | initiator_id |
      | @Class   | @Student1 | removed_due_to_approval_change | {{currentTime()}} | @Teacher     |
      | @Class   | @Student2 | invitation_created             | {{currentTime()}} | @Teacher     |
      | @Class   | @Student3 | join_request_refused           | {{currentTime()}} | @Teacher     |
      | @Class   | @Student4 | join_request_refused           | {{currentTime()}} | @Teacher     |
```

Also, here we disallow implicit creation of new references which have been used in UserIsAManagerOfTheGroupWith() and theGroupIsADescendantOfTheGroup(). The reasons are that
1) Such implicitly created references are inaccessible from tests (there names contain spaces and other special characters).
2) Such implicitly created references would have ids out of the correct sorting order and there objects appear in the order DB tables in unexpected places hardening to check the results in the DB.
3) Implicit things make tests harder to understand. For instance, steps calling UserIsAManagerOfTheGroupWith() doesn't mention creation of an intermediate group at all.
Instead of creating something implicitly, it's always possible to create it explicitly, not hard at all.

After all, we add a new test step `^(@\w+) is a child of the group (@\w+)$` for convenient creation of group_group relations.