### PR TITLE
Speed up the results propagation and make it less locking + Introduce a command recomputing all the results of chapters/skills

### DIFF
--- a/app/api/currentuser/get_full_dump.feature
+++ b/app/api/currentuser/get_full_dump.feature
@@ -115,7 +115,8 @@ Feature: Export the current user's data
           "tasks_with_help": 0, "score_obtained_at": null, "hints_requested": null,
           "latest_activity_at": "2019-05-29T11:00:00Z", "latest_submission_at": null,
           "latest_hint_at": null, "score_edit_comment": null,
-          "started": 0, "started_at": null, "validated_at": null, "help_requested": 0
+          "started": 0, "started_at": null, "validated_at": null, "help_requested": 0,
+          "recomputing_state": "unchanged"
         },
         {
           "attempt_id": "0", "validated": 0,
@@ -125,7 +126,8 @@ Feature: Export the current user's data
           "tasks_with_help": 0, "score_obtained_at": null, "hints_requested": null,
           "latest_activity_at": "2019-05-30T11:00:00Z", "latest_submission_at": null,
           "latest_hint_at": null, "score_edit_comment": null,
-          "started": 0, "started_at": null, "validated_at": null, "help_requested": 0
+          "started": 0, "started_at": null, "validated_at": null, "help_requested": 0,
+          "recomputing_state": "unchanged"
         }
       ],
       "groups_groups": [

--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -45,7 +45,7 @@ Background:
     | 0  | 11             |
   And the database has the following table 'results':
     | attempt_id | participant_id | item_id | score_computed |
-    | 0          | 11             | 21      | 0              |
+    | 0          | 11             | 21      | 1              |
     | 0          | 11             | 50      | 10             |
     | 0          | 11             | 70      | 20             |
   And the database has the following table 'languages':
@@ -317,9 +317,10 @@ Background:
       | 11       | 70      | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 11       | 112     | solution           | content                  | answer              | all                | false              |
     And the table "attempts" should stay unchanged
-    And the table "results" should stay unchanged but the row with item_id "50"
-    And the table "results" at item_id "50" should be:
+    And the table "results" should stay unchanged but the rows with item_ids "21,50"
+    And the table "results" at item_ids "21,50" should be:
       | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 21      | 0              |
       | 0          | 11             | 50      | 0              |
     And the table "results_propagate" should be empty
 
@@ -358,9 +359,10 @@ Background:
     And the table "groups" should stay unchanged
     And the table "permissions_granted" should stay unchanged
     And the table "attempts" should stay unchanged
-    And the table "results" should stay unchanged but the row with item_id "50"
-    And the table "results" at item_id "50" should be:
+    And the table "results" should stay unchanged but the rows with item_ids "21,50"
+    And the table "results" at item_ids "21,50" should be:
       | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 11             | 21      | 0              |
       | 0          | 11             | 50      | 0              |
     And the table "results_propagate" should be empty
 

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -253,7 +253,7 @@ func recomputeResultsMarkedAsToBeRecomputedAndMarkThemAsToBePropagated(s *DataSt
 												 children.item_id = items_items.child_item_id
 										WHERE items_items.parent_item_id = inner_parent.item_id
 									)
-									LIMIT ?
+								LIMIT ?
 							) tmp
 						)
 					UPDATE results_propagate AS target_results_propagate

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -26,12 +26,15 @@ const (
 //  3. For results marked as 'propagating', we insert new permissions_granted for each unlocked item
 //     according to corresponding item_dependencies.
 //  4. We unmark all results marked as 'propagating'.
-//  5. We process all objects that are marked as 'to_be_recomputed' and that have no children marked as 'to_be_recomputed'.
-//     Then, if an object has children, we update
-//     latest_activity_at, tasks_tried, tasks_with_help, validated_at.
-//  6. We mark all modified results marked as 'to_be_recomputed' as 'to_be_propagated' and
+//  5. We atomically process results marked as 'to_be_recomputed' by chunks.
+//     a) We mark as 'recomputing' a chunk of results that are marked as 'to_be_recomputed' and
+//     that have no children marked as 'to_be_recomputed'.
+//     b) For each object marked as 'recomputing', we update
+//     latest_activity_at, tasks_tried, tasks_with_help, validated_at, score_computed.
+//     c) We mark all modified results marked as 'recomputing' as 'to_be_propagated' and
 //     unmark all unchanged results marked as 'to_be_recomputed'.
-//  7. We repeat from step 1.
+//     We repeat this step until there are no more results marked as 'to_be_recomputed'.
+//  6. We repeat from step 1.
 //
 // The `results_propagation` rows are marked in code as well as in the following SQL Triggers:
 // - after_insert_groups_groups/items_items

--- a/cmd/recompute_results_for_chapters_and_skills.go
+++ b/cmd/recompute_results_for_chapters_and_skills.go
@@ -34,7 +34,7 @@ func init() { //nolint:gochecknoinits
 			}
 
 			store := database.NewDataStore(application.Database)
-			itemNumber := -1
+			itemNumber := 0
 			err = store.Items().Where("type = 'Chapter' OR type = 'Skill'").Select("id").
 				ScanAndHandleMaps(func(item map[string]interface{}) error {
 					itemNumber++

--- a/cmd/recompute_results_for_chapters_and_skills.go
+++ b/cmd/recompute_results_for_chapters_and_skills.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql" // use to force database/sql to use mysql
+	"github.com/spf13/cobra"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+)
+
+func init() { //nolint:gochecknoinits
+	recomputeResultsCmd := &cobra.Command{
+		Use:   "recompute-results [environment]",
+		Short: "recompute results for chapters and skills",
+		Long:  `for each chapter/skill marks all results linked to it as to_be_recomputed and runs the results propagation`,
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+
+			// Set the environment.
+			if len(args) > 0 {
+				appenv.SetEnv(args[0])
+			}
+
+			var application *app.Application
+			application, err = app.New()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			store := database.NewDataStore(application.Database)
+			itemNumber := -1
+			err = store.Items().Where("type = 'Chapter' OR type = 'Skill'").Select("id").
+				ScanAndHandleMaps(func(item map[string]interface{}) error {
+					itemNumber++
+					return store.InTransaction(func(store *database.DataStore) error {
+						log.Printf("Recomputing results for item %s (#%d)\n", item["id"], itemNumber)
+						err = store.Exec("INSERT IGNORE INTO results_recompute_for_items (item_id) values (?)", item["id"]).Error()
+						if err != nil {
+							return err
+						}
+						store.ScheduleResultsPropagation()
+						return nil
+					})
+				}).Error()
+			if err != nil {
+				fmt.Println("Error while recomputing results: ", err)
+				os.Exit(1)
+			}
+
+			fmt.Println("Done.")
+		},
+	}
+
+	rootCmd.AddCommand(recomputeResultsCmd)
+}

--- a/db/migrations/2409290723_add_column_results_recomputing_state.sql
+++ b/db/migrations/2409290723_add_column_results_recomputing_state.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `results`
+  ADD COLUMN `recomputing_state` ENUM('recomputing', 'modified', 'unchanged') NOT NULL DEFAULT 'unchanged'
+    COMMENT 'State of the result, used during recomputing' AFTER `help_requested`;
+
+-- +migrate Down
+ALTER TABLE `results` DROP COLUMN `recomputing_state`;

--- a/db/migrations/2409290724_create_trigger_before_update_results.sql
+++ b/db/migrations/2409290724_create_trigger_before_update_results.sql
@@ -15,7 +15,7 @@ BEGIN
       NEW.score_computed <=> OLD.score_computed AND
       -- We always consider results with the default latest_activity_at as changed
       -- because they look like a newly inserted result for a chapter/skill.
-      -- It makes sure that the newly inserted result is propagated.
+      -- This way we make sure that a newly inserted result is propagated.
       NEW.latest_activity_at <> '1000-01-01 00:00:00',
       'unchanged',
       'modified');

