### PR TITLE
Set resultsPropagationChunkSize to 200

### DIFF
--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -9,7 +9,7 @@ import (
 const (
 	resultsPropagationLockName        = "listener_propagate"
 	resultsPropagationLockWaitTimeout = 10 * time.Second
-	resultsPropagationChunkSize       = 1000
+	resultsPropagationChunkSize       = 200
 )
 
 // propagate recomputes fields of results


### PR DESCRIPTION
It seems that 1,000 is too many as well. Let's try 200.