### PR TITLE
Return the modified result data (together with the linked attempt data) in the format of attemptsList response row on success in resultStart

### DIFF
--- a/app/api/answers/create_answer.go
+++ b/app/api/answers/create_answer.go
@@ -123,9 +123,9 @@ func (srv *Service) saveAnswerWithType(rw http.ResponseWriter, httpReq *http.Req
 
 	var result render.Renderer
 	if isCurrent {
-		result = service.UpdateSuccess(nil)
+		result = service.UpdateSuccess[*struct{}](nil)
 	} else {
-		result = service.CreationSuccess(nil)
+		result = service.CreationSuccess[*struct{}](nil)
 	}
 
 	service.MustNotBeError(render.Render(rw, httpReq, result))

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -284,12 +284,12 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) se
 		return nil
 	}))
 
-	srv.respondWithNewAccessToken(r, w, service.CreationSuccess, token.AccessToken, token.Expiry, cookieAttributes)
+	srv.respondWithNewAccessToken(r, w, service.CreationSuccess[map[string]interface{}], token.AccessToken, token.Expiry, cookieAttributes)
 	return service.NoError
 }
 
 func (srv *Service) respondWithNewAccessToken(r *http.Request, w http.ResponseWriter,
-	rendererGenerator func(interface{}) render.Renderer, token string, expiresIn time.Time,
+	rendererGenerator func(map[string]interface{}) render.Renderer, token string, expiresIn time.Time,
 	cookieAttributes *auth.SessionCookieAttributes,
 ) {
 	secondsUntilExpiry := int32(time.Until(expiresIn).Round(time.Second) / time.Second)

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -128,7 +128,7 @@ func (srv *Service) createTempUser(w http.ResponseWriter, r *http.Request) servi
 		return err
 	}))
 
-	srv.respondWithNewAccessToken(r, w, service.CreationSuccess,
+	srv.respondWithNewAccessToken(r, w, service.CreationSuccess[map[string]interface{}],
 		token, time.Now().Add(time.Duration(expiresIn)*time.Second), cookieAttributes)
 	return service.NoError
 }

--- a/app/api/auth/logout.go
+++ b/app/api/auth/logout.go
@@ -36,6 +36,6 @@ func (srv *Service) logout(w http.ResponseWriter, r *http.Request) service.APIEr
 		http.SetCookie(w, cookieAttributes.SessionCookie("", -1000))
 	}
 
-	render.Respond(w, r, &service.Response{Success: true, Message: "success"})
+	render.Respond(w, r, &service.Response[*struct{}]{Success: true, Message: "success"})
 	return service.NoError
 }

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -82,7 +82,8 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 		store.AccessTokens().DeleteExpiredTokensOfUser(user.GroupID)
 	}
 
-	srv.respondWithNewAccessToken(r, w, service.CreationSuccess, newToken, time.Now().Add(time.Duration(expiresIn)*time.Second),
+	srv.respondWithNewAccessToken(r, w, service.CreationSuccess[map[string]interface{}], newToken,
+		time.Now().Add(time.Duration(expiresIn)*time.Second),
 		cookieAttributes)
 	return service.NoError
 }

--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -110,7 +110,7 @@ func (srv *Service) setAdditionalTime(w http.ResponseWriter, r *http.Request) se
 	}
 	service.MustNotBeError(err)
 
-	render.Respond(w, r, service.UpdateSuccess(nil))
+	render.Respond(w, r, service.UpdateSuccess[*struct{}](nil))
 	return service.NoError
 }
 

--- a/app/api/currentuser/delete.go
+++ b/app/api/currentuser/delete.go
@@ -82,7 +82,7 @@ func (srv *Service) delete(w http.ResponseWriter, r *http.Request) service.APIEr
 		}
 	}
 
-	render.Respond(w, r, service.DeletionSuccess(nil))
+	render.Respond(w, r, service.DeletionSuccess[*struct{}](nil))
 
 	return service.NoError
 }

