### PR TITLE
Return loginIDs instead of groupIDs inside tokens in generateProfileEditToken

### DIFF
--- a/app/api/answers/generate_task_token.go
+++ b/app/api/answers/generate_task_token.go
@@ -156,7 +156,7 @@ func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) se
 			observerItemPerms.SubQuery(), observerParticipantPerms.SubQuery()).
 		Where("answers.id = ?", answerID).
 		Where("items.type = 'Task'").
-		WhereUserHaveStartedResultOnItem(user).
+		WhereItemHasResultStartedByUser(user).
 		Limit(1).
 		Take(&answerInfos).Error()
 

--- a/app/api/users/generate_profile_edit_token.feature
+++ b/app/api/users/generate_profile_edit_token.feature
@@ -4,6 +4,10 @@ Feature: Generate Profile Edit Token
       | group     | parent       | members        | require_personal_info_access_approval |
       | @AllUsers |              | @Manager,@User |                                       |
       | @Class    | @ClassParent | @User          | edit                                  |
+    And there are the following users:
+      | user     | login_id |
+      | @Manager | 1        |
+      | @User    | 2        |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
     And I am a manager of the group @ClassParent
@@ -12,8 +16,8 @@ Feature: Generate Profile Edit Token
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:
       """
         {
-          "requester_id": "@Manager",
-          "target_id": "@User",
+          "requester_id": "1",
+          "target_id": "2",
           "exp": "1577838600"
         }
       """
@@ -25,6 +29,10 @@ Feature: Generate Profile Edit Token
       | @AllUsers |               | @Manager,@User |                                       |
       | @School   | @SchoolParent |                |                                       |
       | @Class    | @School       | @User          | edit                                  |
+    And there are the following users:
+      | user     | login_id |
+      | @Manager | 1        |
+      | @User    | 2        |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
     And I am a manager of the group @SchoolParent
@@ -33,8 +41,8 @@ Feature: Generate Profile Edit Token
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:
       """
         {
-          "requester_id": "@Manager",
-          "target_id": "@User",
+          "requester_id": "1",
+          "target_id": "2",
           "exp": "1577838600"
         }
       """
@@ -48,6 +56,10 @@ Feature: Generate Profile Edit Token
       | @AllUsers |         | @Manager,@User |                                       |
       | @School   | @City   |                | edit                                  |
       | @Class    | @School | @User          |                                       |
+    And there are the following users:
+      | user     | login_id |
+      | @Manager | 1        |
+      | @User    | 2        |
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
     And I am a manager of the group @CityParent
@@ -57,8 +69,8 @@ Feature: Generate Profile Edit Token
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:
       """
         {
-          "requester_id": "@Manager",
-          "target_id": "@User",
+          "requester_id": "1",
+          "target_id": "2",
           "exp": "1577838600"
         }
       """

--- a/app/api/users/generate_profile_edit_token.go
+++ b/app/api/users/generate_profile_edit_token.go
@@ -7,6 +7,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jinzhu/gorm"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/encrypt"
 
 	"github.com/go-chi/render"
