### PR TITLE
Introduce a simple map-based implementation of sets allowing to make a set immutable

### DIFF
--- a/golang/package.go
+++ b/golang/package.go
@@ -1,4 +1,4 @@
 /*
-Package golang provides a set of functions making Go more expressive and concise.
+Package golang provides a set of functions and structures making Go more expressive and concise.
 */
 package golang

--- a/golang/set.go
+++ b/golang/set.go
@@ -1,0 +1,96 @@
+package golang
+
+// Set is a simple implementation of set of values of type T.
+// It allows to mark the set as immutable to prevent further modifications.
+// It is not thread-safe.
+type Set[T comparable] struct {
+	data        map[T]struct{}
+	isImmutable bool
+}
+
+// NewSet creates a new set with the given values.
+func NewSet[T comparable](values ...T) *Set[T] {
+	set := &Set[T]{data: make(map[T]struct{}, len(values))}
+	for _, value := range values {
+		set.data[value] = struct{}{}
+	}
+	return set
+}
+
+// MarkImmutable marks the set as immutable.
+func (s *Set[T]) MarkImmutable() *Set[T] {
+	s.isImmutable = true
+	return s
+}
+
+func (s *Set[T]) mustBeMutable() {
+	if s.isImmutable {
+		panic("cannot modify an immutable set")
+	}
+}
+
+// Add adds the given values to the set.
+func (s *Set[T]) Add(value ...T) *Set[T] {
+	s.mustBeMutable()
+	for _, value := range value {
+		s.data[value] = struct{}{}
+	}
+	return s
+}
+
+// Remove removes the given values from the set.
+func (s *Set[T]) Remove(value T) *Set[T] {
+	s.mustBeMutable()
+	delete(s.data, value)
+	return s
+}
+
+// Contains returns true if the set contains the given value.
+func (s *Set[T]) Contains(value T) bool {
+	_, ok := s.data[value]
+	return ok
+}
+
+// IsEmpty returns true if the set is empty.
+func (s *Set[T]) IsEmpty() bool {
+	return len(s.data) == 0
+}
+
+// IsImmutable returns true if the set is immutable.
+func (s *Set[T]) IsImmutable() bool {
+	return s.isImmutable
+}
+
+// Size returns the number of elements in the set.
+func (s *Set[T]) Size() int {
+	return len(s.data)
+}
+
+// MergeWith adds all values from the other set to the set.
+func (s *Set[T]) MergeWith(other *Set[T]) *Set[T] {
+	s.mustBeMutable()
+	for value := range other.data {
+		s.data[value] = struct{}{}
+	}
+	return s
+}
+
+// Values returns all values in the set as a slice.
+// The order of the values is not guaranteed.
+func (s *Set[T]) Values() []T {
+	values := make([]T, 0, len(s.data))
+	for value := range s.data {
+		values = append(values, value)
+	}
+	return values
+}
+
+// Clone returns a mutable shallow copy of the set.
+func (s *Set[T]) Clone() *Set[T] {
+	clone := NewSet[T]()
+	clone.data = make(map[T]struct{}, len(s.data))
+	for value := range s.data {
+		clone.data[value] = struct{}{}
+	}
+	return clone
+}

