### PR TITLE
Rename template functions converting timestamps to RFC3339 used by godog tests

### DIFF
--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -87,7 +87,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[8][at]"))}}"
       },
       {
         "group_id": "33",
@@ -106,7 +106,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[4][at]"))}}"
       },
       {
         "group_id": "1",
@@ -122,10 +122,10 @@ Feature: Get group invitations for the current user
           "description": "Our class group",
           "type": "Class",
           "require_personal_info_access_approval": "none",
-          "require_lock_membership_approval_until": "{{timeDBToRFC(db("groups[1][require_lock_membership_approval_until]"))}}",
+          "require_lock_membership_approval_until": "{{timeDBToRFC3339(db("groups[1][require_lock_membership_approval_until]"))}}",
           "require_watch_approval": true
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[1][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[1][at]"))}}"
       },
       {
         "group_id": "35",
@@ -139,7 +139,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_pending_requests[4][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_pending_requests[4][at]"))}}"
       },
       {
         "group_id": "36",
@@ -153,7 +153,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[10][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[10][at]"))}}"
       }
     ]
     """
@@ -182,14 +182,14 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[8][at]"))}}"
       }
     ]
     """
 
   Scenario: Request the second row
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
+    And the template constant "from_at" is "{{timeDBMsToRFC3339(db("group_membership_changes[4][at]"))}}"
     When I send a GET request to "/current-user/group-invitations?limit=1&from.group_id=4&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -212,7 +212,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC(db("group_membership_changes[4][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[4][at]"))}}"
       }
     ]
     """

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -84,42 +84,42 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -136,42 +136,42 @@ Feature: Get requests for group_id
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]
@@ -188,42 +188,42 @@ Feature: Get requests for group_id
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -240,7 +240,7 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -257,35 +257,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -293,7 +293,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by joining user's login, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.member_id=31&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -303,35 +303,35 @@ Feature: Get requests for group_id
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -339,7 +339,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by action, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToRFC(db("group_membership_changes[1][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=action&from.at={{from_at}}&from.member_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -349,35 +349,35 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "51",
         "inviting_user": {"first_name": "Mark", "group_id": "41", "last_name": "Moe", "login": "mark"},
         "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[6][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[6][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "join_request_refused"
       }
     ]

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -75,7 +75,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -90,7 +90,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -115,7 +115,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -130,7 +130,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -185,7 +185,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -200,7 +200,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -225,7 +225,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -240,7 +240,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -265,7 +265,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -295,7 +295,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -320,7 +320,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -345,7 +345,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -360,7 +360,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -400,7 +400,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -415,7 +415,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -440,7 +440,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -455,7 +455,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -516,7 +516,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]
@@ -541,7 +541,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
         "type": "join_request"
       },
       {
@@ -556,7 +556,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -569,7 +569,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToRFC(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "leave_request"
       }
     ]

--- a/app/api/items/start_result.feature
+++ b/app/api/items/start_result.feature
@@ -70,9 +70,9 @@ Feature: Start a result for an item
           "ended_at": null,
           "help_requested": false,
           "id": "0",
-          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "latest_activity_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "score_computed": 0,
-          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "started_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "user_creator": null,
           "validated": false
         }
@@ -105,9 +105,9 @@ Feature: Start a result for an item
           "ended_at": null,
           "help_requested": false,
           "id": "0",
-          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "latest_activity_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "score_computed": 0,
-          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "started_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "user_creator": null,
           "validated": false
         }
@@ -133,9 +133,9 @@ Feature: Start a result for an item
           "ended_at": null,
           "help_requested": false,
           "id": "0",
-          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "latest_activity_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "score_computed": 0,
-          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "started_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "user_creator": null,
           "validated": false
         }
@@ -201,9 +201,9 @@ Feature: Start a result for an item
           "ended_at": null,
           "help_requested": false,
           "id": "1",
-          "latest_activity_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "latest_activity_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "score_computed": 0,
-          "started_at": "{{timeDBToRFC(currentTimeDB())}}",
+          "started_at": "{{timeDBToRFC3339(currentTimeDB())}}",
           "user_creator": null,
           "validated": false
         }

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -152,8 +152,8 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 	})
 
 	addRelativeTimeDBMsFunction(set)
-	addTimeDBToRFCFunction(set)
-	addTimeDBMsToRFCFunction(set)
+	addtimeDBToRFC3339Function(set)
+	addTimeDBMsToRFC3339Function(set)
 
 	set.AddGlobal("taskPlatformPublicKey", tokentest.TaskPlatformPublicKey)
 	set.AddGlobal("taskPlatformPrivateKey", tokentest.TaskPlatformPrivateKey)
@@ -173,9 +173,9 @@ func addRelativeTimeDBMsFunction(set *jet.Set) *jet.Set {
 	})
 }
 
-func addTimeDBToRFCFunction(set *jet.Set) {
-	set.AddGlobalFunc("timeDBToRFC", func(a jet.Arguments) reflect.Value {
-		a.RequireNumOfArguments("timeDBToRFC", 1, 1)
+func addtimeDBToRFC3339Function(set *jet.Set) {
+	set.AddGlobalFunc("timeDBToRFC3339", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("timeDBToRFC3339", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
 		parsedTime, err := time.Parse("2006-01-02 15:04:05.999999999", dbTime)
 		if err != nil {
@@ -186,9 +186,9 @@ func addTimeDBToRFCFunction(set *jet.Set) {
 	})
 }
 
-func addTimeDBMsToRFCFunction(set *jet.Set) {
-	set.AddGlobalFunc("timeDBMsToRFC", func(a jet.Arguments) reflect.Value {
-		a.RequireNumOfArguments("timeDBMsToRFC", 1, 1)
+func addTimeDBMsToRFC3339Function(set *jet.Set) {
+	set.AddGlobalFunc("timeDBMsToRFC3339", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("timeDBMsToRFC3339", 1, 1)
 		dbTime := a.Get(0).Interface().(string)
 		parsedTime, err := time.Parse("2006-01-02 15:04:05.999", dbTime)
 		if err != nil {


### PR DESCRIPTION
Rename template functions used by godog tests:
timeDBToRFC->timeDBToRFC3339, timeDBMsToRFC->timeDBMsToRFC3339.

Fixes #1135