--- a/db/migrations/2409290724_create_trigger_before_update_results.sql
+++ b/db/migrations/2409290724_create_trigger_before_update_results.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+DROP TRIGGER IF EXISTS `before_update_results`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_results`
+  BEFORE UPDATE
+  ON `results`
+  FOR EACH ROW
+BEGIN
+  IF NEW.recomputing_state = 'recomputing' THEN
+    SET NEW.recomputing_state = IF(
+      NEW.latest_activity_at <=> OLD.latest_activity_at AND
+      NEW.tasks_tried <=> OLD.tasks_tried AND
+      NEW.tasks_with_help <=> OLD.tasks_with_help AND
+      NEW.validated_at <=> OLD.validated_at AND
+      NEW.score_computed <=> OLD.score_computed AND
+      -- We always consider results with the default latest_activity_at as changed
+      -- because they look like a newly inserted result for a chapter/skill.
+      -- It makes sure that the newly inserted result is propagated.
+      NEW.latest_activity_at <> '1000-01-01 00:00:00',
+      'unchanged',
+      'modified');
+  END IF;
+END;
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `before_update_results`;

--- a/db/migrations/2409300018_add_enum_value_recomputing_into_results_propagate_state.sql
+++ b/db/migrations/2409300018_add_enum_value_recomputing_into_results_propagate_state.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `results_propagate` MODIFY `state` ENUM('to_be_propagated','to_be_recomputed','propagating', 'recomputing') NOT NULL COMMENT '"to_be_propagated" means that ancestors should be recomputed';
+
+-- +migrate Down
+ALTER TABLE `results_propagate` MODIFY `state` ENUM('to_be_propagated','to_be_recomputed','propagating') NOT NULL COMMENT '"to_be_propagated" means that ancestors should be recomputed';


### PR DESCRIPTION
1. Speed up the results propagation by propagating only results modified during recomputation instead of propagating all the recomputed results. It makes the results propagation an order of magnitude faster.
2. Split the results recomputation into atomic chunks of 1000 results instead of recomputing all results marked as 'to_be_recomputed' at once. This way, the results propagation will not lock the DB no matter how many results marked as 'to_be_recomputed' will be there.
3. Introduce a new command 'recompute-results' allowing to recompute results of all the chapters/skills one by one without locking the DB.

After this task is deployed, it will finally be possible to finish the deployment of #1177 by simply running 'AlgoreaBackend db-recompute'.