### PR TITLE
PropagationVerifier and some useful methods for making HTTP requests to the app under test

### DIFF
--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 const groups = "groups"
@@ -27,6 +28,8 @@ type createNewAncestorsQueries struct {
 // - before_insert_items_items/groups_groups
 // - before_delete_items_items/groups_groups.
 func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /* #nosec */
+	BeforePropagationStep(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsInit, PropagationStepItemAncestorsInit))
+
 	mustNotBeError(s.InTransaction(func(s *DataStore) error {
 		initTransactionTime := time.Now()
 
@@ -41,6 +44,8 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 
 	hasChanges := true
 	for hasChanges {
+		BeforePropagationStep(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsMain, PropagationStepItemAncestorsMain))
+
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			initStepTransactionTime := time.Now()
 

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -28,7 +28,7 @@ type createNewAncestorsQueries struct {
 // - before_insert_items_items/groups_groups
 // - before_delete_items_items/groups_groups.
 func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /* #nosec */
-	BeforePropagationStep(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsInit, PropagationStepItemAncestorsInit))
+	CallBeforePropagationStepHook(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsInit, PropagationStepItemAncestorsInit))
 
 	mustNotBeError(s.InTransaction(func(s *DataStore) error {
 		initTransactionTime := time.Now()
@@ -44,7 +44,7 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 
 	hasChanges := true
 	for hasChanges {
-		BeforePropagationStep(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsMain, PropagationStepItemAncestorsMain))
+		CallBeforePropagationStepHook(golang.IfElse(objectName == groups, PropagationStepGroupAncestorsMain, PropagationStepItemAncestorsMain))
 
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			initStepTransactionTime := time.Now()

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -102,6 +102,8 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 	// ------------------------------------------------------------------------------------
 	hasChanges := true
 	for hasChanges {
+		BeforePropagationStep(PropagationStepAccessMain)
+
 		mustNotBeError(s.InTransaction(func(store *DataStore) error {
 			initTransactionTime := time.Now()
 

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -102,7 +102,7 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 	// ------------------------------------------------------------------------------------
 	hasChanges := true
 	for hasChanges {
-		BeforePropagationStep(PropagationStepAccessMain)
+		CallBeforePropagationStepHook(PropagationStepAccessMain)
 
 		mustNotBeError(s.InTransaction(func(store *DataStore) error {
 			initTransactionTime := time.Now()

--- a/app/database/propagation_steps.go
+++ b/app/database/propagation_steps.go
@@ -1,6 +1,10 @@
 package database
 
-import "github.com/France-ioi/AlgoreaBackend/v2/golang"
+import (
+	"sync"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+)
 
 // PropagationStep represents a step in the propagation process.
 type PropagationStep string
@@ -61,5 +65,31 @@ func PropagationStepSetResults() *golang.Set[PropagationStep] {
 	).MarkImmutable()
 }
 
-// BeforePropagationStep is a hook that is called before each propagation step.
-var BeforePropagationStep = func(step PropagationStep) {}
+// BeforePropagationStepHookFunc is a type of a function that is called before each propagation step.
+type BeforePropagationStepHookFunc func(step PropagationStep)
+
+var (
+	// beforePropagationStepHook is a hook that is called before each propagation step.
+	beforePropagationStepHook BeforePropagationStepHookFunc = func(step PropagationStep) {}
+	// beforePropagationStepMutex protects beforePropagationStepHook.
+	beforePropagationStepMutex sync.RWMutex
+)
+
+// SetBeforePropagationStepHook sets a hook that is called before each propagation step.
+func SetBeforePropagationStepHook(newHook BeforePropagationStepHookFunc) {
+	beforePropagationStepMutex.Lock()
+	defer beforePropagationStepMutex.Unlock()
+	beforePropagationStepHook = newHook
+}
+
+// GetBeforePropagationStepHook returns a hook that is called before each propagation step.
+func GetBeforePropagationStepHook() BeforePropagationStepHookFunc {
+	beforePropagationStepMutex.RLock()
+	defer beforePropagationStepMutex.RUnlock()
+	return beforePropagationStepHook
+}
+
+// CallBeforePropagationStepHook calls the hook that is called before each propagation step.
+func CallBeforePropagationStepHook(step PropagationStep) {
+	GetBeforePropagationStepHook()(step)
+}

--- a/app/database/propagation_steps.go
+++ b/app/database/propagation_steps.go
@@ -1,0 +1,65 @@
+package database
+
+import "github.com/France-ioi/AlgoreaBackend/v2/golang"
+
+// PropagationStep represents a step in the propagation process.
+type PropagationStep string
+
+const (
+	// PropagationStepGroupAncestorsInit is the first step (initialization) of the group ancestors propagation.
+	PropagationStepGroupAncestorsInit PropagationStep = "group ancestors: init"
+	// PropagationStepGroupAncestorsMain is the main step of the group ancestors propagation.
+	PropagationStepGroupAncestorsMain PropagationStep = "group ancestors: main step"
+
+	// PropagationStepItemAncestorsInit is the first step (initialization) of the item ancestors propagation.
+	PropagationStepItemAncestorsInit PropagationStep = "item ancestors: init"
+	// PropagationStepItemAncestorsMain is the main step of the item ancestors propagation.
+	PropagationStepItemAncestorsMain PropagationStep = "item ancestors: main step"
+
+	// PropagationStepAccessMain is the main step of the access propagation.
+	PropagationStepAccessMain PropagationStep = "access: main step"
+
+	// PropagationStepResultsNamedLockAcquire is the step of acquiring the named lock for results propagation.
+	PropagationStepResultsNamedLockAcquire PropagationStep = "results: acquire named lock"
+	// PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate is the step of inserting into results_propagate inside the named lock.
+	PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate PropagationStep = "results: inside named lock: " +
+		"insert into results_propagate"
+	// PropagationStepResultsInsideNamedLockMarkAndInsertResults is the step of marking and inserting results inside the named lock.
+	PropagationStepResultsInsideNamedLockMarkAndInsertResults PropagationStep = "results: inside named lock: mark and insert results"
+	// PropagationStepResultsInsideNamedLockMain is the main step of the results propagation inside the named lock.
+	PropagationStepResultsInsideNamedLockMain PropagationStep = "results: inside named lock: main step"
+	// PropagationStepResultsInsideNamedLockItemUnlocking is the step of unlocking the items inside the named lock.
+	PropagationStepResultsInsideNamedLockItemUnlocking PropagationStep = "results: inside named lock: item unlocking"
+	// PropagationStepResultsPropagationScheduling is the step of scheduling the propagation of permissions and results.
+	PropagationStepResultsPropagationScheduling PropagationStep = "results: propagation scheduling"
+)
+
+// PropagationStepSetGroupAncestors returns a set of group ancestors propagation steps.
+func PropagationStepSetGroupAncestors() *golang.Set[PropagationStep] {
+	return golang.NewSet(PropagationStepGroupAncestorsInit, PropagationStepGroupAncestorsMain).MarkImmutable()
+}
+
+// PropagationStepSetItemAncestors returns a set of item ancestors propagation steps.
+func PropagationStepSetItemAncestors() *golang.Set[PropagationStep] {
+	return golang.NewSet(PropagationStepItemAncestorsInit, PropagationStepItemAncestorsMain).MarkImmutable()
+}
+
+// PropagationStepSetAccess returns a set of access (permissions) propagation steps.
+func PropagationStepSetAccess() *golang.Set[PropagationStep] {
+	return golang.NewSet(PropagationStepAccessMain).MarkImmutable()
+}
+
+// PropagationStepSetResults returns a set of results propagation steps.
+func PropagationStepSetResults() *golang.Set[PropagationStep] {
+	return golang.NewSet(
+		PropagationStepResultsNamedLockAcquire,
+		PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate,
+		PropagationStepResultsInsideNamedLockMarkAndInsertResults,
+		PropagationStepResultsInsideNamedLockMain,
+		PropagationStepResultsInsideNamedLockItemUnlocking,
+		PropagationStepResultsPropagationScheduling,
+	).MarkImmutable()
+}
+
+// BeforePropagationStep is a hook that is called before each propagation step.
+var BeforePropagationStep = func(step PropagationStep) {}

--- a/app/database/propagation_steps_test.go
+++ b/app/database/propagation_steps_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+)
+
+func TestPropagationStepSets(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		set             *golang.Set[PropagationStep]
+		expectedContent []PropagationStep
+	}{
+		{
+			name:            "PropagationStepSetGroupAncestors",
+			set:             PropagationStepSetGroupAncestors(),
+			expectedContent: []PropagationStep{PropagationStepGroupAncestorsInit, PropagationStepGroupAncestorsMain},
+		},
+		{
+			name:            "PropagationStepSetItemAncestors",
+			set:             PropagationStepSetItemAncestors(),
+			expectedContent: []PropagationStep{PropagationStepItemAncestorsInit, PropagationStepItemAncestorsMain},
+		},
+		{
+			name:            "PropagationStepSetAccess",
+			set:             PropagationStepSetAccess(),
+			expectedContent: []PropagationStep{PropagationStepAccessMain},
+		},
+		{
+			name: "PropagationStepSetResults",
+			set:  PropagationStepSetResults(),
+			expectedContent: []PropagationStep{
+				PropagationStepResultsNamedLockAcquire,
+				PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate,
+				PropagationStepResultsInsideNamedLockMarkAndInsertResults,
+				PropagationStepResultsInsideNamedLockMain,
+				PropagationStepResultsInsideNamedLockItemUnlocking,
+				PropagationStepResultsPropagationScheduling,
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.set.Size(), len(test.expectedContent))
+			for _, step := range test.expectedContent {
+				assert.True(t, test.set.Contains(step), "step %q not found in the set", step)
+			}
+			assert.True(t, test.set.IsImmutable())
+		})
+	}
+}

--- a/app/database/propagation_steps_test.go
+++ b/app/database/propagation_steps_test.go
@@ -52,3 +52,25 @@ func TestPropagationStepSets(t *testing.T) {
 		})
 	}
 }
+
+func TestBeforePropagationStepHook(t *testing.T) {
+	var steps []PropagationStep
+	oldHook := GetBeforePropagationStepHook()
+	defer SetBeforePropagationStepHook(oldHook)
+	SetBeforePropagationStepHook(func(step PropagationStep) {
+		steps = append(steps, step)
+	})
+	CallBeforePropagationStepHook(PropagationStepGroupAncestorsInit)
+	assert.Equal(t, []PropagationStep{PropagationStepGroupAncestorsInit}, steps)
+	SetBeforePropagationStepHook(func(step PropagationStep) {
+		steps = append(steps, step, step)
+	})
+	CallBeforePropagationStepHook(PropagationStepGroupAncestorsMain)
+	assert.Equal(t,
+		[]PropagationStep{
+			PropagationStepGroupAncestorsInit,
+			PropagationStepGroupAncestorsMain,
+			PropagationStepGroupAncestorsMain,
+		},
+		steps)
+}

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -35,15 +35,15 @@ func (s *ResultStore) propagate() (err error) {
 	var groupsUnlocked int64
 	defer recoverPanics(&err)
 
-	BeforePropagationStep(PropagationStepResultsNamedLockAcquire)
+	CallBeforePropagationStepHook(PropagationStepResultsNamedLockAcquire)
 
 	// Use a lock so that we don't execute the listener multiple times in parallel
 	mustNotBeError(s.WithNamedLock(propagateLockName, propagateLockTimeout, func(s *DataStore) error {
-		BeforePropagationStep(PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate)
+		CallBeforePropagationStepHook(PropagationStepResultsInsideNamedLockInsertIntoResultsPropagate)
 
 		s.setResultsPropagationFromResultsPropagateItems()
 
-		BeforePropagationStep(PropagationStepResultsInsideNamedLockMarkAndInsertResults)
+		CallBeforePropagationStepHook(PropagationStepResultsInsideNamedLockMarkAndInsertResults)
 
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			initTransactionTime := time.Now()
@@ -171,7 +171,7 @@ func (s *ResultStore) propagate() (err error) {
 		hasChanges := true
 
 		for hasChanges {
-			BeforePropagationStep(PropagationStepResultsInsideNamedLockMain)
+			CallBeforePropagationStepHook(PropagationStepResultsInsideNamedLockMain)
 
 			mustNotBeError(s.InTransaction(func(s *DataStore) error {
 				initTransactionTime := time.Now()
@@ -304,7 +304,7 @@ func (s *ResultStore) propagate() (err error) {
 			}))
 		}
 
-		BeforePropagationStep(PropagationStepResultsInsideNamedLockItemUnlocking)
+		CallBeforePropagationStepHook(PropagationStepResultsInsideNamedLockItemUnlocking)
 
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			initTransactionTime := time.Now()
@@ -359,7 +359,7 @@ func (s *ResultStore) propagate() (err error) {
 
 	// If items have been unlocked, need to recompute access
 	if groupsUnlocked > 0 {
-		BeforePropagationStep(PropagationStepResultsPropagationScheduling)
+		CallBeforePropagationStepHook(PropagationStepResultsPropagationScheduling)
 
 		mustNotBeError(s.InTransaction(func(s *DataStore) error {
 			// generate permissions_generated from permissions_granted

--- a/testhelpers/http.go
+++ b/testhelpers/http.go
@@ -3,10 +3,57 @@
 package testhelpers
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"testing"
+	"time"
 )
+
+// SendTestHTTPRequest sends an HTTP request to a given path on the test server.
+// It returns the response and the response body as a string. The response body is read completely and closed.
+// The timeout for requests is set to 5 seconds.
+func SendTestHTTPRequest(ts *httptest.Server, method, path string, headers map[string][]string, body io.Reader) (
+	response *http.Response, responseBody string, err error,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, ts.URL+path, body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// add headers
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
+	client := http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	// execute the query
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { /* #nosec */ _ = resp.Body.Close() }()
+
+	return resp, string(respBody), nil
+}
 
 // ValidateJSONContentType validates the content-type header of the response is json
 // If not, return an error.
@@ -20,4 +67,46 @@ func ValidateJSONContentType(resp *http.Response) error {
 		return errors.New("Unexpected Content-Type header. Expected 'application/json', got: " + mediaType)
 	}
 	return nil
+}
+
+// VerifyTestHTTPRequestWithToken makes an HTTP request to the given path on the test server with the given token
+// and verifies that the response status code is as expected.
+// Note, that the request is made with a 5-second timeout.
+func VerifyTestHTTPRequestWithToken(t *testing.T, hookedAppServer *httptest.Server,
+	token string, expectedStatusCode int,
+	method string, path string, headers map[string][]string, body interface{},
+) {
+	t.Helper()
+
+	headersWithToken := make(map[string][]string, len(headers)+1)
+	for key := range headers {
+		headersWithToken[key] = make([]string, len(headers[key]))
+		copy(headersWithToken[key], headers[key])
+	}
+	headersWithToken["Authorization"] = []string{"Bearer " + token}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(mustMarshalJSON(body))
+	}
+
+	response, responseBody, err := SendTestHTTPRequest(
+		hookedAppServer, method, path, headersWithToken, bodyReader)
+	_ = response.Body.Close()
+
+	if err != nil {
+		panic(fmt.Errorf("cannot send %s request to %s with token '%s': %v", method, path, token, err))
+	}
+	if response != nil && response.StatusCode != expectedStatusCode {
+		t.Errorf("unexpected status code %d (expected %d) of %s request to %s with token '%s', status: %s, response body: %s",
+			response.StatusCode, expectedStatusCode, method, path, token, response.Status, responseBody)
+	}
+}
+
+func mustMarshalJSON(v any) []byte {
+	result, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return result
 }

--- a/testhelpers/http.go
+++ b/testhelpers/http.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -92,14 +91,16 @@ func VerifyTestHTTPRequestWithToken(t *testing.T, hookedAppServer *httptest.Serv
 
 	response, responseBody, err := SendTestHTTPRequest(
 		hookedAppServer, method, path, headersWithToken, bodyReader)
-	_ = response.Body.Close()
-
 	if err != nil {
-		panic(fmt.Errorf("cannot send %s request to %s with token '%s': %v", method, path, token, err))
+		t.Errorf("cannot send %s request to %s with token '%s': %v", method, path, token, err)
+		return
 	}
-	if response != nil && response.StatusCode != expectedStatusCode {
-		t.Errorf("unexpected status code %d (expected %d) of %s request to %s with token '%s', status: %s, response body: %s",
-			response.StatusCode, expectedStatusCode, method, path, token, response.Status, responseBody)
+	if response != nil {
+		_ = response.Body.Close()
+		if response.StatusCode != expectedStatusCode {
+			t.Errorf("unexpected status code %d (expected %d) of %s request to %s with token '%s', status: %s, response body: %s",
+				response.StatusCode, expectedStatusCode, method, path, token, response.Status, responseBody)
+		}
 	}
 }
 

--- a/testhelpers/propagation_verifier.go
+++ b/testhelpers/propagation_verifier.go
@@ -102,7 +102,9 @@ func (pv *PropagationVerifier) Run(
 	database.SetBeforePropagationStepHook(func(step database.PropagationStep) {
 		defer func() {
 			if r := recover(); r != nil {
-				t.Errorf("beforePropagationStep(%q) panicked: %v", step, r)
+				if !t.Failed() {
+					t.Errorf("beforePropagationStep(%q) panicked: %v", step, r)
+				}
 			}
 		}()
 

--- a/testhelpers/propagation_verifier.go
+++ b/testhelpers/propagation_verifier.go
@@ -121,7 +121,9 @@ func (pv *PropagationVerifier) Run(
 		calledPropagationSteps[step]++
 
 		if calledPropagationSteps[step] > 10 {
-			t.Fatalf("looks like an infinite loop in propagation step %q, called %d times", step, calledPropagationSteps[step])
+			_ = application.Database.Close() // stop all the app's API handlers
+			t.Errorf("looks like an infinite loop in propagation step %q, called %d times", step, calledPropagationSteps[step])
+			return
 		}
 
 		t.Logf("before propagation step %d: %q (%d)\n", stepCounter, step, calledPropagationSteps[step])

--- a/testhelpers/propagation_verifier.go
+++ b/testhelpers/propagation_verifier.go
@@ -67,12 +67,6 @@ func (pv *PropagationVerifier) Run(
 ) {
 	t.Helper()
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("propagation verifier panicked: %v", r)
-		}
-	}()
-
 	db := SetupDBWithFixtureString(pv.fixture)
 
 	dataStore := database.NewDataStore(db)

--- a/testhelpers/propagation_verifier.go
+++ b/testhelpers/propagation_verifier.go
@@ -1,0 +1,162 @@
+package testhelpers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+)
+
+const (
+	// PropagationStepSanityCheck is a fake propagation step which is called by PropagationVerifier
+	// before triggering propagations in order to check that the hook is working without errors.
+	PropagationStepSanityCheck database.PropagationStep = "sanity check"
+	// PropagationStepAfterAllPropagations is a fake propagation step which is called by PropagationVerifier after all propagations.
+	PropagationStepAfterAllPropagations database.PropagationStep = "after all propagations"
+)
+
+type (
+	// PropagationVerifierHookFunc is a function that is called by PropagationVerifier
+	// before each propagation step and before and after all propagations.
+	PropagationVerifierHookFunc func(step database.PropagationStep, allStepsCounter, currentStepCounter int,
+		dataStore *database.DataStore, appServer *httptest.Server)
+
+	// PropagationStepsSet is a set of propagation steps.
+	PropagationStepsSet = golang.Set[database.PropagationStep]
+)
+
+// PropagationVerifier is a helper to test the propagation steps. It allows to run the code that triggers propagations
+// and the code that should be executed before and after each propagation step.
+// It also allows to check that the required propagation steps were called.
+// Also, the propagation verifier detects infinite loops in the propagation steps by limiting the number of calls to each step.
+type PropagationVerifier struct {
+	fixture                  string
+	hookFunc                 PropagationVerifierHookFunc
+	requiredPropagationSteps *golang.Set[database.PropagationStep]
+}
+
+// NewPropagationVerifier creates a new PropagationVerifier with the required propagation steps.
+func NewPropagationVerifier(requiredPropagationSteps *PropagationStepsSet) *PropagationVerifier {
+	pv := &PropagationVerifier{
+		requiredPropagationSteps: requiredPropagationSteps,
+	}
+	if pv.requiredPropagationSteps == nil {
+		pv.requiredPropagationSteps = golang.NewSet[database.PropagationStep]()
+	}
+	return pv
+}
+
+// WithFixture sets the DB fixture to load before running the verification.
+func (pv *PropagationVerifier) WithFixture(fixture string) *PropagationVerifier {
+	pv.fixture = fixture
+	return pv
+}
+
+// WithHook sets the hook function that will be called before each propagation step and before and after all propagations.
+func (pv *PropagationVerifier) WithHook(hookFunc PropagationVerifierHookFunc) *PropagationVerifier {
+	pv.hookFunc = hookFunc
+	return pv
+}
+
+// Run runs the propagation verifier.
+func (pv *PropagationVerifier) Run(
+	t *testing.T,
+	codeTriggeringPropagations func(dataStore *database.DataStore, appServer *httptest.Server),
+) {
+	t.Helper()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("propagation verifier panicked: %v", r)
+		}
+	}()
+
+	db := SetupDBWithFixtureString(pv.fixture)
+
+	dataStore := database.NewDataStore(db)
+	err := dataStore.InTransaction(func(dataStore *database.DataStore) error {
+		dataStore.ScheduleGroupsAncestorsPropagation()
+		dataStore.ScheduleItemsAncestorsPropagation()
+		dataStore.SchedulePermissionsPropagation()
+		dataStore.ScheduleResultsPropagation()
+		return nil
+	})
+	_ = db.Close()
+	if err != nil {
+		t.Fatalf("initial propagation failed: %v", err)
+	}
+
+	// app server
+	application, err := app.New()
+	if err != nil {
+		t.Fatalf("Unable to load a hooked app: %v", err)
+	}
+	defer func() { _ = application.Database.Close() }()
+	appServer := httptest.NewServer(application.HTTPHandler)
+	defer appServer.Close()
+
+	db = application.Database
+	dataStore = database.NewDataStore(db)
+
+	// set up the hook
+	oldBeforePropagationStep := database.BeforePropagationStep
+	defer func() { database.BeforePropagationStep = oldBeforePropagationStep }()
+	calledPropagationSteps := make(map[database.PropagationStep]int)
+	stepCounter := 0
+	database.BeforePropagationStep = func(step database.PropagationStep) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("BeforePropagationStep(%q) panicked: %v", step, r)
+			}
+		}()
+
+		// Restore the original hook until the end of this function
+		ourBeforePropagationStep := database.BeforePropagationStep
+		database.BeforePropagationStep = oldBeforePropagationStep
+		defer func() { database.BeforePropagationStep = ourBeforePropagationStep }()
+
+		stepCounter++
+
+		if _, ok := calledPropagationSteps[step]; !ok {
+			calledPropagationSteps[step] = 0
+		}
+		calledPropagationSteps[step]++
+
+		if calledPropagationSteps[step] > 10 {
+			t.Fatalf("looks like an infinite loop in propagation step %q, called %d times", step, calledPropagationSteps[step])
+		}
+
+		t.Logf("before propagation step %d: %q (%d)\n", stepCounter, step, calledPropagationSteps[step])
+
+		if pv.hookFunc != nil {
+			pv.hookFunc(step, stepCounter, calledPropagationSteps[step], dataStore, appServer)
+		}
+	}
+
+	// Execute the code that should be executed before the propagation steps just to make sure it doesn't fail
+	t.Log("sanity check before all propagations")
+	database.BeforePropagationStep(PropagationStepSanityCheck)
+	if t.Failed() {
+		return
+	}
+
+	t.Log("triggering propagations")
+	codeTriggeringPropagations(dataStore, appServer)
+
+	t.Log("after all propagations")
+	database.BeforePropagationStep(PropagationStepAfterAllPropagations)
+
+	pv.assertAllRequiredStepsCalled(t, calledPropagationSteps)
+}
+
+func (pv *PropagationVerifier) assertAllRequiredStepsCalled(t *testing.T, calledPropagationSteps map[database.PropagationStep]int) {
+	t.Helper()
+
+	for _, requiredPropagationStep := range pv.requiredPropagationSteps.Values() {
+		if _, ok := calledPropagationSteps[requiredPropagationStep]; !ok {
+			t.Errorf("Required propagation step %q was not called", requiredPropagationStep)
+		}
+	}
+}

--- a/testhelpers/steps_request.go
+++ b/testhelpers/steps_request.go
@@ -69,7 +69,7 @@ func (ctx *TestContext) iSendrequestGeneric(method, path, reqBody string) error 
 	}
 
 	// do request
-	response, body, err := testRequest(testServer, method, path, headers, strings.NewReader(reqBody))
+	response, body, err := SendTestHTTPRequest(testServer, method, path, headers, strings.NewReader(reqBody))
 	defer func() { _ = response.Body.Close() }()
 	if err != nil {
 		return err

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -5,10 +5,7 @@ package testhelpers
 import (
 	"database/sql"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"sort"
 
@@ -175,37 +172,6 @@ func (ctx *TestContext) ScenarioTeardown(*godog.Scenario, error) {
 	}()
 
 	ctx.tearDownApp()
-}
-
-func testRequest(ts *httptest.Server, method, path string, headers map[string][]string, body io.Reader) (*http.Response, string, error) {
-	req, err := http.NewRequest(method, ts.URL+path, body)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// add headers
-	for name, values := range headers {
-		for _, value := range values {
-			req.Header.Add(name, value)
-		}
-	}
-
-	client := http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
-	// execute the query
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, "", err
-	}
-
-	respBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, "", err
-	}
-	defer func() { /* #nosec */ _ = resp.Body.Close() }()
-
-	return resp, string(respBody), nil
 }
 
 // openDB opens a connection to the database.


### PR DESCRIPTION
1. Introduce testhelpers.PropagationVerifier: a tool for testing propagations step by step. To make it work, a hook function database.BeforePropagationStep is introduced as well.
2. Introduce new useful test helpers:
- testhelpers.SendTestHTTPRequest() making http requests to the app under test with a 5-second timeout,
- testhelpers.VerifyTestHTTPRequestWithToken() calling testhelpers.SendTestHTTPRequest() with a token set in the request header and checking the response code.