### PR TITLE
Refactor time-related template functions used in cucumber tests

### DIFF
--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -2,7 +2,7 @@ Feature: Get group invitations for the current user
   Background:
     Given the database has the following table 'groups':
       | id | type    | name                          | description                   | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
-      | 1  | Class   | Our Class                     | Our class group               | none                                  | {{relativeTime("+96h")}}               | true                   |
+      | 1  | Class   | Our Class                     | Our class group               | none                                  | {{relativeTimeDB("+96h")}}             | true                   |
       | 2  | Team    | Our Team                      | Our team group                | none                                  | null                                   | false                  |
       | 3  | Club    | Our Club                      | Our club group                | none                                  | null                                   | false                  |
       | 4  | Friends | Our Friends                   | Group for our friends         | none                                  | null                                   | false                  |
@@ -30,23 +30,23 @@ Feature: Get group invitations for the current user
       | 9               | 21             |
       | 10              | 21             |
     And the database has the following table 'group_membership_changes':
-      | group_id | member_id | action                | at                        | initiator_id |
-      | 1        | 21        | invitation_created    | {{relativeTime("-169h")}} | 12           |
-      | 2        | 21        | invitation_refused    | {{relativeTime("-168h")}} | 21           |
-      | 3        | 21        | join_request_created  | {{relativeTime("-167h")}} | 21           |
-      | 33       | 21        | invitation_created    | {{relativeTime("-167h")}} | 13           |
-      | 4        | 21        | join_request_refused  | {{relativeTime("-166h")}} | 12           |
-      | 34       | 21        | invitation_created    | {{relativeTime("-190h")}} | 13           |
-      | 34       | 21        | invitation_refused    | {{relativeTime("-180h")}} | 21           |
-      | 34       | 21        | invitation_created    | {{relativeTime("-166h")}} | 12           |
-      | 5        | 21        | invitation_accepted   | {{relativeTime("-165h")}} | 12           |
-      | 6        | 21        | join_request_accepted | {{relativeTime("-164h")}} | 12           |
-      | 7        | 21        | removed               | {{relativeTime("-163h")}} | 21           |
-      | 8        | 21        | left                  | {{relativeTime("-162h")}} | 21           |
-      | 9        | 21        | added_directly        | {{relativeTime("-161h")}} | 12           |
-      | 1        | 12        | invitation_created    | {{relativeTime("-170h")}} | 12           |
-      | 10       | 21        | joined_by_code        | {{relativeTime("-180h")}} | null         |
-      | 11       | 21        | joined_by_badge       | {{relativeTime("-190h")}} | null         |
+      | group_id | member_id | action                | at                          | initiator_id |
+      | 1        | 21        | invitation_created    | {{relativeTimeDB("-169h")}} | 12           |
+      | 2        | 21        | invitation_refused    | {{relativeTimeDB("-168h")}} | 21           |
+      | 3        | 21        | join_request_created  | {{relativeTimeDB("-167h")}} | 21           |
+      | 33       | 21        | invitation_created    | {{relativeTimeDB("-167h")}} | 13           |
+      | 4        | 21        | join_request_refused  | {{relativeTimeDB("-166h")}} | 12           |
+      | 34       | 21        | invitation_created    | {{relativeTimeDB("-190h")}} | 13           |
+      | 34       | 21        | invitation_refused    | {{relativeTimeDB("-180h")}} | 21           |
+      | 34       | 21        | invitation_created    | {{relativeTimeDB("-166h")}} | 12           |
+      | 5        | 21        | invitation_accepted   | {{relativeTimeDB("-165h")}} | 12           |
+      | 6        | 21        | join_request_accepted | {{relativeTimeDB("-164h")}} | 12           |
+      | 7        | 21        | removed               | {{relativeTimeDB("-163h")}} | 21           |
+      | 8        | 21        | left                  | {{relativeTimeDB("-162h")}} | 21           |
+      | 9        | 21        | added_directly        | {{relativeTimeDB("-161h")}} | 12           |
+      | 1        | 12        | invitation_created    | {{relativeTimeDB("-170h")}} | 12           |
+      | 10       | 21        | joined_by_code        | {{relativeTimeDB("-180h")}} | null         |
+      | 11       | 21        | joined_by_badge       | {{relativeTimeDB("-190h")}} | null         |
     And the database has the following table 'group_pending_requests':
       | group_id | member_id | type         |
       | 1        | 21        | invitation   |