--- a/golang/set_test.go
+++ b/golang/set_test.go
@@ -1,0 +1,115 @@
+package golang
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSet(t *testing.T) {
+	set1 := NewSet[string]()
+	assert.NotNil(t, set1)
+	assert.False(t, set1.isImmutable)
+	assert.Empty(t, set1.data)
+
+	set2 := NewSet[int]()
+	assert.NotNil(t, set2)
+	assert.False(t, set2.isImmutable)
+	assert.Empty(t, set2.data)
+
+	set3 := NewSet("a", "b", "c")
+	assert.NotNil(t, set3)
+	assert.False(t, set3.isImmutable)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}, "c": {}}, set3.data)
+}
+
+func TestSet_Add(t *testing.T) {
+	set1 := NewSet[string]().Add("a", "b")
+	assert.False(t, set1.isImmutable)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, set1.data)
+
+	set2 := NewSet[int](1)
+	set2.Add(2)
+	assert.False(t, set1.isImmutable)
+	assert.Equal(t, map[int]struct{}{1: {}, 2: {}}, set2.data)
+}
+
+func TestSet_Clone(t *testing.T) {
+	set := NewSet[string]("a", "b")
+	clone := set.Clone()
+	assert.False(t, clone.isImmutable)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, clone.data)
+
+	set.isImmutable = true
+	clone = set.Clone()
+	assert.False(t, clone.isImmutable)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, clone.data)
+}
+
+func TestSet_Contains(t *testing.T) {
+	assert.True(t, NewSet[string]("a", "b").Contains("a"))
+	assert.False(t, NewSet[string]("a", "b").Contains("c"))
+	assert.True(t, NewSet[int](1, 2).Contains(1))
+	assert.False(t, NewSet[int](1, 2).Contains(3))
+}
+
+func TestSet_IsEmpty(t *testing.T) {
+	assert.True(t, NewSet[string]().IsEmpty())
+	assert.True(t, NewSet[string]().MarkImmutable().IsEmpty())
+	assert.False(t, NewSet[string]("a").IsEmpty())
+	assert.False(t, NewSet[string]("a").MarkImmutable().IsEmpty())
+}
+
+func TestSet_IsImmutable(t *testing.T) {
+	set := NewSet[string]()
+	set.isImmutable = true
+	assert.True(t, set.IsImmutable())
+	set.isImmutable = false
+	assert.False(t, set.IsImmutable())
+}
+
+func TestSet_MarkImmutable(t *testing.T) {
+	set := NewSet[string]()
+	assert.False(t, set.isImmutable)
+	assert.NotPanics(t, func() { set.Add("a") })
+	assert.NotPanics(t, func() { set.Remove("a") })
+	assert.NotPanics(t, func() { set.MergeWith(NewSet("a")) })
+
+	assert.Equal(t, set, set.MarkImmutable())
+	assert.True(t, set.isImmutable)
+	assert.Panics(t, func() { set.Add("a") })
+	assert.Panics(t, func() { set.Remove("a") })
+	assert.Panics(t, func() { set.MergeWith(NewSet("a")) })
+
+	assert.True(t, NewSet("a", "b").MarkImmutable().IsImmutable())
+}
+
+func TestSet_MergeWith(t *testing.T) {
+	set1 := NewSet[string]("a", "b")
+	set2 := NewSet[string]("b", "c")
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}, "c": {}}, set1.MergeWith(set2).data)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}, "c": {}}, set1.data)
+	assert.Equal(t, map[string]struct{}{"b": {}, "c": {}}, set2.data)
+}
+
+func TestSet_Remove(t *testing.T) {
+	set := NewSet[string]("a", "b")
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, set.Remove("c").data)
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, set.data)
+	assert.Equal(t, map[int]struct{}{}, NewSet[int]().Remove(0).data)
+}
+
+func TestSet_Size(t *testing.T) {
+	assert.Equal(t, 0, NewSet[string]().Size())
+	assert.Equal(t, 2, NewSet[string]("a", "b").Size())
+	assert.Equal(t, 3, NewSet[string]("a", "b", "c").Size())
+}
+
+func TestSet_Values(t *testing.T) {
+	assert.Equal(t, []string{}, NewSet[string]().Values())
+
+	values := NewSet[string]("a", "b").Values()
+	sort.Strings(values)
+	assert.Equal(t, []string{"a", "b"}, values)
+}


### PR DESCRIPTION
Unfortunately, Golang doesn't have a standard implementation of sets. Nevertheless, there are some popular implementations already, but none of them allows making a set immutable which would be useful for us.

Here I introduce a new simple map-based implementation of sets allowing to make a set immutable. We can use it to replace hard-to-read logic employing maps to imitate sets in our code.