### PR TITLE
Rework before_insert_items & before_update_items triggers

### DIFF
--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -1046,20 +1046,24 @@ func TestItemStore_TriggerBeforeInsert_SetsPlatformID(t *testing.T) {
 					- {id: 4, regexp: "^2.*", priority: 2}
 					- {id: 2, regexp: "^1.*", priority: 3}
 					- {id: 1, regexp: "^4.*", priority: 4}
-				languages: [{tag: fr}]`)
+				languages: [{tag: fr}]
+				items: [{id: 1000, url: "4", default_language_tag: fr}]`)
 			defer func() { _ = db.Close() }()
 
 			itemStore := database.NewDataStore(db).Items()
 			assert.NoError(t, itemStore.WithForeignKeyChecksDisabled(func(store *database.DataStore) error {
 				return store.Items().InsertMap(map[string]interface{}{
+					"id":                   1,
 					"url":                  test.url,
 					"default_language_tag": "fr",
 				})
 			}))
 			var platformID *int64
-			assert.NoError(t, itemStore.PluckFirst("platform_id", &platformID).Error())
+			assert.NoError(t, itemStore.ByID(1).PluckFirst("platform_id", &platformID).Error())
 			if test.wantPlatformID == nil {
-				assert.Nil(t, platformID)
+				if platformID != nil {
+					t.Errorf("wanted platform_id to be nil, but got %d", *platformID)
+				}
 			} else {
 				assert.NotNil(t, platformID)
 				if platformID != nil {
@@ -1104,7 +1108,9 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 			var platformID *int64
 			assert.NoError(t, itemStore.ByID(1).PluckFirst("platform_id", &platformID).Error())
 			if test.wantPlatformID == nil {
-				assert.Nil(t, platformID)
+				if platformID != nil {
+					t.Errorf("wanted platform_id to be nil, but got %d", *platformID)
+				}
 			} else {
 				assert.NotNil(t, platformID)
 				if platformID != nil {

--- a/db/migrations/2408072312_rework_trigger_before_insert_items.sql
+++ b/db/migrations/2408072312_rework_trigger_before_insert_items.sql
@@ -1,0 +1,35 @@
+-- +migrate Up
+DROP TRIGGER IF EXISTS `before_insert_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_insert_items` BEFORE INSERT ON `items` FOR EACH ROW BEGIN
+  IF (NEW.id IS NULL OR NEW.id = 0) THEN
+    SET NEW.id = FLOOR(RAND() * 1000000000) + FLOOR(RAND() * 1000000000) * 1000000000;
+  END IF;
+
+  IF NEW.url IS NOT NULL THEN
+    SET NEW.platform_id = (SELECT platforms.id FROM platforms WHERE NEW.url REGEXP platforms.regexp ORDER BY platforms.priority DESC LIMIT 1);
+  ELSE
+    SET NEW.platform_id = NULL;
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `before_insert_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_insert_items` BEFORE INSERT ON `items` FOR EACH ROW BEGIN
+  IF (NEW.id IS NULL OR NEW.id = 0) THEN
+    SET NEW.id = FLOOR(RAND() * 1000000000) + FLOOR(RAND() * 1000000000) * 1000000000;
+  END IF;
+
+  IF NEW.url IS NOT NULL THEN
+    SELECT platforms.id INTO @platformID FROM platforms
+    WHERE NEW.url REGEXP platforms.regexp
+    ORDER BY platforms.priority DESC LIMIT 1;
+
+    SET NEW.platform_id=@platformID;
+  ELSE
+    SET NEW.platform_id = NULL;
+  END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2408072318_rework_trigger_before_update_items.sql
+++ b/db/migrations/2408072318_rework_trigger_before_update_items.sql
@@ -1,0 +1,31 @@
+-- +migrate Up
+DROP TRIGGER IF EXISTS `before_update_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_items` BEFORE UPDATE ON `items` FOR EACH ROW
+BEGIN
+  IF NOT OLD.url <=> NEW.url THEN
+    IF NEW.url IS NOT NULL THEN
+      SET NEW.platform_id = (SELECT platforms.id FROM platforms WHERE NEW.url REGEXP platforms.regexp ORDER BY platforms.priority DESC LIMIT 1);
+    ELSE
+      SET NEW.platform_id = NULL;
+    END IF;
+  END IF;
+END;
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `before_update_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_items` BEFORE UPDATE ON `items` FOR EACH ROW
+BEGIN
+  IF NOT OLD.url <=> NEW.url THEN
+    IF NEW.url IS NOT NULL THEN
+      SET @platformID = (SELECT platforms.id FROM platforms WHERE NEW.url REGEXP platforms.regexp ORDER BY platforms.priority DESC LIMIT 1);
+
+      SET NEW.platform_id=@platformID;
+    ELSE
+      SET NEW.platform_id = NULL;
+    END IF;
+  END IF;
+END;
+-- +migrate StatementEnd

--- a/db/migrations/2408072320_recalculate_items_platform_id.sql
+++ b/db/migrations/2408072320_recalculate_items_platform_id.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+UPDATE `items`
+SET `platform_id` = IF(
+  `items`.`url` IS NULL,
+  NULL,
+  (SELECT `platforms`.`id`
+   FROM `platforms`
+   WHERE `items`.`url` REGEXP `platforms`.`regexp`
+   ORDER BY `platforms`.`priority` DESC
+   LIMIT 1)
+);
+
+-- +migrate Down
+


### PR DESCRIPTION
1. Fix a bug in `before_update_items` causing new items with non-null `url` not matching any platform to have an unpredictable non-null `platform_id`. Update the related test.
2. Get rid of session variables in `before_insert_items` & `before_update_items` triggers because
  - they are not needed there,
  - use of session variables may lead to unpredictable results when we forget to initialize them with values (like it was in clause 1.).
3. Recalculate `platform_id` for all the items.