### PR TITLE
Disable binlog for docker mysql containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # connect from host using: "mysql -hlocalhost -Dalgorea_db -ualgorea -pa_db_password --protocol=TCP"
   db:
     image: mysql:8.0.28
-    command: --default-authentication-plugin=mysql_native_password --max-allowed-packet=10485760 --innodb_lock_wait_timeout=1
+    command: --default-authentication-plugin=mysql_native_password --max-allowed-packet=10485760 --innodb_lock_wait_timeout=1 --skip-log-bin
     restart: always
     ports:
       - "3306:3306"
@@ -24,7 +24,7 @@ services:
       retries: 10
   db_test:
     image: mysql:8.0.28
-    command: --default-authentication-plugin=mysql_native_password --innodb_lock_wait_timeout=1
+    command: --default-authentication-plugin=mysql_native_password --innodb_lock_wait_timeout=1 --skip-log-bin
     restart: always
     ports:
       - "3307:3306"


### PR DESCRIPTION
MySQL binlogs are not needed in Docker. At the same time, they consume disk space and grow in size. Here we disable them completely. One may remove all `binlog*` files in the db volume after upgrading the DB containers.

Fyi, @GeoffreyHuck 