### PR TITLE
Do not close the db connection explicitly in the propagation command

### DIFF
--- a/cmd/propagation.go
+++ b/cmd/propagation.go
@@ -57,12 +57,6 @@ func init() { //nolint:gochecknoinits
 			}
 
 			fmt.Println("Propagation done.")
-
-			// Close database connection.
-			if application.Database.Close() != nil {
-				fmt.Println("Cannot close DB connection:", err)
-				os.Exit(1)
-			}
 		},
 	}
 


### PR DESCRIPTION
The OS closes all the connections on program exit by itself, no need to do it explicitly.