@@ -32,10 +35,10 @@ type generateProfileEditTokenResponse struct {
 // ProfileEditToken permits a requester user to edit the profile of a target user.
 // swagger:model ProfileEditToken
 type ProfileEditToken struct {
-	// User who requested the token.
+	// `loginID` of the user who requested the token.
 	// required:true
 	RequesterID string `json:"requester_id"`
-	// User whose profile is to be edited.
+	// `loginID` of the user whose profile is to be edited.
 	// required:true
 	TargetID string `json:"target_id"`
 	// Expiry date in the number of seconds since 01/01/1970 UTC.
@@ -52,10 +55,11 @@ type ProfileEditToken struct {
 //
 //
 //		Restrictions:
-//			* the `current user` must be a manager of a group of which the `target user` is a member, and
-//			* the group the `target user` is member of, or one of its ancestor, must have `require_personal_info_access_approval` set to `edit`.
+//			* the `current user` must be a manager of a group to which the `target user` is a descendant, and
+//			* this group must have `require_personal_info_access_approval` set to `edit`,
+//			* both the `current user` and the `target user` must have a `login_id`,
 //
-//		Otherwise, a forbidden error is returned.
+//		otherwise, a forbidden error is returned.
 //
 //	parameters:
 //		- name: target_user_id
@@ -87,26 +91,32 @@ func (srv *Service) generateProfileEditToken(rw http.ResponseWriter, r *http.Req
 	user := srv.GetUser(r)
 	store := srv.GetStore(r)
 
+	var targetUserLoginID *int64
+	if user.LoginID != nil {
+		targetUserLoginID, err = getLoginIDForProfileEditing(store, user, targetUserID)
+		service.MustNotBeError(err)
+	}
+
 	// Checks rights.
-	if !user.CanEditProfile(store, targetUserID) {
+	if targetUserLoginID == nil {
 		return service.InsufficientAccessRightsError
 	}
 
 	response := new(generateProfileEditTokenResponse)
 
-	response.ProfileEditToken, response.Alg = srv.getProfileEditToken(user.GroupID, targetUserID)
+	response.ProfileEditToken, response.Alg = srv.getProfileEditToken(*user.LoginID, *targetUserLoginID)
 
 	render.Respond(rw, r, response)
 
 	return service.NoError
 }
 
-func (srv *Service) getProfileEditToken(requesterID, targetID int64) (token, algorithm string) {
+func (srv *Service) getProfileEditToken(requesterLoginID, targetLoginID int64) (token, algorithm string) {
 	thirtyMinutesLater := time.Now().Add(time.Minute * 30)
 
 	profileEditToken := ProfileEditToken{
-		RequesterID: strconv.FormatInt(requesterID, 10),
-		TargetID:    strconv.FormatInt(targetID, 10),
+		RequesterID: strconv.FormatInt(requesterLoginID, 10),
+		TargetID:    strconv.FormatInt(targetLoginID, 10),
 		Exp:         thirtyMinutesLater.Unix(),
 	}
 
@@ -119,4 +129,32 @@ func (srv *Service) getProfileEditToken(requesterID, targetID int64) (token, alg
 	hexCipher := hex.EncodeToString(cipherText)
 
 	return hexCipher, "AES-256-GCM"
+}
+
+// getLoginIDForProfileEditing returns `login_id` of the given target user
+// if the requesting user can edit the profile of the target user:
+//  1. the requesting user needs to be a manager of a group to which the target user is a descendant, and
+//  2. this group must have `require_personal_info_access_approval` set to `edit`, and
+//  3. the target user must be a user,
+//
+// otherwise, it returns nil.
+func getLoginIDForProfileEditing(s *database.DataStore, requestingUser *database.User, targetUserID int64) (*int64, error) {
+	var targetUserLoginID *int64
+
+	err := s.ActiveGroupAncestors().
+		ManagedByUser(requestingUser).
+		Joins(`JOIN groups_ancestors AS target_user_group_ancestor
+									 ON target_user_group_ancestor.ancestor_group_id = groups_ancestors_active.child_group_id AND
+											target_user_group_ancestor.child_group_id = ?`, targetUserID).
+		Joins("JOIN `users` AS target_user ON target_user.group_id = target_user_group_ancestor.child_group_id").
+		Joins("JOIN `groups` AS target_user_group ON target_user_group.id = target_user_group_ancestor.ancestor_group_id").
+		Where("target_user_group.require_personal_info_access_approval = 'edit'").
+		PluckFirst("target_user.login_id", &targetUserLoginID).
+		Error()
+
+	if gorm.IsRecordNotFoundError(err) {
+		return nil, nil
+	}
+
+	return targetUserLoginID, err
 }

--- a/app/api/users/generate_profile_edit_token.robustness.feature
+++ b/app/api/users/generate_profile_edit_token.robustness.feature
@@ -11,8 +11,41 @@ Feature: Generate Profile Edit Token - robustness
     Then the response code should be 400
     And the response error message should contain "Wrong value for target_user_id (should be int64)"
 
-  Scenario: Should return an error when the target user doesn't exist
-    Given I am @CurrentUser
+  Scenario: Should be forbidden when the current user doesn't have login_id
+    Given there are the following groups:
+      | group     | parent        | members        | require_personal_info_access_approval |
+      | @AllUsers |               | @Manager,@User |                                       |
+      | @School   | @SchoolParent |                |                                       |
+      | @Class    | @School       | @User          | edit                                  |
+    And there are the following users:
+      | user     | login_id |
+      | @Manager | null     |
+      | @User    | 2        |
+    And I am @Manager
+    When I send a POST request to "/users/@User/generate-profile-edit-token"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Should be forbidden when the target user doesn't have login_id
+    Given there are the following groups:
+      | group     | parent        | members        | require_personal_info_access_approval |
+      | @AllUsers |               | @Manager,@User |                                       |
+      | @School   | @SchoolParent |                |                                       |
+      | @Class    | @School       | @User          | edit                                  |
+    And there are the following users:
+      | user     | login_id |
+      | @Manager | 1        |
+      | @User    | null     |
+    And I am @Manager
+    When I send a POST request to "/users/@User/generate-profile-edit-token"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Should be forbidden when the target user doesn't exist
+    Given there are the following users:
+      | user     | login_id |
+      | @Manager | 1        |
+    Given I am @Manager
     When I send a POST request to "/users/42/generate-profile-edit-token"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
@@ -22,6 +55,10 @@ Feature: Generate Profile Edit Token - robustness
       | group     | parent | members           |
       | @AllUsers |        | @NotManager,@User |
       | @Class    |        | @User             |
+    And there are the following users:
+      | user        | login_id |
+      | @NotManager | 1        |
+      | @User       | 2        |
     And I am @NotManager
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 403
@@ -32,6 +69,10 @@ Feature: Generate Profile Edit Token - robustness
       | group     | parent       | members        | require_personal_info_access_approval   |
       | @AllUsers |              | @Manager,@User |                                         |
       | @Class    | @ClassParent | @User          | <require_personal_info_access_approval> |
+    And there are the following users:
+      | user        | login_id |
+      | @Manager    | 1        |
+      | @User       | 2        |
     And I am @Manager
     And I am a manager of the group @ClassParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"

--- a/app/database/items.go
+++ b/app/database/items.go
@@ -16,8 +16,8 @@ func (conn *DB) WhereUserHasPermissionOnItems(user *User, permissionKind, needed
 	return conn.WhereGroupHasPermissionOnItems(user.GroupID, permissionKind, neededPermission)
 }
 
-// WhereUserHaveStartedResultOnItem makes sure that the user have a started result on the item, whatever the attempt.
-func (conn *DB) WhereUserHaveStartedResultOnItem(user *User) *DB {
+// WhereItemHasResultStartedByUser makes sure that the user have a started result on the item, whatever the attempt.
+func (conn *DB) WhereItemHasResultStartedByUser(user *User) *DB {
 	return conn.
 		Joins(`
 				JOIN results AS current_user_results

--- a/app/database/items_test.go
+++ b/app/database/items_test.go
@@ -81,7 +81,7 @@ func TestDB_WhereUserHaveStartedResultOnItem(t *testing.T) {
 		WillReturnRows(mock.NewRows([]string{"id"}))
 
 	var result []interface{}
-	err := db.Table("items").WhereUserHaveStartedResultOnItem(&user).Scan(&result).Error()
+	err := db.Table("items").WhereItemHasResultStartedByUser(&user).Scan(&result).Error()
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -181,23 +181,3 @@ func (u *User) IsMemberOfGroupOrSelf(s *DataStore, groupID int64) bool {
 func (u *User) CanSeeAnswer(s *DataStore, participantID, itemID int64) bool {
 	return u.CanViewItemContent(s, itemID) && u.IsMemberOfGroupOrSelf(s, participantID)
 }
-
-// CanEditProfile checks whether the user can edit the profile of another user.
-// The user needs to:
-//  1. be a manager of a group of which the target user is a member, and
-//  2. the group must have `require_personal_info_access_approval` set to `edit`.
-func (u *User) CanEditProfile(s *DataStore, targetUserID int64) bool {
-	userCanEditProfile, err := s.ActiveGroupAncestors().
-		ManagedByUser(u).
-		Joins(`JOIN groups_ancestors AS target_user_group_ancestor
-									 ON target_user_group_ancestor.ancestor_group_id = groups_ancestors_active.child_group_id AND
-											target_user_group_ancestor.child_group_id = ?`, targetUserID).
-		Joins("JOIN `groups` AS target_user_group ON target_user_group.id = target_user_group_ancestor.ancestor_group_id").
-		Where("target_user_group.require_personal_info_access_approval = 'edit'").
-		Select("1").
-		Limit(1).
-		HasRows()
-	mustNotBeError(err)
-
-	return userCanEditProfile
-}

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -137,7 +137,7 @@ func (u *User) CanWatchGroupMembers(s *DataStore, groupID int64) bool {
 func (u *User) HasStartedResultOnItem(s *DataStore, itemID int64) bool {
 	hasStartedResultOntem, err := s.Items().
 		Where("items.id = ?", itemID).
-		WhereUserHaveStartedResultOnItem(u).
+		WhereItemHasResultStartedByUser(u).
 		Limit(1).
 		HasRows()
 	mustNotBeError(err)


### PR DESCRIPTION
Return loginIDs instead of groupIDs inside tokens in generateProfileEditToken.
Also, rename a method.

Fixes #1150 