### PR TITLE
Fix start_result.feature

### DIFF
--- a/app/api/items/start_result.feature
+++ b/app/api/items/start_result.feature
@@ -1,6 +1,7 @@
 Feature: Start a result for an item
   Background:
     Given time is frozen
+    And the DB time now is "{{currentTimeDB()}}"
     And the database has the following table 'groups':
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -731,6 +731,11 @@ func constructWhereForColumnValues(columnNames, columnValues []string, whereIn b
 
 // DBTimeNow sets the current time in the database to the provided time.
 func (ctx *TestContext) DBTimeNow(timeStrRaw string) error {
+	var err error
+	timeStrRaw, err = ctx.preprocessString(timeStrRaw)
+	if err != nil {
+		return err
+	}
 	MockDBTime(timeStrRaw)
 	return nil
 }

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -81,11 +81,11 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 	})
 
 	set.AddGlobalFunc("currentTimeDB", func(a jet.Arguments) reflect.Value {
-		return reflect.ValueOf(time.Now().UTC().Format("2006-01-02 15:04:05.999999"))
+		return reflect.ValueOf(time.Now().UTC().Round(time.Microsecond).Format("2006-01-02 15:04:05.999999"))
 	})
 
 	set.AddGlobalFunc("currentTimeDBMs", func(a jet.Arguments) reflect.Value {
-		return reflect.ValueOf(time.Now().UTC().Format("2006-01-02 15:04:05.000"))
+		return reflect.ValueOf(time.Now().UTC().Round(time.Millisecond).Format("2006-01-02 15:04:05.000"))
 	})
 
 	set.AddGlobalFunc("generateToken", func(a jet.Arguments) reflect.Value {
@@ -148,7 +148,7 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 		if err != nil {
 			a.Panicf("can't parse duration: %s", err.Error())
 		}
-		return reflect.ValueOf(time.Now().UTC().Add(duration).Format("2006-01-02 15:04:05"))
+		return reflect.ValueOf(time.Now().UTC().Add(duration).Round(time.Second).Format("2006-01-02 15:04:05"))
 	})
 
 	addRelativeTimeDBMsFunction(set)
@@ -169,7 +169,7 @@ func addRelativeTimeDBMsFunction(set *jet.Set) *jet.Set {
 		if err != nil {
 			a.Panicf("can't parse duration: %s", err.Error())
 		}
-		return reflect.ValueOf(time.Now().UTC().Add(duration).Format("2006-01-02 15:04:05.000"))
+		return reflect.ValueOf(time.Now().UTC().Add(duration).Round(time.Millisecond).Format("2006-01-02 15:04:05.000"))
 	})
 }
 
@@ -177,10 +177,11 @@ func addTimeDBToRFCFunction(set *jet.Set) {
 	set.AddGlobalFunc("timeDBToRFC", func(a jet.Arguments) reflect.Value {
 		a.RequireNumOfArguments("timeDBToRFC", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
-		parsedTime, err := time.Parse("2006-01-02 15:04:05", dbTime)
+		parsedTime, err := time.Parse("2006-01-02 15:04:05.999999999", dbTime)
 		if err != nil {
 			a.Panicf("can't parse mysql datetime: %s", err.Error())
 		}
+		parsedTime = parsedTime.Round(time.Second)
 		return reflect.ValueOf(parsedTime.Format(time.RFC3339))
 	})
 }


### PR DESCRIPTION
1. Mock DB time in app/api/items/start_result.feature
2. Round timestamps in time-related template functions used in godog tests when needed.

(Fixes tests in the master branch broken by #1159)