@@ -79,7 +79,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBToJS(db("group_membership_changes[8][at]"))}}"
       },
       {
         "group_id": "33",
@@ -98,7 +98,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
       },
       {
         "group_id": "1",
@@ -114,10 +114,10 @@ Feature: Get group invitations for the current user
           "description": "Our class group",
           "type": "Class",
           "require_personal_info_access_approval": "none",
-          "require_lock_membership_approval_until": "{{timeToRFC(db("groups[1][require_lock_membership_approval_until]"))}}",
+          "require_lock_membership_approval_until": "{{timeDBToJS(db("groups[1][require_lock_membership_approval_until]"))}}",
           "require_watch_approval": true
         },
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}"
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}"
       }
     ]
     """
@@ -146,14 +146,14 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBToJS(db("group_membership_changes[8][at]"))}}"
       }
     ]
     """
 
   Scenario: Request the second row
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[4][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
     When I send a GET request to "/current-user/group-invitations?limit=1&from.group_id=4&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -176,7 +176,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
       }
     ]
     """

--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -79,7 +79,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToJS(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBToRFC(db("group_membership_changes[8][at]"))}}"
       },
       {
         "group_id": "33",
@@ -98,7 +98,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
       },
       {
         "group_id": "1",
@@ -114,10 +114,10 @@ Feature: Get group invitations for the current user
           "description": "Our class group",
           "type": "Class",
           "require_personal_info_access_approval": "none",
-          "require_lock_membership_approval_until": "{{timeDBToJS(db("groups[1][require_lock_membership_approval_until]"))}}",
+          "require_lock_membership_approval_until": "{{timeDBToRFC(db("groups[1][require_lock_membership_approval_until]"))}}",
           "require_watch_approval": true
         },
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}"
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}"
       }
     ]
     """
@@ -146,14 +146,14 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToJS(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBToRFC(db("group_membership_changes[8][at]"))}}"
       }
     ]
     """
 
   Scenario: Request the second row
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
     When I send a GET request to "/current-user/group-invitations?limit=1&from.group_id=4&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -176,7 +176,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
       }
     ]
     """

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -84,42 +84,42 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -136,42 +136,42 @@ Feature: Get requests for group_id
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]
@@ -188,42 +188,42 @@ Feature: Get requests for group_id
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -240,7 +240,7 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -257,35 +257,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -293,7 +293,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by joining user's login, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[3][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.member_id=31&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -303,35 +303,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -339,7 +339,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by action, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[1][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=action&from.at={{from_at}}&from.member_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -349,35 +349,35 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -44,34 +44,34 @@ Feature: Get requests for group_id
       | 13              | 125            | null                           |
     And the groups ancestors are computed
     And the database has the following table 'group_pending_requests':
