### PR TITLE
Introduce a new config setting "server.disable_results_propagation" allowing to disable the results propagation everywhere

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -36,7 +36,7 @@ func TestNew_Success(t *testing.T) {
 	assert.NotNil(app.Database)
 	assert.NotNil(app.HTTPHandler)
 	assert.NotNil(app.apiCtx)
-	assert.Len(app.HTTPHandler.Middlewares(), 8)
+	assert.Len(app.HTTPHandler.Middlewares(), 9)
 	assert.True(len(app.HTTPHandler.Routes()) > 0)
 	assert.Equal("/*", app.HTTPHandler.Routes()[0].Pattern) // test default val
 }
@@ -47,7 +47,7 @@ func TestNew_SuccessNoCompress(t *testing.T) {
 	_ = os.Setenv("ALGOREA_SERVER__COMPRESS", "false")
 	defer func() { _ = os.Unsetenv("ALGOREA_SERVER__COMPRESS") }()
 	app, _ := New()
-	assert.Len(app.HTTPHandler.Middlewares(), 7)
+	assert.Len(app.HTTPHandler.Middlewares(), 8)
 }
 
 func TestNew_NotDefaultRootPath(t *testing.T) {

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -35,6 +35,11 @@ func ProhibitResultsPropagation(conn *DB) {
 	conn.ctx = context.WithValue(conn.ctx, prohibitedPropagationsContextKey, prohibitedPropagations)
 }
 
+// IsResultsPropagationProhibited returns true if the propagation of results is prohibited in the context of the current DB connection.
+func (s *DataStore) IsResultsPropagationProhibited() bool {
+	return getProhibitedPropagationsFromContext(s.DB.ctx).Results
+}
+
 func getProhibitedPropagationsFromContext(ctx context.Context) propagationsBitField {
 	prohibitedPropagations := ctx.Value(prohibitedPropagationsContextKey)
 	if prohibitedPropagations == nil {

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -28,6 +28,28 @@ func NewDataStoreWithTable(conn *DB, tableName string) *DataStore {
 	return &DataStore{conn.Table(tableName), tableName}
 }
 
+// ProhibitResultsPropagation marks the context inside the DB connection as prohibiting the propagation of results.
+func ProhibitResultsPropagation(conn *DB) {
+	prohibitedPropagations := getProhibitedPropagationsFromContext(conn.ctx)
+	prohibitedPropagations.Results = true
+	conn.ctx = context.WithValue(conn.ctx, prohibitedPropagationsContextKey, prohibitedPropagations)
+}
+
+func getProhibitedPropagationsFromContext(ctx context.Context) propagationsBitField {
+	prohibitedPropagations := ctx.Value(prohibitedPropagationsContextKey)
+	if prohibitedPropagations == nil {
+		return propagationsBitField{}
+	}
+	return prohibitedPropagations.(propagationsBitField)
+}
+
+// MergeContext returns a new context based on the given one, with DB-related values copied
+// from the context of the current DB connection.
+func (s *DataStore) MergeContext(ctx context.Context) context.Context {
+	prohibitedPropagations := getProhibitedPropagationsFromContext(s.DB.ctx)
+	return context.WithValue(ctx, prohibitedPropagationsContextKey, prohibitedPropagations)
+}
+
 // ActiveGroupGroups returns a GroupGroupStore working with the `groups_groups_active` view.
 func (s *DataStore) ActiveGroupGroups() *GroupGroupStore {
 	return &GroupGroupStore{NewDataStoreWithTable(s.DB, "groups_groups_active")}
@@ -175,21 +197,25 @@ func (s *DataStore) NewID() int64 {
 	return rand.Int63()
 }
 
-type awaitingTriggers struct {
+type propagationsBitField struct {
 	ItemAncestors  bool
 	GroupAncestors bool
 	Permissions    bool
 	Results        bool
 }
+
 type dbContextKey string
 
-var triggersContextKey = dbContextKey("triggers")
+const (
+	awaitingPropagationsContextKey   = dbContextKey("awaitingPropagations")
+	prohibitedPropagationsContextKey = dbContextKey("prohibitedPropagations")
+)
 
 // InTransaction executes the given function in a transaction and commits.
 // If a propagation is scheduled, it will be run after the transaction commit,
 // so we can run each step of the propagation in a separate transaction.
 func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
-	s.DB.ctx = context.WithValue(s.DB.ctx, triggersContextKey, &awaitingTriggers{})
+	s.DB.ctx = context.WithValue(s.DB.ctx, awaitingPropagationsContextKey, &propagationsBitField{})
 	err := s.inTransaction(func(db *DB) error {
 		dataStore := NewDataStoreWithTable(db, s.tableName)
 		err := txFunc(dataStore)
@@ -200,22 +226,23 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
 		return err
 	}
 
-	triggersToRun := s.ctx.Value(triggersContextKey).(*awaitingTriggers)
+	propagationsToRun := s.ctx.Value(awaitingPropagationsContextKey).(*propagationsBitField)
+	prohibitedPropagations := getProhibitedPropagationsFromContext(s.ctx)
 
-	if triggersToRun.GroupAncestors {
-		triggersToRun.GroupAncestors = false
+	if propagationsToRun.GroupAncestors && !prohibitedPropagations.GroupAncestors {
+		propagationsToRun.GroupAncestors = false
 		s.createNewAncestors("groups", "group")
 	}
-	if triggersToRun.ItemAncestors {
-		triggersToRun.ItemAncestors = false
+	if propagationsToRun.ItemAncestors && !prohibitedPropagations.ItemAncestors {
+		propagationsToRun.ItemAncestors = false
 		s.createNewAncestors("items", "item")
 	}
-	if triggersToRun.Permissions {
-		triggersToRun.Permissions = false
+	if propagationsToRun.Permissions && !prohibitedPropagations.Permissions {
+		propagationsToRun.Permissions = false
 		s.PermissionsGranted().computeAllAccess()
 	}
-	if triggersToRun.Results {
-		triggersToRun.Results = false
+	if propagationsToRun.Results && !prohibitedPropagations.Results {
+		propagationsToRun.Results = false
 		err = s.Results().propagate()
 	}
 
@@ -226,32 +253,32 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
 func (s *DataStore) ScheduleResultsPropagation() {
 	s.mustBeInTransaction()
 
-	triggersToRun := s.DB.ctx.Value(triggersContextKey).(*awaitingTriggers)
-	triggersToRun.Results = true
+	propagationsToRun := s.DB.ctx.Value(awaitingPropagationsContextKey).(*propagationsBitField)
+	propagationsToRun.Results = true
 }
 
 // ScheduleGroupsAncestorsPropagation schedules a run of the groups ancestors propagation after the transaction commit.
 func (s *DataStore) ScheduleGroupsAncestorsPropagation() {
 	s.mustBeInTransaction()
 
-	triggersToRun := s.DB.ctx.Value(triggersContextKey).(*awaitingTriggers)
-	triggersToRun.GroupAncestors = true
+	propagationsToRun := s.DB.ctx.Value(awaitingPropagationsContextKey).(*propagationsBitField)
+	propagationsToRun.GroupAncestors = true
 }
 
 // ScheduleItemsAncestorsPropagation schedules a run of the items ancestors propagation after the transaction commit.
 func (s *DataStore) ScheduleItemsAncestorsPropagation() {
 	s.mustBeInTransaction()
 
-	triggersToRun := s.DB.ctx.Value(triggersContextKey).(*awaitingTriggers)
-	triggersToRun.ItemAncestors = true
+	propagationsToRun := s.DB.ctx.Value(awaitingPropagationsContextKey).(*propagationsBitField)
+	propagationsToRun.ItemAncestors = true
 }
 
 // SchedulePermissionsPropagation schedules a run of the groups ancestors propagation after the transaction commit.
 func (s *DataStore) SchedulePermissionsPropagation() {
 	s.mustBeInTransaction()
 
-	triggersToRun := s.DB.ctx.Value(triggersContextKey).(*awaitingTriggers)
-	triggersToRun.Permissions = true
+	propagationsToRun := s.DB.ctx.Value(awaitingPropagationsContextKey).(*propagationsBitField)
+	propagationsToRun.Permissions = true
 }
 
 // WithForeignKeyChecksDisabled executes the given function with foreign keys checking disabled

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -4,6 +4,7 @@ server:
   compress: false # whether compression is enabled by default
   # domainOverride: dev.algorea.org # use this domain name for cookies and per-domain configuration choosing
   propagation_endpoint: "" # Endpoint to schedule the propagation asynchronously. If empty, propagation is synchronous.
+  disableResultsPropagation: false # Disable the propagation of results.
 auth:
   loginModuleURL: "http://127.0.0.1:8000"
   clientID: "1"

--- a/conf/config.test.sample.yaml
+++ b/conf/config.test.sample.yaml
@@ -4,6 +4,7 @@ server:
   compress: false # whether compression is enabled by default
   # domainOverride: dev.algorea.org # use this domain name for cookies and per-domain configuration choosing
   propagation_endpoint: "" # Endpoint to schedule the propagation asynchronously. If empty, propagation is synchronous.
+  disable_results_propagation: false # Disable the propagation of results.
 auth:
   loginModuleURL: "http://127.0.0.1:8000"
   clientID: "1"


### PR DESCRIPTION
1. Introduce a new config setting "server.disable_results_propagation" allowing to disable the results propagation everywhere for all commands of the app
2. Remove unneeded command line flag --disable-results-propagation of the "propagation" command.