### PR TITLE
Fix item activity log services (display can_watch_answer correctly, show items visible to the team when 'as_team_id' is given).

### DIFF
--- a/app/api/items/get_activity_log.feature
+++ b/app/api/items/get_activity_log.feature
@@ -11,6 +11,8 @@ Feature: Get activity log
       | 13 | Class | Our Class  |
       | 20 | Other | Some Group |
       | 30 | Team  | Our Team   |
+      | 40 | Club  | Our Club   |
+      | 50 | Club  | Team Club  |
     And the database has the following table 'group_managers':
       | group_id | manager_id | can_watch_members |
       | 11       | 31         | true              |
@@ -22,6 +24,8 @@ Feature: Get activity log
       | 13              | 41             | 2019-05-30 11:00:00            |
       | 20              | 21             | null                           |
       | 30              | 21             | null                           |
+      | 40              | 21             | null                           |
+      | 50              | 30             | null                           |
     And the groups ancestors are computed
     And the database has the following table 'attempts':
       | id | participant_id |
@@ -32,8 +36,10 @@ Feature: Get activity log
       | 0          | 200     | 11             | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 | 2020-05-29 06:38:38  |
       | 0          | 200     | 30             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 0          | 201     | 11             | 2017-05-29 06:38:00 | null                | 2020-05-29 06:38:38  |
+      | 0          | 201     | 30             | 2017-05-29 06:37:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 0          | 202     | 11             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 0          | 203     | 11             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
+      | 0          | 204     | 30             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 1          | 200     | 11             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 1          | 200     | 31             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 1          | 200     | 41             | 2016-05-29 06:38:00 | 2016-05-30 12:00:00 | 2020-05-29 06:38:38  |
@@ -97,10 +103,13 @@ Feature: Get activity log
       | 21       | 203     | none               | result              |
       | 21       | 204     | content            | none                |
       | 30       | 200     | content            | answer              |
+      | 30       | 201     | content            | result              |
       | 31       | 200     | content            | answer              |
       | 31       | 201     | content            | answer              |
       | 31       | 202     | content            | answer              |
       | 31       | 203     | content            | none                |
+      | 40       | 201     | content            | answer              |
+      | 50       | 204     | content            | answer              |
     And the database has the following table 'items_ancestors':
       | ancestor_item_id | child_item_id |
       | 200              | 201           |
@@ -124,7 +133,8 @@ Feature: Get activity log
       This spec also checks:
       1) activities ordering,
       2) filtering by users groups,
-      3) that a user cannot see names of other users without approval
+      3) that a user cannot see names of other users without approval,
+      4) that 'can_watch_item_answer' is set correctly respecting implicit permission propagation from ancestor groups.
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
     When I send a GET request to "/items/200/log?watched_group_id=13"
@@ -193,7 +203,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "5",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -205,7 +215,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "4",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -280,7 +290,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "17"
       },
@@ -292,7 +302,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "1"
       },
@@ -304,7 +314,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "7"
       },
@@ -324,7 +334,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "7"
       },
@@ -541,7 +551,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "17"
       }
@@ -600,7 +610,6 @@ Feature: Get activity log
         "participant": {"id": "31", "name": "jane", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Task 1"}, "type": "Task"},
-        "can_watch_item_answer": true,
         "user": {"id": "31", "first_name": "Jane", "last_name": "Doe", "login": "jane"},
         "from_answer_id": "-1"
       }
