### PR TITLE
Silently override existing translation in formdata.FormData.RegisterTranslation()

### DIFF
--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -106,7 +106,7 @@ func (f *FormData) RegisterValidation(tag string, fn validator.Func) {
 func (f *FormData) RegisterTranslation(tag, text string) {
 	_ = f.validate.RegisterTranslation(tag, f.trans,
 		func(ut ut.Translator) (err error) {
-			err = ut.Add(tag, text, false)
+			err = ut.Add(tag, text, true) // Silently override the translation
 			if err != nil {
 				panic(err)
 			}

--- a/app/formdata/form_data_test.go
+++ b/app/formdata/form_data_test.go
@@ -44,15 +44,22 @@ func TestFormData_decodeMapIntoStruct_PanicsWhenMapstructureNewDecoderFails(t *t
 	f.decodeMapIntoStruct(map[string]interface{}{})
 }
 
+func TestFormData_RegisterTranslation_OverridesConflictingTranslationsSilently(t *testing.T) {
+	f := NewFormData(&struct{}{})
+	f.RegisterTranslation("", "")
+	assert.NotPanics(t, func() {
+		f.RegisterTranslation("", "")
+	})
+}
+
 func TestFormData_RegisterTranslation_PanicsOnError(t *testing.T) {
 	f := NewFormData(&struct{}{})
 	defer func() {
 		p := recover()
 		assert.NotNil(t, p)
-		assert.IsType(t, (*ut.ErrConflictingTranslation)(nil), p)
+		assert.IsType(t, (*ut.ErrMissingBracket)(nil), p)
 	}()
-	f.RegisterTranslation("", "")
-	f.RegisterTranslation("", "")
+	f.RegisterTranslation("", "{")
 }
 
 func TestFormData_RegisterTranslation_SetsArgumentsForErrorMessages(t *testing.T) {


### PR DESCRIPTION
As sometimes we call it inside a transaction which can be retried on lock wait timeouts, formdata.FormData.RegisterTranslation() can be called several times with the same parameters. To make it possible without failing, formdata.FormData.RegisterTranslation() should silently override existing translations.