-      | group_id | member_id | type         | at                        | personal_info_view_approved |
-      | 13       | 21        | invitation   | {{relativeTime("-170h")}} | false                       |
-      | 13       | 31        | join_request | {{relativeTime("-168h")}} | true                        |
-      | 13       | 41        | invitation   | {{relativeTime("-170h")}} | false                       |
-      | 13       | 51        | invitation   | {{relativeTime("-164h")}} | false                       |
-      | 14       | 11        | invitation   | 2017-05-28 06:38:38       | true                        |
-      | 14       | 21        | join_request | 2017-05-27 06:38:38       | false                       |
-      | 14       | 22        | join_request | 2017-05-27 06:38:38       | false                       |
-      | 15       | 22        | join_request | 2017-05-27 06:38:38       | true                        |
+      | group_id | member_id | type         | at                          | personal_info_view_approved |
+      | 13       | 21        | invitation   | {{relativeTimeDB("-170h")}} | false                       |
+      | 13       | 31        | join_request | {{relativeTimeDB("-168h")}} | true                        |
+      | 13       | 41        | invitation   | {{relativeTimeDB("-170h")}} | false                       |
+      | 13       | 51        | invitation   | {{relativeTimeDB("-164h")}} | false                       |
+      | 14       | 11        | invitation   | 2017-05-28 06:38:38         | true                        |
+      | 14       | 21        | join_request | 2017-05-27 06:38:38         | false                       |
+      | 14       | 22        | join_request | 2017-05-27 06:38:38         | false                       |
+      | 15       | 22        | join_request | 2017-05-27 06:38:38         | true                        |
     And the database has the following table 'group_membership_changes':
-      | group_id | member_id | action                | at                        | initiator_id |
-      | 13       | 21        | invitation_created    | {{relativeTime("-170h")}} | 11           |
-      | 13       | 11        | invitation_refused    | {{relativeTime("-169h")}} | null         |
-      | 13       | 31        | join_request_created  | {{relativeTime("-168h")}} | 21           |
-      | 13       | 41        | invitation_created    | {{relativeTime("-166h")}} | 21           |
-      | 13       | 22        | join_request_refused  | {{relativeTime("-167h")}} | 11           |
-      | 13       | 51        | invitation_created    | {{relativeTime("-164h")}} | 41           |
-      | 14       | 11        | invitation_created    | 2017-05-28 06:38:38       | 11           |
-      | 14       | 31        | invitation_refused    | 2017-05-26 06:38:38       | 31           |
-      | 14       | 21        | join_request_created  | 2017-05-27 06:38:38       | 21           |
-      | 14       | 22        | join_request_refused  | 2017-05-24 06:38:38       | 11           |
-      | 13       | 121       | invitation_accepted   | 2017-05-29 06:38:38       | 11           |
-      | 13       | 111       | join_request_accepted | 2017-05-23 06:38:38       | 31           |
-      | 13       | 131       | removed               | 2017-05-22 06:38:38       | 21           |
-      | 13       | 122       | left                  | 2017-05-21 06:38:38       | 11           |
-      | 13       | 123       | added_directly        | 2017-05-20 06:38:38       | 11           |
-      | 13       | 124       | joined_by_code        | 2017-05-19 06:38:38       | 11           |
-      | 13       | 125       | joined_by_badge       | 2017-05-19 06:38:38       | 11           |
+      | group_id | member_id | action                | at                          | initiator_id |
+      | 13       | 21        | invitation_created    | {{relativeTimeDB("-170h")}} | 11           |
+      | 13       | 11        | invitation_refused    | {{relativeTimeDB("-169h")}} | null         |
+      | 13       | 31        | join_request_created  | {{relativeTimeDB("-168h")}} | 21           |
+      | 13       | 41        | invitation_created    | {{relativeTimeDB("-166h")}} | 21           |
+      | 13       | 22        | join_request_refused  | {{relativeTimeDB("-167h")}} | 11           |
+      | 13       | 51        | invitation_created    | {{relativeTimeDB("-164h")}} | 41           |
+      | 14       | 11        | invitation_created    | 2017-05-28 06:38:38         | 11           |
+      | 14       | 31        | invitation_refused    | 2017-05-26 06:38:38         | 31           |
+      | 14       | 21        | join_request_created  | 2017-05-27 06:38:38         | 21           |
+      | 14       | 22        | join_request_refused  | 2017-05-24 06:38:38         | 11           |
+      | 13       | 121       | invitation_accepted   | 2017-05-29 06:38:38         | 11           |
+      | 13       | 111       | join_request_accepted | 2017-05-23 06:38:38         | 31           |
+      | 13       | 131       | removed               | 2017-05-22 06:38:38         | 21           |
+      | 13       | 122       | left                  | 2017-05-21 06:38:38         | 11           |
+      | 13       | 123       | added_directly        | 2017-05-20 06:38:38         | 11           |
+      | 13       | 124       | joined_by_code        | 2017-05-19 06:38:38         | 11           |
+      | 13       | 125       | joined_by_badge       | 2017-05-19 06:38:38         | 11           |
 
   Scenario: User is a manager of the group (default sort)
     Given I am the user with id "21"