@@ -608,6 +617,8 @@ Feature: Get activity log
     """
 
   Scenario: A user can view activity of his team
+      This spec also checks that only items visible to the team are shown,
+      not the items visible to the user.
     Given I am the user with id "21"
     When I send a GET request to "/items/200/log?as_team_id=30"
     Then the response code should be 200
@@ -620,7 +631,22 @@ Feature: Get activity log
         "participant": {"id": "30", "name": "Our Team", "type": "Team"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "from_answer_id": "-1"
+      },
+      {
+        "activity_type": "result_validated",
+        "at": "2017-05-30T12:00:00Z",
+        "participant": {"id": "30", "name": "Our Team", "type": "Team"},
+        "attempt_id": "0",
+        "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
+        "from_answer_id": "-1"
+      },
+      {
+        "activity_type": "result_validated",
+        "at": "2017-05-30T12:00:00Z",
+        "participant": {"id": "30", "name": "Our Team", "type": "Team"},
+        "attempt_id": "0",
+        "item": {"id": "204", "string": {"title": null}, "type": "Task"},
         "from_answer_id": "-1"
       },
       {
@@ -629,7 +655,22 @@ Feature: Get activity log
         "participant": {"id": "30", "name": "Our Team", "type": "Team"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "from_answer_id": "-1"
+      },
+      {
+        "activity_type": "result_started",
+        "at": "2017-05-29T06:38:00Z",
+        "participant": {"id": "30", "name": "Our Team", "type": "Team"},
+        "attempt_id": "0",
+        "item": {"id": "204", "string": {"title": null}, "type": "Task"},
+        "from_answer_id": "-1"
+      },
+      {
+        "activity_type": "result_started",
+        "at": "2017-05-29T06:37:00Z",
+        "participant": {"id": "30", "name": "Our Team", "type": "Team"},
+        "attempt_id": "0",
+        "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
         "from_answer_id": "-1"
       }
     ]
@@ -639,7 +680,8 @@ Feature: Get activity log
       This spec also checks:
       1) activities ordering,
       2) filtering by users groups,
-      3) that a user cannot see names of other users without approval
+      3) that a user cannot see names of other users without approval,
+      4) that 'can_watch_item_answer' is set correctly respecting implicit permission propagation from ancestor groups.
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
     When I send a GET request to "/items/log?watched_group_id=13"
@@ -728,7 +770,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "5",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -740,7 +782,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "4",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -859,7 +901,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "17",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -870,7 +912,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 99,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -882,7 +924,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "7",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 98,
         "user": {"id": "31", "login": "jane"}
@@ -947,7 +989,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "27",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_item_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -1012,7 +1054,6 @@ Feature: Get activity log
         "participant": {"id": "31", "name": "jane", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Task 1"}, "type": "Task"},
-        "can_watch_item_answer": true,
         "user": {"id": "31", "first_name": "Jane", "last_name": "Doe", "login": "jane"},
         "from_answer_id": "-1"
       },
@@ -1022,7 +1063,6 @@ Feature: Get activity log
         "participant": {"id": "31", "name": "jane", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Task 1"}, "type": "Task"},
-        "can_watch_item_answer": true,
         "user": {"id": "31", "first_name": "Jane", "last_name": "Doe", "login": "jane"},
         "from_answer_id": "-1"
       }
@@ -1047,7 +1087,6 @@ Feature: Get activity log
         "participant": {"id": "31", "name": "jane", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Task 1"}, "type": "Task"},
-        "can_watch_item_answer": true,
         "user": {"id": "31", "first_name": "Jane", "last_name": "Doe", "login": "jane"},
         "from_answer_id": "-1"
       }
@@ -1072,7 +1111,6 @@ Feature: Get activity log
         "participant": {"id": "31", "name": "jane", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Task 1"}, "type": "Task"},
-        "can_watch_item_answer": true,
         "user": {"id": "31", "first_name": "Jane", "last_name": "Doe", "login": "jane"},
         "from_answer_id": "-1"
       }

--- a/app/api/items/get_activity_log.feature
+++ b/app/api/items/get_activity_log.feature
@@ -134,7 +134,7 @@ Feature: Get activity log
       1) activities ordering,
       2) filtering by users groups,
       3) that a user cannot see names of other users without approval,
-      4) that 'can_watch_item_answer' is set correctly respecting implicit permission propagation from ancestor groups.
+      4) that 'can_watch_answer' is set correctly respecting implicit permission propagation from ancestor groups.
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
     When I send a GET request to "/items/200/log?watched_group_id=13"
@@ -148,7 +148,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "-1"
       },
@@ -159,7 +159,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "15",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -170,7 +170,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "14",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -181,7 +181,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "18"
       },
@@ -192,7 +192,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "13"
       },
@@ -203,7 +203,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "5",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -215,7 +215,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "4",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -227,7 +227,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "12"
       },
@@ -238,7 +238,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "16"
       },
@@ -248,7 +248,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "16"
       },
@@ -259,7 +259,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "11"
       },
@@ -270,7 +270,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "17"
       },
@@ -280,7 +280,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "17"
       },
@@ -290,7 +290,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "17"
       },
@@ -302,7 +302,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "1"
       },
@@ -314,7 +314,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "7"
       },
@@ -325,7 +325,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "from_answer_id": "7"
       },
       {
@@ -334,7 +334,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "7"
       },
@@ -344,7 +344,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "7"
       },
@@ -354,7 +354,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "7"
       }
@@ -379,7 +379,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "-1"
       }
@@ -405,7 +405,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "15",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -416,7 +416,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "14",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       }
@@ -442,7 +442,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "14",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -453,7 +453,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "18"
       }
@@ -479,7 +479,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "31", "login": "jane"},
         "from_answer_id": "18"
       },
@@ -490,7 +490,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "13"
       }
@@ -515,7 +515,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "16"
       },
@@ -526,7 +526,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "0",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "11"
       }
@@ -551,7 +551,7 @@ Feature: Get activity log
         "participant": {"id": "11", "name": "user", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "user": {"id": "11", "first_name": "John", "last_name": "Doe", "login": "user"},
         "from_answer_id": "17"
       }
@@ -576,7 +576,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "7"
       },
@@ -586,7 +586,7 @@ Feature: Get activity log
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "attempt_id": "1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "user": {"id": "41", "first_name": "Paul", "last_name": "Smith", "login": "paul"},
         "from_answer_id": "7"
       }
@@ -681,7 +681,7 @@ Feature: Get activity log
       1) activities ordering,
       2) filtering by users groups,
       3) that a user cannot see names of other users without approval,
-      4) that 'can_watch_item_answer' is set correctly respecting implicit permission propagation from ancestor groups.
+      4) that 'can_watch_answer' is set correctly respecting implicit permission propagation from ancestor groups.
     Given I am the user with id "21"
     And the context variable "forceStraightJoinInItemActivityLog" is "<forceStraightJoinInItemActivityLog>"
     When I send a GET request to "/items/log?watched_group_id=13"
@@ -695,7 +695,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "-1",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -705,7 +705,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "-1",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -715,7 +715,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "-1",
         "item": {"id": "202", "string": { "title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -726,7 +726,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "15",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -737,7 +737,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "14",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -748,7 +748,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "18",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -759,7 +759,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "13",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "user": {"first_name": "Paul", "id": "41", "last_name": "Smith", "login": "paul"}
       },
@@ -770,7 +770,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "5",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -782,7 +782,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "4",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 100,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -794,7 +794,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "25",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -805,7 +805,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "24",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -816,7 +816,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "23",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -827,7 +827,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "28",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -838,7 +838,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "12",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -849,7 +849,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "16",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -859,7 +859,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "16",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -870,7 +870,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "11",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -881,7 +881,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "17",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -891,7 +891,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "17",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -901,7 +901,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "17",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -912,7 +912,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "1",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 99,
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
@@ -924,7 +924,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "7",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "score": 98,
         "user": {"id": "31", "login": "jane"}
@@ -936,7 +936,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "22",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -947,7 +947,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "26",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -958,7 +958,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "21",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -969,7 +969,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "27",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"id": "31", "login": "jane"}
       },
@@ -979,7 +979,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "27",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -989,7 +989,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "27",
         "item": {"id": "201", "string": {"title": "Chapitre 1"}, "type": "Chapter"},
-        "can_watch_item_answer": true,
+        "can_watch_answer": true,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -999,7 +999,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "27",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -1009,7 +1009,7 @@ Feature: Get activity log
         "attempt_id": "0",
         "from_answer_id": "27",
         "item": {"id": "202", "string": {"title": "Chapitre 2"}, "type": "Chapter"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "11", "name": "user", "type": "User"},
         "user": {"first_name": "John", "id": "11", "last_name": "Doe", "login": "user"}
       },
@@ -1019,7 +1019,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "27",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "user": {"first_name": "Paul", "id": "41", "last_name": "Smith", "login": "paul"}
       },
@@ -1029,7 +1029,7 @@ Feature: Get activity log
         "attempt_id": "1",
         "from_answer_id": "27",
         "item": {"id": "200", "string": {"title": "Tache 1"}, "type": "Task"},
-        "can_watch_item_answer": false,
+        "can_watch_answer": false,
         "participant": {"id": "41", "name": "paul", "type": "User"},
         "user": {"first_name": "Paul", "id": "41", "last_name": "Smith", "login": "paul"}
       }

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -2,6 +2,7 @@ package items
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/structures"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 const itemActivityLogStraightJoinBoundary = 10000
@@ -62,8 +64,8 @@ type itemActivityLogResponseRow struct {
 			Title *string `json:"title"`
 		} `json:"string" gorm:"embedded;embedded_prefix:string__"`
 	} `json:"item" gorm:"embedded;embedded_prefix:item__"`
-	// required: true
-	CanWatchItemAnswer bool `json:"can_watch_item_answer"`
+	// only when `{watched_group_id}` is given
+	CanWatchItemAnswer *bool `json:"can_watch_item_answer,omitempty"`
 }
 
 // swagger:operation GET /items/{ancestor_item_id}/log items itemActivityLogForItem
@@ -319,7 +321,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 	}
 	participantsQuery := store.Raw("SELECT ? AS id", participantID)
 
-	visibleItemDescendants := store.Permissions().MatchingUserAncestors(user).
+	visibleItemDescendants := store.Permissions().MatchingGroupAncestors(participantID).
 		Select("item_id AS id").
 		Group("item_id").
 		HavingMaxPermissionAtLeast("view", "info")
@@ -501,8 +503,13 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 				WHEN 5 THEN 'current_answer'
 			END AS activity_type,
 			at, answer_id, attempt_id, participant_id, score,
-			items.id AS item__id, items.type AS item__type,
-			permissions_generated.can_watch_generated_value >= ? AS can_watch_item_answer,
+			items.id AS item__id, items.type AS item__type,`+
+		golang.LazyIf(watchedGroupIDIsSet,
+			func() string {
+				return fmt.Sprintf(`
+			permissions.can_watch_generated_value >= %d AS can_watch_item_answer,`,
+					store.PermissionsGranted().WatchIndexByName("answer"))
+			})+`
 			groups.id AS participant__id,
 			groups.name AS participant__name,
 			groups.type AS participant__type,
@@ -514,19 +521,18 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 			IF(user_strings.language_tag IS NULL, default_strings.title, user_strings.title) AS item__string__title
 		FROM ? AS activities`, visibleItemDescendantsSubQuery, participantsQuerySubQuery,
 		startFromRowCTESubQuery, unionCTEQuery.SubQuery(),
-		store.PermissionsGranted().WatchIndexByName("answer"),
 		user.GroupID, user.GroupID, user.GroupID,
 		unionQuery.SubQuery()).
 		Joins("JOIN items ON items.id = item_id").
-		Joins(`
-			JOIN permissions_generated
-			  ON permissions_generated.item_id = items.id
-       AND permissions_generated.group_id = ?
-		`, user.GroupID).
 		Joins("JOIN `groups` ON groups.id = participant_id").
 		Joins("LEFT JOIN users ON users.group_id = user_id").
 		WithPersonalInfoViewApprovals(user).
 		JoinsUserAndDefaultItemStrings(user)
+
+	if watchedGroupIDIsSet {
+		query = query.JoinsPermissionsForGroupToItems(participantID)
+	}
+
 	return query, service.NoError
 }
 

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -65,7 +65,7 @@ type itemActivityLogResponseRow struct {
 		} `json:"string" gorm:"embedded;embedded_prefix:string__"`
 	} `json:"item" gorm:"embedded;embedded_prefix:item__"`
 	// only when `{watched_group_id}` is given
-	CanWatchItemAnswer *bool `json:"can_watch_item_answer,omitempty"`
+	CanWatchAnswer *bool `json:"can_watch_answer,omitempty"`
 }
 
 // swagger:operation GET /items/{ancestor_item_id}/log items itemActivityLogForItem
@@ -507,7 +507,7 @@ func (srv *Service) constructActivityLogQuery(store *database.DataStore, r *http
 		golang.LazyIf(watchedGroupIDIsSet,
 			func() string {
 				return fmt.Sprintf(`
-			permissions.can_watch_generated_value >= %d AS can_watch_item_answer,`,
+			permissions.can_watch_generated_value >= %d AS can_watch_answer,`,
 					store.PermissionsGranted().WatchIndexByName("answer"))
 			})+`
 			groups.id AS participant__id,

--- a/app/database/permissions.go
+++ b/app/database/permissions.go
@@ -15,7 +15,18 @@ func (conn *DB) HavingMaxPermissionAtLeast(permissionKind, permissionName string
 			NewDataStore(conn).PermissionsGranted().PermissionIndexByKindAndName(permissionKind, permissionName)))
 }
 
-// JoinsPermissionsForGroupToItemsWherePermissionAtLeast returns a composable query with access rights (as *_generated_value)
+// JoinsPermissionsForGroupToItems returns a composable query with access rights (as permissions.*_generated_value)
+// for all the items.
+func (conn *DB) JoinsPermissionsForGroupToItems(groupID int64) *DB {
+	permissionsQuery := NewDataStore(conn.New()).Permissions().
+		AggregatedPermissionsForItems(groupID).
+		Where("permissions.item_id = items.id") // This condition is needed to filter by item_id before aggregating
+	// The JOIN LATERAL allows us to filter permissions on both group_id & item_id here
+	// instead of calculating permissions for all the items before joining
+	return conn.Joins("JOIN LATERAL ? AS permissions ON permissions.item_id = items.id", permissionsQuery.SubQuery())
+}
+
+// JoinsPermissionsForGroupToItemsWherePermissionAtLeast returns a composable query with access rights (as permissions.*_generated_value)
 // for all the items on that the given group has 'permissionKind' >= `neededPermission`.
 func (conn *DB) JoinsPermissionsForGroupToItemsWherePermissionAtLeast(groupID int64, permissionKind, neededPermission string) *DB {
 	permissionsQuery := NewDataStore(conn.New()).Permissions().

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
 )
 
-func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) {
-	db := testhelpers.SetupDBWithFixtureString(`
+const joinsPermissionsForGroupToItemsFixture = `
 		groups: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}]
 		groups_ancestors:
 			- {ancestor_group_id: 1, child_group_id: 1}
@@ -37,8 +36,55 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 			- {group_id: 5, item_id: 2, can_view_generated: solution, can_grant_view_generated: solution, can_watch_generated: none,
 				 can_edit_generated: children, is_owner_generated: 0}
 			- {group_id: 5, item_id: 4, can_view_generated: none, can_grant_view_generated: enter, can_watch_generated: none,
-				 can_edit_generated: children, is_owner_generated: 1}
-	`)
+				 can_edit_generated: children, is_owner_generated: 1}`
+
+func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
+	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
+	defer func() { _ = db.Close() }()
+
+	itemStore := database.NewDataStore(db).Items()
+
+	for _, test := range []struct {
+		ids            []int64
+		expectedResult []map[string]interface{}
+	}{
+		{
+			ids: []int64{1, 2, 3},
+			expectedResult: []map[string]interface{}{
+				{
+					"id": int64(2), "item_id": int64(2), "can_view_generated_value": int64(5), "can_grant_view_generated_value": int64(5),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(3), "is_owner_generated": int64(0),
+				},
+				{
+					"id": int64(3), "item_id": int64(3), "can_view_generated_value": int64(3), "can_grant_view_generated_value": int64(1),
+					"can_watch_generated_value": int64(3), "can_edit_generated_value": int64(2), "is_owner_generated": int64(0),
+				},
+			},
+		},
+		{
+			ids: []int64{1, 4, 5},
+			expectedResult: []map[string]interface{}{
+				{
+					"id": int64(4), "item_id": int64(4), "can_view_generated_value": int64(1), "can_grant_view_generated_value": int64(2),
+					"can_watch_generated_value": int64(1), "can_edit_generated_value": int64(2), "is_owner_generated": int64(1),
+				},
+			},
+		},
+	} {
+		test := test
+		t.Run(fmt.Sprintf("ids: %v", test.ids), func(t *testing.T) {
+			var result []map[string]interface{}
+			assert.NoError(t, itemStore.Select("items.id, permissions.*").
+				JoinsPermissionsForGroupToItems(5).
+				Where("items.id IN (?)", test.ids).Order("items.id").
+				ScanIntoSliceOfMaps(&result).Error())
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
+func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) {
+	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
 	defer func() { _ = db.Close() }()
 
 	itemStore := database.NewDataStore(db).Items()

--- a/golang/if.go
+++ b/golang/if.go
@@ -1,0 +1,35 @@
+package golang
+
+// IfElse returns trueValue if condition is true, otherwise falseValue.
+func IfElse[T any](condition bool, trueValue, falseValue T) T {
+	if condition {
+		return trueValue
+	}
+	return falseValue
+}
+
+// If returns trueValue if condition is true, otherwise the zero value of T.
+func If[T any](condition bool, trueValue T) T {
+	if condition {
+		return trueValue
+	}
+	return Zero[T]()
+}
+
+// LazyIfElse returns the result of trueValueFunc if condition is true, otherwise the result of falseValueFunc.
+// The functions are only called if their result is needed.
+func LazyIfElse[T any](condition bool, trueValueFunc, falseValueFunc func() T) T {
+	if condition {
+		return trueValueFunc()
+	}
+	return falseValueFunc()
+}
+
+// LazyIf returns the result of trueValueFunc if condition is true, otherwise the zero value of T.
+// The function is only called if its result is needed.
+func LazyIf[T any](condition bool, trueValueFunc func() T) T {
+	if condition {
+		return trueValueFunc()
+	}
+	return Zero[T]()
+}

--- a/golang/if_test.go
+++ b/golang/if_test.go
@@ -1,0 +1,87 @@
+package golang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIfElse(t *testing.T) {
+	assert.Equal(t, 1, IfElse(true, 1, 2))
+	assert.Equal(t, 2, IfElse(false, 1, 2))
+	assert.Equal(t, "a", IfElse(true, "a", "b"))
+	assert.Equal(t, "b", IfElse(false, "a", "b"))
+	assert.Equal(t, true, IfElse(true, true, false))
+}
+
+func TestIf(t *testing.T) {
+	str := "str"
+	strPtr := &str
+
+	assert.Equal(t, 1, If(true, 1))
+	assert.Equal(t, 0, If(false, 1))
+	assert.Equal(t, "a", If(true, "a"))
+	assert.Equal(t, "", If(false, "a"))
+	assert.Equal(t, true, If(true, true))
+	assert.Equal(t, false, If(false, true))
+	assert.Equal(t, (*string)(nil), If(false, strPtr))
+}
+
+func TestLazyIfElse_TrueValueFuncIsCalled(t *testing.T) {
+	var trueValueFuncCalled, falseValueFuncCalled bool
+	assert.Equal(t, 1,
+		LazyIfElse(true, func() int {
+			trueValueFuncCalled = true
+			return 1
+		}, func() int {
+			falseValueFuncCalled = true
+			return 2
+		}))
+	assert.True(t, trueValueFuncCalled)
+	assert.False(t, falseValueFuncCalled)
+}
+
+func TestLazyIfElse_FalseValueFuncIsCalled(t *testing.T) {
+	var trueValueFuncCalled, falseValueFuncCalled bool
+	assert.Equal(t, 2,
+		LazyIfElse(false, func() int {
+			trueValueFuncCalled = true
+			return 1
+		}, func() int {
+			falseValueFuncCalled = true
+			return 2
+		}))
+	assert.False(t, trueValueFuncCalled)
+	assert.True(t, falseValueFuncCalled)
+}
+
+func TestLazyIf_TrueValueFuncIsCalled(t *testing.T) {
+	var trueValueFuncCalled bool
+	assert.Equal(t, 1,
+		LazyIf(true, func() int {
+			trueValueFuncCalled = true
+			return 1
+		}))
+	assert.True(t, trueValueFuncCalled)
+}
+
+func TestLazyIf_TrueValueFuncIsNotCalled(t *testing.T) {
+	var trueValueFuncCalled bool
+	assert.Equal(t, "",
+		LazyIf(false, func() string {
+			trueValueFuncCalled = true
+			return "a"
+		}))
+	assert.False(t, trueValueFuncCalled)
+}
+
+func TestLazyIf_TrueValueFuncIsNotCalled_ZeroPointer(t *testing.T) {
+	var trueValueFuncCalled bool
+	assert.Equal(t, (*string)(nil),
+		LazyIf(false, func() *string {
+			trueValueFuncCalled = true
+			result := "a"
+			return &result
+		}))
+	assert.False(t, trueValueFuncCalled)
+}

--- a/golang/package.go
+++ b/golang/package.go
@@ -1,0 +1,4 @@
+/*
+Package golang provides a set of functions making Go more expressive and concise.
+*/
+package golang

--- a/golang/zero.go
+++ b/golang/zero.go
@@ -1,0 +1,6 @@
+package golang
+
+// Zero returns the zero value of T.
+func Zero[T any]() (result T) {
+	return
+}

--- a/golang/zero_test.go
+++ b/golang/zero_test.go
@@ -1,0 +1,19 @@
+package golang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZero(t *testing.T) {
+	assert.Equal(t, false, Zero[bool]())
+	assert.Equal(t, 0, Zero[int]())
+	assert.Equal(t, int64(0), Zero[int64]())
+	assert.Equal(t, "", Zero[string]())
+	assert.Equal(t, []byte(nil), Zero[[]byte]())
+	assert.Equal(t, struct{}{}, Zero[struct{}]())
+	assert.Equal(t, (*bool)(nil), Zero[*bool]())
+	assert.Equal(t, (*int64)(nil), Zero[*int64]())
+	assert.Equal(t, (*string)(nil), Zero[*string]())
+}


### PR DESCRIPTION
1. "can_watch_item_answer" added in #1027 didn't respect implicit permissions propagation from ancestor groups (see https://france-ioi.github.io/algorea-devdoc/items/access-rights/#propagation). So, when a user is a descendant of a group having can_watch_generated='answer' on an item, "can_watch_item_answer" was still false, it only respected direct permissions of the user. Here we fix this issue.
2. "can_watch_item_answer" added in #1027 was displayed even if no 'watch_group_id' was given which doesn't make sense. This PR removes "can_watch_item_answer" from the responses if "watch_group_id" is not given.
3. Here we rename "can_watch_item_answer" into "can_watch_answer" as there is no need to be so specific.
4. The service used to return items visible to the user (not to the team) when "as_team_id" was given. This PR eliminates this issue as well.

Also, some useful functions making code more expressive and concise are being introduced here (see the new package "golang").

Fixes #1025 (really)