--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -87,7 +87,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[8][at]"))}}"
       },
       {
         "group_id": "33",
@@ -106,7 +106,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
       },
       {
         "group_id": "1",
@@ -125,7 +125,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": "{{timeDBToRFC(db("groups[1][require_lock_membership_approval_until]"))}}",
           "require_watch_approval": true
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[1][at]"))}}"
       },
       {
         "group_id": "35",
@@ -139,7 +139,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[4][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_pending_requests[4][at]"))}}"
       },
       {
         "group_id": "36",
@@ -153,7 +153,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[10][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[10][at]"))}}"
       }
     ]
     """
@@ -182,14 +182,14 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[8][at]"))}}"
       }
     ]
     """
 
   Scenario: Request the second row
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
+    And the template constant "from_at" is "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
     When I send a GET request to "/current-user/group-invitations?limit=1&from.group_id=4&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -212,7 +212,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
       }
     ]
     """

--- a/app/api/currentuser/refresh.go
+++ b/app/api/currentuser/refresh.go
@@ -41,7 +41,7 @@ func (srv *Service) refresh(w http.ResponseWriter, r *http.Request) service.APIE
 		return nil
 	}))
 
-	response := service.UpdateSuccess(nil)
+	response := service.UpdateSuccess[*struct{}](nil)
 	render.Respond(w, r, &response)
 
 	return service.NoError

--- a/app/api/currentuser/render_group_group_transition_result.go
+++ b/app/api/currentuser/render_group_group_transition_result.go
@@ -31,8 +31,8 @@ func RenderGroupGroupTransitionResult(w http.ResponseWriter, r *http.Request, re
 	case database.Full:
 		return service.ErrConflict(errors.New("the group is full"))
 	case database.ApprovalsMissing:
-		errorResponse := &service.ErrorResponse{
-			Response: service.Response{
+		errorResponse := &service.ErrorResponse[map[string]interface{}]{
+			Response: service.Response[map[string]interface{}]{
 				HTTPStatusCode: http.StatusUnprocessableEntity,
 				Success:        false,
 				Message:        "Unprocessable Entity",

--- a/app/api/currentuser/update.go
+++ b/app/api/currentuser/update.go
@@ -45,7 +45,7 @@ func (srv *Service) update(w http.ResponseWriter, r *http.Request) service.APIEr
 	// the user middleware has already checked that the user exists so we just ignore the case where nothing is updated
 	service.MustNotBeError(srv.GetStore(r).Users().ByID(user.GroupID).UpdateColumn(requestData).Error())
 
-	response := service.Response{Success: true, Message: "updated"}
+	response := service.Response[*struct{}]{Success: true, Message: "updated"}
 	render.Respond(w, r, &response)
 
 	return service.NoError

--- a/app/api/currentuser/update_notifications_read_at.go
+++ b/app/api/currentuser/update_notifications_read_at.go
@@ -27,7 +27,7 @@ func (srv *Service) updateNotificationsReadAt(w http.ResponseWriter, r *http.Req
 	service.MustNotBeError(srv.GetStore(r).Users().ByID(user.GroupID).
 		UpdateColumn("notifications_read_at", database.Now()).Error())
 
-	response := service.Response{Success: true, Message: "updated"}
+	response := service.Response[*struct{}]{Success: true, Message: "updated"}
 	render.Respond(w, r, &response)
 
 	return service.NoError

--- a/app/api/groups/add_child.go
+++ b/app/api/groups/add_child.go
@@ -85,7 +85,7 @@ func (srv *Service) addChild(w http.ResponseWriter, r *http.Request) service.API
 	}
 
 	service.MustNotBeError(err)
-	service.MustNotBeError(render.Render(w, r, service.CreationSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.CreationSuccess[*struct{}](nil)))
 
 	return service.NoError
 }

--- a/app/api/groups/create_manager.go
+++ b/app/api/groups/create_manager.go
@@ -103,6 +103,6 @@ func (srv *Service) createGroupManager(w http.ResponseWriter, r *http.Request) s
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.CreationSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.CreationSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/delete_group.go
+++ b/app/api/groups/delete_group.go
@@ -93,6 +93,6 @@ func (srv *Service) deleteGroup(w http.ResponseWriter, r *http.Request) service.
 	}
 
 	service.MustNotBeError(err)
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -58,7 +58,6 @@ type groupParticipantProgressResponseChild struct {
 
 	// required: true
 	// Extensions:
-	// ---
 	// x-nullable: false
 	CurrentUserPermissions *structures.ItemPermissions `json:"current_user_permissions"`
 

--- a/app/api/groups/get_requests.go
+++ b/app/api/groups/get_requests.go
@@ -42,7 +42,6 @@ type groupRequestsViewResponseRow struct {
 		// `users.group_id`
 		// required: true
 		// Extensions:
-		// ---
 		// x-nullable: false
 		GroupID *int64 `json:"group_id,string"`
 		// required: true

--- a/app/api/groups/remove_child.go
+++ b/app/api/groups/remove_child.go
@@ -111,6 +111,6 @@ func (srv *Service) removeChild(w http.ResponseWriter, r *http.Request) service.
 	}
 
 	service.MustNotBeError(err)
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/remove_code.go
+++ b/app/api/groups/remove_code.go
@@ -53,6 +53,6 @@ func (srv *Service) removeCode(w http.ResponseWriter, r *http.Request) service.A
 		store.Groups().Where("id = ?", groupID).
 			UpdateColumn("code", nil).Error())
 
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/remove_manager.go
+++ b/app/api/groups/remove_manager.go
@@ -90,6 +90,6 @@ func (srv *Service) removeGroupManager(w http.ResponseWriter, r *http.Request) s
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/remove_members.go
+++ b/app/api/groups/remove_members.go
@@ -110,7 +110,7 @@ func (srv *Service) removeMembers(w http.ResponseWriter, r *http.Request) servic
 		results[id] = result
 	}
 
-	response := service.Response{
+	response := service.Response[database.GroupGroupTransitionResults]{
 		Success: true,
 		Message: "deleted",
 		Data:    results,

--- a/app/api/groups/remove_user_batch.go
+++ b/app/api/groups/remove_user_batch.go
@@ -126,6 +126,6 @@ func (srv *Service) removeUserBatch(w http.ResponseWriter, r *http.Request) serv
 			Where("group_prefix = ?", groupPrefix).
 			Where("custom_prefix = ?", customPrefix).Delete().Error())
 
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/requests.go
+++ b/app/api/groups/requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 func renderGroupGroupTransitionResults(w http.ResponseWriter, r *http.Request, results database.GroupGroupTransitionResults) {
-	response := service.Response{
+	response := service.Response[database.GroupGroupTransitionResults]{
 		Success: true,
 		Message: "updated",
 		Data:    results,

--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -236,7 +236,7 @@ func (srv *Service) updateGroup(w http.ResponseWriter, r *http.Request) service.
 	}
 	service.MustNotBeError(err)
 
-	response := service.Response{Success: true, Message: "updated"}
+	response := service.Response[*struct{}]{Success: true, Message: "updated"}
 	render.Respond(w, r, &response)
 
 	return service.NoError

--- a/app/api/groups/update_manager.go
+++ b/app/api/groups/update_manager.go
@@ -97,6 +97,6 @@ func (srv *Service) updateGroupManager(w http.ResponseWriter, r *http.Request) s
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -212,7 +212,7 @@ func (srv *Service) updatePermissions(w http.ResponseWriter, r *http.Request) se
 
 	service.MustNotBeError(err)
 
-	response := service.Response{Success: true, Message: "updated"}
+	response := service.Response[*struct{}]{Success: true, Message: "updated"}
 	render.Respond(w, r, &response)
 
 	return service.NoError

--- a/app/api/items/apply_dependency.go
+++ b/app/api/items/apply_dependency.go
@@ -128,6 +128,6 @@ func (srv *Service) applyDependency(rw http.ResponseWriter, httpReq *http.Reques
 	service.MustNotBeError(err)
 
 	// response
-	service.MustNotBeError(render.Render(rw, httpReq, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(rw, httpReq, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/items/create_dependency.go
+++ b/app/api/items/create_dependency.go
@@ -130,7 +130,7 @@ func (srv *Service) createDependency(w http.ResponseWriter, r *http.Request) ser
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.CreationSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.CreationSuccess[*struct{}](nil)))
 
 	return service.NoError
 }

--- a/app/api/items/delete_dependency.go
+++ b/app/api/items/delete_dependency.go
@@ -73,6 +73,6 @@ func (srv *Service) deleteDependency(rw http.ResponseWriter, httpReq *http.Reque
 	service.MustNotBeError(err)
 
 	// response
-	service.MustNotBeError(render.Render(rw, httpReq, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(rw, httpReq, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/items/delete_item.go
+++ b/app/api/items/delete_item.go
@@ -81,6 +81,6 @@ func (srv *Service) deleteItem(w http.ResponseWriter, r *http.Request) service.A
 	}
 
 	service.MustNotBeError(err)
-	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.DeletionSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/items/end_attempt.go
+++ b/app/api/items/end_attempt.go
@@ -101,6 +101,6 @@ func (srv *Service) endAttempt(w http.ResponseWriter, r *http.Request) service.A
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/items/publish_result.go
+++ b/app/api/items/publish_result.go
@@ -99,6 +99,6 @@ func (srv *Service) publishResult(w http.ResponseWriter, r *http.Request) servic
 	if !result {
 		message = "failed"
 	}
-	render.Respond(w, r, &service.Response{Success: result, Message: message})
+	render.Respond(w, r, &service.Response[*struct{}]{Success: result, Message: message})
 	return service.NoError
 }

--- a/app/api/items/start_result.feature
+++ b/app/api/items/start_result.feature
@@ -1,6 +1,7 @@
 Feature: Start a result for an item
   Background:
-    Given the database has the following table 'groups':
+    Given time is frozen
+    And the database has the following table 'groups':
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |
       | 91  | Other | 50               | null          |
@@ -61,7 +62,19 @@ Feature: Start a result for an item
       """
       {
         "message": "updated",
-        "success": true
+        "success": true,
+        "data": {
+          "allows_submissions_until": "9999-12-31T23:59:59Z",
+          "created_at": "2019-05-30T11:00:00Z",
+          "ended_at": null,
+          "help_requested": false,
+          "id": "0",
+          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "score_computed": 0,
+          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "user_creator": null,
+          "validated": false
+        }
       }
       """
     And the table "attempts" should stay unchanged
@@ -84,7 +97,19 @@ Feature: Start a result for an item
       """
       {
         "message": "updated",
-        "success": true
+        "success": true,
+        "data": {
+          "allows_submissions_until": "9999-12-31T23:59:59Z",
+          "created_at": "2019-05-30T11:00:00Z",
+          "ended_at": null,
+          "help_requested": false,
+          "id": "0",
+          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "score_computed": 0,
+          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "user_creator": null,
+          "validated": false
+        }
       }
       """
     And the table "attempts" should stay unchanged
@@ -100,7 +125,19 @@ Feature: Start a result for an item
       """
       {
         "message": "updated",
-        "success": true
+        "success": true,
+        "data": {
+          "allows_submissions_until": "9999-12-31T23:59:59Z",
+          "created_at": "2019-05-30T11:00:00Z",
+          "ended_at": null,
+          "help_requested": false,
+          "id": "0",
+          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "score_computed": 0,
+          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "user_creator": null,
+          "validated": false
+        }
       }
       """
     And the table "attempts" should stay unchanged
@@ -123,7 +160,19 @@ Feature: Start a result for an item
       """
       {
         "message": "updated",
-        "success": true
+        "success": true,
+        "data": {
+          "allows_submissions_until": "9999-12-31T23:59:59Z",
+          "created_at": "2019-05-30T11:00:00Z",
+          "ended_at": null,
+          "help_requested": false,
+          "id": "1",
+          "latest_activity_at": "2019-05-30T11:00:00Z",
+          "score_computed": 0,
+          "started_at": "2019-05-30T11:00:00Z",
+          "user_creator": null,
+          "validated": false
+        }
       }
       """
     And the table "attempts" should stay unchanged
@@ -144,7 +193,19 @@ Feature: Start a result for an item
       """
       {
         "message": "updated",
-        "success": true
+        "success": true,
+        "data": {
+          "allows_submissions_until": "9999-12-31T23:59:59Z",
+          "created_at": "2019-05-30T11:00:00Z",
+          "ended_at": null,
+          "help_requested": false,
+          "id": "1",
+          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "score_computed": 0,
+          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "user_creator": null,
+          "validated": false
+        }
       }
       """
     And the table "attempts" should stay unchanged

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -22,9 +22,7 @@ type updatedStartResultResponse struct { // nolint:unused
 		// required: true
 		Success bool `json:"success"`
 		// required: true
-		// Extensions:
-		// x-nullable: false
-		Data *attemptsListResponseRow `json:"data"`
+		Data attemptsListResponseRow `json:"data"`
 	}
 }
 

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -9,52 +9,72 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 )
 
+// The request has successfully updated the object
+// swagger:response updatedStartResultResponse
+type updatedStartResultResponse struct { // nolint:unused
+	// in: body
+	Body struct {
+		// "updated"
+		// enum: updated
+		// required: true
+		Message string `json:"message"`
+		// true
+		// required: true
+		Success bool `json:"success"`
+		// required: true
+		// Extensions:
+		// x-nullable: false
+		Data *attemptsListResponseRow `json:"data"`
+	}
+}
+
 // swagger:operation POST /items/{ids}/start-result items resultStart
 //
-//	---
-//	summary: Start a result
-//	description: >
-//		Creates a new started result for the given item and attempt or sets `started_at` of an existing result (if it hasn't been set).
-//		If `as_team_id` is given, the created result is linked to the `as_team_id` group instead of the user's self group.
+//		---
+//		summary: Start a result
+//		description: >
+//			Creates a new started result for the given item and attempt or sets `started_at` of an existing result (if it hasn't been set).
+//	   The started result is then returned as `data`.
+//			If `as_team_id` is given, the created result is linked to the `as_team_id` group instead of the user's self group.
 //
 //
-//			Restrictions:
+//				Restrictions:
 //
-//		* if `as_team_id` is given, it should be a user's parent team group,
-//		* the first item in `{ids}` should be a root activity/skill (groups.root_activity_id/root_skill_id) of a group
-//			the participant is a descendant of or manages,
-//		* the last item in `{ids}` should not require explicit entry (`items.requires_explicit_entry` should be false),
-//		* `{ids}` should be an ordered list of parent-child items,
-//		* the group starting the result should have at least 'content' access on each of the items in `{ids}`,
-//		* the participant should have a started, allowing submission, not ended result for each item but the last,
-//			with `{attempt_id}` (or its parent attempt each time we reach a root of an attempt) as the attempt,
-//		* if `{ids}` consists of only one item, the `{attempt_id}` should be zero,
+//			* if `as_team_id` is given, it should be a user's parent team group,
+//			* the first item in `{ids}` should be a root activity/skill (groups.root_activity_id/root_skill_id) of a group
+//				the participant is a descendant of or manages,
+//			* the last item in `{ids}` should not require explicit entry (`items.requires_explicit_entry` should be false),
+//			* `{ids}` should be an ordered list of parent-child items,
+//			* the group starting the result should have at least 'content' access on each of the items in `{ids}`,
+//			* the participant should have a started, allowing submission, not ended result for each item but the last,
+//				with `{attempt_id}` (or its parent attempt each time we reach a root of an attempt) as the attempt,
+//			* if `{ids}` consists of only one item, the `{attempt_id}` should be zero,
 //
-//		otherwise the 'forbidden' error is returned.
-//	parameters:
-//		- name: ids
-//			in: path
-//			type: string
-//			description: slash-separated list of item IDs
-//			required: true
-//		- name: attempt_id
-//			in: query
-//			type: integer
-//			required: true
-//		- name: as_team_id
-//			in: query
-//			type: integer
-//	responses:
-//		"201":
-//			"$ref": "#/responses/updatedResponse"
-//		"400":
-//			"$ref": "#/responses/badRequestResponse"
-//		"401":
-//			"$ref": "#/responses/unauthorizedResponse"
-//		"403":
-//			"$ref": "#/responses/forbiddenResponse"
-//		"500":
-//			"$ref": "#/responses/internalErrorResponse"
+//			otherwise the 'forbidden' error is returned.
+//		parameters:
+//			- name: ids
+//				in: path
+//				type: string
+//				description: slash-separated list of item IDs
+//				required: true
+//			- name: attempt_id
+//				in: query
+//				type: integer
+//				required: true
+//			- name: as_team_id
+//				in: query
+//				type: integer
+//		responses:
+//			"200":
+//				"$ref": "#/responses/updatedStartResultResponse"
+//			"400":
+//				"$ref": "#/responses/badRequestResponse"
+//			"401":
+//				"$ref": "#/responses/unauthorizedResponse"
+//			"403":
+//				"$ref": "#/responses/forbiddenResponse"
+//			"500":
+//				"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.APIError {
 	var err error
 
@@ -70,6 +90,7 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 	participantID := service.ParticipantIDFromContext(r.Context())
 
+	var attemptInfo attemptsListResponseRow
 	apiError := service.NoError
 	err = srv.GetStore(r).InTransaction(func(store *database.DataStore) error {
 		var ok bool
@@ -105,6 +126,15 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 			service.SchedulePropagation(store, srv.GetPropagationEndpoint(), []string{"results"})
 		}
+
+		service.MustNotBeError(constructQueryForGettingAttemptsList(store, participantID, itemID, srv.GetUser(r)).
+			Where("attempts.id = ?", attemptID).
+			Scan(&attemptInfo).Error())
+
+		if attemptInfo.UserCreator.GroupID == nil {
+			attemptInfo.UserCreator = nil
+		}
+
 		return nil
 	})
 	if apiError != service.NoError {
@@ -112,6 +142,6 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(&attemptInfo)))
 	return service.NoError
 }

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -112,6 +112,6 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -206,7 +206,7 @@ func (srv *Service) updateItem(w http.ResponseWriter, r *http.Request) service.A
 	service.SchedulePropagation(store, srv.GetPropagationEndpoint(), propagationsToRun)
 
 	// response
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }
 

--- a/app/api/items/update_item_string.go
+++ b/app/api/items/update_item_string.go
@@ -123,7 +123,7 @@ func (srv *Service) updateItemString(w http.ResponseWriter, r *http.Request) ser
 	service.MustNotBeError(err)
 
 	// response
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }
 

--- a/app/api/items/update_result.go
+++ b/app/api/items/update_result.go
@@ -111,6 +111,6 @@ func (srv *Service) updateResult(w http.ResponseWriter, r *http.Request) service
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -174,7 +174,7 @@ func (srv *Service) updateThread(w http.ResponseWriter, r *http.Request) service
 	}
 	service.MustNotBeError(err)
 
-	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(nil)))
+	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess[*struct{}](nil)))
 	return service.NoError
 }
 

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -11,8 +11,8 @@ import (
 )
 
 // ErrorResponse is an extension of the response for returning errors.
-type ErrorResponse struct {
-	Response
+type ErrorResponse[T any] struct {
+	Response[T]
 	ErrorText string      `json:"error_text,omitempty"` // application-level error message, for debugging
 	Errors    interface{} `json:"errors,omitempty"`     // form errors
 }
@@ -31,12 +31,12 @@ var NoError = APIError{0, nil}
 var InsufficientAccessRightsError = ErrForbidden(errors.New("insufficient access rights"))
 
 func (e APIError) httpResponse() render.Renderer {
-	response := Response{
+	response := Response[*struct{}]{
 		HTTPStatusCode: e.HTTPStatusCode,
 		Success:        false,
 		Message:        http.StatusText(e.HTTPStatusCode),
 	}
-	result := ErrorResponse{Response: response}
+	result := ErrorResponse[*struct{}]{Response: response}
 	if e.Error == nil {
 		return &result
 	}

--- a/app/service/responses.go
+++ b/app/service/responses.go
@@ -11,15 +11,15 @@ import (
 )
 
 // Response is used for generating non-data responses, i.e. on error or on POST/PUT/PATCH/DELETE request.
-type Response struct {
-	HTTPStatusCode int         `json:"-"`
-	Success        bool        `json:"success"`
-	Message        string      `json:"message"`
-	Data           interface{} `json:"data,omitempty"`
+type Response[T any] struct {
+	HTTPStatusCode int    `json:"-"`
+	Success        bool   `json:"success"`
+	Message        string `json:"message"`
+	Data           T      `json:"data,omitempty"`
 }
 
 // Render generates the HTTP response from Response.
-func (resp *Response) Render(_ http.ResponseWriter, r *http.Request) error {
+func (resp *Response[T]) Render(_ http.ResponseWriter, r *http.Request) error {
 	if resp.Success && resp.Message == "" {
 		resp.Message = "success"
 	}
@@ -28,8 +28,8 @@ func (resp *Response) Render(_ http.ResponseWriter, r *http.Request) error {
 }
 
 // CreationSuccess generated a success response for a POST creation.
-func CreationSuccess(data interface{}) render.Renderer {
-	return &Response{
+func CreationSuccess[T any](data T) render.Renderer {
+	return &Response[T]{
 		HTTPStatusCode: http.StatusCreated,
 		Success:        true,
 		Message:        "created",
@@ -38,8 +38,8 @@ func CreationSuccess(data interface{}) render.Renderer {
 }
 
 // UpdateSuccess generated a success response for a PUT updating.
-func UpdateSuccess(data interface{}) render.Renderer {
-	return &Response{
+func UpdateSuccess[T any](data T) render.Renderer {
+	return &Response[T]{
 		HTTPStatusCode: http.StatusOK,
 		Success:        true,
 		Message:        "updated",
@@ -48,8 +48,8 @@ func UpdateSuccess(data interface{}) render.Renderer {
 }
 
 // DeletionSuccess generated a success response for a DELETE deletion.
-func DeletionSuccess(data interface{}) render.Renderer {
-	return &Response{
+func DeletionSuccess[T any](data T) render.Renderer {
+	return &Response[T]{
 		HTTPStatusCode: http.StatusOK,
 		Success:        true,
 		Message:        "deleted",
@@ -59,7 +59,7 @@ func DeletionSuccess(data interface{}) render.Renderer {
 
 // UnchangedSuccess generated a success response for a POST/PUT/DELETE action if no data have been modified.
 func UnchangedSuccess(httpStatus int) render.Renderer {
-	return &Response{
+	return &Response[map[string]bool]{
 		HTTPStatusCode: httpStatus,
 		Success:        true,
 		Message:        "unchanged",

--- a/app/service/responses_test.go
+++ b/app/service/responses_test.go
@@ -68,7 +68,7 @@ func TestUnchangedSuccess(t *testing.T) {
 }
 
 func TestResponse_Render(t *testing.T) {
-	response := &Response{HTTPStatusCode: http.StatusOK, Message: "", Success: true}
+	response := &Response[*struct{}]{HTTPStatusCode: http.StatusOK, Message: "", Success: true}
 	recorder := httpResponseForResponse(response)
 	assertlib.Equal(t, `{"success":true,"message":"success"}`+"\n", recorder.Body.String())
 	assertlib.Equal(t, http.StatusOK, recorder.Code)

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -472,7 +472,7 @@ func (ctx *TestContext) TheResponseHeadersShouldBe(
 
 // TheResponseErrorMessageShouldContain checks that the response contains the provided string.
 func (ctx *TestContext) TheResponseErrorMessageShouldContain(s string) (err error) {
-	errorResp := service.ErrorResponse{}
+	errorResp := service.ErrorResponse[interface{}]{}
 	// decode response
 	if err = json.Unmarshal([]byte(ctx.lastResponseBody), &errorResp); err != nil {
 		return fmt.Errorf("unable to decode the response as JSON: %s -- Data: %v", err, ctx.lastResponseBody)

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -153,6 +153,7 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 
 	addRelativeTimeDBMsFunction(set)
 	addTimeDBToRFCFunction(set)
+	addTimeDBMsToRFCFunction(set)
 
 	set.AddGlobal("taskPlatformPublicKey", tokentest.TaskPlatformPublicKey)
 	set.AddGlobal("taskPlatformPrivateKey", tokentest.TaskPlatformPrivateKey)
@@ -176,7 +177,19 @@ func addTimeDBToRFCFunction(set *jet.Set) {
 	set.AddGlobalFunc("timeDBToRFC", func(a jet.Arguments) reflect.Value {
 		a.RequireNumOfArguments("timeDBToRFC", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
-		parsedTime, err := time.Parse("2006-01-02 15:04:05.999999999", dbTime)
+		parsedTime, err := time.Parse("2006-01-02 15:04:05", dbTime)
+		if err != nil {
+			a.Panicf("can't parse mysql datetime: %s", err.Error())
+		}
+		return reflect.ValueOf(parsedTime.Format(time.RFC3339))
+	})
+}
+
+func addTimeDBMsToRFCFunction(set *jet.Set) {
+	set.AddGlobalFunc("timeDBMsToRFC", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("timeDBMsToRFC", 1, 1)
+		dbTime := a.Get(0).Interface().(string)
+		parsedTime, err := time.Parse("2006-01-02 15:04:05.999", dbTime)
 		if err != nil {
 			a.Panicf("can't parse mysql datetime: %s", err.Error())
 		}


### PR DESCRIPTION
1. service.Response is being converted into a generic to make the type of Data field specific. Otherwise, json.Marshal() ignores custom marshallers defined with pointer receivers for its fields as it is non-addressable resulting in marshalling database.Time as '{}'.
2. A new template function timeDBMsToRFC() for godog tests is being introduced to format RFC3339 time with milliseconds explicitly.
3. The existing template function timeDBToRFC() is being modified to return timestamps without the fraction part.
4. The resultStart service is being changed to return attemptsList response row on success.

Fixes #1156 