@@ -84,42 +84,42 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -136,42 +136,42 @@ Feature: Get requests for group_id
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]
@@ -188,42 +188,42 @@ Feature: Get requests for group_id
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -240,7 +240,7 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -257,35 +257,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -293,7 +293,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by joining user's login, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[3][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[3][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.member_id=31&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -303,35 +303,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -339,7 +339,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by action, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeToRFC(db("group_membership_changes[1][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToJS(db("group_membership_changes[1][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=action&from.at={{from_at}}&from.member_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -349,35 +349,35 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToJS(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -75,7 +75,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -90,7 +90,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -115,7 +115,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -130,7 +130,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -185,7 +185,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -200,7 +200,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -225,7 +225,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -240,7 +240,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -265,7 +265,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -295,7 +295,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -320,7 +320,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -345,7 +345,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -360,7 +360,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -400,7 +400,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -415,7 +415,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -440,7 +440,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -455,7 +455,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -516,7 +516,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]
@@ -541,7 +541,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -556,7 +556,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -569,7 +569,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToJS(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -46,15 +46,15 @@ Feature: Get pending requests for managed groups
       | 13              | 124            | null                           |
     And the groups ancestors are computed
     And the database has the following table 'group_pending_requests':
-      | group_id | member_id | type          | at                        | personal_info_view_approved |
-      | 13       | 21        | invitation    | {{relativeTime("-170h")}} | true                        |
-      | 13       | 31        | join_request  | {{relativeTime("-168h")}} | false                       |
-      | 13       | 41        | join_request  | {{relativeTime("-169h")}} | true                        |
-      | 13       | 11        | leave_request | {{relativeTime("-171h")}} | false                       |
-      | 14       | 11        | invitation    | 2017-05-28 06:38:38       | false                       |
-      | 14       | 21        | join_request  | 2017-05-27 06:38:38       | false                       |
-      | 14       | 31        | leave_request | 2017-05-27 06:38:38       | false                       |
-      | 23       | 21        | join_request  | 2017-05-27 06:38:38       | true                        |
+      | group_id | member_id | type          | at                          | personal_info_view_approved |
+      | 13       | 21        | invitation    | {{relativeTimeDB("-170h")}} | true                        |
+      | 13       | 31        | join_request  | {{relativeTimeDB("-168h")}} | false                       |
+      | 13       | 41        | join_request  | {{relativeTimeDB("-169h")}} | true                        |
+      | 13       | 11        | leave_request | {{relativeTimeDB("-171h")}} | false                       |
+      | 14       | 11        | invitation    | 2017-05-28 06:38:38         | false                       |
+      | 14       | 21        | join_request  | 2017-05-27 06:38:38         | false                       |
+      | 14       | 31        | leave_request | 2017-05-27 06:38:38         | false                       |
+      | 23       | 21        | join_request  | 2017-05-27 06:38:38         | true                        |
 
   Scenario: group_id is given (default sort)
     Given I am the user with id "21"
@@ -75,7 +75,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -90,7 +90,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -115,7 +115,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -130,7 +130,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -185,7 +185,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -200,7 +200,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -225,7 +225,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -240,7 +240,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -265,7 +265,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -295,7 +295,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -320,7 +320,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -345,7 +345,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -360,7 +360,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -400,7 +400,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -415,7 +415,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -440,7 +440,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -455,7 +455,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -516,7 +516,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]
@@ -541,7 +541,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -556,7 +556,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -569,7 +569,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeToRFC(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToJS(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]

--- a/app/api/groups/reject_join_requests.feature
+++ b/app/api/groups/reject_join_requests.feature
@@ -27,12 +27,12 @@ Feature: Reject group requests
       | 22              | 13             |
     And the groups ancestors are computed
     And the database has the following table 'group_pending_requests':
-      | group_id | member_id | type         | at                        |
-      | 13       | 21        | invitation   | {{relativeTime("-170h")}} |
-      | 13       | 31        | join_request | {{relativeTime("-168h")}} |
-      | 14       | 11        | invitation   | {{relativeTime("-167h")}} |
-      | 14       | 21        | join_request | {{relativeTime("-166h")}} |
-      | 13       | 141       | join_request | {{relativeTime("-165h")}} |
+      | group_id | member_id | type         | at                          |
+      | 13       | 21        | invitation   | {{relativeTimeDB("-170h")}} |
+      | 13       | 31        | join_request | {{relativeTimeDB("-168h")}} |
+      | 14       | 11        | invitation   | {{relativeTimeDB("-167h")}} |
+      | 14       | 21        | join_request | {{relativeTimeDB("-166h")}} |
+      | 13       | 141       | join_request | {{relativeTimeDB("-165h")}} |
 
   Scenario Outline: Reject requests
     Given I am the user with id "21"

--- a/app/api/groups/withdraw_invitations.feature
+++ b/app/api/groups/withdraw_invitations.feature
@@ -27,12 +27,12 @@ Feature: Withdraw group invitations
       | 22              | 13             |
     And the groups ancestors are computed
     And the database has the following table 'group_pending_requests':
-      | group_id | member_id | type         | at                        |
-      | 13       | 21        | join_request | {{relativeTime("-170h")}} |
-      | 13       | 31        | invitation   | {{relativeTime("-168h")}} |
-      | 14       | 11        | join_request | {{relativeTime("-167h")}} |
-      | 14       | 21        | invitation   | {{relativeTime("-166h")}} |
-      | 13       | 141       | invitation   | {{relativeTime("-165h")}} |
+      | group_id | member_id | type         | at                          |
+      | 13       | 21        | join_request | {{relativeTimeDB("-170h")}} |
+      | 13       | 31        | invitation   | {{relativeTimeDB("-168h")}} |
+      | 14       | 11        | join_request | {{relativeTimeDB("-167h")}} |
+      | 14       | 21        | invitation   | {{relativeTimeDB("-166h")}} |
+      | 13       | 141       | invitation   | {{relativeTimeDB("-165h")}} |
 
   Scenario Outline: Withdraw invitations
     Given I am the user with id "21"

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -84,6 +84,14 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 		return reflect.ValueOf(time.Now().UTC().Format(a.Get(0).Interface().(string)))
 	})
 
