### PR TITLE
Fix wrongly specified success response code for DELETE requests to groupDelete & groupRemoveChild in swagger docs

### DIFF
--- a/app/api/groups/delete_group.go
+++ b/app/api/groups/delete_group.go
@@ -41,7 +41,7 @@ import (
 //			format: int64
 //			required: true
 //	responses:
-//		"201":
+//		"200":
 //			"$ref": "#/responses/deletedResponse"
 //		"400":
 //			"$ref": "#/responses/badRequestResponse"

--- a/app/api/groups/remove_child.go
+++ b/app/api/groups/remove_child.go
@@ -55,7 +55,7 @@ import (
 //			enum: [0,1]
 //			default: 0
 //	responses:
-//		"201":
+//		"200":
 //			"$ref": "#/responses/deletedResponse"
 //		"400":
 //			"$ref": "#/responses/badRequestResponse"


### PR DESCRIPTION
The actual success code is 200, but the swagger comments specify it as 201.