### PR TITLE
Rework processing of results_propagate_items table

### DIFF
--- a/app/database/result_store_propagate_recomputes_items_integration_test.go
+++ b/app/database/result_store_propagate_recomputes_items_integration_test.go
@@ -1,0 +1,76 @@
+//go:build !unit
+
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+)
+
+func TestResultStore_Propagate_RecomputesResultsForItemsFromTableResultsRecomputeForItems(t *testing.T) {
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups: [{id: 1}, {id: 2}, {id: 3}]
+		items:
+			- {id: 111, default_language_tag: fr}
+			- {id: 222, default_language_tag: fr}
+			- {id: 333, default_language_tag: fr}
+			- {id: 444, default_language_tag: fr, requires_explicit_entry: 1}
+		items_items:
+			- {parent_item_id: 111, child_item_id: 222, child_order: 1}
+			- {parent_item_id: 222, child_item_id: 333, child_order: 1}
+			- {parent_item_id: 444, child_item_id: 333, child_order: 1}
+		items_ancestors:
+			- {ancestor_item_id: 111, child_item_id: 222}
+			- {ancestor_item_id: 111, child_item_id: 333}
+			- {ancestor_item_id: 222, child_item_id: 333}
+			- {ancestor_item_id: 444, child_item_id: 333}
+		results:
+			- {participant_id: 1, attempt_id: 1, item_id: 111, latest_activity_at: '2019-05-30 11:00:00',  validated_at: '2019-05-30 11:00:00'}
+			- {participant_id: 2, attempt_id: 1, item_id: 222, latest_activity_at: '2019-05-30 11:00:00', validated_at: '2019-05-30 11:00:00'}
+			- {participant_id: 3, attempt_id: 2, item_id: 111, latest_activity_at: '2019-05-30 11:00:00', validated_at: '2019-05-30 11:00:00'}
+			- {participant_id: 3, attempt_id: 2, item_id: 333, latest_activity_at: '2019-05-30 11:00:00', validated_at: '2019-05-30 11:00:00'}
+			- {participant_id: 1, attempt_id: 1, item_id: 444, latest_activity_at: '2019-05-30 11:00:00', validated_at: '2019-05-30 11:00:00'}
+			- {participant_id: 2, attempt_id: 1, item_id: 444, latest_activity_at: '2019-05-30 11:00:00', validated_at: '2019-05-30 11:00:00'}
+		attempts:
+			- {participant_id: 1, id: 1}
+			- {participant_id: 2, id: 1}
+			- {participant_id: 3, id: 2}
+		results_recompute_for_items:
+			- {item_id: 111}
+			- {item_id: 222}
+	`)
+	defer func() { _ = db.Close() }()
+	dataStore := database.NewDataStore(db)
+
+	require.NoError(t,
+		dataStore.InTransaction(func(dataStore *database.DataStore) error {
+			dataStore.ScheduleResultsPropagation()
+			return nil
+		}), "Results Propagation failed")
+
+	hasRows, err := dataStore.Table("results_recompute_for_items").HasRows()
+	assert.NoError(t, err)
+	assert.False(t, hasRows)
+	hasRows, err = dataStore.Table("results_propagate").HasRows()
+	assert.NoError(t, err)
+	assert.False(t, hasRows)
+
+	expectedTime, _ := time.Parse(time.DateTime, "2019-05-30 11:00:00")
+	expectedDBTime := database.Time(expectedTime)
+	var result []validationDateResultRow
+	queryResultsAndStatesForTests(t, dataStore.Results(), &result, "validated_at")
+	assert.Equal(t, []validationDateResultRow{
+		{ParticipantID: 1, AttemptID: 1, ItemID: 111, State: "done", ValidatedAt: nil},
+		{ParticipantID: 1, AttemptID: 1, ItemID: 444, State: "done", ValidatedAt: &expectedDBTime},
+		{ParticipantID: 2, AttemptID: 1, ItemID: 222, State: "done", ValidatedAt: nil},
+		{ParticipantID: 2, AttemptID: 1, ItemID: 444, State: "done", ValidatedAt: &expectedDBTime},
+		{ParticipantID: 3, AttemptID: 2, ItemID: 111, State: "done", ValidatedAt: nil},
+		{ParticipantID: 3, AttemptID: 2, ItemID: 333, State: "done", ValidatedAt: &expectedDBTime},
+	}, result)
+}

--- a/db/migrations/2409191745_add_column_results_propagate_items_is_processing.sql
+++ b/db/migrations/2409191745_add_column_results_propagate_items_is_processing.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+ALTER TABLE `results_propagate_items`
+  ADD COLUMN `is_being_processed` TINYINT(1) NOT NULL DEFAULT 0 AFTER `item_id`,
+  ADD INDEX `is_being_processed` (`is_being_processed`);
+
+-- +migrate Down
+ALTER TABLE `results_propagate_items`
+  DROP INDEX `is_being_processed`,
+  DROP COLUMN `is_being_processed`;

--- a/db/migrations/2409192252_rename_table_results_propagate_items_to_results_recompute_for_items.sql
+++ b/db/migrations/2409192252_rename_table_results_propagate_items_to_results_recompute_for_items.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+RENAME TABLE `results_propagate_items` TO `results_recompute_for_items`;
+
+-- +migrate Down
+RENAME TABLE `results_recompute_for_items` TO `results_propagate_items`;

--- a/db/migrations/2409192304_rename_table_results_propagate_items_into_results_recompute_for_items_in_triggers.sql
+++ b/db/migrations/2409192304_rename_table_results_propagate_items_into_results_recompute_for_items_in_triggers.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT IGNORE INTO `results_recompute_for_items` (`item_id`) VALUES (OLD.`parent_item_id`);
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT IGNORE INTO `results_propagate_items` (`item_id`) VALUES (OLD.`parent_item_id`);
+END
+-- +migrate StatementEnd


### PR DESCRIPTION
1) As the only place we insert new items into results_propagate_items is the `before_delete_items_items` trigger which inserts `OLD.parent_item_id` there in order to have its results recomputed, it doesn't make sense to mark such results as 'to_be_propagated' as we have been doing until now. We should always mark such results as 'to_be_recomputed'.

2) As the items in the table are supposed to be marked as 'to_be_recomputed', the table name seems to be misleading. Instead of 'results_propagate_items', it should be 'results_recompute_for_items'. Here we rename it.

3) The currently deployed code inserts results by chunks, but it can work incorrectly when a concurrent DB session is inserting new results for marked items into the results table. In this case, some results can be mistakenly silently skipped.

4) Added the missing test.

As marking the results for parent items of deleted items_items to be recomputed has not been working correctly for VERY long time, **upon deployment of this PR**, we should recompute all the results linked to chapters and skills. It can be done by executing:
```
insert into results_recompute_for_items (item_id) select id from items where type IN ('Skill','Chapter');
```
and running the 'propagation'/'db-recompute' command after that.

**NOTE:** Recomputing all the results linked to chapters and skills will lock the DB for several minutes (because of the UPDATE query in recomputeResultsMarkedAsToBeRecomputedAndMarkThemAsToBePropagated()), as there will be an unsupported situation where there will be too many results marked as to 'to_be_recomputed' at once. This situation cannot occur normally.