### PR TITLE
Do not trigger a panic by casting the recovered value of any type to error in database.recoverPanics()

### DIFF
--- a/app/database/db.go
+++ b/app/database/db.go
@@ -647,13 +647,15 @@ func mustNotBeError(err error) {
 	}
 }
 
-func recoverPanics(returnErr *error) { // nolint:gocritic
+func recoverPanics(returnErr *error) {
 	if p := recover(); p != nil {
 		switch e := p.(type) {
 		case runtime.Error:
 			panic(e)
+		case error:
+			*returnErr = e
 		default:
-			*returnErr = p.(error)
+			panic(p)
 		}
 	}
 }

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -1271,6 +1271,28 @@ func Test_recoverPanics_PanicsOnRuntimeError(t *testing.T) {
 	assert.Equal(t, "runtime error: index out of range [0] with length 0", panicValue.(error).Error())
 }
 
+func Test_recoverPanics_PanicsOnRecoveringValueOfNonErrorType(t *testing.T) {
+	expectedPanicValue := "some panic"
+	didPanic, panicValue := func() (didPanic bool, panicValue interface{}) {
+		defer func() {
+			if p := recover(); p != nil {
+				didPanic = true
+				panicValue = p
+			}
+		}()
+
+		_ = func() (err error) {
+			defer recoverPanics(&err)
+			panic(expectedPanicValue)
+		}()
+
+		return false, nil
+	}()
+
+	assert.True(t, didPanic)
+	assert.Equal(t, expectedPanicValue, panicValue)
+}
+
 func TestDB_withNamedLock_ReturnsErrLockWaitTimeoutExceededWhenGetLockTimeouts(t *testing.T) {
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()


### PR DESCRIPTION
Currently, database.recoverPanics() function casts any recovered value except to runtime.Error to `error` by using a type assertion which causes a panic when the value doesn't implement `error` interface. This behaviour hides the real error message and replaces it with the type assertion error.

This change modifies the behaviour. From now, database.recoverPanics() will panic with the recovered value explicitly keeping the original error message.

Also, a test checking the new behaviour is added here.