+	set.AddGlobalFunc("currentTimeDB", func(a jet.Arguments) reflect.Value {
+		return reflect.ValueOf(time.Now().UTC().Format("2006-01-02 15:04:05.999999"))
+	})
+
+	set.AddGlobalFunc("currentTimeDBMs", func(a jet.Arguments) reflect.Value {
+		return reflect.ValueOf(time.Now().UTC().Format("2006-01-02 15:04:05.000"))
+	})
+
 	set.AddGlobalFunc("generateToken", func(a jet.Arguments) reflect.Value {
 		a.RequireNumOfArguments("generateToken", 2, 2)
 		var privateKey *rsa.PrivateKey
@@ -137,8 +145,8 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 		return reflect.Value{}
 	})
 
-	set.AddGlobalFunc("relativeTime", func(a jet.Arguments) reflect.Value {
-		a.RequireNumOfArguments("relativeTime", 1, 1)
+	set.AddGlobalFunc("relativeTimeDB", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("relativeTimeDB", 1, 1)
 		durationString := a.Get(0).Interface().(string)
 		duration, err := time.ParseDuration(durationString)
 		if err != nil {
@@ -147,7 +155,8 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 		return reflect.ValueOf(time.Now().UTC().Add(duration).Format("2006-01-02 15:04:05"))
 	})
 
-	addTimeToRFCFunction(set)
+	addRelativeTimeDBMsFunction(set)
+	addTimeDBToJSFunction(set)
 
 	set.AddGlobal("taskPlatformPublicKey", tokentest.TaskPlatformPublicKey)
 	set.AddGlobal("taskPlatformPrivateKey", tokentest.TaskPlatformPrivateKey)
@@ -155,14 +164,26 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 	return set
 }
 
-func addTimeToRFCFunction(set *jet.Set) {
-	set.AddGlobalFunc("timeToRFC", func(a jet.Arguments) reflect.Value {
-		a.RequireNumOfArguments("timeToRFC", 1, 1)
+func addRelativeTimeDBMsFunction(set *jet.Set) *jet.Set {
+	return set.AddGlobalFunc("relativeTimeDBMs", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("relativeTimeDBMs", 1, 1)
+		durationString := a.Get(0).Interface().(string)
+		duration, err := time.ParseDuration(durationString)
+		if err != nil {
+			a.Panicf("can't parse duration: %s", err.Error())
+		}
+		return reflect.ValueOf(time.Now().UTC().Add(duration).Format("2006-01-02 15:04:05.000"))
+	})
+}
+
+func addTimeDBToJSFunction(set *jet.Set) {
+	set.AddGlobalFunc("timeDBToJS", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("timeDBToJS", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
-		parsedTime, err := time.Parse("2006-01-02 15:04:05", dbTime)
+		parsedTime, err := time.Parse("2006-01-02 15:04:05.999999999", dbTime)
 		if err != nil {
 			a.Panicf("can't parse mysql datetime: %s", err.Error())
 		}
-		return reflect.ValueOf(parsedTime.Format(time.RFC3339))
+		return reflect.ValueOf(parsedTime.Format(time.RFC3339Nano))
 	})
 }

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -156,7 +156,7 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 	})
 
 	addRelativeTimeDBMsFunction(set)
-	addTimeDBToJSFunction(set)
+	addTimeDBToRFCFunction(set)
 
 	set.AddGlobal("taskPlatformPublicKey", tokentest.TaskPlatformPublicKey)
 	set.AddGlobal("taskPlatformPrivateKey", tokentest.TaskPlatformPrivateKey)
@@ -176,9 +176,9 @@ func addRelativeTimeDBMsFunction(set *jet.Set) *jet.Set {
 	})
 }
 
-func addTimeDBToJSFunction(set *jet.Set) {
-	set.AddGlobalFunc("timeDBToJS", func(a jet.Arguments) reflect.Value {
-		a.RequireNumOfArguments("timeDBToJS", 1, 1)
+func addTimeDBToRFCFunction(set *jet.Set) {
+	set.AddGlobalFunc("timeDBToRFC", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("timeDBToRFC", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
 		parsedTime, err := time.Parse("2006-01-02 15:04:05.999999999", dbTime)
 		if err != nil {


### PR DESCRIPTION
1. Rename template functions used in cucumber tests for clarity:
- relativeTime -> relativeTimeDB (returns time relative to the current time in the DB format),
- timeToRFC -> timeDBToJS (converts time from DB format to JS format).
2. Add support for nanoseconds in timeDBToJS (will be used in next PRs).
3. Add a new function relativeTimeDBMs (similar to relativeTimeDB, but with milliseconds; will be used in next PRs).
4. Add new functions currentTimeDB & currentTimeDBMs returning the current time in the DB format (with and without milliseconds; will be used in next PRs).