### PR TITLE
Refactor cucumber test helpers

### DIFF
--- a/app/api/answers/create_answer.feature
+++ b/app/api/answers/create_answer.feature
@@ -3,28 +3,28 @@ Feature: Create a 'saved' answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | type |
       | 13 | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 13             |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 13             | 50      |
       | 1          | 101            | 50      |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | attempt_id | participant_id | item_id | type       | created_at          |
       | 100 | 101       | 1          | 101            | 50      | Submission | 2017-05-29 06:38:38 |
 

--- a/app/api/answers/create_answer.robustness.feature
+++ b/app/api/answers/create_answer.robustness.feature
@@ -3,27 +3,27 @@ Feature: Create a 'saved' answer - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | type |
       | 13 | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
       | 13              | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 101            | 50      |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | attempt_id | participant_id | item_id | created_at          |
       | 100 | 101       | 1          | 101            | 50      | 2017-05-29 06:38:38 |
 

--- a/app/api/answers/generate_task_token.feature
+++ b/app/api/answers/generate_task_token.feature
@@ -1,27 +1,27 @@
 Feature: Generate a read-only task token for an item from an answer
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name     | type  |
       | 101 | john     | User  |
       | 102 | team     | Team  |
       | 103 | manager  | User  |
       | 104 | Groupe A | Class |
       | 105 | jack     | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | john    | 101      |
       | manager | 103      |
       | jack    | 105      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 102             | 101            |
       | 102             | 105            |
       | 104             | 101            |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 104      | 103        | 1                 |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                    | type | entry_participant_type | default_language_tag | text_id |
       | 10 | http://taskplatform/10 | Task | User                   | fr                   | task10  |
       | 20 | http://taskplatform/20 | Task | Team                   | fr                   | task20  |
@@ -29,7 +29,7 @@ Feature: Generate a read-only task token for an item from an answer
       | 40 | http://taskplatform/40 | Task | User                   | fr                   | task40  |
       | 50 | http://taskplatform/50 | Task | User                   | fr                   | task50  |
       | 60 | http://taskplatform/60 | Task | User                   | fr                   | task60  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_watch_generated |
       | 101      | 10      | content            | none                |
       | 103      | 10      | content            | answer              |
@@ -44,14 +44,14 @@ Feature: Generate a read-only task token for an item from an answer
       | 105      | 50      | content            | answer              |
       | 102      | 60      | content            | none                |
       | 104      | 60      | content            | answer              |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 0  | 102            |
       | 1  | 102            |
       | 0  | 103            |
       | 1  | 103            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | validated_at        | hints_requested | hints_cached |
       | 0          | 101            | 10      | 2020-01-01 01:01:01 | null                | null            | 0            |
       | 0          | 103            | 10      | 2020-01-01 01:01:01 | null                | null            | 0            |
@@ -66,7 +66,7 @@ Feature: Generate a read-only task token for an item from an answer
       | 0          | 102            | 50      | 2020-01-01 01:01:01 | null                | null            | 0            |
       | 0          | 101            | 60      | 2020-01-01 01:01:01 | null                | null            | 0            |
       | 1          | 102            | 60      | 2020-01-01 01:01:01 | null                | [1,2,3,4]       | 4            |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | participant_id | attempt_id | item_id | author_id | created_at          |
       | 1  | 101            | 0          | 10      | 101       | 2020-01-01 01:01:01 |
       | 2  | 102            | 0          | 20      | 105       | 2020-01-01 01:01:01 |

--- a/app/api/answers/generate_task_token.robustness.feature
+++ b/app/api/answers/generate_task_token.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Generate a read-only task token for an item from an answer - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name | type |
       | 101 | john     | User |
       | 102 | team     | Team |
@@ -8,32 +8,32 @@ Feature: Generate a read-only task token for an item from an answer - robustness
       | 104 | jess     | User |
       | 105 | jim      | User |
       | 106 | Groupe A | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jack  | 103      |
       | jess  | 104      |
       | jim   | 105      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 102             | 101            |
       | 106             | 101            |
       | 106             | 103            |
       | 106             | 104            |
       | 106             | 105            |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 106      | 103        | 0                 |
       | 106      | 104        | 1                 |
       | 106      | 105        | 1                 |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | entry_participant_type | default_language_tag | text_id |
       | 10 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Chapter | Team                   | fr                   | task10  |
       | 20 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | User                   | fr                   | task20  |
       | 30 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | Team                   | fr                   | task30  |
       | 40 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | User                   | fr                   | task40  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_watch_generated |
       | 101      | 10      | content            | none                |
       | 101      | 20      | info               | none                |
@@ -43,14 +43,14 @@ Feature: Generate a read-only task token for an item from an answer - robustness
       | 104      | 40      | content            | none                |
       | 105      | 40      | content            | answer              |
       | 106      | 40      | content            | none                |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 0  | 102            |
       | 0  | 103            |
       | 0  | 104            |
       | 0  | 105            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 0          | 101            | 10      | 2020-01-01 01:01:01 |
       | 0          | 101            | 20      | 2020-01-01 01:01:01 |
@@ -63,7 +63,7 @@ Feature: Generate a read-only task token for an item from an answer - robustness
       | 0          | 103            | 40      | 2020-01-01 01:01:01 |
       | 0          | 104            | 40      | 2020-01-01 01:01:01 |
       | 0          | 105            | 40      | null                |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | participant_id | attempt_id | item_id | author_id  | created_at          |
       | 1  | 101            | 0          | 10      | 101        | 2020-01-01 01:01:01 |
       | 2  | 101            | 0          | 20      | 101        | 2020-01-01 01:01:01 |

--- a/app/api/answers/get_answer.feature
+++ b/app/api/answers/get_answer.feature
@@ -1,6 +1,6 @@
 Feature: Get an answer by id
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | type  |
     | 11 | jdoe    | User  |
     | 13 | Group B | Class |
@@ -9,12 +9,12 @@ Background:
     | 24 | jane    | User  |
     | 25 | Group D | Class |
     | 26 | Club    | Club  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id | first_name | last_name |
     | jdoe  | 0         | 11       | John       | Doe       |
     | other | 0         | 21       | George     | Bush      |
     | jane  | 0         | 24       | Jane       | Doe       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 13              | 21             |
@@ -22,28 +22,28 @@ Background:
     | 25              | 24             |
     | 26              | 13             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | default_language_tag |
     | 200 | fr                   |
     | 210 | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       | can_watch_generated |
     | 13       | 200     | content                  | none                |
     | 23       | 210     | content_with_descendants | none                |
     | 25       | 210     | none                     | answer              |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 11             | 200     |
     | 1          | 13             | 210     |
-  And the database has the following table 'answers':
+  And the database has the following table "answers":
     | id  | author_id | participant_id | attempt_id | item_id | type       | state  | answer   | created_at          |
     | 101 | 11        | 11             | 1          | 200     | Submission | State1 | print(1) | 2017-05-29 06:38:38 |
     | 102 | 11        | 13             | 1          | 210     | Submission | State2 | print(2) | 2017-05-29 06:38:38 |
-  And the database has the following table 'gradings':
+  And the database has the following table "gradings":
     | answer_id | score | graded_at           |
     | 101       | 100   | 2018-05-29 06:38:38 |
     | 102       | 100   | 2019-05-29 06:38:38 |
-  And the database has the following table 'group_managers':
+  And the database has the following table "group_managers":
     | group_id | manager_id | can_watch_members |
     | 26       | 25         | true              |
 

--- a/app/api/answers/get_answer.robustness.feature
+++ b/app/api/answers/get_answer.robustness.feature
@@ -1,28 +1,28 @@
 Feature: Get user's answer by id
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name | type |
       | 11 | jdoe | User |
       | 13 | team | Team |
       | 14 | jane | User |
       | 15 | bill | User |
       | 16 | jeff | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | jdoe  | 11       |
       | jane  | 14       |
       | bill  | 15       |
       | jeff  | 16       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 14             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | entry_participant_type | default_language_tag |
       | 200 | User                   | fr                   |
       | 210 | Team                   | fr                   |
       | 220 | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | item_id | group_id | can_view_generated | can_watch_generated |
       | 200     | 11       | info               | none                |
       | 200     | 14       | none               | none                |
@@ -30,25 +30,25 @@ Feature: Get user's answer by id
       | 200     | 16       | content            | result              |
       | 200     | 17       | content            | answer              |
       | 220     | 14       | content            | none                |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 11             |
       | 1  | 13             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 11             | 200     |
       | 1          | 13             | 210     |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | type       | state    | answer   | created_at          |
       | 101 | 11        | 11             | 1          | 200     | Submission | State101 | print(1) | 2017-05-29 06:38:38 |
       | 102 | 11        | 11             | 1          | 200     | Submission | State102 | print(1) | 2017-05-29 06:38:38 |
       | 103 | 11        | 13             | 1          | 200     | Submission | State103 | print(1) | 2017-05-29 06:38:38 |
       | 104 | 11        | 11             | 1          | 220     | Submission | State104 | print(1) | 2017-05-29 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | score | graded_at           |
       | 101       | 100   | 2018-05-29 06:38:38 |
       | 102       | 100   | 2019-05-29 06:38:38 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 15         | false             |
       | 13       | 16         | true              |

--- a/app/api/answers/get_best.feature
+++ b/app/api/answers/get_best.feature
@@ -1,6 +1,6 @@
 Feature: Get a current answer
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id  | name         | type  |
     | 11  | jdoe         | User  |
     | 12  | jdoenoanswer | User  |
@@ -10,36 +10,36 @@ Background:
     | 21  | manager      | User  |
     | 23  | Group C      | Class |
     | 100 | top          | User  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login        | group_id | first_name   | last_name |
     | jdoe         | 11       | John         | Doe       |
     | jdoenoanswer | 12       | JohnNoAnswer | Doe       |
     | manager      | 21       | Man          | Ager      |
     | top          | 100      | Top          | Score     |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 14              | 11             |
     | 13              | 21             |
     | 15              | 21             |
     | 23              | 21             |
   And the groups ancestors are computed
-  And the database has the following table 'group_managers':
+  And the database has the following table "group_managers":
     | group_id | manager_id | can_watch_members |
     | 13       | 21         | true              |
     | 15       | 21         | true              |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | default_language_tag |
     | 200 | fr                   |
     | 210 | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       | can_watch_generated |
     | 12       | 200     | content                  | answer              |
     | 13       | 200     | content                  | answer              |
     | 14       | 200     | content                  | none                |
     | 15       | 200     | content                  | answer              |
     | 23       | 210     | content_with_descendants | answer              |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 11             | 200     |
     | 2          | 11             | 200     |
@@ -49,7 +49,7 @@ Background:
     | 1          | 13             | 210     |
     | 1          | 11             | 210     |
     | 1          | 100            | 210     |
-  And the database has the following table 'answers':
+  And the database has the following table "answers":
     | id  | author_id | participant_id | attempt_id | item_id | type       | state    | answer    | created_at          |
     | 101 | 11        | 11             | 1          | 200     | Submission | State101 | print(1)  | 2020-01-01 06:00:00 |
     | 102 | 11        | 11             | 2          | 200     | Submission | State102 | print(2)  | 2020-01-01 07:00:00 |
@@ -62,7 +62,7 @@ Background:
     | 109 | 11        | 11             | 1          | 210     | Submission | State109 | print(9)  | 2020-01-01 14:00:00 |
     | 110 | 100       | 100            | 1          | 200     | Submission | State110 | print(10) | 2020-01-01 15:00:00 |
     | 111 | 100       | 100            | 1          | 210     | Submission | State111 | print(11) | 2020-01-01 16:00:00 |
-  And the database has the following table 'gradings':
+  And the database has the following table "gradings":
     | answer_id | score | graded_at           |
     | 101       | 91    | 2020-01-01 06:00:01 |
     | 102       | 97    | 2020-01-01 07:00:01 |

--- a/app/api/answers/get_best.robustness.feature
+++ b/app/api/answers/get_best.robustness.feature
@@ -1,46 +1,46 @@
 Feature: Get the best answer - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type |
       | 11 | jdoe    | User |
       | 12 | manager | User |
       | 13 | team    | Team |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | jdoe    | 11       |
       | manager | 12       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | entry_participant_type | default_language_tag |
       | 200 | User                   | fr                   |
       | 210 | Team                   | fr                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 12             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 12         | true              |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | item_id | group_id | can_view_generated | can_watch_generated |
       | 200     | 11       | info               | none                |
       | 210     | 11       | content            | answer              |
       | 210     | 12       | content            | result              |
       | 210     | 13       | content            | answer              |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 11             |
       | 2  | 13             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 11             | 200     |
       | 2          | 13             | 210     |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | type          | state    | answer   | created_at          |
       | 101 | 11        | 11             | 1          | 200     | Submission    | State101 | print(1) | 2020-01-01 06:00:00 |
       | 102 | 13        | 13             | 2          | 210     | Submission    | State102 | print(3) | 2020-01-01 06:00:00 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | score | graded_at           |
       | 101       | 100   | 2020-01-01 06:00:00 |
       | 102       | 100   | 2020-01-01 06:00:00 |

--- a/app/api/answers/get_current.feature
+++ b/app/api/answers/get_current.feature
@@ -1,38 +1,38 @@
 Feature: Get a current answer
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | type  |
     | 11 | jdoe    | User  |
     | 13 | Team    | Team  |
     | 14 | Group B | Class |
     | 21 | other   | User  |
     | 23 | Group C | Class |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id | first_name | last_name |
     | jdoe  | 0         | 11       | John       | Doe       |
     | other | 0         | 21       | George     | Bush      |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 14              | 11             |
     | 13              | 21             |
     | 23              | 21             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | default_language_tag |
     | 200 | fr                   |
     | 210 | fr                   |
     | 220 | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 14       | 200     | content                  |
     | 23       | 210     | content_with_descendants |
     | 11       | 220     | content                  |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 11             | 200     |
     | 1          | 11             | 220     |
     | 1          | 13             | 210     |
-  And the database has the following table 'answers':
+  And the database has the following table "answers":
     | id  | author_id | participant_id | attempt_id | item_id | type       | state   | answer   | created_at          |
     |   1 | 11        | 11             | 1          | 200     | Submission | State1 | print(1) | 2017-05-29 06:38:37 |
     |   2 | 11        | 11             | 1          | 200     | Saved      | State2 | print(2) | 2017-05-29 06:38:37 |
@@ -53,7 +53,7 @@ Background:
     | 205 | 11        | 13             | 1          | 210     | Saved      | State205 | print(5) | 2017-05-29 06:38:38 |
     | 206 | 11        | 13             | 2          | 210     | Current    | State206 | print(6) | 2017-05-29 06:38:38 |
     | 207 | 11        | 11             | 2          | 200     | Current    | State207 | print(7) | 2018-05-29 06:38:37 |
-  And the database has the following table 'gradings':
+  And the database has the following table "gradings":
     | answer_id | score | graded_at           |
     | 101       | 91    | 2018-05-29 06:38:31 |
     | 102       | 92    | 2019-05-29 06:38:32 |

--- a/app/api/answers/get_current.robustness.feature
+++ b/app/api/answers/get_current.robustness.feature
@@ -1,35 +1,35 @@
 Feature: Get a current answer - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name | type |
       | 11 | jdoe | User |
       | 13 | team | Team |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | jdoe  | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | entry_participant_type | default_language_tag |
       | 200 | User                   | fr                   |
       | 210 | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | item_id | group_id | can_view_generated |
       | 200     | 11       | info               |
       | 210     | 11       | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 11             |
       | 1  | 13             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 11             | 200     |
       | 1          | 13             | 210     |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | type       | state    | answer   | created_at          |
       | 101 | 11        | 11             | 1          | 200     | Current    | State101 | print(1) | 2017-05-29 06:38:38 |
       | 102 | 11        | 11             | 1          | 200     | Current    | State102 | print(1) | 2017-05-29 06:38:38 |
       | 103 | 11        | 11             | 1          | 210     | Submission | State103 | print(1) | 2017-05-29 06:38:38 |
       | 104 | 11        | 11             | 2          | 210     | Current    | State104 | print(1) | 2017-05-29 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | score | graded_at           |
       | 101       | 100   | 2018-05-29 06:38:38 |
       | 102       | 100   | 2019-05-29 06:38:38 |

--- a/app/api/answers/list_answers.robustness.feature
+++ b/app/api/answers/list_answers.robustness.feature
@@ -1,17 +1,17 @@
 Feature: List answers - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name | type |
     | 1  | jdoe | User |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 1        |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 1        | 190     | content_with_descendants |
     | 1        | 200     | none                     |

--- a/app/api/answers/list_answers_with_attempt_id.feature
+++ b/app/api/answers/list_answers_with_attempt_id.feature
@@ -1,49 +1,49 @@
 Feature: List answers by attempt_id
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 21 | owner   | -2    | User  |
     | 41 | Group C | -2    | Class |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id | first_name  | last_name |
     | jdoe  | 0         | 11       | John        | Doe       |
     | owner | 0         | 21       | Jean-Michel | Blanquer  |
-  And the database has the following table 'group_managers':
+  And the database has the following table "group_managers":
     | group_id | manager_id |
     | 13       | 21         |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id | personal_info_view_approved_at |
     | 13              | 11             | 2019-05-30 11:00:00            |
     | 41              | 21             | null                           |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content                  |
     | 41       | 200     | content_with_descendants |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id |
     | 1  | 11             |
     | 2  | 11             |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 11             | 200     |
     | 2          | 11             | 200     |
     | 1          | 11             | 210     |
-  And the database has the following table 'answers':
+  And the database has the following table "answers":
     | id | author_id | participant_id | attempt_id | item_id | type       | state  | created_at          |
     | 1  | 11        | 11             | 1          | 200     | Submission | State1 | 2017-05-29 06:38:38 |
     | 2  | 11        | 11             | 2          | 200     | Submission | State2 | 2017-05-29 06:38:38 |
     | 3  | 11        | 11             | 1          | 210     | Submission | State3 | 2017-05-29 06:38:38 |
-  And the database has the following table 'gradings':
+  And the database has the following table "gradings":
     | answer_id | score | graded_at           |
     | 1         | 100   | 2018-05-29 06:38:38 |
     | 2         | 100   | 2019-05-29 06:38:38 |

--- a/app/api/answers/list_answers_with_attempt_id.robustness.feature
+++ b/app/api/answers/list_answers_with_attempt_id.robustness.feature
@@ -1,33 +1,33 @@
 Feature: List answers by attempt_id - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 21 | guest   | -2    | User  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
     | guest | 0         | 21       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | info                     |
     | 21       | 190     | content_with_descendants |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id |
     | 1  | 13             |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 13             | 190     |
     | 1          | 13             | 210     |

--- a/app/api/answers/list_answers_with_author_id.feature
+++ b/app/api/answers/list_answers_with_author_id.feature
@@ -1,6 +1,6 @@
 Feature: List answers by (item_id, author_id) pair
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
@@ -8,32 +8,32 @@ Background:
     | 23 | Group C | -2    | Class |
     | 24 | Group D | -2    | Class |
     | 25 | jane    | -2    | User  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id | first_name | last_name |
     | jdoe  | 0         | 11       | John       | Doe       |
     | other | 0         | 21       | George     | Bush      |
     | jane  | 0         | 25       | Jane       | Doe       |
-  And the database has the following table 'group_managers':
+  And the database has the following table "group_managers":
     | group_id | manager_id |
     | 13       | 21         |
     | 24       | 21         |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id | personal_info_view_approved_at |
     | 13              | 11             | 2019-05-30 11:00:00            |
     | 13              | 25             | null                           |
     | 23              | 25             | 2019-05-30 11:00:00            |
     | 23              | 21             | null                           |
   And the groups ancestors are computed
-  And the database has the following table 'group_pending_requests':
+  And the database has the following table "group_pending_requests":
     | group_id | member_id | personal_info_view_approved |
     | 13       | 25        | true                        |
     | 23       | 25        | true                        |
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
@@ -41,24 +41,24 @@ Background:
     | 23       | 190     | none                     |
     | 23       | 200     | content_with_descendants |
     | 23       | 210     | info                     |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id |
     | 1  | 11             |
     | 2  | 11             |
     | 1  | 13             |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id |
     | 1          | 11             | 200     |
     | 2          | 11             | 200     |
     | 1          | 11             | 210     |
     | 1          | 13             | 200     |
-  And the database has the following table 'answers':
+  And the database has the following table "answers":
     | id | author_id | attempt_id | participant_id | item_id | type       | state  | created_at          |
     | 1  | 11        | 1          | 11             | 200     | Submission | State1 | 2017-05-29 06:37:38 |
     | 2  | 11        | 2          | 11             | 200     | Submission | State2 | 2017-05-29 06:38:38 |
     | 3  | 11        | 1          | 11             | 210     | Submission | State3 | 2017-05-29 06:39:38 |
     | 4  | 25        | 1          | 13             | 200     | Submission | State4 | 2017-05-29 06:39:38 |
-  And the database has the following table 'gradings':
+  And the database has the following table "gradings":
     | answer_id | score | graded_at           |
     | 1         | 100   | 2018-05-29 06:38:38 |
     | 2         | 100   | 2019-05-29 06:38:38 |

--- a/app/api/answers/list_answers_with_author_id.robustness.feature
+++ b/app/api/answers/list_answers_with_author_id.robustness.feature
@@ -1,24 +1,24 @@
 Feature: List answers by (item_id, author_id) pair - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id  | name    | grade | type  |
     | 11  | jdoe    | -2    | User  |
     | 13  | Group B | -2    | Class |
     | 404 | guest   | -2    | Class |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
     | guest | 0         | 404      |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |

--- a/app/api/answers/submit.feature
+++ b/app/api/answers/submit.feature
@@ -3,33 +3,33 @@ Feature: Submit a new answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | name | type |
       | 201 | team | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
       | 201             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 10 | fr                   |
       | 50 | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
       | 201      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 101            |
       | 1  | 201            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested                 | hints_cached | submissions | latest_activity_at  | started_at          |
       | 1          | 101            | 50      | [{"rotorIndex":0,"cellRank":0}] | 12           | 2           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
       | 1          | 101            | 10      | null                            | 0            | 0           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |

--- a/app/api/answers/submit.robustness.feature
+++ b/app/api/answers/submit.robustness.feature
@@ -3,22 +3,22 @@ Feature: Submit a new answer - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | read_only | default_language_tag |
       | 50 | 1         | fr                   |
       | 60 | 0         | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
       | 101      | 60      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | allows_submissions_until |
       | 101            | 1  | 2019-05-30 11:00:00      |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id |
       | 101            | 1          | 60      |
 

--- a/app/api/answers/update_current.feature
+++ b/app/api/answers/update_current.feature
@@ -3,28 +3,28 @@ Feature: Update the 'current' answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | type |
       | 13 | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 13             |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 13             | 50      |
       | 1          | 101            | 50      |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | type       | created_at          |
       | 100 | 101       | 101            | 1          | 50      | Submission | 2017-05-29 06:38:38 |
 
@@ -74,7 +74,7 @@ Feature: Update the 'current' answer
 
   Scenario: User is able to replace the 'current' answer
     Given I am the user with id "101"
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | author_id | participant_id | attempt_id | item_id | type    | created_at          |
       | 101       | 101            | 1          | 50      | Current | 2017-05-29 06:38:38 |
     When I send a PUT request to "/items/50/attempts/1/answers/current" with the following body:

--- a/app/api/answers/update_current.robustness.feature
+++ b/app/api/answers/update_current.robustness.feature
@@ -3,23 +3,23 @@ Feature: Update participant's current answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 1          | 101            | 50      |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 100 | 101       | 101            | 1          | 50      | 2017-05-29 06:38:38 |
 

--- a/app/api/auth/create_access_token.feature
+++ b/app/api/auth/create_access_token.feature
@@ -12,11 +12,11 @@ Feature: Create an access token
           allUsersGroup: 2
           TempUsersGroup: 4
       """
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name      | type | created_at          |
       | 2  | AllUsers  | Base | 2020-01-01 00:00:00 |
       | 4  | TempUsers | Base | 2020-01-01 00:00:00 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 4              |
 
@@ -184,24 +184,24 @@ Feature: Create an access token
         "badges":null,"client_id":null,"verification":null,"subscription_news":false
       }
       """
-    And the database table 'groups' has also the following rows:
+    And the database table "groups" has also the following rows:
       | id | name     | type | description | created_at          | is_open | send_emails |
       | 11 | mohammed | User | mohammed    | 2019-05-10 10:42:11 | false   | true        |
       | 13 | john     | User | john        | 2018-05-10 10:42:11 | false   | false       |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | latest_login_at     | latest_activity_at  | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address           | zipcode  | city                | land_line_number  | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip     | time_zone     | notify_news | photo_autoload | public_first_name | public_last_name |
       | 11       | 2019-06-16 21:01:25 | 2019-06-16 22:05:44 | 2019-05-10 10:42:11 | 2019-05-11 10:42:11    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | Rue Tebessi Larbi | 16000    | Algiers             | +213 778 02 85 31 | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 192.168.0.1 | Europe/Moscow | true        | false          | false             | false            |
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | 2019-05-11 10:42:11    | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 | null          | true        | false          | false             | false            |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 11             |
       | 2               | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token         |
       | 1          | 11      | previousrefreshtoken1 |
       | 2          | 13      | previousrefreshtoken2 |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token                | expires_at          | issued_at           |
       | 1          | previousaccesstoken1 | 2020-06-16 22:02:49 | 2019-07-16 22:02:28 |
       | 2          | previousaccesstoken2 | 2020-06-16 22:02:49 | 2019-07-16 22:02:28 |
@@ -267,10 +267,10 @@ Feature: Create an access token
         clientSecret: "tzxsLyFtJiGnmD6sjZMqSEidVpVsL3hEoSxIXCpI"
       """
     And the template constant "code_from_oauth" is "somecode"
-    And the database table 'groups' has also the following rows:
+    And the database table "groups" has also the following rows:
       | id | name     | type | description | created_at          | is_open | send_emails |
       | 11 | mohammed | User | mohammed    | 2019-05-10 10:42:11 | false   | true        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | latest_login_at     | latest_activity_at  | registered_at       | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address           | zipcode | city    | land_line_number  | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip     |
       | 11       | 2019-06-16 21:01:25 | 2019-06-16 22:05:44 | 2019-05-10 10:42:11 | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | Rue Tebessi Larbi | 16000   | Algiers | +213 778 02 85 31 | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 192.168.0.1 |
     And the groups ancestors are computed
@@ -392,24 +392,24 @@ Feature: Create an access token
     And the template constant "code_from_oauth" is "someanothercode"
     And the template constant "access_token_from_oauth" is "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImU3ODI4N2I2MjhhMjhlYmQ0NGU3ZDYwMGI3YzQ2MmQzMzFiZWUyZjg2ZWE2NGQ4MzNiOTBhMjJkYTNkYThmZjRlYzMyYTFiN2EyNDA2MWZmIn0.eyJhdWQiOiIxIiwianRpIjoiZTc4Mjg3YjYyOGEyOGViZDQ0ZTdkNjAwYjdjNDYyZDMzMWJlZTJmODZlYTY0ZDgzM2I5MGEyMmRhM2RhOGZmNGVjMzJhMWI3YTI0MDYxZmYiLCJpYXQiOjE1NjM4NDg4MjIsIm5iZiI6MTU2Mzg0ODgyMiwiZXhwIjoxNTk1NDcxMjIyLCJzdWIiOiIxMDAwMDAwMDEiLCJzY29wZXMiOlsiYWNjb3VudCJdfQ.W6aP5IdCRTGGlNp8IK-YF4lzoKD07ilv4xhNoNjyVdJkGic8eP4lnTE4s1NSvNxsrXkiYvwt78QAbQL6uCTqhdI-NHxDYOW-2EWUFYwRZxuLXqYuNkZD7iq9bN6kwLaZEUy-YpBIegC1bHUtKrUAHtS_4ZulNsJaN57V6M_W0VtiYDdox9OXzfAswWtHgedx6lNo-WfRhxfLf8gkWVHd6pRzYcKTWB3eeEy_lxNdw_v78IOM1WcdClp59pZT5C66OtQPhpOkHe33hMZgPuiVq887pwbIN3eaqXbX0D1CiELy_3NXMGFQoMBY8JHkch-2yJmOS-nA0vlUOpj4ddjfW8Rt15Yjq6Nuwy0okvzy5hlcK5vHnx9ORyyW9iEF2IK8Nt07nBrk-9scIhNLverdyL62gKJdrWvcn1gEHbCdY3A-0WPYhZ6sjH1NG2wmIcctjHe3ZCaP9JmEtdKH9RGQ5tnxoaA9H0ouJiXBrcc5uZ5h4nQqwZ5Cwf6--inkMe9kGmlq5AgqWZqpXpY11I9XInK6zjBngn2fEwgg0nRz72RK1i3s65YO8p7MiDTSE1_dMy72OQrA943HvrPd51SoJUmPI_VprG6Ayekyl_CJzIhF4vCyH6uWl8K4l83xxx6lXiVxfv0gl4bdQLBKlpku55rzMCNt34bHZHvH4vL4qzk"
     And the template constant "refresh_token_from_oauth" is "def502004ce3901576b99f1db359f8a5d2192336218515e7ca08fd2b923df4eb87c163d1660997f90cc16f4da734b9cb1ebff982574e4bc85c7d2de97cf4712dee42b7b729732c62d957a2e3c74d5b306d5b23bdf7be64074988a8f95e629709101a7f62f1ee36c3ece2e4ddf2f83ada76048276a3317ac6773a79968f1bc9ab5f16cb561e7547210a3bca354bfa36228da67dada8f68b5ad3d0d98b54222b18fdd46ad5ef47ce29cecbba63c6611604e8338dadeaa27de719fbe8479ffe49d8831d78ee825b37521215997ba139ae0d39534dc543f9d31e67a50dd03cd1c46fbf0990bcf89921307c4c85dd94c28158a5e28f3fd88d12b581d7da6aa2615930844329579c18ef1c1390cd17b1baf7236d82c59e80cbc7e68ed6c0ae35cabce1bfeb9ea29b50cd087ed1caadca5cad8f680d1c9ce5296da2da40479849d66b6ef31e1f2bc4f9bb094d288d331e94fe1e4e52526145b0f03a2a7b1c7743cd99ae79e2abaf2b92b87081bc014fcc65304cb1cb"
-    And the database table 'groups' has also the following rows:
+    And the database table "groups" has also the following rows:
       | id | name     | type | description | created_at          | is_open | send_emails |
       | 11 | mohammed | User | mohammed    | 2019-05-10 10:42:11 | false   | true        |
       | 13 | john     | User | john        | 2018-05-10 10:42:11 | false   | false       |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | latest_login_at     | latest_activity_at  | registered_at       | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address           | zipcode  | city                | land_line_number  | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip     |
       | 11       | 2019-06-16 21:01:25 | 2019-06-16 22:05:44 | 2019-05-10 10:42:11 | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | Rue Tebessi Larbi | 16000    | Algiers             | +213 778 02 85 31 | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 192.168.0.1 |
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 11             |
       | 2               | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token         |
       | 1          | 11      | previousrefreshtoken1 |
       | 2          | 13      | previousrefreshtoken2 |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token                | expires_at          | issued_at           |
       | 1          | previousaccesstoken1 | 2020-06-16 22:02:49 | 2019-06-16 22:02:28 |
       | 2          | previousaccesstoken2 | 2020-06-16 22:02:49 | 2019-06-16 22:02:28 |
@@ -827,7 +827,7 @@ Feature: Create an access token
         ],
       "client_id":1,"verification":[],"subscription_news":true}
       """
-    And the database table 'groups' has also the following rows:
+    And the database table "groups" has also the following rows:
       | id                  | name       | type  | description | is_open | send_emails | text_id                                 | require_personal_info_access_approval |
       | 8674665223082153551 | Example #1 | Other | null        | false   | false       | https://badges.example.com/examples/one | edit                                  |
     When I send a POST request to "/auth/token?code={{code_from_oauth}}&code_verifier=123456&redirect_uri=http%3A%2F%2Fmy.url"

--- a/app/api/auth/create_temp_user.feature
+++ b/app/api/auth/create_temp_user.feature
@@ -8,11 +8,11 @@ Feature: Create a temporary user
           allUsersGroup: 2
           tempUsersGroup: 4
       """
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name      | type | text_id   |
       | 2  | AllUsers  | Base | AllUsers  |
       | 4  | TempUsers | User | TempUsers |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 4              |
     And the time now is "2020-07-16T22:02:28Z"

--- a/app/api/auth/logout.feature
+++ b/app/api/auth/logout.feature
@@ -1,15 +1,15 @@
 Feature: Sign the current user out
   Background:
-    Given the database has the following table 'users':
+    Given the database has the following table "users":
       | group_id | login |
       | 2        | john  |
       | 3        | jane  |
     And the DB time now is "2019-07-16 22:02:28"
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token       |
       | 1          | 2       | somerefreshtoken    |
       | 2          | 3       | refreshtokenforjane |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token                     | expires_at          |
       | 1          | someaccesstoken           | 2019-07-16 22:02:29 |
       | 1          | anotheraccesstoken        | 2019-07-16 22:02:40 |
@@ -38,10 +38,10 @@ Feature: Sign the current user out
     And the table "users" should stay unchanged
 
   Scenario: Should delete only the current session on log out when there is more than one session opened for the user
-    Given the database table 'sessions' has also the following row:
+    Given the database table "sessions" has also the following row:
       | session_id | user_id | refresh_token        |
       | 3          | 2       | anothesessionforjohn |
-    And the database table 'access_tokens' has also the following row:
+    And the database table "access_tokens" has also the following row:
       | session_id | token                      | expires_at          |
       | 3          | anothersessiontokenforjohn | 2019-07-16 22:02:40 |
     And the "Authorization" request header is "Bearer someaccesstoken"
@@ -68,7 +68,7 @@ Feature: Sign the current user out
 
   Scenario Outline: The user logs out successfully with the session cookie provided
     Given the time now is "2019-07-16T22:02:28Z"
-    And the database table 'access_tokens' has also the following row:
+    And the database table "access_tokens" has also the following row:
       | session_id | token              | expires_at          |
       | 1          | onemoreaccesstoken | 2019-07-16 22:02:40 |
       | 1          | thirdaccesstoken   | 2019-07-16 22:02:40 |

--- a/app/api/auth/refresh_access_token.feature
+++ b/app/api/auth/refresh_access_token.feature
@@ -1,23 +1,23 @@
 Feature: Create a new access token
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name        | type |
       | 12 | tmp-1234567 | User |
       | 13 | jane        | User |
       | 14 | john        | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login       | temp_user |
       | 12       | tmp-1234567 | true      |
       | 13       | jane        | false     |
       | 14       | john        | false     |
     And the time now is "2020-01-01T02:00:00Z"
     And the DB time now is "2020-01-01 02:00:00"
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token             |
       | 1          | 12      |                           |
       | 2          | 13      | jane_current_refreshtoken |
       | 3          | 14      | john_current_refreshtoken |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | issued_at           | expires_at          | token              |
       | 1          | 2020-01-01 00:00:01 | 2020-01-01 02:00:01 | tmp_old_token      |
       | 1          | 2020-01-01 01:00:12 | 2020-01-01 03:00:12 | tmp_current_token  |
@@ -115,7 +115,7 @@ Feature: Create a new access token
   Scenario Outline: >
       Accepts access_token cookie and removes it if cookie attributes differ for a normal user,
       since old tokens are used, the most recent one is returned
-    Given the database table 'access_tokens' has also the following rows:
+    Given the database table "access_tokens" has also the following rows:
       | session_id | issued_at           | expires_at          | token           |
       | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old1_token |
       | 2          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | jane_old2_token |
@@ -145,7 +145,7 @@ Feature: Create a new access token
 
   Scenario Outline: Accepts access_token cookie and removes it if cookie attributes differ for a temporary user
     Given the generated auth key is "tmp_new_token"
-    And the database table 'access_tokens' has also the following rows:
+    And the database table "access_tokens" has also the following rows:
       | session_id | issued_at           | expires_at          | token          |
       | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old1_token |
       | 1          | 2020-01-01 01:00:00 | 2020-01-01 03:00:00 | tmp_old2_token |

--- a/app/api/auth/refresh_access_token.robustness.feature
+++ b/app/api/auth/refresh_access_token.robustness.feature
@@ -1,16 +1,16 @@
 Feature: Refresh an access token - robustness
   Background:
     Given the DB time now is "2020-01-01 01:00:00"
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name        | type |
       | 13 | jane        | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login       | temp_user |
       | 13       | jane        | false     |
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token |
       | 1          | 13      |               |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | issued_at           | expires_at          | token              |
       | 1          | 2019-01-01 00:00:00 | 2019-01-01 02:00:00 | jane_expired_token |
       | 1          | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 | jane_current_token |

--- a/app/api/contests/get_administered_list.feature
+++ b/app/api/contests/get_administered_list.feature
@@ -8,19 +8,19 @@ Feature: Get the contests that the user has administration rights on (contestAdm
       | admin          | 51       | en               |
       | guest          | 61       | en               |
       | panas          | 71       | uk               |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type  | name       |
       | 80 | Other | Some group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 80              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | en  |
       | fr  |
       | sl  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | default_language_tag | allows_multiple_attempts | entry_participant_type | requires_explicit_entry |
       | 10 | 00:00:02 | en                   | 0                        | Team                   | true                    |
       | 40 | 00:00:00 | fr                   | 0                        | Team                   | false                   |
@@ -29,13 +29,13 @@ Feature: Get the contests that the user has administration rights on (contestAdm
       | 70 | 00:00:03 | fr                   | 0                        | User                   | true                    |
       | 80 | 00:00:03 | sl                   | 0                        | Team                   | true                    |
       | 90 | 00:00:03 | sl                   | 0                        | User                   | true                    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 0           |
       | 10             | 70            | 1           |
       | 60             | 70            | 0           |
       | 90             | 80            | 0           |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title      |
       | 10      | en           | Chapter    |
       | 10      | fr           | Chapitre   |
@@ -45,7 +45,7 @@ Feature: Get the contests that the user has administration rights on (contestAdm
       | 70      | fr           | Concours 2 |
       | 80      | sl           | null       |
       | 90      | sl           | null       |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 21       | 40      | solution                 | enter                    | result              |
       | 21       | 50      | solution                 | enter                    | result              |

--- a/app/api/contests/get_group_by_name.feature
+++ b/app/api/contests/get_group_by_name.feature
@@ -1,6 +1,6 @@
 Feature: Get group by name (contestGetGroupByName)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 6  | Group B | Team  |
       | 7  | Group B | Team  |
@@ -14,12 +14,12 @@ Feature: Get group by name (contestGetGroupByName)
       | 31 | john    | User  |
       | 41 | jane    | User  |
       | 50 | Group D | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | john  | 31       |
       | jane  | 41       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 6        | 21         | false                  | true              |
       | 7        | 21         | true                   | false             |
@@ -28,7 +28,7 @@ Feature: Get group by name (contestGetGroupByName)
       | 16       | 21         | true                   | true              |
       | 31       | 21         | true                   | true              |
       | 41       | 21         | true                   | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 11             |
       | 10              | 13             |
@@ -42,19 +42,19 @@ Feature: Get group by name (contestGetGroupByName)
       | 50              | 15             |
       | 50              | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | entry_participant_type | default_language_tag |
       | 50 | 00:00:00 | Team                   | fr                   |
       | 60 | 00:00:01 | Team                   | fr                   |
       | 10 | 00:00:02 | User                   | fr                   |
       | 70 | 00:00:03 | Team                   | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 60               | 70            |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 16       | 70      | 16              | 9999-12-31 23:59:58 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 10       | 50      | content                  | enter                    | result              |
       | 11       | 50      | none                     | none                     | none                |
@@ -73,7 +73,7 @@ Feature: Get group by name (contestGetGroupByName)
       | 31       | 70      | content_with_descendants | none                     | none                |
       | 41       | 10      | content                  | none                     | none                |
       | 41       | 70      | content                  | none                     | none                |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 10       | 50      | 01:00:00        |
       | 11       | 50      | 00:01:00        |

--- a/app/api/contests/get_group_by_name.robustness.feature
+++ b/app/api/contests/get_group_by_name.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get group by name (contestGetGroupByName) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type |
       | 12 | Group A | Team |
       | 13 | Group B | Team |
@@ -8,17 +8,17 @@ Feature: Get group by name (contestGetGroupByName) - robustness
       | 15 | Group A | Team |
       | 21 | owner   | User |
       | 31 | john    | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 13       | 21         | true                   | true              |
       | 14       | 21         | true                   | false             |
       | 15       | 21         | false                  | true              |
       | 31       | 21         | true                   | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | default_language_tag | entry_participant_type |
       | 10 | 00:00:02 | fr                   | Team                   |
       | 11 | 00:00:02 | fr                   | Team                   |
@@ -27,7 +27,7 @@ Feature: Get group by name (contestGetGroupByName) - robustness
       | 60 | null     | fr                   | User                   |
       | 70 | 00:00:03 | fr                   | Team                   |
       | 80 | 00:00:03 | fr                   | Team                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 13       | 10      | info                     | none                     | none                |
       | 13       | 11      | info                     | none                     | none                |

--- a/app/api/contests/get_members_additional_times.feature
+++ b/app/api/contests/get_members_additional_times.feature
@@ -1,6 +1,6 @@
 Feature: Get additional times for a group of users/teams on a contest (contestListMembersAdditionalTime)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name        | type    |
       | 10 | Parent      | Club    |
       | 11 | Group A     | Friends |
@@ -14,14 +14,14 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
       | 41 | jane        | User    |
       | 51 | jack        | User    |
       | 61 | jack        | User    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | john  | 31       |
       | jane  | 41       |
       | jack  | 51       |
       | paul  | 61       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 11       | 21         | true                   | true              |
       | 13       | 21         | false                  | false             |
@@ -31,7 +31,7 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
       | 17       | 21         | false                  | false             |
       | 31       | 21         | false                  | false             |
       | 41       | 21         | false                  | false             |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 11             |
       | 10              | 13             |
@@ -47,22 +47,22 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
       | 15              | 31             |
       | 15              | 41             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | entry_participant_type | default_language_tag |
       | 50 | 00:00:00 | User                   | fr                   |
       | 60 | 00:00:01 | Team                   | fr                   |
       | 10 | 00:00:02 | User                   | fr                   |
       | 70 | 00:00:03 | Team                   | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 51       | 50      | 51              | 9999-12-31 23:59:58 | 9999-12-31 23:59:59 |
       | 61       | 50      | 61              | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 10       | 50      | none                     | none                     | none                |
       | 11       | 50      | none                     | none                     | none                |
@@ -78,7 +78,7 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
       | 31       | 70      | content_with_descendants | none                     | none                |
       | 41       | 50      | info                     | none                     | none                |
       | 41       | 70      | content                  | none                     | none                |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 10       | 50      | 01:00:00        |
       | 11       | 50      | 00:01:00        |
@@ -92,7 +92,7 @@ Feature: Get additional times for a group of users/teams on a contest (contestLi
       | 31       | 50      | 00:01:00        |
       | 31       | 70      | 00:01:00        |
       | 41       | 70      | 00:01:00        |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 13             | 1  | 60           |
       | 15             | 1  | 60           |

--- a/app/api/contests/get_members_additional_times.robustness.feature
+++ b/app/api/contests/get_members_additional_times.robustness.feature
@@ -1,28 +1,28 @@
 Feature: Get additional times for a group of users/teams on a contest (contestListMembersAdditionalTime) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    |
       | 12 | Group A |
       | 13 | Group B |
       | 14 | Group C |
       | 15 | Group D |
       | 21 | owner   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 13       | 21         | true                   | true              |
       | 14       | 21         | true                   | false             |
       | 15       | 21         | false                  | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | default_language_tag |
       | 50 | 00:00:00 | fr                   |
       | 60 | null     | fr                   |
       | 10 | 00:00:02 | fr                   |
       | 70 | 00:00:03 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 13       | 50      | content                  | none                     | none                |
       | 13       | 60      | info                     | none                     | none                |

--- a/app/api/contests/set_additional_time.feature
+++ b/app/api/contests/set_additional_time.feature
@@ -1,6 +1,6 @@
 Feature: Set additional time in the contest for the group (contestSetAdditionalTime)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    |
       | 10 | Parent  | Club    |
       | 11 | Group A | Class   |
@@ -14,18 +14,18 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 34 | item50  | Other   |
       | 35 | item60  | Other   |
       | 36 | item70  | Other   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | john  | 31       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 13       | 21         | true                   | true              |
       | 14       | 21         | false                  | false             |
       | 15       | 21         | true                   | true              |
       | 16       | 21         | true                   | true              |
       | 31       | 21         | true                   | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 10              | 11             | 9999-12-31 23:59:59 |
       | 10              | 21             | 9999-12-31 23:59:59 |
@@ -39,21 +39,21 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 36              | 16             | 2018-12-31 23:59:59 |
       | 36              | 31             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | participants_group_id | default_language_tag |
       | 10 | 00:00:02 | 33                    | fr                   |
       | 50 | 00:00:00 | 34                    | fr                   |
       | 60 | 00:00:01 | 35                    | fr                   |
       | 70 | 00:00:03 | 36                    | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
       | 10               | 70            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 1           |
       | 10             | 70            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 10       | 50      | none                     | enter                    | none                |
       | 11       | 50      | none                     | none                     | none                |
@@ -65,7 +65,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21       | 60      | content_with_descendants | none                     | none                |
       | 21       | 70      | content_with_descendants | content                  | answer              |
       | 36       | 10      | info                     | none                     | none                |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 10       | 50      | 01:00:00        |
       | 11       | 50      | 00:01:00        |
@@ -74,7 +74,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21       | 50      | 00:01:00        |
       | 21       | 60      | 00:01:00        |
       | 21       | 70      | 00:01:00        |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until | ended_at            |
       | 1  | 13             | 3018-05-29 06:38:38 | 21         | 0                 | 50           | 2018-12-31 23:59:59      | null                |
       | 1  | 14             | 3019-05-29 06:38:38 | 21         | 0                 | 50           | 9999-12-31 23:59:59      | 2019-05-30 11:00:00 |
@@ -82,7 +82,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 1  | 16             | 3019-05-29 06:38:38 | 21         | 0                 | 70           | 2018-12-31 23:59:59      | null                |
       | 1  | 31             | 3017-05-29 06:38:38 | 21         | 0                 | 70           | 9999-12-31 23:59:59      | null                |
       | 2  | 14             | 3019-05-29 06:38:38 | 21         | 0                 | 50           | 9999-12-31 23:59:59      | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 13             | 50      | 3018-05-29 06:38:38 |
       | 1          | 13             | 70      | 3018-05-29 06:38:38 |

--- a/app/api/contests/set_additional_time.robustness.feature
+++ b/app/api/contests/set_additional_time.robustness.feature
@@ -1,24 +1,24 @@
 Feature: Set additional time in the contest for the group (contestSetAdditionalTime) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 12 | Group A | Class |
       | 13 | Group B | Other |
       | 14 | Group C | Other |
       | 21 | owner   | User  |
       | 31 | john    | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | john  | 31       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access | can_watch_members |
       | 12       | 21         | false                  | true              |
       | 13       | 21         | true                   | true              |
       | 14       | 21         | true                   | false             |
       | 31       | 21         | true                   | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | entry_participant_type | default_language_tag |
       | 50 | 00:00:00 | User                   | fr                   |
       | 60 | null     | User                   | fr                   |
@@ -27,7 +27,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 80 | 00:00:04 | Team                   | fr                   |
       | 90 | 00:00:04 | Team                   | fr                   |
       | 95 | 00:00:04 | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated |
       | 13       | 50      | content                  | enter                    | result              |
       | 13       | 60      | content_with_descendants | enter                    | result              |
@@ -38,7 +38,7 @@ Feature: Set additional time in the contest for the group (contestSetAdditionalT
       | 21       | 80      | content                  | enter                    | result              |
       | 21       | 90      | content                  | enter                    | none                |
       | 21       | 95      | info                     | enter                    | result              |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 13       | 50      | 01:00:00        |
       | 13       | 60      | 01:01:00        |

--- a/app/api/currentuser/accept_group_invitation.feature
+++ b/app/api/currentuser/accept_group_invitation.feature
@@ -1,44 +1,44 @@
 Feature: User accepts an invitation to join a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | require_personal_info_access_approval |
       | 11 | none                                  |
       | 14 | none                                  |
       | 15 | view                                  |
       | 21 | none                                  |
       | 22 | none                                  |
-    Given the database has the following table 'users':
+    Given the database has the following table "users":
       | group_id |
       | 21       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 14              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 30 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 20      | content            |
       | 15       | 20      | info               |
       | 21       | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 21             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 21             | 30      |
 
   Scenario: Successfully accept an invitation
     Given I am the user with id "21"
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 11       | 21        | invitation |
     When I send a POST request to "/current-user/group-invitations/11/accept"
@@ -77,7 +77,7 @@ Feature: User accepts an invitation to join a group
 
   Scenario: Successfully accept an invitation into a group that requires approvals
     Given I am the user with id "21"
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 15       | 21        | invitation |
     When I send a POST request to "/current-user/group-invitations/15/accept?approvals=personal_info_view,lock_membership,watch"

--- a/app/api/currentuser/accept_group_invitation.robustness.feature
+++ b/app/api/currentuser/accept_group_invitation.robustness.feature
@@ -1,6 +1,6 @@
 Feature: User accepts an invitation to join a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | require_personal_info_access_approval | frozen_membership |
       | 11 | Class   | none                                  | false             |
       | 13 | Friends | none                                  | false             |
@@ -10,19 +10,19 @@ Feature: User accepts an invitation to join a group - robustness
       | 17 | Team    | none                                  | true              |
       | 21 | User    | none                                  | false             |
       | 22 | User    | none                                  | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login | temp_user |
       | 21       | john  | false     |
       | 22       | tmp   | true      |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 1234 | fr                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 14              | 21             |
       | 21              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 11       | 21        | join_request |
       | 13       | 21        | invitation   |
@@ -30,7 +30,7 @@ Feature: User accepts an invitation to join a group - robustness
       | 14       | 22        | invitation   |
       | 16       | 21        | invitation   |
       | 17       | 21        | invitation   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 14             | 1  | 1234         |
       | 15             | 2  | 1234         |
@@ -82,13 +82,13 @@ Feature: User accepts an invitation to join a group - robustness
 
   Scenario: User tries to accept an invitation to join a team while entry conditions would not be met if he joins
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_max_team_size |
       | 2  | fr                   | 0                   |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 16             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 16             | 1          | 2       | 2019-05-30 11:00:00 |
     When I send a POST request to "/current-user/group-invitations/16/accept?approvals=personal_info_view"

--- a/app/api/currentuser/create_group_join_request.feature
+++ b/app/api/currentuser/create_group_join_request.feature
@@ -1,35 +1,35 @@
 Feature: User sends a request to join a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | is_public | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
       | 11 | 1         | edit                                  | 9999-12-31 23:59:59                    | 1                      |
       | 14 | 1         | none                                  | null                                   | 0                      |
       | 21 | 0         | none                                  | null                                   | 0                      |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                      |
       | 14       | 21        | join_request | 2019-05-30 11:00:00.001 |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 30 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 20      | content            |
       | 21       | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 21             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 21             | 30      |
 
@@ -75,7 +75,7 @@ Feature: User sends a request to join a group
 
   Scenario: Automatically accepts the request if the user can manage group memberships
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 11       | 21         | memberships |
     When I send a POST request to "/current-user/group-requests/11?approvals=personal_info_view,lock_membership,watch"

--- a/app/api/currentuser/create_group_join_request.robustness.feature
+++ b/app/api/currentuser/create_group_join_request.robustness.feature
@@ -1,6 +1,6 @@
 Feature: User sends a request to join a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | is_public | type    | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval | frozen_membership | enforce_max_participants | max_participants |
       | 11 | 1         | Class   | none                                  | null                                   | 0                      | false             | false                    | 0                |
       | 13 | 1         | Friends | none                                  | null                                   | 0                      | false             | false                    | 0                |
@@ -14,28 +14,28 @@ Feature: User sends a request to join a group - robustness
       | 21 | 0         | User    | none                                  | null                                   | 0                      | false             | false                    | 0                |
       | 22 | 0         | User    | none                                  | null                                   | 0                      | false             | false                    | 0                |
       | 23 | 1         | User    | none                                  | null                                   | 0                      | false             | false                    | 0                |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login | temp_user |
       | 21       | john  | false     |
       | 22       | tmp   | true      |
       | 23       | jane  | false     |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 1234 | fr                   |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 17       | 21         | memberships |
       | 19       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 16              | 21             |
       | 21              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 11       | 21        | invitation   |
       | 14       | 21        | join_request |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 14             | 1  | 1234         |
       | 16             | 2  | 1234         |
@@ -77,13 +77,13 @@ Feature: User sends a request to join a group - robustness
 
   Scenario Outline: User tries to send a request while while entry conditions would not be met if he joins
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_max_team_size |
       | 2  | fr                   | 0                   |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | <team_id>      | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | <team_id>      | 1          | 2       | 2019-05-30 11:00:00 |
     When I send a POST request to "/current-user/group-requests/<team_id>"
@@ -205,7 +205,7 @@ Feature: User sends a request to join a group - robustness
 
   Scenario: Can't send request to a group when an approval is missing even while being a group manager
     Given I am the user with id "23"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_manage  |
       | 16       | 21         | memberships |
     When I send a POST request to "/current-user/group-requests/16?approvals=personal_info_view,lock_membership"
@@ -228,7 +228,7 @@ Feature: User sends a request to join a group - robustness
 
   Scenario: Can't send request to a user even while being a group manager
     Given I am the user with id "23"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_manage  |
       | 23       | 23         | memberships |
     When I send a POST request to "/current-user/group-requests/23?approvals=personal_info_view,lock_membership"
@@ -263,7 +263,7 @@ Feature: User sends a request to join a group - robustness
 
   Scenario: Can't send request to a group with frozen membership even while being a group manager
     Given I am the user with id "23"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_manage  |
       | 18       | 21         | memberships |
     When I send a POST request to "/current-user/group-requests/18"

--- a/app/api/currentuser/create_group_leave_request.feature
+++ b/app/api/currentuser/create_group_leave_request.feature
@@ -1,19 +1,19 @@
 Feature: User sends a request to leave a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | require_lock_membership_approval_until |
       | 11 | 3000-01-01 00:00:00                    |
       | 14 | 4000-01-01 00:00:00                    |
       | 21 | null                                   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 11              | 21             | 2019-05-30 11:00:00         |
       | 14              | 21             | 2019-06-30 11:00:00         |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | 14       | 21        | leave_request | 2019-05-30 11:00:00.001 |
 

--- a/app/api/currentuser/create_group_leave_request.robustness.feature
+++ b/app/api/currentuser/create_group_leave_request.robustness.feature
@@ -1,23 +1,23 @@
 Feature: User creates a request to leave a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | require_lock_membership_approval_until | frozen_membership |
       | 11 | 2019-05-30 11:00:00                    | false             |
       | 14 | null                                   | false             |
       | 15 | null                                   | true              |
       | 21 | null                                   | false             |
       | 22 | null                                   | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login |
       | 21       | john  |
       | 22       | jane  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 11              | 21             | null                        |
       | 14              | 22             | 2019-05-30 11:00:00         |
       | 15              | 21             | null                        |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | 14       | 21        | leave_request | 2019-05-30 11:00:00.001 |
 

--- a/app/api/currentuser/delete.feature
+++ b/app/api/currentuser/delete.feature
@@ -1,27 +1,27 @@
 Feature: Delete the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | name       | require_lock_membership_approval_until |
       | 2   | Base  | AllUsers   | 9999-12-31 23:59:59                    |
       | 4   | Base  | TempUsers  | null                                   |
       | 21  | User  | user       | null                                   |
       | 31  | User  | tmp-1234   | null                                   |
       | 100 | Class | Some class | null                                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 4              |
       | 2               | 21             |
       | 4               | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | at                  |
       | 100      | 21        | 2019-05-30 11:00:00 |
       | 100      | 31        | 2019-05-30 11:00:00 |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | at                      |
       | 100      | 21        | 2019-05-30 11:00:00.001 |
       | 100      | 31        | 2019-05-30 11:00:00.001 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | temp_user | login    | group_id | login_id |
       | 0         | user     | 21       | 1234567  |
       | 1         | tmp-1234 | 31       | null     |

--- a/app/api/currentuser/delete.robustness.feature
+++ b/app/api/currentuser/delete.robustness.feature
@@ -1,19 +1,19 @@
 Feature: Delete the current user - robustness
   Background:
     Given the DB time now is "2019-08-09 23:59:59"
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type  | name      | require_lock_membership_approval_until |
       | 2  | Base  | AllUsers  | null                                   |
       | 4  | Base  | TempUsers | null                                   |
       | 21 | User  | user      | null                                   |
       | 50 | Class | Our class | 2019-08-10 00:00:00                    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 2               | 4              | null                        |
       | 2               | 21             | null                        |
       | 50              | 21             | 2019-05-30 11:00:00         |
     And the groups ancestors are computed
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | temp_user | login | group_id | login_id |
       | 0         | user  | 21       | 1234567  |
     And the application config is:

--- a/app/api/currentuser/get_dump.feature
+++ b/app/api/currentuser/get_dump.feature
@@ -1,7 +1,7 @@
 Feature: Export the short version of the current user's data
   Background:
     Given the DB time now is "2019-07-16 22:02:28"
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type    | name               | description            |
       | 1  | Class   | Our Class          | Our class group        |
       | 2  | Team    | Our Team           | Our team group         |
@@ -14,55 +14,55 @@ Feature: Export the short version of the current user's data
       | 9  | Friends | Some other friends | Another friends group  |
       | 11 | User    | user self          |                        |
       | 31 | User    | jane               |                        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name | grade |
       | user  | 11       | John       | Doe       | 1     |
       | jane  | 31       | Jane       | Doe       | 2     |
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token    |
       | 1          | 11      | refreshTokenFor1 |
       | 2          | 31      | refreshTokenFor2 |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token        | expires_at          |
       | 1          | accessToken1 | 3000-01-01 00:00:00 |
       | 2          | accessToken2 | 3000-01-01 00:00:00 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 11             |
       | 5               | 11             |
       | 6               | 11             |
       | 9               | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 1        | 11         | memberships           | 1                      | 0                 |
       | 2        | 11         | memberships_and_group | 0                      | 1                 |
       | 6        | 9          | memberships           | 1                      | 1                 |
       | 9        | 8          | none                  | 0                      | 0                 |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 1        | 11        | invitation   |
       | 3        | 11        | join_request |
       | 1        | 31        | invitation   |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action               | at                      | initiator_id |
       | 4        | 11        | join_request_refused | 2019-07-10 00:02:28.001 | 11           |
       | 7        | 11        | removed              | 2019-07-10 03:02:28.002 | 31           |
       | 8        | 11        | left                 | 2019-07-10 04:02:28.003 | 11           |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 404 | fr                   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 11             |
       | 0  | 2              |
       | 0  | 1              |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 11             | 404     |
       | 0          | 2              | 404     |
       | 0          | 1              | 404     |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | author_id | participant_id | attempt_id | item_id | created_at          |
       | 1  | 11        | 11             | 0          | 404     | 2019-07-09 20:02:28 |
       | 2  | 31        | 1              | 0          | 404     | 2019-07-09 20:02:28 |

--- a/app/api/currentuser/get_full_dump.feature
+++ b/app/api/currentuser/get_full_dump.feature
@@ -1,7 +1,7 @@
 Feature: Export the current user's data
   Background:
     Given the DB time now is "2019-07-16 22:02:28"
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type    | name               | description            |
       | 1  | Class   | Our Class          | Our class group        |
       | 2  | Team    | Our Team           | Our team group         |
@@ -16,20 +16,20 @@ Feature: Export the current user's data
       | 11 | User    | user self          |                        |
       | 21 | User    | jack               |                        |
       | 31 | User    | jane               |                        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name | grade |
       | user  | 11       | John       | Doe       | 1     |
       | jack  | 21       | Jack       | Smith     | 2     |
       | jane  | 31       | Jane       | Doe       | 2     |
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id | refresh_token    |
       | 1          | 21      | refreshTokenFor1 |
       | 2          | 11      | refreshTokenFor2 |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token     | issued_at           | expires_at          |
       | 1          | tokenFor1 | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
       | 2          | tokenFor2 | 2020-01-01 00:00:00 | 2020-01-01 02:00:00 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 11             |
       | 5               | 11             |
@@ -37,37 +37,37 @@ Feature: Export the current user's data
       | 9               | 11             |
       | 10              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 1        | 11         | memberships           | 1                      | 0                 |
       | 2        | 11         | memberships_and_group | 0                      | 1                 |
       | 6        | 9          | memberships           | 1                      | 1                 |
       | 9        | 8          | none                  | 0                      | 0                 |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                      |
       | 1        | 11        | invitation   | 2019-08-10 00:00:00.001 |
       | 3        | 11        | join_request | 2019-08-11 00:00:00.002 |
       | 1        | 21        | invitation   | 2019-08-12 00:00:00.003 |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action               | at                      | initiator_id |
       | 4        | 11        | join_request_refused | 2019-07-10 00:02:28.001 | 11           |
       | 7        | 11        | removed              | 2019-07-10 03:02:28.002 | 31           |
       | 8        | 11        | left                 | 2019-07-10 04:02:28.003 | 11           |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 404 | fr                   |
       | 405 | fr                   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 11             | 2019-05-28 11:00:00 |
       | 0  | 2              | 2019-05-28 11:00:00 |
       | 0  | 1              | 2019-05-28 11:00:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  |
       | 0          | 11             | 404     | 2019-05-30 11:00:00 |
       | 0          | 2              | 404     | 2019-05-29 11:00:00 |
       | 0          | 1              | 405     | 2019-05-28 11:00:00 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | author_id | participant_id | attempt_id | item_id | created_at          |
       | 1  | 11        | 11             | 0          | 404     | 2019-07-09 21:02:28 |
       | 2  | 21        | 1              | 0          | 405     | 2019-07-09 21:02:28 |

--- a/app/api/currentuser/get_group_activities.feature
+++ b/app/api/currentuser/get_group_activities.feature
@@ -1,6 +1,6 @@
 Feature: Get root activities for a participant group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name      | grade | type  | root_activity_id | created_at          |
       | 1  | all       | -2    | Base  | 220              | 2019-01-30 08:26:49 |
       | 11 | jdoe      | -2    | User  | null             | 2019-01-30 08:26:48 |
@@ -20,17 +20,17 @@ Feature: Get root activities for a participant group
       | 27 | Group Z   | -2    | Club  | 300              | 2019-01-30 08:26:42 |
       | 29 | Class     | -2    | Class | 280              | 2019-01-30 08:26:42 |
       | 30 | manager   | -2    | User  | 280              | 2019-01-30 08:26:42 |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login     | temp_user | group_id | default_language |
       | jdoe      | 0         | 11       |                  |
       | info_root | 0         | 14       |                  |
       | info_mid  | 0         | 16       |                  |
       | fr_user   | 0         | 18       | fr               |
       | manager   | 0         | 30       | fr               |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 12             |
       | 1               | 13             |
@@ -50,13 +50,13 @@ Feature: Get root activities for a participant group
       | 26              | 27             |
       | 29              | 30             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 12         | 1        | true              |
       | 12         | 19       | true              |
       | 29         | 22       | true              |
       | 30         | 24       | true              |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
       | 200 | Task    | en                   | false    | false                   | User                   |
       | 210 | Chapter | en                   | false    | false                   | User                   |
@@ -72,7 +72,7 @@ Feature: Get root activities for a participant group
       | 280 | Task    | en                   | false    | false                   | User                   |
       | 290 | Task    | en                   | false    | false                   | User                   |
       | 300 | Task    | en                   | false    | false                   | User                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
       | 11       | 200     | solution                 | solution_with_grant      | none                | none               | true               |
@@ -126,7 +126,7 @@ Feature: Get root activities for a participant group
       | 29       | 280     | content_with_descendants | none                     | none                | none               | false              |
       | 30       | 290     | content_with_descendants | none                     | none                | none               | false              |
       | 29       | 300     | content_with_descendants | none                     | none                | none               | false              |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | content_view_propagation |
       | 200            | 210           | 3           | none                     |
       | 200            | 220           | 2           | as_info                  |
@@ -134,7 +134,7 @@ Feature: Get root activities for a participant group
       | 210            | 211           | 1           | none                     |
       | 230            | 231           | 2           | none                     |
       | 230            | 232           | 1           | none                     |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       |
       | 200     | en           | Category 1  |
       | 210     | en           | Chapter A   |
@@ -150,7 +150,7 @@ Feature: Get root activities for a participant group
       | 250     | en           | null        |
       | 270     | en           | null        |
       | 290     | en           | null        |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
       | 0  | 11             | 2019-01-30 08:26:41 | null         | null              | null                |
       | 1  | 11             | 2019-01-30 08:26:41 | 200          | 0                 | 2019-01-30 09:26:48 |
@@ -159,7 +159,7 @@ Feature: Get root activities for a participant group
       | 0  | 18             | 2018-01-30 09:26:42 | null         | null              | null                |
       | 0  | 19             | 2018-01-30 09:26:42 | null         | null              | null                |
       | 0  | 26             | 2017-01-30 09:26:42 | null         | null              | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
       | 0          | 11             | 200     | 91             | 11          | 2019-01-30 09:26:41 | null                | 2019-01-30 09:36:41 |
       | 0          | 11             | 210     | 92             | 12          | 2019-01-30 09:26:42 | 2019-01-31 09:26:42 | 2019-01-30 09:36:42 |

--- a/app/api/currentuser/get_group_activities.robustness.feature
+++ b/app/api/currentuser/get_group_activities.robustness.feature
@@ -1,22 +1,22 @@
 Feature: Get root activities for a participant group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name      | grade | type  | root_activity_id | created_at          |
       | 11 | jdoe      | -2    | User  | null             | 2019-01-30 08:26:48 |
       | 13 | Group B   | -2    | Team  | 230              | 2019-01-30 08:26:46 |
       | 14 | Group C   | -2    | Team  | 230              | 2019-01-30 08:26:46 |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login     | temp_user | group_id |
       | jdoe      | 0         | 11       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 14              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 11         | 13       | true              |
 

--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -1,6 +1,6 @@
 Feature: Get group invitations for the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name                          | description                   | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
       | 1  | Class   | Our Class                     | Our class group               | none                                  | {{relativeTimeDB("+96h")}}             | true                   |
       | 2  | Team    | Our Team                      | Our team group                | none                                  | null                                   | false                  |
@@ -20,12 +20,12 @@ Feature: Get group invitations for the current user
       | 34 | Class   | Other group with invitation 2 | Other group with invitation 2 | edit                                  | null                                   | false                  |
       | 35 | Class   | Group with broken change log  | Group with broken change log  | edit                                  | null                                   | false                  |
       | 36 | Class   | Group without inviting user   | Group without inviting user   | edit                                  | null                                   | false                  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login       | temp_user | group_id | first_name  | last_name | grade |
       | owner       | 0         | 21       | Jean-Michel | Blanquer  | 3     |
       | user        | 0         | 12       | John        | Doe       | 1     |
       | anotheruser | 0         | 13       | Another     | User      | 1     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 5               | 21             |
       | 6               | 21             |
@@ -33,7 +33,7 @@ Feature: Get group invitations for the current user
       | 10              | 21             |
     And the time now is "2020-01-01T01:00:00.001Z"
     And the DB time now is "2020-01-01 01:00:00.001"
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                            | initiator_id |
       | 1        | 21        | invitation_created    | {{relativeTimeDBMs("-169h")}} | 12           |
       | 2        | 21        | invitation_refused    | {{relativeTimeDBMs("-168h")}} | 21           |
@@ -53,7 +53,7 @@ Feature: Get group invitations for the current user
       | 1        | 12        | invitation_created    | {{relativeTimeDBMs("-170h")}} | 12           |
       | 10       | 21        | joined_by_code        | {{relativeTimeDBMs("-180h")}} | null         |
       | 11       | 21        | joined_by_badge       | {{relativeTimeDBMs("-190h")}} | null         |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                            |
       | 1        | 21        | invitation   | {{currentTimeDBMs()}}         |
       | 33       | 21        | invitation   | {{currentTimeDBMs()}}         |

--- a/app/api/currentuser/get_group_memberships.feature
+++ b/app/api/currentuser/get_group_memberships.feature
@@ -1,6 +1,6 @@
 Feature: Get group memberships for the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type                | name                       | description                | frozen_membership | require_lock_membership_approval_until |
       | 1  | Class               | Our Class                  | Our class group            | false             | null                                   |
       | 2  | Team                | Our Team                   | Our team group             | false             | null                                   |
@@ -16,11 +16,11 @@ Feature: Get group memberships for the current user
       | 30 | Team                | Frozen Team                | Frozen Team                | true              | null                                   |
       | 31 | Team                | Team With Entry Conditions | Team With Entry Conditions | false             | null                                   |
       | 32 | ContestParticipants |                            |                            | false             | null                                   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | grade |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 0         | 11       | John        | Doe       | 1     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 5               | 21             | 2019-05-30 11:00:00         |
       | 6               | 21             | 2019-05-30 11:00:00         |
@@ -31,7 +31,7 @@ Feature: Get group memberships for the current user
       | 31              | 21             | null                        |
       | 32              | 21             | null                        |
     And the groups ancestors are computed
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                      |
       | 1        | 21        | invitation_created    | 2017-02-28 06:38:38.001 |
       | 2        | 21        | invitation_refused    | 2017-03-29 06:38:38.001 |
@@ -42,13 +42,13 @@ Feature: Get group memberships for the current user
       | 7        | 21        | removed               | 2017-08-29 06:38:38.001 |
       | 8        | 21        | left                  | 2017-09-29 06:38:38.001 |
       | 1        | 11        | added_directly        | 2017-11-29 06:38:38.001 |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | All                              |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 31             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 31             | 1          | 2       | 2019-05-30 11:00:00 |
 

--- a/app/api/currentuser/get_group_memberships_history.feature
+++ b/app/api/currentuser/get_group_memberships_history.feature
@@ -1,6 +1,6 @@
 Feature: Get group memberships history for the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name               |
       | 1  | Class   | Our Class          |
       | 2  | Team    | Our Team           |
@@ -14,12 +14,12 @@ Feature: Get group memberships history for the current user
       | 11 | User    | user               |
       | 13 | User    | jane               |
       | 21 | User    | owner              |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade | notifications_read_at |
       | owner | 21       | Jean-Michel | Blanquer  | 3     | 2017-06-29 06:38:38   |
       | user  | 11       | John        | Doe       | 1     | null                  |
       | jane  | 13       | Jane        | Doe       | 2     | 2019-06-29 06:38:38   |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                      |
       | 1        | 21        | invitation_created    | 2017-02-28 06:38:38.001 |
       | 2        | 21        | invitation_refused    | 2017-03-29 06:38:38.001 |

--- a/app/api/currentuser/get_group_skills.feature
+++ b/app/api/currentuser/get_group_skills.feature
@@ -1,6 +1,6 @@
 Feature: Get root skills for a participant group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name      | grade | type  | root_skill_id | created_at          |
       | 1  | all       | -2    | Base  | 220           | 2019-01-30 08:26:49 |
       | 11 | jdoe      | -2    | User  | null          | 2019-01-30 08:26:48 |
@@ -20,17 +20,17 @@ Feature: Get root skills for a participant group
       | 27 | Group Z   | -2    | Club  | 300           | 2019-01-30 08:26:42 |
       | 29 | Class     | -2    | Class | 280           | 2019-01-30 08:26:42 |
       | 30 | manager   | -2    | User  | 280           | 2019-01-30 08:26:42 |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login     | temp_user | group_id | default_language |
       | jdoe      | 0         | 11       |                  |
       | info_root | 0         | 14       |                  |
       | info_mid  | 0         | 16       |                  |
       | fr_user   | 0         | 18       | fr               |
       | manager   | 0         | 30       | fr               |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 12             |
       | 1               | 13             |
@@ -50,13 +50,13 @@ Feature: Get root skills for a participant group
       | 26              | 27             |
       | 29              | 30             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 12         | 1        | true              |
       | 12         | 19       | true              |
       | 29         | 22       | true              |
       | 30         | 24       | true              |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type  | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
       | 200 | Skill | en                   | false    | false                   | User                   |
       | 210 | Skill | en                   | false    | false                   | User                   |
@@ -72,7 +72,7 @@ Feature: Get root skills for a participant group
       | 280 | Skill | en                   | false    | false                   | User                   |
       | 290 | Skill | en                   | false    | false                   | User                   |
       | 300 | Skill | en                   | false    | false                   | User                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
       | 11       | 200     | solution                 | solution_with_grant      | none                | none               | true               |
@@ -126,7 +126,7 @@ Feature: Get root skills for a participant group
       | 29       | 280     | content_with_descendants | none                     | none                | none               | false              |
       | 30       | 290     | content_with_descendants | none                     | none                | none               | false              |
       | 29       | 300     | content_with_descendants | none                     | none                | none               | false              |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | content_view_propagation |
       | 200            | 210           | 3           | none                     |
       | 200            | 220           | 2           | as_info                  |
@@ -134,7 +134,7 @@ Feature: Get root skills for a participant group
       | 210            | 211           | 1           | none                     |
       | 230            | 231           | 2           | none                     |
       | 230            | 232           | 1           | none                     |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title        |
       | 200     | en           | Skill 1      |
       | 210     | en           | Skill 2      |
@@ -150,7 +150,7 @@ Feature: Get root skills for a participant group
       | 250     | en           | null         |
       | 270     | en           | null         |
       | 290     | en           | null         |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
       | 0  | 11             | 2019-01-30 08:26:41 | null         | null              | null                |
       | 1  | 11             | 2019-01-30 08:26:41 | 200          | 0                 | 2019-01-30 09:26:48 |
@@ -159,7 +159,7 @@ Feature: Get root skills for a participant group
       | 0  | 18             | 2018-01-30 09:26:42 | null         | null              | null                |
       | 0  | 19             | 2018-01-30 09:26:42 | null         | null              | null                |
       | 0  | 26             | 2017-01-30 09:26:42 | null         | null              | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
       | 0          | 11             | 200     | 91             | 11          | 2019-01-30 09:26:41 | null                | 2019-01-30 09:36:41 |
       | 0          | 11             | 210     | 92             | 12          | 2019-01-30 09:26:42 | 2019-01-31 09:26:42 | 2019-01-30 09:36:42 |

--- a/app/api/currentuser/get_group_skills.robustness.feature
+++ b/app/api/currentuser/get_group_skills.robustness.feature
@@ -1,22 +1,22 @@
 Feature: Get root skills for a participant group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name      | grade | type  | root_activity_id | created_at          |
       | 11 | jdoe      | -2    | User  | null             | 2019-01-30 08:26:48 |
       | 13 | Group B   | -2    | Team  | 230              | 2019-01-30 08:26:46 |
       | 14 | Group C   | -2    | Team  | 230              | 2019-01-30 08:26:46 |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login     | temp_user | group_id |
       | jdoe      | 0         | 11       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 14              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 11         | 13       | true              |
 

--- a/app/api/currentuser/get_managed_groups.feature
+++ b/app/api/currentuser/get_managed_groups.feature
@@ -1,6 +1,6 @@
 Feature: List groups managed by the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | type  | description |
       | 5  | Group         | Class | null        |
       | 11 | user          | User  | null        |
@@ -8,18 +8,18 @@ Feature: List groups managed by the current user
       | 14 | Our Friends   | Other | null        |
       | 15 | Another Group | Other | Super Group |
       | 21 | owner         | User  | null        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 5               | 21             |
       | 6               | 21             |
       | 9               | 21             |
       | 1               | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 13       | 5          | memberships_and_group | 1                      | 0                 |
       | 13       | 21         | none                  | 0                      | 0                 |

--- a/app/api/currentuser/get_managed_groups.robustness.feature
+++ b/app/api/currentuser/get_managed_groups.robustness.feature
@@ -1,9 +1,9 @@
 Feature: List groups managed by the current user - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | type  | description |
       | 21 | owner         | User  | null        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
 

--- a/app/api/currentuser/join_group_by_code.feature
+++ b/app/api/currentuser/join_group_by_code.feature
@@ -1,6 +1,6 @@
 Feature: Join a group using a code (groupsJoinByCode)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  | code       | code_expires_at     | code_lifetime | require_watch_approval |
       | 11 | Team  | 3456789abc | 2037-05-29 06:38:38 | 3723          | 0                      |
       | 12 | Team  | abc3456789 | null                | 45296         | 0                      |
@@ -9,28 +9,28 @@ Feature: Join a group using a code (groupsJoinByCode)
       | 16 | Class | 2345668999 | null                | null          | 0                      |
       | 17 | Team  | null       | null                | null          | 0                      |
       | 21 | User  | null       | null                | null          | 0                      |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 17              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 11       | 21        | invitation   |
       | 14       | 21        | join_request |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 20 | fr                   | All                              |
       | 30 | fr                   | All                              |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 20      | content            |
       | 12       | 20      | content            |
@@ -38,14 +38,14 @@ Feature: Join a group using a code (groupsJoinByCode)
       | 15       | 20      | info               |
       | 16       | 20      | info               |
       | 21       | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id |
       | 0  | 16             | 30           |
       | 0  | 17             | 30           |
       | 0  | 21             | null         |
       | 1  | 16             | 30           |
       | 1  | 21             | 30           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 0          | 17             | 30      | 2019-05-30 11:00:00 |
       | 0          | 21             | 30      | 2019-05-30 11:00:00 |

--- a/app/api/currentuser/join_group_by_code.robustness.feature
+++ b/app/api/currentuser/join_group_by_code.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Join a group using a code (groupsJoinByCode) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  | code       | code_expires_at     | code_lifetime | require_watch_approval | frozen_membership | max_participants | enforce_max_participants |
       | 11 | Club  | 3456789abc | 2017-04-29 06:38:38 | null          | 0                      | false             | 0                | false                    |
       | 12 | Team  | abc3456789 | null                | null          | 1                      | false             | 0                | false                    |
@@ -10,21 +10,21 @@ Feature: Join a group using a code (groupsJoinByCode) - robustness
       | 19 | Other | 987654abcd | null                | null          | 0                      | false             | 0                | true                     |
       | 21 | User  | null       | null                | null          | 0                      | false             | 0                | false                    |
       | 22 | User  | 3333333333 | null                | null          | 0                      | false             | 0                | false                    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | temp_user |
       | john  | 21       | false     |
       | tmp   | 22       | true      |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 1234 | fr                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 14              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 11       | 21        | invitation |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 14             | 1  | 1234         |
       | 17             | 2  | 1234         |
@@ -155,13 +155,13 @@ Feature: Join a group using a code (groupsJoinByCode) - robustness
 
   Scenario: Cannot join if joining breaks entry conditions for the team
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | All                              |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 12             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 12             | 1          | 2       | 2019-05-30 11:00:00 |
     When I send a POST request to "/current-user/group-memberships/by-code?code=abc3456789&approvals=watch"

--- a/app/api/currentuser/leave_group.feature
+++ b/app/api/currentuser/leave_group.feature
@@ -1,14 +1,14 @@
 Feature: User leaves a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | require_lock_membership_approval_until |
       | 11 | 2019-08-20 00:00:00                    |
       | 14 | 2019-08-20 00:00:00                    |
       | 21 | null                                   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 11              | 21             | 2019-05-30 11:00:00         |
       | 14              | 21             | null                        |

--- a/app/api/currentuser/leave_group.robustness.feature
+++ b/app/api/currentuser/leave_group.robustness.feature
@@ -1,6 +1,6 @@
 Feature: User leaves a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  | require_lock_membership_approval_until | frozen_membership |
       | 11 | Class | null                                   | false             |
       | 14 | Team  | null                                   | false             |
@@ -9,11 +9,11 @@ Feature: User leaves a group - robustness
       | 17 | Base  | null                                   | false             |
       | 21 | User  | null                                   | false             |
       | 31 | User  | null                                   | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login |
       | 21       | john  |
       | 31       | jane  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 14              | 21             | null                        |
       | 14              | 31             | null                        |
@@ -21,7 +21,7 @@ Feature: User leaves a group - robustness
       | 16              | 31             | null                        |
       | 17              | 31             | null                        |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 11       | 21        | join_request |
 
@@ -81,13 +81,13 @@ Feature: User leaves a group - robustness
 
   Scenario: Fails if leaving breaks entry conditions for the team
     Given I am the user with id "31"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | All                              |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 14             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 14             | 1          | 2       | 2019-05-30 11:00:00 |
     When I send a DELETE request to "/current-user/group-memberships/14"

--- a/app/api/currentuser/refresh.feature
+++ b/app/api/currentuser/refresh.feature
@@ -53,10 +53,10 @@ Feature: Update the local user info cache
       | group_id | latest_login_at     | latest_activity_at  | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address           | zipcode  | city                | land_line_number  | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip     | time_zone | notify_news | photo_autoload | public_first_name | public_last_name |
       | 11       | 2019-06-16 21:01:25 | 2019-06-16 22:05:44 | 2019-05-10 10:42:11 | 2019-06-15 22:05:44    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | Rue Tebessi Larbi | 16000    | Algiers             | +213 778 02 85 31 | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 192.168.0.1 | null      | false       | false          | false             | false            |
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | null                   | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 | null      | false       | false          | false             | false            |
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id |
       | 1          | 11      |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token       | expires_at          | issued_at           |
       | 1          | accesstoken | 2020-06-16 22:02:49 | 2019-06-16 22:02:28 |
     And the login module "account" endpoint for token "accesstoken" returns 200 with body:
@@ -89,10 +89,10 @@ Feature: Update the local user info cache
       | group_id | latest_login_at     | latest_activity_at  | registered_at       | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address           | zipcode  | city                | land_line_number  | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip     | time_zone | notify_news | photo_autoload | public_first_name | public_last_name |
       | 11       | 2019-06-16 21:01:25 | 2019-06-16 22:05:44 | 2019-05-10 10:42:11 | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | Rue Tebessi Larbi | 16000    | Algiers             | +213 778 02 85 31 | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 192.168.0.1 | null      | false       | false          | false             | false            |
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 | null      | false       | false          | false             | false            |
-    And the database has the following table 'sessions':
+    And the database has the following table "sessions":
       | session_id | user_id |
       | 1          | 11      |
-    And the database has the following table 'access_tokens':
+    And the database has the following table "access_tokens":
       | session_id | token       | expires_at          | issued_at           |
       | 1          | accesstoken | 2020-06-16 22:02:49 | 2019-06-16 22:02:28 |
     And the login module "account" endpoint for token "accesstoken" returns 200 with body:

--- a/app/api/currentuser/reject_group_invitation.feature
+++ b/app/api/currentuser/reject_group_invitation.feature
@@ -1,15 +1,15 @@
 Feature: User rejects an invitation to join a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 14 |
       | 21 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 11       | 21        | invitation |
 

--- a/app/api/currentuser/reject_group_invitation.robustness.feature
+++ b/app/api/currentuser/reject_group_invitation.robustness.feature
@@ -1,16 +1,16 @@
 Feature: User rejects an invitation to join a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 13 |
       | 14 |
       | 21 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login |
       | 21       | john  |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 11       | 21        | join_request |
       | 13       | 21        | invitation   |

--- a/app/api/currentuser/search_for_available_groups.feature
+++ b/app/api/currentuser/search_for_available_groups.feature
@@ -1,6 +1,6 @@
 Feature: Search for groups available to the current user
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type                | name                                  | description            | is_public |
       | 1  | Class               | amazing Class                         | Our class group        | 1         |
       | 2  | Team                | amazing Team                          | null                   | 1         |
@@ -15,10 +15,10 @@ Feature: Search for groups available to the current user
       | 11 | User                | Another amazing User                  | Another user group     | 1         |
       | 21 | User                | amazing user self                     |                        | 0         |
       | 22 | ContestParticipants | amazing                               |                        | 1         |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | grade |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 2               | 21             | 2019-05-30 11:00:00 |
       | 5               | 21             | 9999-12-31 23:59:59 |
@@ -26,7 +26,7 @@ Feature: Search for groups available to the current user
       | 9               | 21             | 9999-12-31 23:59:59 |
       | 10              | 21             | 9999-12-31 23:59:59 |
       | 1               | 7              | 9999-12-31 23:59:59 |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 1        | 21        | invitation   |
       | 3        | 21        | join_request |

--- a/app/api/currentuser/withdraw_group_join_request.feature
+++ b/app/api/currentuser/withdraw_group_join_request.feature
@@ -1,15 +1,15 @@
 Feature: User withdraws a request to join a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 14 |
       | 21 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                  |
       | 11       | 21        | join_request | 2019-05-30 11:00:00 |
       | 14       | 21        | join_request | 2019-05-30 11:00:00 |

--- a/app/api/currentuser/withdraw_group_join_request.robustness.feature
+++ b/app/api/currentuser/withdraw_group_join_request.robustness.feature
@@ -1,17 +1,17 @@
 Feature: User withdraws a request to join a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 14 |
       | 21 |
       | 22 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login |
       | 21       | john  |
       | 22       | jane  |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                      |
       | 14       | 21        | join_request | 2019-05-30 11:00:00.001 |
 

--- a/app/api/currentuser/withdraw_group_leave_request.feature
+++ b/app/api/currentuser/withdraw_group_leave_request.feature
@@ -1,19 +1,19 @@
 Feature: User withdraws a request to leave a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 14 |
       | 21 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id |
       | 21       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 11              | 21             |
       | 14              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                  |
       | 11       | 21        | leave_request | 2019-05-30 11:00:00 |
       | 14       | 21        | leave_request | 2019-05-30 11:00:00 |

--- a/app/api/currentuser/withdraw_group_leave_request.robustness.feature
+++ b/app/api/currentuser/withdraw_group_leave_request.robustness.feature
@@ -1,21 +1,21 @@
 Feature: User withdraws a request to leave a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id |
       | 11 |
       | 14 |
       | 21 |
       | 22 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login |
       | 21       | john  |
       | 22       | jane  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 11              | 21             |
       | 14              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | 14       | 21        | leave_request | 2019-05-30 11:00:00.001 |
 

--- a/app/api/groups/accept_join_requests.feature
+++ b/app/api/groups/accept_join_requests.feature
@@ -1,6 +1,6 @@
 Feature: Accept group requests
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    | require_personal_info_access_approval | enforce_max_participants | max_participants |
       | 11  | Class   | none                                  | false                    | null             |
       | 13  | Team    | none                                  | false                    | null             |
@@ -15,46 +15,46 @@ Feature: Accept group requests
       | 141 | User    | none                                  | false                    | null             |
       | 151 | User    | none                                  | false                    | null             |
       | 161 | User    | none                                  | false                    | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 1234 | fr                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at | lock_membership_approved_at | watch_approved_at |
       | 14              | 111            | null                           | null                        | null              |
       | 14              | 121            | null                           | null                        | null              |
       | 14              | 123            | null                           | null                        | null              |
       | 14              | 151            | null                           | null                        | null              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 30 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 13       | 20      | content            |
       | 31       | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 31             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 31             | 30      |
 
   Scenario: Accept requests
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 21         | memberships |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved | lock_membership_approved | watch_approved | at                      |
       | 13       | 11        | invitation   | 0                           | 0                        | 0              | 2019-06-05 00:00:00.000 |
       | 13       | 21        | join_request | 0                           | 0                        | 0              | 2019-06-06 00:00:00.000 |
@@ -125,10 +125,10 @@ Feature: Accept group requests
 
   Scenario: The group is full
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 21         | memberships |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved | lock_membership_approved | watch_approved | at                      |
       | 14       | 11        | invitation   | 0                           | 0                        | 0              | 2019-06-05 00:00:00.000 |
       | 14       | 21        | invitation   | 0                           | 0                        | 0              | 2019-06-01 00:00:00.000 |
@@ -162,10 +162,10 @@ Feature: Accept group requests
 
   Scenario Outline: Accept team requests
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved   | lock_membership_approved   | watch_approved   | at                      |
       | 13       | 21        | invitation   | 0                             | 0                          | 0                | 2019-06-01 00:00:00.000 |
       | 13       | 31        | join_request | <personal_info_view_approved> | <lock_membership_approved> | <watch_approved> | <at>                    |
@@ -220,21 +220,21 @@ Feature: Accept group requests
 
   Scenario: Accept requests for a team while skipping members of other teams participating in the same contests
     Given I am the user with id "21"
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id  | type |
       | 444 | Team |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id |
       | 444             | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
-    And the database table 'attempts' has also the following rows:
+    And the database table "attempts" has also the following rows:
       | participant_id | id | root_item_id |
       | 13             | 1  | 1234         |
       | 444            | 2  | 1234         |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved | lock_membership_approved | watch_approved | at                      |
       | 13       | 31        | join_request | 1                           | 1                        | 1              | 2019-06-04 00:00:00.000 |
     When I send a POST request to "/groups/13/join-requests/accept?group_ids=31"
@@ -258,19 +258,19 @@ Feature: Accept group requests
 
   Scenario: Accept request for a team for which entry conditions would become not satisfied
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 1  | fr                   | All                              |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 13             | 1  | 1            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 13             | 1          | 1       | 2019-05-30 11:00:00 |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved | lock_membership_approved | watch_approved | at                      |
       | 13       | 31        | join_request | 1                           | 1                        | 1              | 2019-06-04 00:00:00.000 |
     When I send a POST request to "/groups/13/join-requests/accept?group_ids=31"
@@ -294,10 +294,10 @@ Feature: Accept group requests
 
   Scenario: Checks approvals if required
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 14       | 21         | memberships_and_group |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | personal_info_view_approved | lock_membership_approved | watch_approved | at                      |
       | 14       | 21        | join_request | 0                           | 0                        | 0              | 2019-06-06 00:00:00.000 |
     When I send a POST request to "/groups/14/join-requests/accept?group_ids=21"

--- a/app/api/groups/accept_join_requests.robustness.feature
+++ b/app/api/groups/accept_join_requests.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Accept group requests - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | frozen_membership |
       | 11  | User  | false             |
       | 12  | User  | false             |
@@ -15,25 +15,25 @@ Feature: Accept group requests - robustness
       | 123 | User  | false             |
       | 131 | User  | false             |
       | 141 | User  | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 11       | John        | Doe       | 1     |
       | jane  | 12       | Jane        | Doe       | 1     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 12       | 12         | memberships |
       | 13       | 21         | memberships |
       | 13       | 12         | none        |
       | 15       | 21         | memberships |
       | 31       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 111            |
       | 13              | 121            |
       | 13              | 123            |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 13       | 21        | invitation   |
       | 13       | 31        | join_request |

--- a/app/api/groups/accept_leave_requests.feature
+++ b/app/api/groups/accept_leave_requests.feature
@@ -1,6 +1,6 @@
 Feature: Accept requests to leave a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    |
       | 11  | Class   |
       | 13  | Friends |
@@ -16,10 +16,10 @@ Feature: Accept requests to leave a group
       | 151 | User    |
       | 161 | User    |
       | 444 | Team    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 13              | 31             | 9999-12-31 23:59:59 |
       | 13              | 111            | 9999-12-31 23:59:59 |
@@ -29,7 +29,7 @@ Feature: Accept requests to leave a group
       | 13              | 151            | 9999-12-31 23:59:59 |
       | 14              | 21             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          |
       | 13       | 21        | invitation    |
       | 13       | 31        | leave_request |
@@ -40,7 +40,7 @@ Feature: Accept requests to leave a group
 
   Scenario: Accept requests to leave a group
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
     When I send a POST request to "/groups/13/leave-requests/accept?group_ids=31,141,21,11,13,122,151"
@@ -102,7 +102,7 @@ Feature: Accept requests to leave a group
 
   Scenario: Accept request to leave a team
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 21         | memberships |
     When I send a POST request to "/groups/14/leave-requests/accept?group_ids=21"
@@ -153,19 +153,19 @@ Feature: Accept requests to leave a group
 
   Scenario: Accept request to leave a team for which entry conditions would become unsatisfied
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 21         | memberships |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 14             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 14             | 1          | 2       | 2019-05-30 11:00:00 |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | Half                             |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 14              | 111            |
     And the groups ancestors are computed

--- a/app/api/groups/accept_leave_requests.robustness.feature
+++ b/app/api/groups/accept_leave_requests.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Accept requests to leave a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    | frozen_membership |
       | 11  | Class   | false             |
       | 13  | Team    | false             |
@@ -16,10 +16,10 @@ Feature: Accept requests to leave a group - robustness
       | 151 | User    | false             |
       | 161 | User    | false             |
       | 444 | Team    | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 31             |
       | 13              | 111            |
@@ -29,7 +29,7 @@ Feature: Accept requests to leave a group - robustness
       | 13              | 151            |
       | 14              | 151            |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          |
       | 13       | 21        | invitation    |
       | 13       | 31        | leave_request |
@@ -38,7 +38,7 @@ Feature: Accept requests to leave a group - robustness
       | 14       | 11        | invitation    |
       | 14       | 21        | join_request  |
       | 14       | 151       | leave_request |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 21         | memberships |
       | 444      | 21         | memberships |
@@ -55,7 +55,7 @@ Feature: Accept requests to leave a group - robustness
 
   Scenario: Fails when the user is a manager of the parent group, but doesn't have enough rights to manage memberships
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage |
       | 13       | 21         | none       |
     When I send a POST request to "/groups/13/leave-requests/accept?group_ids=31,141,21,11,13"
@@ -68,7 +68,7 @@ Feature: Accept requests to leave a group - robustness
 
   Scenario: Fails when the user has enough rights to manage memberships, but the group is a user
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 21       | 21         | memberships |
     When I send a POST request to "/groups/21/leave-requests/accept?group_ids=31,141,21,11,13"

--- a/app/api/groups/add_child.feature
+++ b/app/api/groups/add_child.feature
@@ -1,38 +1,38 @@
 Feature: Add a parent-child relation between two groups
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 11 | Group A | Class |
       | 13 | Group B | Class |
       | 14 | Group C | Class |
       | 21 | Self    | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name |
       | owner | 0         | 21       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 11       | 21         | memberships_and_group |
       | 13       | 21         | memberships           |
       | 14       | 21         | memberships_and_group |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 30 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 13       | 20      | content            |
       | 21       | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 11             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 11             | 30      |
 

--- a/app/api/groups/add_child.robustness.feature
+++ b/app/api/groups/add_child.robustness.feature
@@ -1,7 +1,7 @@
 Feature: Add a parent-child relation between two groups - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name     | type  |
       | 11 | Group A  | Class |
       | 13 | Group B  | Class |
@@ -14,12 +14,12 @@ Feature: Add a parent-child relation between two groups - robustness
       | 77 | Group C  | Class |
       | 78 | Group D  | Class |
       | 79 | Group E  | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id | first_name  | last_name |
       | owner   | 21       | Jean-Michel | Blanquer  |
       | student | 25       | Jane        | Doe       |
       | admin   | 27       | John        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 11       | 21         | memberships_and_group |
       | 13       | 21         | memberships           |
@@ -31,7 +31,7 @@ Feature: Add a parent-child relation between two groups - robustness
       | 16       | 27         | memberships_and_group |
       | 18       | 27         | memberships_and_group |
       | 19       | 27         | memberships_and_group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
     And the groups ancestors are computed

--- a/app/api/groups/check_code.feature
+++ b/app/api/groups/check_code.feature
@@ -1,7 +1,7 @@
 Feature: Check if the group code is valid
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  | code       | code_expires_at     | code_lifetime | frozen_membership | name           | require_lock_membership_approval_until | require_personal_info_access_approval | require_watch_approval | root_activity_id | root_skill_id |
       | 3  | Base  | null       | null                | null          | false             | Base Group     | null                                   | none                                  | false                  | null             | null          |
       | 11 | Team  | 3456789abc | 2037-05-29 06:38:38 | 3723          | false             | Our Team       | null                                   | edit                                  | false                  | 1234             | null          |
@@ -15,27 +15,27 @@ Feature: Check if the group code is valid
       | 21 | User  | null       | null                | null          | false             | john           | null                                   | none                                  | false                  | null             | null          |
       | 22 | User  | 3333333333 | null                | null          | false             | tmp            | null                                   | none                                  | false                  | null             | null          |
       | 23 | User  | null       | null                | null          | false             | jane           | null                                   | none                                  | false                  | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | group_id | login | temp_user | first_name | last_name |
       | 21       | john  | false     | null       | null      |
       | 22       | tmp   | true      | null       | null      |
       | 23       | jane  | false     | Jane       | Doe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 14              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 1234 | fr                   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id |
       | 0  | 21             | null         |
       | 2  | 14             | 1234         |
       | 2  | 18             | 1234         |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 21             | 30      |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 11       | 21         |
       | 11       | 23         |
@@ -98,14 +98,14 @@ Feature: Check if the group code is valid
 
   Scenario: The user is temporary (custom all-users group)
     Given I am the user with id "22"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | allows_multiple_attempts |
       | 2  | fr                   | false                    |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 3              | 1  | 2            |
       | 11             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 3              | 1          | 2       | 2019-05-30 11:00:00 |
       | 11             | 1          | 2       | 2019-05-30 11:00:00 |
@@ -125,13 +125,13 @@ Feature: Check if the group code is valid
 
   Scenario: Joining would break entry conditions for the team
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | All                              |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 12             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 12             | 1          | 2       | 2019-05-30 11:00:00 |
     When I send a GET request to "/groups/is-code-valid?code=abc3456789"

--- a/app/api/groups/check_code.robustness.feature
+++ b/app/api/groups/check_code.robustness.feature
@@ -1,9 +1,9 @@
 Feature: Check if the group code is valid - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  |
       | 21 | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | temp_user |
       | john  | 21       | false     |
 

--- a/app/api/groups/create_code.feature
+++ b/app/api/groups/create_code.feature
@@ -1,15 +1,15 @@
 Feature: Create a new code for the given group
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | code       | code_lifetime | code_expires_at     |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class | 3456789abc | 3600          | 2017-10-14 05:39:48 |
       | 21 | owner   | -4    | owner           | 2019-04-06 09:26:40 | User  | null       | null          | null                |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
     And the groups ancestors are computed

--- a/app/api/groups/create_code.robustness.feature
+++ b/app/api/groups/create_code.robustness.feature
@@ -1,19 +1,19 @@
 Feature: Create a new code for the given group - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | code       | code_lifetime | code_expires_at     |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class | 3456789abc | 3600          | 2017-10-14 05:39:48 |
       | 21 | owner   | -4    | owner           | 2019-04-06 09:26:40 | User  | null       | null          | null                |
       | 31 | jane    | -4    | jane            | 2019-04-06 09:26:40 | User  | null       | null          | null                |
       | 41 | user    | -4    | user            | 2019-04-06 09:26:40 | User  | null       | null          | null                |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
       | user  | 0         | 41       | John        | Doe       | en               |
       | jane  | 0         | 31       | Jane        | Doe       | en               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 13       | 31         | none        |

--- a/app/api/groups/create_group.feature
+++ b/app/api/groups/create_group.feature
@@ -1,10 +1,10 @@
 Feature: Create a group (groupCreate)
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name  | type |
       | 21 | owner | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name |
       | owner | 0         | 21       | Jean-Michel | Blanquer  |
     And the groups ancestors are computed

--- a/app/api/groups/create_group.robustness.feature
+++ b/app/api/groups/create_group.robustness.feature
@@ -1,17 +1,17 @@
 Feature: Create a group (groupCreate) - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name  | type |
       | 21 | owner | User |
       | 31 | tmp12 | User |
       | 51 | john  | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login  | temp_user | group_id |
       | owner  | 0         | 21       |
       | tmp12  | 1         | 31       |
       | john   | 0         | 51       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
     And the groups ancestors are computed
 

--- a/app/api/groups/create_invitations.feature
+++ b/app/api/groups/create_invitations.feature
@@ -1,6 +1,6 @@
 Feature: Invite users
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | require_personal_info_access_approval | enforce_max_participants | max_participants |
       | 13  | Team  | none                                  | true                     | 2                |
       | 21  | User  | none                                  | false                    | null             |
@@ -10,7 +10,7 @@ Feature: Invite users
       | 104 | User  | none                                  | false                    | null             |
       | 444 | Team  | none                                  | false                    | null             |
       | 555 | Class | view                                  | false                    | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | temp_user |
       | owner | 21       | Jean-Michel | Blanquer  | false     |
       | john  | 101      | John        | Doe       | false     |
@@ -18,31 +18,31 @@ Feature: Invite users
       | Jane  | 103      | Jane        | Smith     | false     |
       | tmp   | 104      | Temp        | User      | true      |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag |
       | 20   | fr                   |
       | 30   | fr                   |
       | 1234 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 555      | 20      | content            |
       | 101      | 30      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 101            | 30      |
 
   Scenario: Successfully invite users
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
     When I send a POST request to "/groups/13/invitations" with the following body:
@@ -80,7 +80,7 @@ Feature: Invite users
 
   Scenario: The group is full
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
     When I send a POST request to "/groups/13/invitations" with the following body:
@@ -113,16 +113,16 @@ Feature: Invite users
 
   Scenario: Successfully invite users into a team skipping those who are members of other teams participating in the same contests
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id |
       | 444             | 21             |
       | 444             | 101            |
       | 444             | 102            |
     And the groups ancestors are computed
-    And the database table 'attempts' has also the following rows:
+    And the database table "attempts" has also the following rows:
       | participant_id | id | root_item_id |
       | 13             | 1  | 1234         |
       | 444            | 2  | 1234         |
@@ -156,10 +156,10 @@ Feature: Invite users
 
   Scenario: Convert join-requests into invitations or make them accepted depending on approvals
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 555      | 21         | memberships_and_group |
-    And the database table 'group_pending_requests' has also the following rows:
+    And the database table "group_pending_requests" has also the following rows:
       | group_id | member_id | type         | personal_info_view_approved | at                  |
       | 555      | 101       | join_request | 1                           | 2019-05-30 11:00:00 |
       | 555      | 102       | join_request | 0                           | 2019-05-30 11:00:00 |

--- a/app/api/groups/create_invitations.robustness.feature
+++ b/app/api/groups/create_invitations.robustness.feature
@@ -1,17 +1,17 @@
 Feature: Invite users - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  |
       | 11  | User  |
       | 13  | Class |
       | 21  | User  |
       | 22  | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 11       | John        | Doe       |
       | jane  | 22       | Jane        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 13       | 22         | none        |

--- a/app/api/groups/create_manager.feature
+++ b/app/api/groups/create_manager.feature
@@ -1,20 +1,20 @@
 Feature: Make a user a group manager (groupManagerCreate)
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name  | type  |
       | 1  | Group | Class |
       | 2  | Team  | Team  |
       | 21 | owner | User  |
       | 22 | Class | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 2              |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
 

--- a/app/api/groups/create_manager.robustness.feature
+++ b/app/api/groups/create_manager.robustness.feature
@@ -1,19 +1,19 @@
 Feature: Make a user a group manager (groupManagerCreate) - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    |
       | 1  | Group   | Class   |
       | 2  | Team    | Team    |
       | 3  | Friends | Friends |
       | 21 | owner   | User    |
       | 22 | john    | User    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 22       | John        | Doe       |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
       | 21         | 3        | memberships           |

--- a/app/api/groups/create_user_batch.feature
+++ b/app/api/groups/create_user_batch.feature
@@ -1,24 +1,24 @@
 Feature: Create a user batch
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name     | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
       | 2  | Base    | AllUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
       | 3  | Club    | Club     | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
       | 4  | Friends | Friends  | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
       | 21 | User    | owner    | 2016-08-10 12:34:55 | none                                  | null                                   | 0                      |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | default_language |
       | owner | 21       | Jean-Michel | Blanquer  | en               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 3        | 21         | memberships           |
       | 4        | 21         | memberships_and_group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 21             |
       | 3               | 4              |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new | max_users |
       | test         | 3        | 1         | 2         |
     And the application config is:

--- a/app/api/groups/create_user_batch.robustness.feature
+++ b/app/api/groups/create_user_batch.robustness.feature
@@ -1,30 +1,30 @@
 Feature: Create a user batch - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name     | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
       | 2  | Base    | AllUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
       | 3  | Club    | Club     | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
       | 4  | Friends | Friends  | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
       | 21 | User    | owner    | 2016-08-10 12:34:55 | none                                  | null                                   | 0                      |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 3        | 21         | memberships           |
       | 4        | 21         | memberships_and_group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 2               | 21             |
       | 3               | 4              |
       | 3               | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new | max_users |
       | test         | 3        | 1         | 2         |
       | test2        | 2        | 1         | 2         |
       | test3        | 3        | 0         | 2         |
-    And the database has the following table 'user_batches_v2':
+    And the database has the following table "user_batches_v2":
       | group_prefix | custom_prefix | size |
       | test         | custom        | 1    |
     And the application config is:

--- a/app/api/groups/delete_group.feature
+++ b/app/api/groups/delete_group.feature
@@ -1,6 +1,6 @@
 Feature: Delete a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name              | type  |
       | 11 | Group A           | Class |
       | 13 | Group B           | Class |
@@ -17,16 +17,16 @@ Feature: Delete a group
           domains: [127.0.0.1]
           allUsersGroup: 31
       """
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 14       | 21         | none                  |
       | 15       | 14         | memberships_and_group |
       | 22       | 21         | memberships           |
       | 30       | 21         | memberships_and_group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 13              | 11             | 2019-05-30 11:00:00 |
       | 14              | 21             | 9999-12-31 23:59:59 |
@@ -36,23 +36,23 @@ Feature: Delete a group
       | 22              | 14             | 9999-12-31 23:59:59 |
       | 31              | 21             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 13       | 11        | invitation |
       | 22       | 11        | invitation |
       | 22       | 13        | invitation |
       | 22       | 14        | invitation |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id |
       | 13       | 11        |
       | 22       | 11        |
       | 22       | 13        |
       | 22       | 14        |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 1  | fr                   |
       | 2  | fr                   |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | participant_id | item_id | status                  | helper_group_id |
       | 21             | 1       | waiting_for_participant | 30              |
       | 21             | 2       | waiting_for_participant | 22              |

--- a/app/api/groups/delete_group.robustness.feature
+++ b/app/api/groups/delete_group.robustness.feature
@@ -1,21 +1,21 @@
 Feature: Delete a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name     | type  |
       | 11 | Group A  | Class |
       | 21 | owner    | User  |
       | 23 | teacher  | User  |
       | 55 | User     | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id | first_name  | last_name |
       | owner   | 21       | Jean-Michel | Blanquer  |
       | teacher | 23       | John        | Smith     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 11       | 21         | memberships_and_group |
       | 11       | 23         | memberships           |
       | 55       | 23         | memberships_and_group |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 11              | 55             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed

--- a/app/api/groups/get_breadcrumbs.feature
+++ b/app/api/groups/get_breadcrumbs.feature
@@ -1,6 +1,6 @@
 Feature: Get breadcrumbs (groupBreadcrumbsView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                                | type    | is_public |
       | 1  | Joined Base                         | Base    | false     |
       | 2  | Managed Base                        | Base    | false     |
@@ -31,11 +31,11 @@ Feature: Get breadcrumbs (groupBreadcrumbsView)
       | 27 | Public                              | Base    | true      |
       | 41 | user                                | User    | false     |
       | 49 | User                                | User    | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
       | jack  | 49       | Jack        | Smith     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 41         |
       | 4        | 41         |
@@ -45,7 +45,7 @@ Feature: Get breadcrumbs (groupBreadcrumbsView)
       | 15       | 41         |
       | 19       | 21         |
       | 23       | 25         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 3               | 4              | 9999-12-31 23:59:59 |
@@ -95,7 +95,7 @@ Feature: Get breadcrumbs (groupBreadcrumbsView)
       | 23              | 41             | 2010-01-01 00:00:00 |
       | 25              | 41             | 2010-01-01 00:00:00 |
     And the groups ancestors are computed
-    And the database has the following table 'groups_ancestors':
+    And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
       | 5                 | 41             | 2010-01-01 00:00:00 |
       | 7                 | 41             | 2010-01-01 00:00:00 |

--- a/app/api/groups/get_breadcrumbs.robustness.feature
+++ b/app/api/groups/get_breadcrumbs.robustness.feature
@@ -1,21 +1,21 @@
 Feature: Get breadcrumbs (groupBreadcrumbsView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                | type                | is_public |
       | 1  | Team                | Team                | true      |
       | 2  | Managed By Team     | Class               | false     |
       | 41 | user                | User                | true      |
       | 42 | ContestParticipants | ContestParticipants | false     |
       | 43 | Another Team        | Team                | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 1          |
       | 42       | 41         |
       | 43       | 41         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 42              | 41             | 9999-12-31 23:59:59 |

--- a/app/api/groups/get_children.feature
+++ b/app/api/groups/get_children.feature
@@ -1,6 +1,6 @@
 Feature: Get group children (groupChildrenView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name                | grade | type    | is_open | is_public | code       |
       | 11  | Group A             | -3    | Class   | true    | true      | ybqybxnlyo |
       | 13  | Group B             | -2    | Class   | true    | true      | ybabbxnlyo |
@@ -26,14 +26,14 @@ Feature: Get group children (groupChildrenView)
       | 101 | Managed group       | 0     | Class   | true    | true      | managedgrp |
       | 102 | Managed subgroup    | 0     | Class   | true    | true      | managedsub |
       | 103 | Managed subsubgroup | 0     | Class   | true    | true      | managedssb |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id | first_name  | last_name |
       | owner   | 21       | Jean-Michel | Blanquer  |
       | jack    | 29       | Jack        | Smith     |
       | john    | 51       | John        | Doe       |
       | jane    | 53       | Jane        | Doe       |
       | manager | 100      | Manager     | Manager   |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 13       | 11         | memberships           | true                   | false             |
       | 13       | 21         | none                  | false                  | false             |
@@ -45,7 +45,7 @@ Feature: Get group children (groupChildrenView)
     # But in this test file, this behavior is not implemented.
     # Because this test file doesn't use the new Gherkin test system (steps_app_language).
     # That's why we return "is_empty": false for this group.
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 11              | 29             |
       | 13              | 21             |

--- a/app/api/groups/get_children.robustness.feature
+++ b/app/api/groups/get_children.robustness.feature
@@ -1,13 +1,13 @@
 Feature: Get group children (groupChildrenView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | type  | is_open | is_public | code       |
       | 11 | Group A | -3    | Class | true    | false     | ybqybxnlyo |
       | 13 | Group B | -2    | Class | true    | true      | ybabbxnlyo |
     And the database has the following users:
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
     And the groups ancestors are computed

--- a/app/api/groups/get_current_user_team_by_item.feature
+++ b/app/api/groups/get_current_user_team_by_item.feature
@@ -1,18 +1,18 @@
 Feature: Get current user's team for item (teamGetByItemID)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type |
       | 12 | User |
       | 13 | User |
       | 14 | User |
       | 20 | Team |
       | 21 | Team |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | user  | 12       |
       | jane  | 13       |
       | john  | 14       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 20              | 12             |
       | 20              | 13             |
@@ -20,7 +20,7 @@ Feature: Get current user's team for item (teamGetByItemID)
       | 21              | 12             |
       | 21              | 13             |
       | 21              | 14             |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | root_item_id |
       | 20             | 1  | 100          |
       | 21             | 1  | 100          |

--- a/app/api/groups/get_current_user_team_by_item.robustness.feature
+++ b/app/api/groups/get_current_user_team_by_item.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get current user's team for item (teamGetByItemID) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type  |
       | 11 | User  |
       | 12 | User  |
@@ -12,7 +12,7 @@ Feature: Get current user's team for item (teamGetByItemID) - robustness
       | 19 | User  |
       | 20 | Team  |
       | 21 | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login  | group_id |
       | owner  | 11       |
       | user   | 12       |
@@ -22,7 +22,7 @@ Feature: Get current user's team for item (teamGetByItemID) - robustness
       | james  | 16       |
       | jeremy | 17       |
       | jacob  | 19       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 21              | 19             |
 

--- a/app/api/groups/get_granted_permissions.feature
+++ b/app/api/groups/get_granted_permissions.feature
@@ -1,6 +1,6 @@
 Feature: Get permissions granted to group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name        | type  |
       | 8  | Club        | Club  |
       | 9  | Class       | Class |
@@ -11,18 +11,18 @@ Feature: Get permissions granted to group
       | 26 | other class | Class |
       | 27 | third class | Class |
       | 31 | jane        | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | default_language |
       | owner | 21       | Jean-Michel | Blanquer  | fr               |
       | user  | 23       | John        | Doe       | en               |
       | jane  | 31       | Jane        | Doe       | en               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 25       | 8          | 1                      |
       | 26       | 8          | 1                      |
       | 10       | 21         | 0                      |
       | 31       | 21         | 0                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 8               | 21             |
       | 9               | 10             |
@@ -32,20 +32,20 @@ Feature: Get permissions granted to group
       | 25              | 27             |
       | 26              | 25             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag | requires_explicit_entry | type    |
       | 100 | fr                   | true                    | Chapter |
       | 101 | en                   | false                   | Task    |
       | 102 | fr                   | true                    | Chapter |
       | 103 | fr                   | false                   | Chapter |
       | 104 | fr                   | false                   | Chapter |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id  | language_tag | title      |
       | 101      | en           | Task A     |
       | 102      | en           | Chapter B  |
       | 102      | fr           | Chapitre B |
       | 104      | fr           | Chapitre C |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_request_help_to | can_make_session_official | can_enter_from      | can_enter_until     |
       | 31       | 102     | 10              | group_membership | info     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 25       | 101     | 25              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -65,7 +65,7 @@ Feature: Get permissions granted to group
       | 25       | 101     | 10              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 3999-12-31 23:59:59 |
       | 25       | 103     | 25              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 31       | 101     | 27              | group_membership | content  | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_grant_view_generated | can_watch_generated | can_edit_generated |
       | 8        | 101     | enter                    | none                | none               |
       | 21       | 102     | none                     | answer_with_grant   | none               |
@@ -172,7 +172,7 @@ Feature: Get permissions granted to group
 
   Scenario: can_grant_group_access=1 for a ancestor group
     Given I am the user with id "21"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_grant_group_access |
       | 9        | 8          | 1                      |
     When I send a GET request to "/groups/25/granted_permissions"
@@ -326,7 +326,7 @@ Feature: Get permissions granted to group
 
   Scenario: can_grant_group_access=1 for the group's ancestor, descendants=1
     Given I am the user with id "21"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_grant_group_access |
       | 9        | 8          | 1                      |
     When I send a GET request to "/groups/25/granted_permissions?descendants=1"
@@ -372,7 +372,7 @@ Feature: Get permissions granted to group
 
   Scenario: can_grant_group_access=1 for the group's ancestor, descendants=1, order by group.name, source_group.name, item.title
     Given I am the user with id "21"
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_grant_group_access |
       | 9        | 8          | 1                      |
     When I send a GET request to "/groups/25/granted_permissions?descendants=1&sort=group.name,source_group.name,item.title"

--- a/app/api/groups/get_granted_permissions.robustness.feature
+++ b/app/api/groups/get_granted_permissions.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get permissions granted to group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | type  |
       | 21 | owner         | User  |
       | 23 | user          | User  |
@@ -8,19 +8,19 @@ Feature: Get permissions granted to group - robustness
       | 26 | another class | Class |
       | 27 | third class   | Class |
       | 31 | admin         | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 23       | John        | Doe       |
       | admin | 31       | Allie       | Grater    |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 23       | 21         | 1                      |
       | 25       | 21         | 0                      |
       | 25       | 31         | 1                      |
       | 26       | 21         | 1                      |
       | 26       | 31         | 1                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 25              | 23             |
       | 25              | 31             |

--- a/app/api/groups/get_group.feature
+++ b/app/api/groups/get_group.feature
@@ -1,6 +1,6 @@
 Feature: Get group by groupID (groupView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | root_activity_id    | root_skill_id | is_open | is_public | code       | code_lifetime | code_expires_at     | open_activity_when_joining | require_personal_info_access_approval | require_watch_approval | require_lock_membership_approval_until | frozen_membership |
       | 8  | Other   | -4    | Parent of 9     | 2019-04-06 09:26:40 | Other | null                | null          | false   | false     | efghijklmn | null          | null                | false                      | none                                  | false                  | null                                   | false             |
       | 9  | Club    | -4    | Club            | 2019-04-06 09:26:40 | Other | null                | null          | false   | false     | null       | null          | null                | false                      | none                                  | false                  | null                                   | false             |
@@ -19,7 +19,7 @@ Feature: Get group by groupID (groupView)
       | 61 | ian     | 0     | null            | 2019-01-06 09:26:40 | User  | null                | null          | false   | false     | null       | null          | null                | false                      | none                                  | false                  | null                                   | false             |
       | 71 | dirk    | 0     | null            | 2019-01-06 09:26:40 | User  | null                | null          | false   | false     | null       | null          | null                | false                      | none                                  | false                  | null                                   | false             |
       | 81 | chuck   | 0     | null            | 2019-01-06 09:26:40 | User  | null                | null          | false   | false     | null       | null          | null                | false                      | none                                  | false                  | null                                   | false             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | john  | 31       |
@@ -28,7 +28,7 @@ Feature: Get group by groupID (groupView)
       | ian   | 61       |
       | dirk  | 71       |
       | chuck | 81       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 8               | 9              | null                        |
       | 9               | 21             | null                        |
@@ -45,19 +45,19 @@ Feature: Get group by groupID (groupView)
       | 19              | 81             | null                        |
       | 15              | 11             | null                        |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 13       | 21         | none                  | false                  | false             |
       | 15       | 21         | memberships_and_group | true                   | true              |
       | 16       | 9          | none                  | false                  | false             |
       | 19       | 21         | none                  | false                  | false             |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | entry_min_admitted_members_ratio |
       | 2  | fr                   | All                              |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 17             | 1  | 2            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 17             | 1          | 2       | 2019-05-30 11:00:00 |
 

--- a/app/api/groups/get_group.robustness.feature
+++ b/app/api/groups/get_group.robustness.feature
@@ -1,9 +1,9 @@
 Feature: Get group by groupID (groupView) - robustness
   Background:
-    Given the database has the following table 'users':
+    Given the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name                | grade | description         | created_at          | type                | root_activity_id    | is_open | is_public | code       | code_lifetime | code_expires_at     | open_activity_when_joining |
       | 11 | Group A             | -3    | Group A is here     | 2019-02-06 09:26:40 | Class               | 1672978871462145361 | true    | true      | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 | true                       |
       | 13 | Group B             | -2    | Group B is here     | 2019-03-06 09:26:40 | Class               | 1672978871462145461 | true    | false     | ybabbxnlyo | 3600          | 2017-10-14 05:39:48 | true                       |

--- a/app/api/groups/get_group_progress.feature
+++ b/app/api/groups/get_group_progress.feature
@@ -1,6 +1,6 @@
 Feature: Display the current progress of a group on a subset of items (groupGroupProgress)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -26,7 +26,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | johna | 51       |
@@ -39,11 +39,11 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | janec | 65       |
       | janed | 67       |
       | janee | 69       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 4          | true              |
       | 3        | 21         | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 1               | 14             | # direct child of group_id with type = 'Team' (ignored)
@@ -72,7 +72,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 18              | 19             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | type    | default_language_tag |
       | 200  | Chapter | fr                   |
       | 210  | Chapter | fr                   |
@@ -118,7 +118,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 418  | Task    | fr                   |
       | 419  | Task    | fr                   |
       | 1010 | Task    | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -160,7 +160,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 410            | 417           | 6           |
       | 410            | 418           | 7           |
       | 410            | 419           | 8           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -203,7 +203,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
       | 4        | 1010    | none                     | answer_with_grant   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -223,7 +223,7 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | 5  | 15             | 2017-03-29 06:38:38 |
       | 9  | 14             | 2017-05-29 06:38:38 |
       | 8  | 15             | 2017-03-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        |
       | 0          | 14             | 210     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 125          | 127         | null                |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                |

--- a/app/api/groups/get_group_progress.robustness.feature
+++ b/app/api/groups/get_group_progress.robustness.feature
@@ -4,30 +4,30 @@ Feature: Display the current progress of a group on a subset of items (groupGrou
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
       | 20 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 20              | 21             |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_group_progress_csv.feature
+++ b/app/api/groups/get_group_progress_csv.feature
@@ -1,6 +1,6 @@
 Feature: Export the current progress of a group on a subset of items as a CSV file (groupGroupProgressCsv)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -25,7 +25,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | default_language |
       | owner | 21       | en               |
       | johna | 51       | fr               |
@@ -38,11 +38,11 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | janec | 65       | fr               |
       | janed | 67       | fr               |
       | janee | 69       | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 4          | true              |
       | 3        | 21         | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 1               | 12             |
@@ -73,7 +73,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 17              | 59             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | type    | default_language_tag |
       | 200  | Chapter | fr                   |
       | 210  | Chapter | fr                   |
@@ -119,7 +119,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 418  | Task    | fr                   |
       | 419  | Task    | fr                   |
       | 1010 | Task    | fr                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title         |
       | 200     | fr           | Chapitre 200  |
       | 210     | fr           | Chapitre 210  |
@@ -166,7 +166,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 418     | fr           | Item 418      |
       | 419     | fr           | Item 419      |
       | 1010    | fr           | Chapitre 1010 |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -208,7 +208,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 410            | 417           | 6           |
       | 410            | 418           | 7           |
       | 410            | 419           | 8           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -251,7 +251,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
       | 4        | 1010    | none                     | answer_with_grant   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -271,7 +271,7 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | 5  | 15             | 2017-03-29 06:38:38 |
       | 9  | 14             | 2017-05-29 06:38:38 |
       | 8  | 15             | 2017-03-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        |
       | 0          | 14             | 210     | 2017-05-29 06:38:38 | 50             | 2017-05-29 06:38:38 | 125          | 127         | null                |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                |

--- a/app/api/groups/get_group_progress_csv.robustness.feature
+++ b/app/api/groups/get_group_progress_csv.robustness.feature
@@ -4,30 +4,30 @@ Feature: Export the current progress of a group on a subset of items as a CSV fi
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
       | 20 |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 20              | 21             |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_managers.feature
+++ b/app/api/groups/get_managers.feature
@@ -11,20 +11,20 @@ Feature: Get managers of group_id
       | jeff  | 71       | Jeff        | Joe        |
       | larry | 81       | null        | null       |
       | lp    | 91       | null        | null       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name        | type    |
       | 12 | Our Club    | Club    |
       | 13 | Our Class   | Class   |
       | 14 | Our Friends | Friends |
       | 15 | Other       | Other   |
       | 16 | Team        | Team    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 12              | 13             |
       | 13              | 71             |
       | 15              | 13             |
       | 16              | 81             |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            | can_grant_group_access | can_watch_members |
       | 12       | 81         | memberships           | 1                      | 0                 |
       | 13       | 14         | none                  | 0                      | 0                 |

--- a/app/api/groups/get_managers.robustness.feature
+++ b/app/api/groups/get_managers.robustness.feature
@@ -4,13 +4,13 @@ Feature: Get managers of group_id - robustness
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 13              | 11             | 2019-05-30 11:00:00 |
     And the groups ancestors are computed

--- a/app/api/groups/get_members.feature
+++ b/app/api/groups/get_members.feature
@@ -11,17 +11,17 @@ Feature: Get members of group_id
       | jeff  | 71       | Jeff        | Bezos      | 7     |
       | larry | 81       | Larry       | Ellison    | 8     |
       | lp    | 91       | Larry       | Page       | 6     |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
       | 14 |
       | 22 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
       | 13       | 91         |
       | 22       | 21         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          | personal_info_view_approved_at |
       | 13              | 51             | 9999-12-31 23:59:59 | null                           | # still shows personal info because of 22-51
       | 13              | 61             | 9999-12-31 23:59:59 | 2019-05-30 11:00:00            |
@@ -33,7 +33,7 @@ Feature: Get members of group_id
       | 22              | 13             | 9999-12-31 23:59:59 | null                           |
       | 22              | 51             | 9999-12-31 23:59:59 | 2019-05-30 11:00:00            |
     And the groups ancestors are computed
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                  | initiator_id |
       | 13       | 11        | invitation_refused    | 2017-11-29 06:38:38 | 31           |
       | 13       | 21        | invitation_created    | 2017-10-29 06:38:38 | 11           |

--- a/app/api/groups/get_members.robustness.feature
+++ b/app/api/groups/get_members.robustness.feature
@@ -4,10 +4,10 @@ Feature: Get members of group_id - robustness
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
     And the groups ancestors are computed

--- a/app/api/groups/get_navigation.feature
+++ b/app/api/groups/get_navigation.feature
@@ -1,6 +1,6 @@
 Feature: Get navigation data (groupNavigationView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                                     | type    | is_public |
       | 1  | Joined Base                              | Base    | false     |
       | 2  | Managed Base                             | Base    | false     |
@@ -42,13 +42,13 @@ Feature: Get navigation data (groupNavigationView)
       | 49 | jack                                     | User    | false     |
       | 50 | jane                                     | User    | false     |
       | 51 | john                                     | User    | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
       | jack  | 49       | Jack        | Smith     |
       | jane  | 50       | Jane        | Doe       |
       | john  | 51       | John        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 41         |
       | 4        | 41         |
@@ -60,7 +60,7 @@ Feature: Get navigation data (groupNavigationView)
       | 23       | 25         |
       | 28       | 50         |
       | 31       | 51         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 3               | 4              | 9999-12-31 23:59:59 |
@@ -120,7 +120,7 @@ Feature: Get navigation data (groupNavigationView)
       | 23              | 41             | 2010-01-01 00:00:00 |
       | 25              | 41             | 2010-01-01 00:00:00 |
     And the groups ancestors are computed
-    And the database has the following table 'groups_ancestors':
+    And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
       | 5                 | 41             | 2010-01-01 00:00:00 |
       | 7                 | 41             | 2010-01-01 00:00:00 |

--- a/app/api/groups/get_navigation.robustness.feature
+++ b/app/api/groups/get_navigation.robustness.feature
@@ -1,17 +1,17 @@
 Feature: Get navigation data (groupNavigationView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name            | type  | is_public |
       | 1  | Team            | Team  | true      |
       | 2  | Managed By Team | Class | false     |
       | 41 | user            | User  | true      |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 1          |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed

--- a/app/api/groups/get_parents.feature
+++ b/app/api/groups/get_parents.feature
@@ -1,6 +1,6 @@
 Feature: Get group parents (groupParentsView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name                                       | type                | is_public |
       | 21  | owner                                      | User                | false     |
       | 151 | Grand-parent of a joined group             | Club                | false     |
@@ -36,17 +36,17 @@ Feature: Get group parents (groupParentsView)
       | 265 | Public group 2                             | Club                | true      |
       | 400 | jack                                       | User                | false     |
       | 500 | Owner's group                              | Club                | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | jack  | 400      | Jack        | Smith     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 158      | 21         | false                  |
       | 161      | 500        | true                   |
       | 162      | 21         | false                  |
       | 162      | 500        | true                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 151             | 152            |
       | 151             | 400            |

--- a/app/api/groups/get_parents.robustness.feature
+++ b/app/api/groups/get_parents.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get group parents (groupParentsView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name                                       | type                | is_public |
       | 21  | owner                                      | User                | false     |
       | 151 | Grand-parent of a joined group             | Club                | false     |
@@ -36,17 +36,17 @@ Feature: Get group parents (groupParentsView) - robustness
       | 265 | Public group 2                             | Club                | true      |
       | 400 | jack                                       | User                | false     |
       | 500 | Owner's group                              | Club                | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | jack  | 400      | Jack        | Smith     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 158      | 21         | false                  |
       | 161      | 500        | true                   |
       | 162      | 21         | false                  |
       | 162      | 500        | true                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 151             | 152            |
       | 151             | 400            |

--- a/app/api/groups/get_participant_progress.feature
+++ b/app/api/groups/get_participant_progress.feature
@@ -1,6 +1,6 @@
 Feature: Display the current progress of a participant on children of an item (groupParticipantProgress)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -27,7 +27,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login  | group_id | default_language |
       | owner  | 21       | en               |
       | owner2 | 22       | en               |
@@ -41,13 +41,13 @@ Feature: Display the current progress of a participant on children of an item (g
       | janec  | 65       | fr               |
       | janed  | 67       | fr               |
       | janee  | 69       | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 21         | true              |
       | 1        | 22         | true              |
       | 19       | 4          | true              |
       | 51       | 4          | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 1               | 67             |
@@ -75,7 +75,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 19              | 69             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | type    | default_language_tag | no_score |
       | 200  | Chapter | fr                   | false    |
       | 210  | Chapter | fr                   | false    |
@@ -123,12 +123,12 @@ Feature: Display the current progress of a participant on children of an item (g
       | 1010 | Chapter | fr                   | false    |
       | 1020 | Chapter | fr                   | false    |
       | 1030 | Task    | fr                   | false    |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title    |
       | 214     | fr           | Tâche 14 |
       | 215     | en           | Task 15  |
       | 215     | fr           | Tâche 15 |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -171,7 +171,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 410            | 418           | 7           |
       | 410            | 419           | 8           |
       | 1020           | 1030          | 0           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 4        | 210     | content                  | none                |
       | 21       | 210     | none                     | result              |
@@ -242,7 +242,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 51       | 217     | none                     | none                |
       | 51       | 1020    | content                  | result              |
       | 51       | 1030    | content                  | result              |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2020-01-01 00:03:00 |
       | 1  | 14             | 2020-01-01 00:03:00 |
@@ -257,7 +257,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 5  | 14             | 2020-01-01 00:03:00 |
       | 0  | 21             | 2020-01-01 00:03:00 |
       | 0  | 51             | 2020-01-01 00:03:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
       | 0          | 14             | 211     | 2020-01-01 00:03:00 | 0              | 2020-01-01 00:03:00 | 100          | 100         | 2020-01-01 00:04:00 | 2020-01-01 00:14:01 | # latest_activity_at for 51, 211 comes from this line (the last activity is made by a team)
       | 1          | 14             | 211     | 2020-01-01 00:02:00 | 40             | 2020-01-01 00:03:00 | 2            | 3           | 2020-01-01 00:03:02 | 2020-01-01 00:14:00 | # min(validated_at) for 51, 211 comes from this line (from a team)

--- a/app/api/groups/get_participant_progress.robustness.feature
+++ b/app/api/groups/get_participant_progress.robustness.feature
@@ -4,25 +4,25 @@ Feature: Display the current progress of a participant on children of an item (g
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type |
       | 13 | Base |
       | 14 | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 14              | 21             |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
       | 14       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | content                  | result              |
       | 14       | 200     | info                     | answer              |
@@ -30,7 +30,7 @@ Feature: Display the current progress of a participant on children of an item (g
       | 21       | 200     | content                  | answer              |
       | 21       | 210     | content                  | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_permissions.feature
+++ b/app/api/groups/get_permissions.feature
@@ -1,39 +1,39 @@
 Feature: Get permissions for a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | type  |
       | 10 | Other      | Other |
       | 21 | owner      | User  |
       | 23 | user       | User  |
       | 25 | some class | Class |
       | 31 | jane       | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 23       | John        | Doe       |
       | jane  | 31       | Jane        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 25       | 21         | 1                      |
       | 31       | 21         | 0                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 25             |
       | 25              | 23             |
       | 25              | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 100 | fr                   |
       | 101 | fr                   |
       | 102 | fr                   |
       | 103 | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | content_view_propagation | grant_view_propagation | watch_propagation | edit_propagation | child_order |
       | 100            | 101           | as_info                  | false                  | false             | false            | 0           |
       | 101            | 102           | as_content               | false                  | false             | false            | 0           |
       | 102            | 103           | as_content               | true                   | true              | true             | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 100              | 101           |
       | 100              | 102           |
@@ -41,12 +41,12 @@ Feature: Get permissions for a group
       | 101              | 102           |
       | 101              | 103           |
       | 102              | 103           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated        | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 23       | 100     | content_with_descendants  | none                     | none                | none               | false              |
       | 23       | 101     | info                      | none                     | none                | none               | false              |
       | 23       | 103     | solution                  | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view      | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 100     | 23              | other            | content                  | none                | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 103     | 23              | group_membership | solution                 | solution_with_grant | answer_with_grant | all_with_grant | true     | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -61,11 +61,11 @@ Feature: Get permissions for a group
 
   Scenario: No permissions
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 21       | 103     | solution           | solution                 | answer              | all                | true               |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | source_group_id | latest_update_at    |
       | 21       | 102     | solution | solution_with_grant | answer_with_grant | all_with_grant | 23              | 2019-05-30 11:00:00 |
     When I send a GET request to "/groups/25/permissions/23/102"
@@ -114,7 +114,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given directly
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2017-12-31 23:59:59 | 9998-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -125,7 +125,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -178,7 +178,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via group membership
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2017-12-31 23:59:59 | 9998-12-31 23:59:59 |
@@ -189,7 +189,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -242,7 +242,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via ancestor's group membership
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -253,7 +253,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -306,7 +306,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via item unlocking
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -317,7 +317,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -370,7 +370,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via ancestor's item unlocking
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -381,7 +381,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -434,7 +434,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via self
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -445,7 +445,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -498,7 +498,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via ancestor's self
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -509,7 +509,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2017-12-31 23:59:59 | 9998-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | content                  | content_with_descendants | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -562,7 +562,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via other
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -573,7 +573,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2017-12-31 23:59:59 | 9998-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -626,7 +626,7 @@ Feature: Get permissions for a group
 
   Scenario: Maximum permissions given via ancestor's other
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -637,7 +637,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | none                     | none                     | none              | none           | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2017-12-31 23:59:59 | 9998-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -690,7 +690,7 @@ Feature: Get permissions for a group
 
   Scenario: can_enter_from aggregation
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 2021-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 2022-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -701,7 +701,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 2027-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | none                     | none                     | none              | none           | false    | false                     | 2028-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2029-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -754,7 +754,7 @@ Feature: Get permissions for a group
 
   Scenario: can_enter_from aggregation (dates in the reverse order)
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 2029-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 2028-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -765,7 +765,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 2023-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | none                     | none                     | none              | none           | false    | false                     | 2022-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2021-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -818,7 +818,7 @@ Feature: Get permissions for a group
 
   Scenario: can_enter_from aggregation (ignores rows with can_enter_until in the past)
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 2029-12-31 23:59:59 | 2020-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 2028-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -829,7 +829,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 2023-12-31 23:59:59 | 2020-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | none                     | none                     | none              | none           | false    | false                     | 2022-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2021-12-31 23:59:59 | 2020-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -882,7 +882,7 @@ Feature: Get permissions for a group
 
   Scenario: can_enter_from aggregation (can_enter_from in the past)
     Given I am the user with id "21"
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | origin           | can_view                 | can_grant_view           | can_watch         | can_edit       | is_owner | can_make_session_official | can_enter_from      | can_enter_until     |
       | 23       | 102     | 25              | group_membership | content_with_descendants | solution                 | answer            | all            | false    | false                     | 2011-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 23              | group_membership | content                  | content                  | result            | children       | false    | false                     | 2012-12-31 23:59:59 | 9999-12-31 23:59:59 |
@@ -893,7 +893,7 @@ Feature: Get permissions for a group
       | 10       | 102     | 1               | self             | none                     | none                     | none              | none           | false    | false                     | 2017-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 23       | 102     | 2               | other            | none                     | none                     | none              | none           | false    | false                     | 2018-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 10       | 102     | 1               | other            | solution                 | solution_with_grant      | answer_with_grant | all_with_grant | true     | true                      | 2019-12-31 23:59:59 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
@@ -946,7 +946,7 @@ Feature: Get permissions for a group
 
   Scenario Outline: Access rights for the current user
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated   | can_watch_generated   | can_edit_generated   | is_owner_generated |
       | 21       | 102     | none               | <can_grant_view_generated> | <can_watch_generated> | <can_edit_generated> | false              |
     When I send a GET request to "/groups/25/permissions/23/102"

--- a/app/api/groups/get_permissions.robustness.feature
+++ b/app/api/groups/get_permissions.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get permissions for a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | type  |
       | 21 | owner         | User  |
       | 23 | user          | User  |
@@ -8,36 +8,36 @@ Feature: Get permissions for a group - robustness
       | 26 | another class | Class |
       | 27 | third class   | Class |
       | 31 | admin         | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 23       | John        | Doe       |
       | admin | 31       | Allie       | Grater    |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 23       | 21         | 1                      |
       | 25       | 21         | 0                      |
       | 25       | 31         | 1                      |
       | 26       | 21         | 1                      |
       | 26       | 31         | 1                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 25              | 23             |
       | 25              | 31             |
       | 26              | 23             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 100 | fr                   |
       | 101 | fr                   |
       | 102 | fr                   |
       | 103 | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | content_view_propagation | child_order |
       | 100            | 101           | as_info                  | 0           |
       | 101            | 102           | as_content               | 0           |
       | 102            | 103           | as_content               | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 100              | 101           |
       | 100              | 102           |
@@ -45,7 +45,7 @@ Feature: Get permissions for a group - robustness
       | 101              | 102           |
       | 101              | 103           |
       | 102              | 103           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 100     | solution           | solution_with_grant      | none                | none               | true               |
       | 21       | 101     | none               | none                     | none                | none               | false              |
@@ -54,7 +54,7 @@ Feature: Get permissions for a group - robustness
       | 25       | 100     | content            | none                     | answer_with_grant   | none               | false              |
       | 25       | 101     | info               | none                     | answer              | all                | false              |
       | 31       | 102     | none               | content_with_descendants | none                | none               | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view           | can_enter_until     | is_owner | source_group_id | latest_update_at    |
       | 21       | 100     | none     | none                     | 9999-12-31 23:59:59 | 1        | 23              | 2019-05-30 11:00:00 |
       | 21       | 102     | none     | solution                 | 9999-12-31 23:59:59 | 1        | 23              | 2019-05-30 11:00:00 |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -19,7 +19,7 @@ Feature: Get permissions can_request_help_to for a group
       | @ClassParent             | @ClassParentParent       |          |
       | @Class                   | @ClassParent             |          |
       | @OtherSourceGroup        |                          |          |
-    And @Teacher is a manager of the group @ClassAnotherParent and can grant group access
+    And the group @Teacher is a manager of the group @ClassAnotherParent and can grant group access
     And the group @Class is a child of the group @ClassAnotherParent
     And there are the following items:
       | item                        | type    |

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -20,7 +20,7 @@ Feature: Get permissions can_request_help_to for a group
       | @Class                   | @ClassParent             |          |
       | @OtherSourceGroup        |                          |          |
     And @Teacher is a manager of the group @ClassAnotherParent and can grant group access
-    And @Class is a child of the group @ClassAnotherParent
+    And the group @Class is a child of the group @ClassAnotherParent
     And there are the following items:
       | item                        | type    |
       | @ChapterParent              | Chapter |

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -8,7 +8,7 @@ Feature: Get requests for group_id
       | jane    | 0         | 31       | Jane        | Doe       | 2     |
       | mark    | 0         | 41       | Mark        | Moe       | 2     |
       | larry   | 0         | 51       | Larry       | Loe       | 2     |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  |
       | 13  |
       | 14  |
@@ -20,11 +20,11 @@ Feature: Get requests for group_id
       | 124 |
       | 125 |
       | 131 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 14       | 15         | none        |
       | 13       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 13              | 21             | null                           |
       | 13              | 11             | null                           |
@@ -43,7 +43,7 @@ Feature: Get requests for group_id
       | 13              | 124            | null                           |
       | 13              | 125            | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                          | personal_info_view_approved |
       | 13       | 21        | invitation   | {{relativeTimeDB("-170h")}} | false                       |
       | 13       | 31        | join_request | {{relativeTimeDB("-168h")}} | true                        |
@@ -53,7 +53,7 @@ Feature: Get requests for group_id
       | 14       | 21        | join_request | 2017-05-27 06:38:38         | false                       |
       | 14       | 22        | join_request | 2017-05-27 06:38:38         | false                       |
       | 15       | 22        | join_request | 2017-05-27 06:38:38         | true                        |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                          | initiator_id |
       | 13       | 21        | invitation_created    | {{relativeTimeDB("-170h")}} | 11           |
       | 13       | 11        | invitation_refused    | {{relativeTimeDB("-169h")}} | null         |

--- a/app/api/groups/get_requests.robustness.feature
+++ b/app/api/groups/get_requests.robustness.feature
@@ -5,10 +5,10 @@ Feature: Get requests for group_id - robustness
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 0         | 11       | John        | Doe       | 1     |
       | jane  | 0         | 31       | Jane        | Doe       | 2     |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 13       | 31         | none        |

--- a/app/api/groups/get_roots.feature
+++ b/app/api/groups/get_roots.feature
@@ -1,6 +1,6 @@
 Feature: Get root groups (groupRootsView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                                     | type    |
       | 1  | Joined Base                              | Base    |
       | 2  | Managed Base                             | Base    |
@@ -41,13 +41,13 @@ Feature: Get root groups (groupRootsView)
       | 50 | jane                                     | User    |
       | 51 | john                                     | User    |
       | 52 | AllUsers                                 | Base    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
       | jack  | 49       | Jack        | Smith     |
       | jane  | 50       | Jane        | Doe       |
       | john  | 51       | John        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 41         |
       | 4        | 41         |
@@ -60,7 +60,7 @@ Feature: Get root groups (groupRootsView)
       | 26       | 50         |
       | 28       | 51         |
       | 52       | 41         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 3               | 4              | 9999-12-31 23:59:59 |
@@ -111,7 +111,7 @@ Feature: Get root groups (groupRootsView)
       | 52              | 50             | 9999-12-31 23:59:59 |
       | 52              | 51             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'groups_ancestors':
+    And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
       | 5                 | 41             | 2010-01-01 00:00:00 |
       | 7                 | 41             | 2010-01-01 00:00:00 |

--- a/app/api/groups/get_team_descendants.feature
+++ b/app/api/groups/get_team_descendants.feature
@@ -1,6 +1,6 @@
 Feature: List team descendants of the group (groupTeamDescendantView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           | grade |
       | 1  | Base    | Root 1         | -2    |
       | 3  | Base    | Root 2         | -2    |
@@ -25,7 +25,7 @@ Feature: List team descendants of the group (groupTeamDescendantView)
       | 65 | User    | janec          | -2    |
       | 67 | User    | janed          | -2    |
       | 69 | User    | janee          | -2    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 10    |
       | johna | 51       | John        | Adams     | 1     |
@@ -38,11 +38,11 @@ Feature: List team descendants of the group (groupTeamDescendantView)
       | janec | 65       | Jane        | null      | 4     |
       | janed | 67       | Jane        | Doe       | -2    |
       | janee | 69       | Jane        | Edwards   | null  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 1        | 21         |
       | 22       | 20         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 1               | 11             | null                           |
       | 3               | 13             | null                           |

--- a/app/api/groups/get_team_descendants.robustness.feature
+++ b/app/api/groups/get_team_descendants.robustness.feature
@@ -4,10 +4,10 @@ Feature: List team descendants of the group (groupTeamDescendantView) - robustne
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
     And the groups ancestors are computed

--- a/app/api/groups/get_team_progress.feature
+++ b/app/api/groups/get_team_progress.feature
@@ -1,6 +1,6 @@
 Feature: Display the current progress of teams on a subset of items (groupTeamProgress)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -25,7 +25,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | johna | 51       |
@@ -38,10 +38,10 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | janec | 65       |
       | janed | 67       |
       | janee | 69       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 4          | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 3               | 13             |
@@ -64,7 +64,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 16              | 67             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Chapter | fr                   |
       | 210 | Chapter | fr                   |
@@ -109,7 +109,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 417 | Task    | fr                   |
       | 418 | Task    | fr                   |
       | 419 | Task    | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -151,7 +151,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 410            | 417           | 7           |
       | 410            | 418           | 8           |
       | 410            | 419           | 9           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -193,7 +193,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 20       | 417     | none                     | none                |
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -205,7 +205,7 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | 1  | 15             | 2017-04-29 06:38:38 |
       | 2  | 15             | 2017-03-29 06:38:38 |
       | 5  | 14             | 2017-05-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
       | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                | 2018-05-30 06:38:38 |

--- a/app/api/groups/get_team_progress.robustness.feature
+++ b/app/api/groups/get_team_progress.robustness.feature
@@ -4,26 +4,26 @@ Feature: Display the current progress of teams on a subset of items (groupTeamPr
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_team_progress_csv.feature
+++ b/app/api/groups/get_team_progress_csv.feature
@@ -1,6 +1,6 @@
 Feature: Export the current progress of teams on a subset of items as CSV (groupTeamProgressCSV)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -25,7 +25,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | default_language |
       | owner | 21       | en               |
       | johna | 51       | fr               |
@@ -38,10 +38,10 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | janec | 65       | fr               |
       | janed | 67       | fr               |
       | janee | 69       | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 4          | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 3               | 13             |
@@ -64,7 +64,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 16              | 67             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Chapter | fr                   |
       | 210 | Chapter | fr                   |
@@ -109,7 +109,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 417 | Task    | fr                   |
       | 418 | Task    | fr                   |
       | 419 | Task    | fr                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title         |
       | 200     | fr           | Chapitre 200  |
       | 210     | fr           | Chapitre 210  |
@@ -156,7 +156,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 418     | fr           | Item 418      |
       | 419     | fr           | Item 419      |
       | 1010    | fr           | Chapitre 1010 |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -198,7 +198,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 410            | 417           | 7           |
       | 410            | 418           | 8           |
       | 410            | 419           | 9           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -240,7 +240,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 20       | 417     | none                     | none                |
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -252,7 +252,7 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | 1  | 15             | 2017-04-29 06:38:38 |
       | 2  | 15             | 2017-03-29 06:38:38 |
       | 5  | 14             | 2017-05-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
       | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | null                | 2018-05-30 06:38:38 |

--- a/app/api/groups/get_team_progress_csv.robustness.feature
+++ b/app/api/groups/get_team_progress_csv.robustness.feature
@@ -4,26 +4,26 @@ Feature: Export the current progress of teams on a subset of items as CSV (group
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_user_batch_prefixes.feature
+++ b/app/api/groups/get_user_batch_prefixes.feature
@@ -1,26 +1,26 @@
 Feature: List user-batch prefixes (userBatchPrefixesView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    |
       | 13 | class   | Class   |
       | 14 | class2  | Class   |
       | 15 | friends | Friends |
       | 16 | class3  | Class   |
       | 21 | user    | User    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 16       | 21         | none        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 15             |
       | 13              | 21             |
       | 16              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new | max_users |
       | test         | 13       | 1         | 90        |
       | test1        | 13       | 1         | 1000      |
@@ -28,7 +28,7 @@ Feature: List user-batch prefixes (userBatchPrefixesView)
       | test3        | 15       | 1         | 70        |
       | test4        | 14       | 1         | 60        |
       | test5        | 16       | 1         | 15        |
-    And the database has the following table 'user_batches_v2':
+    And the database has the following table "user_batches_v2":
       | group_prefix | custom_prefix | size | creator_id |
       | test         | custom        | 100  | null       |
       | test         | custom1       | 200  | 13         |

--- a/app/api/groups/get_user_batch_prefixes.robustness.feature
+++ b/app/api/groups/get_user_batch_prefixes.robustness.feature
@@ -1,19 +1,19 @@
 Feature: List user-batch prefixes (userBatchPrefixesView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name   | grade | type  |
       | 13 | class  | -2    | Class |
       | 14 | class2 | -2    | Class |
       | 21 | user   | -2    | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 14       | 21         | none        |
       | 21       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 21             |
     And the groups ancestors are computed

--- a/app/api/groups/get_user_batches.feature
+++ b/app/api/groups/get_user_batches.feature
@@ -1,28 +1,28 @@
 Feature: List user batches (userBatchesView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name   | grade | type  |
       | 13 | class  | -2    | Class |
       | 14 | class2 | -2    | Class |
       | 21 | user   | -2    | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new |
       | test         | 13       | 1         |
       | test1        | 13       | 1         |
       | test2        | 13       | 0         |
       | test3        | 21       | 1         |
       | test4        | 14       | 1         |
-    And the database has the following table 'user_batches_v2':
+    And the database has the following table "user_batches_v2":
       | group_prefix | custom_prefix | size | creator_id |
       | test         | custom        | 100  | null       |
       | test         | custom1       | 200  | 13         |

--- a/app/api/groups/get_user_batches.robustness.feature
+++ b/app/api/groups/get_user_batches.robustness.feature
@@ -1,18 +1,18 @@
 Feature: List user batches (userBatchesView) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name   | grade | type  |
       | 13 | class  | -2    | Class |
       | 14 | class2 | -2    | Class |
       | 21 | user   | -2    | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 14       | 21         | none        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 21             |
     And the groups ancestors are computed

--- a/app/api/groups/get_user_descendants.feature
+++ b/app/api/groups/get_user_descendants.feature
@@ -1,6 +1,6 @@
 Feature: List user descendants of the group (groupUserDescendantView)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           | grade |
       | 1  | Base    | Root 1         | -2    |
       | 3  | Base    | Root 2         | -2    |
@@ -16,14 +16,14 @@ Feature: List user descendants of the group (groupUserDescendantView)
       | 21 | User    | owner          | -2    |
       | 22 | Club    | Club           | -2    |
       | 23 | Club    | School         | -2    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 10    |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 1        | 21         |
       | 23       | 22         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 3               | 13             |
@@ -38,19 +38,19 @@ Feature: List user descendants of the group (groupUserDescendantView)
     And the groups ancestors are computed
 
   Scenario: One group with 5 grand children (different parents)
-    Given the database table 'groups' has also the following rows:
+    Given the database table "groups" has also the following rows:
       | id | type | name  | grade |
       | 51 | User | johna | -2    |
       | 53 | User | johnb | -2    |
       | 55 | User | johnc | -2    |
       | 57 | User | jackd | -2    |
-    And the database table 'users' has also the following rows:
+    And the database table "users" has also the following rows:
       | login | group_id | first_name | last_name | grade |
       | johna | 51       | null       | Adams     | 1     |
       | johnb | 53       | John       | Baker     | null  |
       | johnc | 55       | John       | null      | 3     |
       | jackd | 57       | Jack       | Doe       | 3     |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 11              | 51             | null                           |
       | 11              | 21             | null                           |
@@ -137,13 +137,13 @@ Feature: List user descendants of the group (groupUserDescendantView)
     """
 
   Scenario: Non-descendant parents should not appear (one group with 1 grand child, having also a parent which is not descendant)
-    Given the database table 'groups' has also the following rows:
+    Given the database table "groups" has also the following rows:
       | id | type | name  | grade |
       | 51 | User | johna | -2    |
-    And the database table 'users' has also the following rows:
+    And the database table "users" has also the following rows:
       | login | group_id | first_name | last_name | grade |
       | johna | 51       | null       | Adams     | 1     |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 11              | 51             | 2019-05-30 11:00:00            |
       | 13              | 51             | null                           |
@@ -164,13 +164,13 @@ Feature: List user descendants of the group (groupUserDescendantView)
     """
 
   Scenario: Only actual memberships count
-    Given the database table 'groups' has also the following rows:
+    Given the database table "groups" has also the following rows:
       | id | type | name  | grade |
       | 51 | User | johna | -2    |
-    And the database table 'users' has also the following rows:
+    And the database table "users" has also the following rows:
       | login | group_id | first_name | last_name | grade |
       | johna | 51       | John       | Adams     | 1     |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id | expires_at          |
       | 11              | 51             | 2019-05-30 11:00:00 |
     And the groups ancestors are computed
@@ -184,13 +184,13 @@ Feature: List user descendants of the group (groupUserDescendantView)
     """
 
   Scenario: No duplication (one group with 1 grand children connected through 2 different parents)
-    Given the database table 'groups' has also the following rows:
+    Given the database table "groups" has also the following rows:
       | id | type | name  | grade |
       | 51 | User | johna | -2    |
-    And the database table 'users' has also the following rows:
+    And the database table "users" has also the following rows:
       | login | group_id | first_name | last_name | grade |
       | johna | 51       | null       | Adams     | 1     |
-    And the database table 'groups_groups' has also the following rows:
+    And the database table "groups_groups" has also the following rows:
       | parent_group_id | child_group_id |
       | 11              | 51             |
       | 14              | 51             |

--- a/app/api/groups/get_user_descendants.robustness.feature
+++ b/app/api/groups/get_user_descendants.robustness.feature
@@ -4,10 +4,10 @@ Feature: List user descendants of the group (groupUserDescendantView) - robustne
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 21         |
     And the groups ancestors are computed

--- a/app/api/groups/get_user_progress.feature
+++ b/app/api/groups/get_user_progress.feature
@@ -1,6 +1,6 @@
 Feature: Display the current progress of users on a subset of items (groupUserProgress)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -26,7 +26,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | owner | 21       |
       | johna | 51       |
@@ -39,12 +39,12 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | janec | 65       |
       | janed | 67       |
       | janee | 69       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 21         | true              |
       | 19       | 4          | true              |
       | 51       | 4          | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 11             |
       | 1               | 67             |
@@ -71,7 +71,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 19              | 69             |
       | 20              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Chapter | fr                   |
       | 210 | Chapter | fr                   |
@@ -116,7 +116,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 417 | Task    | fr                   |
       | 418 | Task    | fr                   |
       | 419 | Task    | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -158,7 +158,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 410            | 417           | 6           |
       | 410            | 418           | 7           |
       | 410            | 419           | 8           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -201,7 +201,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
       | 4        | 1010    | none                     | answer_with_grant   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -214,7 +214,7 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | 4  | 14             | 2017-05-29 06:38:38 |
       | 1  | 15             | 2017-03-29 06:38:38 |
       | 5  | 14             | 2017-05-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
       | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | 2017-05-30 06:38:38 | 2018-05-30 06:38:38 | # latest_activity_at for 51, 211 comes from this line (the last activity is made by a team)

--- a/app/api/groups/get_user_progress.robustness.feature
+++ b/app/api/groups/get_user_progress.robustness.feature
@@ -4,26 +4,26 @@ Feature: Display the current progress of users on a subset of items (groupUserPr
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_user_progress_csv.feature
+++ b/app/api/groups/get_user_progress_csv.feature
@@ -1,6 +1,6 @@
 Feature: Export the current progress of users on a subset of items as CSV (groupUserProgressCSV)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name           |
       | 1  | Base    | Root 1         |
       | 3  | Base    | Root 2         |
@@ -26,7 +26,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 65 | User    | janec          |
       | 67 | User    | janed          |
       | 69 | User    | janee          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | default_language |
       | owner | 21       | Jean-Michel | Blanquer  | en               |
       | johna | 51       | John        | Adams     | fr               |
@@ -39,12 +39,12 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | janec | 65       | null        | null      | fr               |
       | janed | 67       | null        | null      | fr               |
       | janee | 69       | Jane        | Ebbot     | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 1        | 21         | true              |
       | 19       | 4          | true              |
       | 51       | 4          | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 1               | 11             | null                           |
       | 1               | 67             | null                           |
@@ -71,7 +71,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 19              | 69             | null                           |
       | 20              | 21             | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | type    | default_language_tag |
       | 200  | Chapter | fr                   |
       | 210  | Chapter | fr                   |
@@ -117,7 +117,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 418  | Task    | fr                   |
       | 419  | Task    | fr                   |
       | 1010 | Chapter | fr                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title         |
       | 200     | fr           | Chapitre 200  |
       | 210     | fr           | Chapitre 210  |
@@ -164,7 +164,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 418     | fr           | Item 418      |
       | 419     | fr           | Item 419      |
       | 1010    | fr           | Chapitre 1010 |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |
@@ -206,7 +206,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 410            | 417           | 6           |
       | 410            | 418           | 7           |
       | 410            | 419           | 8           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 21       | 210     | none                     | result              |
       | 21       | 211     | info                     | none                |
@@ -249,7 +249,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 21       | 418     | none                     | none                |
       | 20       | 419     | none                     | none                |
       | 4        | 1010    | none                     | answer_with_grant   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 14             | 2017-05-29 06:38:38 |
       | 1  | 14             | 2017-05-29 06:38:38 |
@@ -262,7 +262,7 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | 4  | 14             | 2017-05-29 06:38:38 |
       | 1  | 15             | 2017-03-29 06:38:38 |
       | 5  | 14             | 2017-05-29 06:38:38 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
       | 0          | 14             | 210     | 2017-05-29 05:38:38 | 50             | 2017-05-29 06:38:38 | 115          | 127         | null                | 2019-05-29 06:38:38 |
       | 0          | 14             | 211     | 2017-05-29 06:38:38 | 0              | 2017-05-29 06:38:38 | 100          | 100         | 2017-05-30 06:38:38 | 2018-05-30 06:38:38 | # latest_activity_at for 51, 211 comes from this line (the last activity is made by a team)

--- a/app/api/groups/get_user_progress_csv.robustness.feature
+++ b/app/api/groups/get_user_progress_csv.robustness.feature
@@ -4,26 +4,26 @@ Feature: Export the current progress of users on a subset of items as CSV (group
       | login | group_id |
       | owner | 21       |
       | user  | 11       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
       | 13       | 21         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag |
       | 200 | Task    | fr                   |
       | 210 | Chapter | fr                   |
       | 211 | Task    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 11       | 210     | info                     | result              |
       | 20       | 210     | none                     | answer              |
       | 21       | 210     | none                     | answer_with_grant   |
       | 21       | 211     | info                     | none                |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 200            | 210           | 0           |
       | 200            | 220           | 1           |

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -6,7 +6,7 @@ Feature: Get pending requests for managed groups
       | user    | 0         | 11       | John        | Doe       | 1     |
       | jane    | 0         | 31       | Jane        | Doe       | 2     |
       | richard | 0         | 41       | Richard     | Roe       | 2     |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | name       |
       | 1   | Root       |
       | 13  | Class      |
@@ -19,13 +19,13 @@ Feature: Get pending requests for managed groups
       | 123 | Subgroup 4 |
       | 124 | Subgroup 5 |
       | 131 | Subgroup 6 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 1        | 21         | memberships |
       | 13       | 21         | memberships |
       | 13       | 31         | none        |
       | 14       | 31         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 1               | 13             | null                           |
       | 1               | 14             | null                           |
@@ -45,7 +45,7 @@ Feature: Get pending requests for managed groups
       | 13              | 123            | null                           |
       | 13              | 124            | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                          | personal_info_view_approved |
       | 13       | 21        | invitation    | {{relativeTimeDB("-170h")}} | true                        |
       | 13       | 31        | join_request  | {{relativeTimeDB("-168h")}} | false                       |

--- a/app/api/groups/get_user_requests.robustness.feature
+++ b/app/api/groups/get_user_requests.robustness.feature
@@ -5,10 +5,10 @@ Feature: Get pending requests for managed groups - robustness
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 0         | 11       | John        | Doe       | 1     |
       | jane  | 0         | 31       | Jane        | Doe       | 2     |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id |
       | 13 |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 13       | 31         | none        |

--- a/app/api/groups/path_from_root.feature
+++ b/app/api/groups/path_from_root.feature
@@ -1,6 +1,6 @@
 Feature: Find a group path
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                                     | type    | is_public |
       | 1  | Joined Base                              | Base    | false     |
       | 2  | Managed Base                             | Base    | false     |
@@ -43,13 +43,13 @@ Feature: Find a group path
       | 49 | jack                                     | User    | false     |
       | 50 | jane                                     | User    | false     |
       | 51 | john                                     | User    | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
       | jack  | 49       | Jack        | Smith     |
       | jane  | 50       | Jane        | Doe       |
       | john  | 51       | John        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 41         |
       | 4        | 41         |
@@ -61,7 +61,7 @@ Feature: Find a group path
       | 23       | 25         |
       | 28       | 50         |
       | 30       | 51         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 3               | 4              | 9999-12-31 23:59:59 |
@@ -121,7 +121,7 @@ Feature: Find a group path
       | 23              | 41             | 2010-01-01 00:00:00 |
       | 25              | 41             | 2010-01-01 00:00:00 |
     And the groups ancestors are computed
-    And the database has the following table 'groups_ancestors':
+    And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
       | 5                 | 41             | 2010-01-01 00:00:00 |
       | 7                 | 41             | 2010-01-01 00:00:00 |

--- a/app/api/groups/path_from_root.robustness.feature
+++ b/app/api/groups/path_from_root.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Find a group path - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                                     | type    | is_public |
       | 1  | Joined Base                              | Base    | false     |
       | 2  | Managed Base                             | Base    | false     |
@@ -43,13 +43,13 @@ Feature: Find a group path - robustness
       | 49 | jack                                     | User    | false     |
       | 50 | jane                                     | User    | false     |
       | 51 | john                                     | User    | false     |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 41       | Jean-Michel | Blanquer  |
       | jack  | 49       | Jack        | Smith     |
       | jane  | 50       | Jane        | Doe       |
       | john  | 51       | John        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 2        | 41         |
       | 4        | 41         |
@@ -61,7 +61,7 @@ Feature: Find a group path - robustness
       | 23       | 25         |
       | 28       | 50         |
       | 30       | 51         |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 1               | 41             | 9999-12-31 23:59:59 |
       | 3               | 4              | 9999-12-31 23:59:59 |
@@ -121,7 +121,7 @@ Feature: Find a group path - robustness
       | 23              | 41             | 2010-01-01 00:00:00 |
       | 25              | 41             | 2010-01-01 00:00:00 |
     And the groups ancestors are computed
-    And the database has the following table 'groups_ancestors':
+    And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
       | 5                 | 41             | 2010-01-01 00:00:00 |
       | 7                 | 41             | 2010-01-01 00:00:00 |

--- a/app/api/groups/reject_join_requests.feature
+++ b/app/api/groups/reject_join_requests.feature
@@ -1,6 +1,6 @@
 Feature: Reject group requests
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  |
       | 11  |
       | 13  |
@@ -15,10 +15,10 @@ Feature: Reject group requests
       | 131 |
       | 141 |
       | 151 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 111            |
       | 13              | 121            |
@@ -26,7 +26,7 @@ Feature: Reject group requests
       | 13              | 151            |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                          |
       | 13       | 21        | invitation   | {{relativeTimeDB("-170h")}} |
       | 13       | 31        | join_request | {{relativeTimeDB("-168h")}} |
@@ -36,7 +36,7 @@ Feature: Reject group requests
 
   Scenario Outline: Reject requests
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage   |
       | 13       | 21         | <can_manage> |
     When I send a POST request to "/groups/13/join-requests/reject?group_ids=31,141,21,11,13,22,151"

--- a/app/api/groups/reject_join_requests.robustness.feature
+++ b/app/api/groups/reject_join_requests.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Reject group requests - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  |
       | 11  | User  |
       | 12  | User  |
@@ -14,17 +14,17 @@ Feature: Reject group requests - robustness
       | 123 | User  |
       | 131 | User  |
       | 141 | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 11       | John        | Doe       | 1     |
       | jane  | 12       | Jane        | Doe       | 1     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 12       | 12         | memberships |
       | 13       | 21         | memberships |
       | 13       | 12         | none        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 111            |
       | 13              | 121            |

--- a/app/api/groups/reject_leave_requests.feature
+++ b/app/api/groups/reject_leave_requests.feature
@@ -1,6 +1,6 @@
 Feature: Reject requests to leave a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    |
       | 11  | Class   |
       | 13  | Team    |
@@ -16,10 +16,10 @@ Feature: Reject requests to leave a group
       | 151 | User    |
       | 161 | User    |
       | 444 | Team    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 31             |
       | 13              | 111            |
@@ -28,7 +28,7 @@ Feature: Reject requests to leave a group
       | 13              | 141            |
       | 13              | 151            |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          |
       | 13       | 21        | invitation    |
       | 13       | 31        | leave_request |
@@ -39,7 +39,7 @@ Feature: Reject requests to leave a group
 
   Scenario: Reject requests to leave a group
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
     When I send a POST request to "/groups/13/leave-requests/reject?group_ids=31,141,21,11,13,122,151"

--- a/app/api/groups/reject_leave_requests.robustness.feature
+++ b/app/api/groups/reject_leave_requests.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Accept requests to leave a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    |
       | 11  | Class   |
       | 13  | Team    |
@@ -16,10 +16,10 @@ Feature: Accept requests to leave a group - robustness
       | 151 | User    |
       | 161 | User    |
       | 444 | Team    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 31             |
       | 13              | 111            |
@@ -28,7 +28,7 @@ Feature: Accept requests to leave a group - robustness
       | 13              | 141            |
       | 13              | 151            |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          |
       | 13       | 21        | invitation    |
       | 13       | 31        | leave_request |
@@ -49,7 +49,7 @@ Feature: Accept requests to leave a group - robustness
 
   Scenario: Fails when the user is a manager of the parent group, but doesn't have enough rights to manage memberships
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage |
       | 13       | 21         | none       |
     When I send a POST request to "/groups/13/leave-requests/reject?group_ids=31,141,21,11,13"
@@ -62,7 +62,7 @@ Feature: Accept requests to leave a group - robustness
 
   Scenario: Fails when the user has enough rights to manage memberships, but the group is a user
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 21       | 21         | memberships |
     When I send a POST request to "/groups/21/leave-requests/reject?group_ids=31,141,21,11,13"

--- a/app/api/groups/remove_child.feature
+++ b/app/api/groups/remove_child.feature
@@ -1,34 +1,34 @@
 Feature: Remove a direct parent-child relation between two groups
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 11 | Group A | Class |
       | 13 | Group B | Class |
       | 14 | Group C | Class |
       | 21 | Self    | User  |
       | 22 | Group   | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 14       | 21         | none        |
       | 22       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 22              | 11             |
       | 22              | 13             |
       | 22              | 14             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type       |
       | 13       | 11        | invitation |
       | 22       | 11        | invitation |
       | 22       | 13        | invitation |
       | 22       | 14        | invitation |
-    And the database has the following table 'group_membership_changes':
+    And the database has the following table "group_membership_changes":
       | group_id | member_id |
       | 13       | 11        |
       | 22       | 11        |

--- a/app/api/groups/remove_child.robustness.feature
+++ b/app/api/groups/remove_child.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Remove a direct parent-child relation between two groups - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name     | type  |
       | 11 | Group A  | Class |
       | 13 | Group B  | Class |
@@ -12,11 +12,11 @@ Feature: Remove a direct parent-child relation between two groups - robustness
       | 23 | teacher  | User  |
       | 53 | AllUsers | Base  |
       | 55 | User     | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id | first_name  | last_name |
       | owner   | 21       | Jean-Michel | Blanquer  |
       | teacher | 23       | John        | Smith     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
       | 14       | 21         | memberships |
@@ -27,7 +27,7 @@ Feature: Remove a direct parent-child relation between two groups - robustness
       | 55       | 21         | memberships |
       | 11       | 23         | none        |
       | 55       | 23         | none        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 11              | 55             | 9999-12-31 23:59:59 |
       | 13              | 11             | 9999-12-31 23:59:59 |

--- a/app/api/groups/remove_code.feature
+++ b/app/api/groups/remove_code.feature
@@ -1,15 +1,15 @@
 Feature: Remove the code of the given group
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | code       | code_lifetime | code_expires_at     |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class | 3456789abc | 3600          | 2017-10-14 05:39:48 |
       | 21 | owner   | -4    | owner           | 2019-04-06 09:26:40 | User  | null       | null          | null                |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
     And the groups ancestors are computed

--- a/app/api/groups/remove_code.robustness.feature
+++ b/app/api/groups/remove_code.robustness.feature
@@ -1,20 +1,20 @@
 Feature: Remove the code of the given group - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | code       | code_lifetime | code_expires_at     |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class | 3456789abc | 3600          | 2017-10-14 05:39:48 |
       | 21 | owner   | -4    | owner           | 2019-04-06 09:26:40 | User  | null       | null          | null                |
       | 31 | jane    | -4    | owner           | 2019-04-06 09:26:40 | User  | null       | null          | null                |
       | 41 | user    | -4    | user            | 2019-04-06 09:26:40 | User  | null       | null          | null                |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
       | user  | 0         | 41       | John        | Doe       | en               |
       | jane  | 0         | 31       | Jane        | Doe       | en               |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
       | 13       | 31         | none                  |

--- a/app/api/groups/remove_manager.feature
+++ b/app/api/groups/remove_manager.feature
@@ -1,21 +1,21 @@
 Feature: Remove a group manager (groupManagerDelete)
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name  | type  |
       | 1  | Group | Class |
       | 2  | Team  | Team  |
       | 21 | owner | User  |
       | 22 | john  | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 22       | John        | Doe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 2              |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
       | 21         | 2        | none                  |

--- a/app/api/groups/remove_manager.robustness.feature
+++ b/app/api/groups/remove_manager.robustness.feature
@@ -1,19 +1,19 @@
 Feature: Remove a group manager (groupManagerDelete) - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    |
       | 1  | Group   | Class   |
       | 2  | Team    | Team    |
       | 3  | Friends | Friends |
       | 21 | owner   | User    |
       | 22 | john    | User    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 22       | John        | Doe       |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
       | 21         | 3        | memberships           |

--- a/app/api/groups/remove_members.feature
+++ b/app/api/groups/remove_members.feature
@@ -1,6 +1,6 @@
 Feature: Remove members from a group (groupRemoveMembers)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  |
       | 13  |
       | 14  |
@@ -17,7 +17,7 @@ Feature: Remove members from a group (groupRemoveMembers)
       | 121 |
       | 131 |
       | 132 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login  | group_id |
       | owner  | 21       |
       | john   | 31       |
@@ -30,7 +30,7 @@ Feature: Remove members from a group (groupRemoveMembers)
       | jenna  | 101      |
       | jannet | 111      |
       | judith | 121      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 51             |
       | 13              | 61             |
@@ -39,7 +39,7 @@ Feature: Remove members from a group (groupRemoveMembers)
       | 13              | 131            |
       | 14              | 41             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 13       | 21        | invitation   |
       | 13       | 41        | join_request |
@@ -48,7 +48,7 @@ Feature: Remove members from a group (groupRemoveMembers)
 
   Scenario Outline: Remove members
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage   |
       | 13       | 21         | <can_manage> |
     When I send a DELETE request to "/groups/13/members?user_ids=31,41,51,61,71,81,91,101,111,121,131,404"

--- a/app/api/groups/remove_members.robustness.feature
+++ b/app/api/groups/remove_members.robustness.feature
@@ -1,22 +1,22 @@
 Feature: Remove members from a group (groupRemoveMembers)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type |
       | 11 | User |
       | 13 | Club |
       | 21 | User |
       | 31 | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 11       | John        | Doe       | 1     |
       | jane  | 31       | Jane        | Doe       | 1     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 31         | none                  |
       | 13       | 21         | memberships_and_group |

--- a/app/api/groups/remove_user_batch.feature
+++ b/app/api/groups/remove_user_batch.feature
@@ -1,6 +1,6 @@
 Feature: Remove user batch (userBatchRemove)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                      | type  | require_lock_membership_approval_until |
       | 13 | class                     | Class | 9999-12-31 23:59:59                    |
       | 21 | user                      | User  | null                                   |
@@ -10,7 +10,7 @@ Feature: Remove user batch (userBatchRemove)
       | 25 | test_custom1_another_user | User  | null                                   |
       | 26 | test1_custom_user         | User  | null                                   |
       | 27 | test1_custom_another_user | User  | null                                   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login                     | group_id |
       | owner                     | 21       |
       | test1_custom_another_user | 27       |
@@ -19,20 +19,20 @@ Feature: Remove user batch (userBatchRemove)
       | test_custom_user          | 22       |
       | test_custom1_another_user | 25       |
       | test_custom1_user         | 24       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 21         | memberships |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 13              | 21             | null                        |
       | 13              | 22             | 2019-05-30 11:00:00         |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new |
       | test         | 13       | 1         |
       | test1        | 13       | 1         |
       | test2        | 13       | 0         |
-    And the database has the following table 'user_batches_v2':
+    And the database has the following table "user_batches_v2":
       | group_prefix | custom_prefix | size | creator_id |
       | test         | custom        | 100  | null       |
       | test         | custom1       | 200  | 13         |

--- a/app/api/groups/remove_user_batch.robustness.feature
+++ b/app/api/groups/remove_user_batch.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Remove user batch (userBatchRemove) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name                      | type  | require_lock_membership_approval_until |
       | 13 | class                     | Class | null                                   |
       | 14 | class2                    | Class | 9999-12-31 23:59:59                    |
@@ -11,7 +11,7 @@ Feature: Remove user batch (userBatchRemove) - robustness
       | 25 | test_custom1_another_user | User  | null                                   |
       | 26 | test1_custom_user         | User  | null                                   |
       | 27 | test1_custom_another_user | User  | null                                   |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login                     | group_id |
       | owner                     | 21       |
       | test1_custom_another_user | 27       |
@@ -20,24 +20,24 @@ Feature: Remove user batch (userBatchRemove) - robustness
       | test_custom1_user         | 24       |
       | test_custom_another_user  | 23       |
       | test_custom_user          | 22       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 13       | 13         | memberships |
       | 13       | 22         | none        |
     And the groups ancestors are computed
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
       | 13              | 21             | null                        |
       | 14              | 22             | 2019-05-30 11:00:00         |
     And the groups ancestors are computed
-    And the database has the following table 'user_batch_prefixes':
+    And the database has the following table "user_batch_prefixes":
       | group_prefix | group_id | allow_new |
       | test         | 13       | 1         |
       | test1        | 13       | 1         |
       | test2        | 13       | 0         |
       | test3        | 21       | 1         |
       | test4        | 14       | 1         |
-    And the database has the following table 'user_batches_v2':
+    And the database has the following table "user_batches_v2":
       | group_prefix | custom_prefix | size | creator_id |
       | test         | custom        | 100  | null       |
       | test         | custom1       | 200  | 13         |

--- a/app/api/groups/search_for_possible_subgroups.feature
+++ b/app/api/groups/search_for_possible_subgroups.feature
@@ -1,6 +1,6 @@
 Feature: Search for possible subgroups
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | type    | name                                  | description            |
       | 1  | Class   | amazing Class                         | Our class group        |
       | 2  | Team    | amazing Team                          | null                   |
@@ -15,10 +15,10 @@ Feature: Search for possible subgroups
       | 11 | User    | Another amazing User                  | Another user group     |
       | 12 | Club    | Club                                  | Parent group           |
       | 21 | User    | amazing user self                     |                        |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | grade |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 5               | 21             |
       | 6               | 21             |
@@ -29,13 +29,13 @@ Feature: Search for possible subgroups
       | 1               | 7              |
       | 4               | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 1        | 21         | memberships           |
       | 4        | 21         | memberships_and_group |
       | 2        | 5          | memberships_and_group |
       | 12       | 5          | memberships_and_group |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         |
       | 1        | 21        | invitation   |
       | 3        | 21        | join_request |

--- a/app/api/groups/update_group.feature
+++ b/app/api/groups/update_group.feature
@@ -1,6 +1,6 @@
 Feature: Update a group (groupEdit)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type    | root_activity_id    | root_skill_id | is_open | is_public | code       | code_lifetime | code_expires_at     | open_activity_when_joining | is_official_session | require_members_to_join_parent | organizer | address_line1 | address_line2 | address_postcode | address_city | address_country | expected_start      | frozen_membership | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval | max_participants | enforce_max_participants |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class   | 1672978871462145361 | null          | true    | true      | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 | true                       | false               | false                          | null      | null          | null          | null             | null         | null            | null                | false             | none                                  | null                                   | false                  | null             | false                    |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class   | 1672978871462145461 | null          | true    | true      | ybabbxnlyo | 3600          | 2017-10-14 05:39:48 | true                       | false               | false                          | null      | null          | null          | null             | null         | null            | null                | false             | edit                                  | 2020-01-01 00:00:00                    | true                   | 5                | true                     |
@@ -15,12 +15,12 @@ Feature: Update a group (groupEdit)
       | 31 | user    | -4    | owner           | 2019-04-06 09:26:40 | User    | null                | null          | false   | false     | null       | null          | null                | false                      | false               | false                          | null      | null          | null          | null             | null         | null            | null                | false             | none                                  | null                                   | false                  | null             | false                    |
       | 41 | john    | -4    | john            | 2019-04-06 09:26:40 | User    | null                | null          | false   | false     | null       | null          | null                | false                      | false               | false                          | null      | null          | null          | null             | null         | null            | null                | false             | none                                  | null                                   | false                  | null             | false                    |
       | 50 | Admins  | -4    | Admins          | 2019-04-06 09:26:40 | Club    | null                | null          | false   | false     | null       | null          | null                | false                      | false               | false                          | null      | null          | null          | null             | null         | null            | null                | false             | none                                  | null                                   | false                  | null             | false                    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name | default_language |
       | owner | 0         | 21       | Jean-Michel | Blanquer  | fr               |
       | other | 0         | 24       | John        | Doe       | en               |
       | jane  | 0         | 25       | Jane        | Doe       | en               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
       | 14       | 21         | none                  |
@@ -29,26 +29,26 @@ Feature: Update a group (groupEdit)
       | 16       | 25         | none                  |
       | 17       | 25         | none                  |
       | 18       | 25         | memberships           |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 41             |
       | 50              | 21             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          |
       | 13       | 21        | invitation    |
       | 13       | 24        | join_request  |
       | 13       | 31        | join_request  |
       | 13       | 41        | leave_request |
       | 14       | 31        | join_request  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag | type    |
       | 123  | fr                   | Task    |
       | 4567 | fr                   | Skill   |
       | 5678 | fr                   | Chapter |
       | 6789 | fr                   | Task    |
       | 7890 | fr                   | Task    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 21       | 4567    | info               |
       | 21       | 5678    | info               |
@@ -56,7 +56,7 @@ Feature: Update a group (groupEdit)
       | 21       | 7890    | info               |
       | 24       | 123     | info               |
       | 50       | 123     | info               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_make_session_official | is_owner | source_group_id |
       | 24       | 123     | true                      | false    | 13              |
       | 50       | 123     | false                     | true     | 13              |
@@ -325,21 +325,21 @@ Feature: Update a group (groupEdit)
 
   Scenario: Should be able to update the description, root_activity_id and root_skill_id from a value to null
     Given I am the user with id "100"
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | manager | 100      |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 101      | 100        | memberships_and_group |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | name    | description       | root_activity_id | root_skill_id |
       | 100 | manager |                   | null             | null          |
       | 101 | Group   | Group description | 200              | 100           |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 101             | 100            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag | type  |
       | 100 | fr                   | Skill |
     When I send a PUT request to "/groups/101" with the following body:

--- a/app/api/groups/update_group.robustness.feature
+++ b/app/api/groups/update_group.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Update a group (groupEdit) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | description     | created_at          | type  | root_activity_id    | is_official_session | is_open | is_public | code       | code_lifetime | code_expires_at     | open_activity_when_joining | frozen_membership | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval | max_participants | enforce_max_participants |
       | 11 | Group A | -3    | Group A is here | 2019-02-06 09:26:40 | Class | 1672978871462145361 | false               | true    | true      | ybqybxnlyo | 3600          | 2017-10-13 05:39:48 | true                       | 0                 | none                                  | null                                   | false                  | null             | false                    |
       | 13 | Group B | -2    | Group B is here | 2019-03-06 09:26:40 | Class | 1672978871462145461 | false               | true    | true      | ybabbxnlyo | 3600          | 2017-10-14 05:39:48 | true                       | 1                 | none                                  | null                                   | false                  | 5                | true                     |
@@ -11,12 +11,12 @@ Feature: Update a group (groupEdit) - robustness
       | 21 | owner   | -4    | owner           | 2019-04-06 09:26:40 | User  | null                | false               | false   | false     | null       | null          | null                | false                      | 0                 | none                                  | null                                   | false                  | null             | false                    |
       | 31 | user    | -4    | owner           | 2019-04-06 09:26:40 | User  | null                | false               | false   | false     | null       | null          | null                | false                      | 0                 | none                                  | null                                   | false                  | null             | false                    |
       | 41 | user    | -4    | owner           | 2019-04-06 09:26:40 | User  | null                | false               | false   | false     | null       | null          | null                | false                      | 0                 | none                                  | null                                   | false                  | null             | false                    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id | first_name  | last_name |
       | owner | 0         | 21       | Jean-Michel | Blanquer  |
       | user  | 0         | 31       | John        | Doe       |
       | jane  | 0         | 41       | Jane        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 13       | 21         | memberships_and_group |
       | 14       | 21         | memberships_and_group |
@@ -26,23 +26,23 @@ Feature: Update a group (groupEdit) - robustness
       | 17       | 31         | none                  |
       | 17       | 41         | memberships_and_group |
     And the groups ancestors are computed
-    And the database table 'groups_ancestors' has also the following rows:
+    And the database table "groups_ancestors" has also the following rows:
       | ancestor_group_id | child_group_id | expires_at          |
       | 17                | 21             | 2019-05-30 11:00:00 |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag | type   |
       | 123  | fr                   | Task   |
       | 124  | fr                   | Task   |
       | 5678 | fr                   | Task   |
       | 6789 | fr                   | Skill  |
       | 7890 | fr                   | Skill  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 21       | 123     | info               |
       | 21       | 124     | info               |
       | 21       | 5678    | none               |
       | 21       | 6789    | info               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_make_session_official | source_group_id |
       | 21       | 123     | false                     | 13              |
       | 17       | 124     | true                      | 13              |
@@ -333,20 +333,20 @@ Feature: Update a group (groupEdit) - robustness
   Scenario Outline: Should return an error if a require_* field is strengthened, and there is at least one user in the group, but approval_change_action is not given
     Given I am the user with id "21"
     And the time now is "2020-01-01T01:00:00Z"
-    And the database table 'groups' has also the following rows:
+    And the database table "groups" has also the following rows:
       | id  | name  | grade | description | created_at          | type  | root_activity_id | is_official_session | is_open | is_public | code | code_lifetime | code_expires_at     | open_activity_when_joining | frozen_membership | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       | max_participants | enforce_max_participants |
       | 101 | Group | 1     | Group       | 2020-01-01 00:00:00 | Class | null             | true                | true    | true      | null | null          | 2020-01-01 00:00:00 | true                       | 0                 | <require_personal_info_access_approval_old> | <require_lock_membership_approval_until_old> | <require_watch_approval_old> | 1                | false                    |
       | 110 | Team  | 1     | Team        | 2020-01-01 00:00:00 | Team  | null             | true                | true    | true      | null | null          | 2020-01-01 00:00:00 | true                       | 0                 | <require_personal_info_access_approval_old> | <require_lock_membership_approval_until_old> | <require_watch_approval_old> | 1                | false                    |
-    And the database table 'group_managers' has also the following rows:
+    And the database table "group_managers" has also the following rows:
       | group_id | manager_id | can_manage            |
       | 101      | 21         | memberships_and_group |
     # There must be at least one user in the group. Otherwise it's not considered a strengthening.
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 101             | 110            |
     And the groups ancestors are computed
     # There is at least one user in the group
-    And the database table 'groups_ancestors' has also the following rows:
+    And the database table "groups_ancestors" has also the following rows:
       | ancestor_group_id | child_group_id | expires_at          |
       | 101               | 21             | 2021-01-01 00:00:00 |
     When I send a PUT request to "/groups/101" with the following body:

--- a/app/api/groups/update_group_require_strengthened.feature
+++ b/app/api/groups/update_group_require_strengthened.feature
@@ -12,7 +12,7 @@ Feature:
       | @School   |              | @Teacher            |                                             |                                              |                              |
       | @Class    | @ClassParent | @Student1,@Student2 | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
       | @SubGroup | @Class       | @Student3,@Student4 |                                             |                                              |                              |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     And the time now is "2020-01-01T01:00:00.001Z"
     And the DB time now is "2020-01-01 01:00:00.001"
     When I send a PUT request to "/groups/@Class" with the following body:
@@ -50,7 +50,7 @@ Feature:
       | group   | parent       | members         | require_personal_info_access_approval       | require_lock_membership_approval_until       | require_watch_approval       |
       | @School |              | @Teacher        |                                             |                                              |                              |
       | @Class  | @ClassParent | <group_members> | <old_require_personal_info_access_approval> | <old_require_lock_membership_approval_until> | <old_require_watch_approval> |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     And the time now is "2020-01-01T01:00:00.001Z"
     When I send a PUT request to "/groups/@Class" with the following body:
     """
@@ -91,7 +91,7 @@ Feature:
       | group   | parent       | members   | require_lock_membership_approval_until |
       | @School |              | @Teacher  |                                        |
       | @Class  | @ClassParent | @Student1 | 2020-01-01 12:00:00                    |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -117,7 +117,7 @@ Feature:
       | @Class   | @Student4 | join_request  | 2020-01-01 00:00:04.000 |
       | @Class   | @Student5 | invitation    | 2020-01-01 00:00:05.000 |
       | @Other   | @Student5 | join_request  | 2020-01-01 00:00:15.000 |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -152,7 +152,7 @@ Feature:
       | @Class   | @Student4 | join_request  | 2020-01-01 00:00:04.000 |
       | @Class   | @Student5 | invitation    | 2020-01-01 00:00:05.000 |
       | @Other   | @Student5 | join_request  | 2020-01-01 00:00:15.000 |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     And the time now is "2020-01-01T01:00:00.001Z"
     And the DB time now is "2020-01-01 01:00:00.001"
     When I send a PUT request to "/groups/@Class" with the following body:
@@ -182,7 +182,7 @@ Feature:
       | @School   |              | @Teacher            |                        |
       | @Class    | @ClassParent | @Student1,@Student2 | false                  |
       | @SubGroup | @Class       | @Student3,@Student4 |                        |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {
@@ -218,7 +218,7 @@ Feature:
       | @Class   | @Student6 | invitation    | 2020-01-01 00:00:06.000 |
       | @Other   | @Student5 | leave_request | 2020-01-01 00:00:15.000 |
       | @Other   | @Student6 | join_request  | 2020-01-01 00:00:16.000 |
-    And @Teacher is a manager of the group @ClassParent and can manage memberships and group
+    And the group @Teacher is a manager of the group @ClassParent and can can manage memberships and the group
     When I send a PUT request to "/groups/@Class" with the following body:
     """
     {

--- a/app/api/groups/update_group_require_strengthened.feature
+++ b/app/api/groups/update_group_require_strengthened.feature
@@ -110,7 +110,7 @@ Feature:
       | @School |              | @Teacher                      |                        |
       | @Class  | @ClassParent | @Student1,@Student2           | false                  |
       | @Other  |              | @Student3,@Student4,@Student5 |                        |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | @Class   | @Student1 | leave_request | 2020-01-01 00:00:01.000 |
       | @Class   | @Student3 | join_request  | 2020-01-01 00:00:03.000 |
@@ -145,7 +145,7 @@ Feature:
       | @School |              | @Teacher                      |                        |
       | @Class  | @ClassParent | @Student1,@Student2           | false                  |
       | @Other  |              | @Student3,@Student4,@Student5 |                        |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | @Class   | @Student1 | leave_request | 2020-01-01 00:00:01.000 |
       | @Class   | @Student3 | join_request  | 2020-01-01 00:00:03.000 |
@@ -209,7 +209,7 @@ Feature:
       | @School |              | @Teacher                      |                                        |
       | @Class  | @ClassParent | @Student1,@Student2,@Student3 | 2020-01-01 12:00:00                    |
       | @Other  |              | @Student4,@Student5,@Student6 |                                        |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                      |
       | @Class   | @Student1 | leave_request | 2020-01-01 00:00:01.000 |
       | @Class   | @Student2 | leave_request | 2020-01-01 00:00:02.000 |

--- a/app/api/groups/update_manager.feature
+++ b/app/api/groups/update_manager.feature
@@ -1,21 +1,21 @@
 Feature: Update the group manager's permissions (groupManagerEdit)
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name  | type  |
       | 1  | Group | Class |
       | 2  | Team  | Team  |
       | 21 | owner | User  |
       | 22 | john  | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 22       | John        | Doe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 2              |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
       | 21         | 2        | none                  |

--- a/app/api/groups/update_manager.robustness.feature
+++ b/app/api/groups/update_manager.robustness.feature
@@ -1,19 +1,19 @@
 Feature: Update the group manager's permissions (groupManagerEdit) - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    |
       | 1  | Group   | Class   |
       | 2  | Team    | Team    |
       | 3  | Friends | Friends |
       | 21 | owner   | User    |
       | 22 | john    | User    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 22       | John        | Doe       |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_manage            |
       | 21         | 1        | memberships_and_group |
       | 21         | 3        | memberships           |

--- a/app/api/groups/update_permissions.feature
+++ b/app/api/groups/update_permissions.feature
@@ -1,37 +1,37 @@
 Feature: Change item access rights for a group
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | type  |
       | 21 | owner      | User  |
       | 23 | user       | User  |
       | 25 | some class | Class |
       | 31 | jane       | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 23       | John        | Doe       |
       | jane  | 31       | Jane        | Doe       |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 25       | 21         | 1                      |
       | 31       | 21         | 0                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 25              | 23             |
       | 25              | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 100 | fr                   |
       | 101 | fr                   |
       | 102 | fr                   |
       | 103 | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | content_view_propagation | grant_view_propagation | watch_propagation | edit_propagation | child_order |
       | 100            | 101           | as_info                  | false                  | false             | false            | 0           |
       | 101            | 102           | as_content               | false                  | false             | false            | 0           |
       | 102            | 103           | as_content               | true                   | true              | true             | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 100              | 101           |
       | 100              | 102           |
@@ -39,28 +39,28 @@ Feature: Change item access rights for a group
       | 101              | 102           |
       | 101              | 103           |
       | 102              | 103           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated        |
       | 23       | 100     | content_with_descendants  |
       | 23       | 101     | info                      |
       | 23       | 103     | info                      |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | source_group_id | latest_update_at    |
       | 23       | 100     | content  | 23              | 2019-05-30 11:00:00 |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 21             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 21             | 103     |
 
   Scenario Outline: Create a new permissions_granted row (with results propagation)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 21       | 103     | solution           | solution                 | answer              | all                | true               |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | source_group_id | latest_update_at    |
       | 21       | 102     | solution | solution_with_grant | answer_with_grant | all_with_grant | 23              | 2019-05-30 11:00:00 |
       | 23       | 102     | none     | none                | none              | none           | 23              | 2019-05-30 11:00:00 |
@@ -101,11 +101,11 @@ Feature: Change item access rights for a group
 
   Scenario Outline: Create a new permissions_granted row (without results propagation)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 21       | 103     | solution           | solution                 | answer              | all                | true               |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | source_group_id | latest_update_at    |
       | 21       | 102     | solution | solution_with_grant | answer_with_grant | all_with_grant | 23              | 2019-05-30 11:00:00 |
       | 23       | 102     | none     | none                | none              | none           | 23              | 2019-05-30 11:00:00 |
@@ -139,11 +139,11 @@ Feature: Change item access rights for a group
 
   Scenario Outline: Update an existing permissions_granted row
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | none               | none                     | none                | none               | false              |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | is_owner | origin           | source_group_id | latest_update_at    |
       | 21       | 102     | solution | solution_with_grant | answer_with_grant | all_with_grant | true     | group_membership | 23              | 2019-05-30 11:00:00 |
       | 23       | 102     | none     | none                | none              | none           | false    | group_membership | 23              | 2019-05-30 11:00:00 |
@@ -184,14 +184,14 @@ Feature: Change item access rights for a group
 
   Scenario: Create a new permissions_granted row (the group has only 'content' access on the item's parent)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | 1                  |
       | 21       | 103     | none               | none                     | none                | none               | 0                  |
       | 31       | 101     | content            | none                     | none                | none               | 0                  |
       | 31       | 102     | none               | none                     | none                | none               | 0                  |
       | 31       | 103     | none               | none                     | none                | none               | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | is_owner | source_group_id | origin           | latest_update_at    |
       | 21       | 102     | none     | 1        | 23              | group_membership | 2019-05-30 11:00:00 |
       | 31       | 101     | content  | 0        | 23              | group_membership | 2019-05-30 11:00:00 |
@@ -228,7 +228,7 @@ Feature: Change item access rights for a group
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has full access to the item itself)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       | can_grant_view_generated | is_owner_generated |
       | 21       | 100     | solution                 | solution                 | 1                  |
       | 21       | 101     | none                     | none                     | 0                  |
@@ -238,7 +238,7 @@ Feature: Change item access rights for a group
       | 31       | 101     | content_with_descendants | none                     | 0                  |
       | 31       | 102     | content_with_descendants | none                     | 0                  |
       | 31       | 103     | content_with_descendants | none                     | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view                 | can_grant_view | is_owner | source_group_id | origin           | latest_update_at    |
       | 21       | 100     | solution                 | solution       | 1        | 23              | group_membership | 2019-05-30 11:00:00 |
       | 31       | 100     | content_with_descendants | none           | 0        | 23              | group_membership | 2019-05-30 11:00:00 |
@@ -280,7 +280,7 @@ Feature: Change item access rights for a group
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has 'content' access to the item itself)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | is_owner_generated |
       | 21       | 100     | solution           | solution                 | 1                  |
       | 21       | 101     | none               | none                     | 0                  |
@@ -290,7 +290,7 @@ Feature: Change item access rights for a group
       | 31       | 101     | content            | none                     | 0                  |
       | 31       | 102     | content            | none                     | 0                  |
       | 31       | 103     | content            | none                     | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view | is_owner | source_group_id | origin           | latest_update_at    |
       | 21       | 100     | none     | solution       | 1        | 23              | group_membership | 2019-05-30 11:00:00 |
       | 31       | 100     | content  | none           | 0        | 23              | group_membership | 2019-05-30 11:00:00 |
@@ -332,7 +332,7 @@ Feature: Change item access rights for a group
 
   Scenario: Create a new permissions_granted row (the group has no access to the item's parents, but has info access to the item itself)
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | is_owner_generated |
       | 21       | 100     | solution           | solution                 | 1                  |
       | 21       | 101     | none               | none                     | 0                  |
@@ -342,7 +342,7 @@ Feature: Change item access rights for a group
       | 31       | 101     | info               | none                     | 0                  |
       | 31       | 102     | info               | none                     | 0                  |
       | 31       | 103     | info               | none                     | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view | is_owner | source_group_id | origin           | latest_update_at    |
       | 21       | 100     | none     | solution       | 1        | 23              | group_membership | 2019-05-30 11:00:00 |
       | 31       | 100     | info     | none           | 0        | 23              | group_membership | 2019-05-30 11:00:00 |
@@ -384,11 +384,11 @@ Feature: Change item access rights for a group
 
   Scenario: Drops invalid permissions from an existing permissions_granted row
     Given I am the user with id "21"
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
       | 23       | 102     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | false              |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | can_make_session_official | is_owner | origin           | source_group_id | latest_update_at    |
       | 21       | 102     | solution | solution_with_grant | answer_with_grant | all_with_grant | true                      | true     | group_membership | 23              | 2019-05-30 11:00:00 |
       | 23       | 102     | none     | none                | none              | none           | false                     | false    | group_membership | 23              | 2019-05-30 11:00:00 |
@@ -421,20 +421,20 @@ Feature: Change item access rights for a group
 
   Scenario Outline: There are no item's parents visible to the group, but the item is a root activity of one of the group's ancestors
     Given I am the user with id "21"
-    And the database table 'items' has also the following row:
+    And the database table "items" has also the following row:
       | id  | default_language_tag |
       | 104 | fr                   |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | name                 | type  | root_activity_id   | root_skill_id   |
       | 40 | Group with root item | Class | <root_activity_id> | <root_skill_id> |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 40              | 23             |
     And the groups ancestors are computed
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view | can_grant_view      | can_watch         | can_edit       | can_make_session_official | is_owner | origin           | source_group_id | latest_update_at    |
       | 21       | 104     | solution | solution_with_grant | answer_with_grant | all_with_grant | true                      | true     | group_membership | 23              | 2019-05-30 11:00:00 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 21       | 104     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
     When I send a PUT request to "/groups/25/permissions/23/104" with the following body:

--- a/app/api/groups/update_permissions.robustness.feature
+++ b/app/api/groups/update_permissions.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Change item access rights for a group - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | type  |
       | 21 | owner         | User  |
       | 23 | user          | User  |
@@ -8,36 +8,36 @@ Feature: Change item access rights for a group - robustness
       | 26 | another class | Class |
       | 27 | third class   | Class |
       | 31 | admin         | User  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | user  | 23       | John        | Doe       |
       | admin | 31       | Allie       | Grater    |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_grant_group_access |
       | 23       | 21         | 1                      |
       | 25       | 21         | 0                      |
       | 25       | 31         | 1                      |
       | 26       | 21         | 1                      |
       | 26       | 31         | 1                      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 25              | 23             |
       | 25              | 31             |
       | 26              | 23             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 100 | fr                   |
       | 101 | fr                   |
       | 102 | fr                   |
       | 103 | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | content_view_propagation | child_order |
       | 100            | 101           | as_info                  | 0           |
       | 101            | 102           | as_content               | 0           |
       | 102            | 103           | as_content               | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 100              | 101           |
       | 100              | 102           |
@@ -45,7 +45,7 @@ Feature: Change item access rights for a group - robustness
       | 101              | 102           |
       | 101              | 103           |
       | 102              | 103           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | is_owner_generated |
       | 21       | 100     | solution           | solution_with_grant      | 1                  |
       | 21       | 101     | none               | none                     | 0                  |
@@ -54,7 +54,7 @@ Feature: Change item access rights for a group - robustness
       | 25       | 100     | content            | none                     | 0                  |
       | 25       | 101     | info               | none                     | 0                  |
       | 31       | 102     | none               | content_with_descendants | 0                  |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view           | can_enter_until     | is_owner | source_group_id | latest_update_at    |
       | 21       | 100     | none     | none                     | 9999-12-31 23:59:59 | 1        | 23              | 2019-05-30 11:00:00 |
       | 21       | 102     | none     | solution                 | 9999-12-31 23:59:59 | 1        | 23              | 2019-05-30 11:00:00 |

--- a/app/api/groups/update_permissions_can_request_help_to.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.feature
@@ -82,7 +82,7 @@ Feature: Change item access rights for a group - can_request_help_to
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
     And @Class is a manager of the group @HelperGroupParent and can watch its members
-    And @HelperGroup is a child of the group @HelperGroupParent
+    And the group @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_view | can_grant_view | can_request_help_to |
       | @Item | @Teacher |          | content        |                     |

--- a/app/api/groups/update_permissions_can_request_help_to.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.feature
@@ -17,7 +17,7 @@ Feature: Change item access rights for a group - can_request_help_to
       | @Class          | @ClassParent |          |
       | @OldHelperGroup |              |          |
       | @NewHelperGroup |              |          |
-    And @Teacher is a manager of the group @ClassParent and can grant group access
+    And the group @Teacher is a manager of the group @ClassParent and can grant group access
     And there are the following tasks:
       | item  |
       | @Item |
@@ -81,7 +81,7 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should work when trying to set can_request_help_to to a group not visible by the giver (current-user) if it was already set at the same value previously
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
-    And @Class is a manager of the group @HelperGroupParent and can watch its members
+    And the group @Class is a manager of the group @HelperGroupParent and can watch for submissions from the group and its descendants
     And the group @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_view | can_grant_view | can_request_help_to |

--- a/app/api/groups/update_permissions_can_request_help_to.robustness.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.robustness.feature
@@ -16,7 +16,7 @@ Feature: Change item access rights for a group - can_request_help_to
       | @School      |              | @Teacher |
       | @Class       | @ClassParent |          |
       | @HelperGroup |              |          |
-    And @Teacher is a manager of the group @ClassParent and can grant group access
+    And the group @Teacher is a manager of the group @ClassParent and can grant group access
     And there are the following tasks:
       | item  |
       | @Item |
@@ -114,7 +114,7 @@ Feature: Change item access rights for a group - can_request_help_to
   Scenario: Should be access denied when trying to set can_request_help_to to a group not visible by the giver (current-user)
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
-    And @Class is a manager of the group @HelperGroupParent and can watch its members
+    And the group @Class is a manager of the group @HelperGroupParent and can watch for submissions from the group and its descendants
     And the group @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_grant_view |

--- a/app/api/groups/update_permissions_can_request_help_to.robustness.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.robustness.feature
@@ -115,7 +115,7 @@ Feature: Change item access rights for a group - can_request_help_to
     Given I am @Teacher
     # This is the only case for @HelperGroup to be visible by @Class and not @Teacher. Details in comment in update_permissions.go.
     And @Class is a manager of the group @HelperGroupParent and can watch its members
-    And @HelperGroup is a child of the group @HelperGroupParent
+    And the group @HelperGroup is a child of the group @HelperGroupParent
     And there are the following item permissions:
       | item  | group    | can_grant_view |
       | @Item | @Teacher | content        |

--- a/app/api/groups/withdraw_invitations.feature
+++ b/app/api/groups/withdraw_invitations.feature
@@ -1,6 +1,6 @@
 Feature: Withdraw group invitations
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  |
       | 11  |
       | 13  |
@@ -15,10 +15,10 @@ Feature: Withdraw group invitations
       | 131 |
       | 141 |
       | 151 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 111            |
       | 13              | 121            |
@@ -26,7 +26,7 @@ Feature: Withdraw group invitations
       | 13              | 151            |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                          |
       | 13       | 21        | join_request | {{relativeTimeDB("-170h")}} |
       | 13       | 31        | invitation   | {{relativeTimeDB("-168h")}} |
@@ -36,7 +36,7 @@ Feature: Withdraw group invitations
 
   Scenario Outline: Withdraw invitations
     Given I am the user with id "21"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage   |
       | 13       | 21         | <can_manage> |
     When I send a POST request to "/groups/13/invitations/withdraw?group_ids=31,141,21,11,13,22,151"

--- a/app/api/groups/withdraw_invitations.robustness.feature
+++ b/app/api/groups/withdraw_invitations.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Withdraw group invitations - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type    |
       | 11  | User    |
       | 12  | User    |
@@ -14,17 +14,17 @@ Feature: Withdraw group invitations - robustness
       | 123 | Team    |
       | 131 | User    |
       | 141 | Team    |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name | grade |
       | owner | 21       | Jean-Michel | Blanquer  | 3     |
       | user  | 11       | John        | Doe       | 1     |
       | jane  | 12       | Jane        | Doe       | 1     |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage  |
       | 12       | 12         | memberships |
       | 13       | 21         | memberships |
       | 13       | 12         | none        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 111            |
       | 13              | 121            |

--- a/app/api/items/apply_dependency.feature
+++ b/app/api/items/apply_dependency.feature
@@ -1,6 +1,6 @@
 Feature: Apply an item dependency
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Apply an item dependency
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,21 +33,21 @@ Feature: Apply an item dependency
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 200               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 210               | 20    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | content                  | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | all                | none                | true               |
@@ -67,10 +67,10 @@ Feature: Apply an item dependency
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id |
       | 0  | 11             | 2019-05-30 10:00:00 | null         | null              |
       | 0  | 13             | 2019-05-30 10:00:00 | null         | null              |
@@ -80,7 +80,7 @@ Feature: Apply an item dependency
       | 1  | 13             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 17             | 2019-05-30 10:00:00 | 200          | 0                 |
       | 1  | 26             | 2019-05-30 10:00:00 | null         | null              |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 100     | null                | 2019-05-30 11:00:01 | 22             | null                |
       | 0          | 11             | 200     | null                | 2019-05-30 11:00:01 | 11.1           | null                |

--- a/app/api/items/apply_dependency.robustness.feature
+++ b/app/api/items/apply_dependency.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Apply an item dependency - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Apply an item dependency - robustness
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,21 +33,21 @@ Feature: Apply an item dependency - robustness
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 200               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 210               | 20    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | children           | none                | true               |
@@ -67,10 +67,10 @@ Feature: Apply an item dependency - robustness
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id |
       | 0  | 11             | 2019-05-30 10:00:00 | null         | null              |
       | 0  | 13             | 2019-05-30 10:00:00 | null         | null              |
@@ -80,7 +80,7 @@ Feature: Apply an item dependency - robustness
       | 1  | 13             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 17             | 2019-05-30 10:00:00 | 200          | 0                 |
       | 1  | 26             | 2019-05-30 10:00:00 | null         | null              |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 100     | null                | 2019-05-30 11:00:01 | 22             | null                |
       | 0          | 11             | 200     | null                | 2019-05-30 11:00:01 | 11.1           | null                |

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -3,38 +3,38 @@ Feature: Ask for a hint
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | name | type |
       | 201 | team | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
       | 201             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'platforms':
+    And the database has the following table "platforms":
       | id | regexp                                            | public_key                |
       | 10 | http://taskplatform.mblockelet.info/task.html\?.* | {{taskPlatformPublicKey}} |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | platform_id | url                                                                     | default_language_tag |
       | 50 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | fr                   |
       | 10 | null        | null                                                                    | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
       | 201      | 50      | content            |
     And time is frozen
 
   Scenario: User is able to ask for a hint
-    Given the database has the following table 'attempts':
+    Given the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          |
       | 0          | 101            | 50      | [0,  1, "hint" , null] | 4            | 2019-05-30 11:00:00 |
       | 0          | 101            | 10      | null                   | 0            | 2019-05-30 11:00:00 |
@@ -94,10 +94,10 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for a hint for a team (participant_id is the first integer in idAttempt in the task token)
-    Given the database has the following table 'attempts':
+    Given the database has the following table "attempts":
       | id | participant_id |
       | 0  | 201            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        | hints_cached | started_at          |
       | 0          | 201            | 50      | [0,  1, "hint" , null] | 4            | 2020-01-01 00:00:00 |
       | 0          | 201            | 10      | null                   | 0            | 2020-01-01 00:00:00 |
@@ -157,10 +157,10 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for a hint with a minimal hint token
-    Given the database has the following table 'attempts':
+    Given the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        | started_at          |
       | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 |
       | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 |
@@ -220,10 +220,10 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: User is able to ask for an already given hint
-    Given the database has the following table 'attempts':
+    Given the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        | started_at          |
       | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 |
       | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 |
@@ -283,10 +283,10 @@ Feature: Ask for a hint
     And the table "results_propagate" should be empty
 
   Scenario: Can't parse hints_requested
-    Given the database has the following table 'attempts':
+    Given the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested | started_at          |
       | 0          | 101            | 50      | not an array    | 2019-05-30 11:00:00 |
       | 0          | 101            | 10      | null            | 2019-05-30 11:00:00 |

--- a/app/api/items/ask_hint.robustness.feature
+++ b/app/api/items/ask_hint.robustness.feature
@@ -3,35 +3,35 @@ Feature: Ask for a hint - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'platforms':
+    And the database has the following table "platforms":
       | id | regexp                     | public_key                | priority |
       | 10 | https://platformwithkey    | {{taskPlatformPublicKey}} | 0        |
       | 11 | https://nokeyplatform.test |                           | 1        |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | platform_id | url                           | read_only | default_language_tag |
       | 50 | 10          | https://platformwithkey/50    | 1         | fr                   |
       | 10 | 10          | https://platformwithkey/10    | 0         | fr                   |
       | 51 | 11          | https://nokeyplatform.test/51 | 1         | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 10      | content            |
       | 101      | 50      | content            |
       | 101      | 51      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | allows_submissions_until |
       | 0  | 101            | 9999-12-31 23:59:59      |
       | 1  | 101            | 2019-05-30 11:00:00      |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        |
       | 0          | 101            | 50      | [0,  1, "hint" , null] |
       | 0          | 101            | 51      | [0,  1, "hint" , null] |

--- a/app/api/items/create_attempt.feature
+++ b/app/api/items/create_attempt.feature
@@ -1,38 +1,38 @@
 Feature: Create an attempt for an item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id |
       | 99  | Other | 50               |
       | 100 | Class | 10               |
       | 101 | User  | null             |
       | 102 | Team  | 60               |
       | 111 | User  | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 99              | 111            |
       | 100             | 111            |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | default_language_tag |
       | 10 | null                                                                    | Chapter | 1                        | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 10      | content                  |
@@ -40,7 +40,7 @@ Feature: Create an attempt for an item
       | 102      | 70      | content                  |
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 101            | 2019-05-30 11:00:00 |
       | 0  | 102            | 2019-05-30 11:00:00 |

--- a/app/api/items/create_attempt.robustness.feature
+++ b/app/api/items/create_attempt.robustness.feature
@@ -1,25 +1,25 @@
 Feature: Create an attempt for an item - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 101 | User  | null             | null          |
       | 102 | Team  | null             | null          |
       | 103 | Class | 50               | 90            |
       | 104 | Team  | 50               | 90            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 103             | 101            |
       | 104             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type   | allows_multiple_attempts | default_language_tag |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 0                        | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   |
       | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill  | 1                        | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | info               |
       | 101      | 60      | content            |
@@ -96,13 +96,13 @@ Feature: Create an attempt for an item - robustness
 
   Scenario: There is an attempt for the (group, item) pair already, but items.allows_multiple_attempts = 0
     Given I am the user with id "101"
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated |
       | 104      | 50      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 104            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 0          | 104            | 50      | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/50/attempts?as_team_id=104&parent_attempt_id=0"
@@ -112,7 +112,7 @@ Feature: Create an attempt for an item - robustness
 
   Scenario: Not enough permissions for the last item in the path
     Given I am the user with id "101"
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated |
       | 104      | 50      | info               |
     When I send a POST request to "/items/50/attempts?as_team_id=104&parent_attempt_id=0"

--- a/app/api/items/create_dependency.feature
+++ b/app/api/items/create_dependency.feature
@@ -1,6 +1,6 @@
 Feature: Create an item dependency
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Create an item dependency
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,17 +33,17 @@ Feature: Create an item dependency
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 210               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | content                  | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | all                | none                | true               |
@@ -63,7 +63,7 @@ Feature: Create an item dependency
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
 

--- a/app/api/items/create_dependency.robustness.feature
+++ b/app/api/items/create_dependency.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Create an item dependency - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Create an item dependency - robustness
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,17 +33,17 @@ Feature: Create an item dependency - robustness
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 210               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | content                  | children           | result              | true               |
       | 11       | 210     | solution                 | enter                    | all                | none                | true               |
@@ -63,7 +63,7 @@ Feature: Create an item dependency - robustness
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
 
@@ -161,7 +161,7 @@ Feature: Create an item dependency - robustness
 
   Scenario: The dependency already exists
     Given I am the user with id "11"
-    And the database table 'item_dependencies' has also the following row:
+    And the database table "item_dependencies" has also the following row:
       | item_id | dependent_item_id | score | grant_content_view |
       | 210     | 210               | 22    | true               |
     When I send a POST request to "/items/210/prerequisites/210" with the following body:

--- a/app/api/items/create_item.feature
+++ b/app/api/items/create_item.feature
@@ -1,29 +1,29 @@
 Feature: Create item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    | root_activity_id | root_skill_id |
       | 10 | Friends | Friends | null             | null          |
       | 11 | jdoe    | User    | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | entry_frozen_teams | no_score | default_language_tag |
       | 21 | true               | false    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_edit_generated |
       | 11       | 21      | solution           | children           |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_edit | source_group_id | latest_update_at    |
       | 11       | 21      | solution | children | 11              | 2019-05-30 11:00:00 |
     And the groups ancestors are computed
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 11             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 11             | 21      |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | sl  |
 
@@ -76,7 +76,7 @@ Feature: Create item
 
   Scenario: Valid when as_root_of_group_id is given, but parent_item_id is not given (not a skill)
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 10       | 11         | memberships_and_group |
     When I send a POST request to "/items" with the following body:
@@ -125,17 +125,17 @@ Feature: Create item
 
   Scenario: Valid when as_root_of_group_id is given, but parent_item_id is not given (skill with children)
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 10       | 11         | memberships_and_group |
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id | default_language_tag |
       | 12 | fr                   |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 10       | 21      | none                     | content                  | none                | none               | 0                  |
       | 11       | 12      | content_with_descendants | solution                 | answer              | all                | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view                 | can_grant_view      | can_watch         | can_edit       | is_owner | source_group_id | latest_update_at    |
       | 11       | 12      | content_with_descendants | solution            | answer            | all            | 0        | 11              | 2019-05-30 11:00:00 |
     When I send a POST request to "/items" with the following body:
@@ -192,22 +192,22 @@ Feature: Create item
 
   Scenario: Set can_request_help for children
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_manage            |
       | 10       | 11         | memberships_and_group |
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id   | default_language_tag |
       | 1001 | fr                   |
       | 1002 | fr                   |
       | 1003 | fr                   |
       | 1004 | fr                   |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 11       | 1001    | content_with_descendants | content                  | answer              | none               | 0                  |
       | 11       | 1002    | content_with_descendants | enter                    | answer              | none               | 0                  |
       | 11       | 1003    | content_with_descendants | content                  | answer              | none               | 0                  |
       | 11       | 1004    | content_with_descendants | enter                    | answer              | none               | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view                 | can_grant_view | can_watch | can_edit | is_owner | source_group_id | latest_update_at    |
       | 11       | 1001    | content_with_descendants | content        | answer    | none     | 0        | 11              | 2019-05-30 11:00:00 |
       | 11       | 1002    | content_with_descendants | enter          | answer    | none     | 0        | 11              | 2019-05-30 11:00:00 |
@@ -249,20 +249,20 @@ Feature: Create item
 
   Scenario Outline: Valid (all the fields are set)
     Given I am the user with id "11"
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id | default_language_tag |
       | 12 | fr                   |
       | 34 | fr                   |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 10       | 21      | none                     | content                  | none                | none               | 0                  |
       | 11       | 12      | content_with_descendants | solution                 | answer              | all                | 0                  |
       | 11       | 34      | solution                 | solution_with_grant      | answer_with_grant   | all_with_grant     | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view                 | can_grant_view      | can_watch         | can_edit       | is_owner | source_group_id | latest_update_at    |
       | 11       | 12      | content_with_descendants | solution            | answer            | all            | 0        | 11              | 2019-05-30 11:00:00 |
       | 11       | 34      | solution                 | solution_with_grant | answer_with_grant | all_with_grant | 0        | 11              | 2019-05-30 11:00:00 |
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id |
       | 0          | 11             | 12      |
     When I send a POST request to "/items" with the following body:
@@ -381,18 +381,18 @@ Feature: Create item
 
   Scenario: Valid when type=Skill
     Given I am the user with id "11"
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id | default_language_tag | type    |
       | 12 | fr                   | Skill   |
       | 34 | fr                   | Chapter |
       | 50 | fr                   | Skill   |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 10       | 21      | none                     | content                  | none                | none               | 0                  |
       | 11       | 12      | content_with_descendants | solution                 | answer              | all                | 0                  |
       | 11       | 34      | solution                 | solution_with_grant      | answer_with_grant   | all_with_grant     | 0                  |
       | 11       | 50      | solution                 | solution_with_grant      | answer_with_grant   | all_with_grant     | 0                  |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_view                 | can_grant_view      | can_watch         | can_edit       | is_owner | source_group_id | latest_update_at    |
       | 11       | 12      | content_with_descendants | solution            | answer            | all            | 0        | 11              | 2019-05-30 11:00:00 |
       | 11       | 34      | solution                 | solution_with_grant | answer_with_grant | all_with_grant | 0        | 11              | 2019-05-30 11:00:00 |

--- a/app/api/items/create_item.robustness.feature
+++ b/app/api/items/create_item.robustness.feature
@@ -4,10 +4,10 @@ Feature: Create item - robustness
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
       | tmp   | 1         | 12       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name    | type    |
       | 30 | Friends | Friends |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | no_score | default_language_tag | type    | text_id        |
       | 4  | false    | fr                   | Chapter | null           |
       | 5  | false    | fr                   | Skill   | null           |
@@ -20,13 +20,13 @@ Feature: Create item - robustness
       | 27 | false    | fr                   | Chapter | null           |
       | 28 | false    | fr                   | Chapter | existingTextId |
 
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 4              | 21            | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 4                | 21            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_edit_generated |
       | 11       | 4       | solution           | children           |
       | 11       | 5       | solution           | children           |
@@ -35,13 +35,13 @@ Feature: Create item - robustness
       | 11       | 24      | solution           | none               |
       | 11       | 25      | info               | none               |
       | 11       | 26      | info               | none               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | source_group_id | can_edit |
       | 11       | 4       | solution | 11              | children |
       | 11       | 21      | solution | 11              | children |
       | 11       | 23      | solution | 11              | none     |
     And the groups ancestors are computed
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | sl  |
 
@@ -497,10 +497,10 @@ Feature: Create item - robustness
 
   Scenario Outline: Parent item cannot have children
     Given I am the user with id "11"
-    And the database table 'items' has also the following row:
+    And the database table "items" has also the following row:
       | id | default_language_tag | type   |
       | 90 | fr                   | <type> |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated | can_edit_generated |
       | 11       | 90      | content            | children           |
     When I send a POST request to "/items" with the following body:
@@ -642,10 +642,10 @@ Feature: Create item - robustness
 
   Scenario Outline: Not enough permissions for setting propagation in children items_items
     Given I am the user with id "11"
-    And the database table 'items' has also the following row:
+    And the database table "items" has also the following row:
       | id | default_language_tag |
       | 90 | fr                   |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | <permission_column> | can_view_generated |
       | 11       | 90      | <permission_value>  | info               |
     When I send a POST request to "/items" with the following body:

--- a/app/api/items/delete_dependency.feature
+++ b/app/api/items/delete_dependency.feature
@@ -1,6 +1,6 @@
 Feature: Delete an item dependency
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Delete an item dependency
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,18 +33,18 @@ Feature: Delete an item dependency
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 210               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 210               | 20    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | content                  | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | all                | none                | true               |
@@ -64,7 +64,7 @@ Feature: Delete an item dependency
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
 

--- a/app/api/items/delete_dependency.robustness.feature
+++ b/app/api/items/delete_dependency.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Delete an item dependency - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,20 +10,20 @@ Feature: Delete an item dependency - robustness
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | requires_explicit_entry |
       | 100 | Task    | en                   | true                    |
       | 200 | Task    | en                   | true                    |
       | 210 | Chapter | en                   | false                   |
       | 220 | Chapter | en                   | false                   |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -33,18 +33,18 @@ Feature: Delete an item dependency - robustness
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 100     | 210               | 22    | true               |
       | 100     | 220               | 10    | true               |
       | 200     | 210               | 20    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | origin         | latest_update_at    | can_view                 | can_enter_from      | can_enter_until     | can_grant_view | can_watch | can_edit | can_make_session_official | is_owner |
       | 22       | 200     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 3019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 22       | 210     | 22              | item_unlocking | 2019-05-30 11:00:00 | info                     | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
       | 26       | 210     | 26              | item_unlocking | 2019-05-30 11:00:00 | content_with_descendants | 2019-12-31 23:59:59 | 2020-01-31 23:59:59 | none           | none      | none     | false                     | false    |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | content                  | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | children           | none                | true               |
@@ -64,7 +64,7 @@ Feature: Delete an item dependency - robustness
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | content_with_descendants | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
 

--- a/app/api/items/delete_item.feature
+++ b/app/api/items/delete_item.feature
@@ -1,83 +1,83 @@
 Feature: Delete an item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    | root_activity_id | root_skill_id |
       | 10 | Friends | Friends | null             | null          |
       | 11 | jdoe    | User    | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items_propagate':
+    And the database has the following table "items_propagate":
       | id | ancestors_computation_state |
       | 20 | done                        |
       | 21 | done                        |
       | 22 | done                        |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 21 | fr                   |
       | 22 | fr                   |
-    And the database has the following table 'permissions_propagate':
+    And the database has the following table "permissions_propagate":
       | group_id | item_id |
       | 10       | 22      |
       | 11       | 21      |
       | 11       | 22      |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | is_owner_generated |
       | 10       | 22      | true               |
       | 11       | 21      | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | is_owner | source_group_id |
       | 10       | 22      | true     | 10              |
       | 11       | 21      | false    | 10              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id |
       | 0  | 10             | null         |
       | 1  | 10             | 22           |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | participant_id | attempt_id | item_id | author_id | created_at          |
       | 10             | 0          | 21      | 10        | 2019-05-30 11:00:00 |
       | 10             | 0          | 22      | 10        | 2019-05-30 11:00:00 |
       | 10             | 1          | 21      | 10        | 2019-05-30 11:00:00 |
-    And the database has the following table 'filters':
+    And the database has the following table "filters":
       | id | user_id | item_id |
       | 1  | 10      | 21      |
       | 2  | 10      | 22      |
       | 3  | 11      | null    |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id |
       | 10       | 21      |
       | 11       | 22      |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id |
       | 21      | 21                |
       | 21      | 22                |
       | 22      | 21                |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 21            |
       | 20               | 22            |
       | 21               | 22            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 21            | 1           |
       | 21             | 22            | 1           |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag |
       | 20      | fr           |
       | 21      | fr           |
       | 22      | en           |
       | 22      | fr           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 10             | 21      |
       | 0          | 10             | 22      |
       | 1          | 10             | 21      |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
       | en  |

--- a/app/api/items/delete_item.robustness.feature
+++ b/app/api/items/delete_item.robustness.feature
@@ -1,84 +1,84 @@
 Feature: Delete an item - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type    | root_activity_id | root_skill_id |
       | 10 | Friends | Friends | null             | null          |
       | 11 | jdoe    | User    | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items_propagate':
+    And the database has the following table "items_propagate":
       | id | ancestors_computation_state |
       | 20 | done                        |
       | 21 | done                        |
       | 22 | done                        |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 20 | fr                   |
       | 21 | fr                   |
       | 22 | fr                   |
-    And the database has the following table 'permissions_propagate':
+    And the database has the following table "permissions_propagate":
       | group_id | item_id |
       | 10       | 21      |
       | 10       | 22      |
       | 11       | 21      |
       | 11       | 22      |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | is_owner_generated |
       | 10       | 21      | true               |
       | 11       | 22      | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | is_owner | source_group_id |
       | 10       | 21      | true     | 10              |
       | 11       | 22      | false    | 10              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id |
       | 0  | 10             | null         |
       | 1  | 10             | 22           |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | participant_id | attempt_id | item_id | author_id | created_at          |
       | 10             | 0          | 21      | 10        | 2019-05-30 11:00:00 |
       | 10             | 0          | 22      | 10        | 2019-05-30 11:00:00 |
       | 10             | 1          | 21      | 10        | 2019-05-30 11:00:00 |
-    And the database has the following table 'filters':
+    And the database has the following table "filters":
       | id | user_id | item_id |
       | 1  | 10      | 21      |
       | 2  | 10      | 22      |
       | 3  | 11      | null    |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id |
       | 10       | 21      |
       | 11       | 22      |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id |
       | 21      | 21                |
       | 21      | 22                |
       | 22      | 21                |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 21            |
       | 20               | 22            |
       | 21               | 22            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 21            | 1           |
       | 21             | 22            | 1           |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag |
       | 20      | fr           |
       | 21      | fr           |
       | 22      | en           |
       | 22      | fr           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id |
       | 0          | 10             | 21      |
       | 0          | 10             | 22      |
       | 1          | 10             | 21      |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
       | en  |

--- a/app/api/items/end_attempt.feature
+++ b/app/api/items/end_attempt.feature
@@ -1,6 +1,6 @@
 Feature: End an attempt (itemAttemptEnd)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type                |
       | 101 | User                |
       | 102 | Team                |
@@ -8,11 +8,11 @@ Feature: End an attempt (itemAttemptEnd)
       | 201 | ContestParticipants |
       | 202 | ContestParticipants |
       | 203 | ContestParticipants |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 102             | 101            | 9999-12-31 23:59:59 |
       | 201             | 101            | 9999-12-31 23:59:59 |
@@ -24,24 +24,24 @@ Feature: End an attempt (itemAttemptEnd)
       | 203             | 102            | 2019-12-31 23:59:59 |
       | 203             | 111            | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | participants_group_id | default_language_tag |
       | 10 | null                                                                    | Chapter | 0                        | 201                   | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 0                        | 202                   | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | 203                   | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 60      | content                  |
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id | allows_submissions_until | ended_at            |
       | 1  | 101            | 10           | null              | 9999-12-31 23:59:59      | null                |
       | 1  | 102            | 10           | null              | 9999-12-31 23:59:59      | null                |

--- a/app/api/items/end_attempt.robustness.feature
+++ b/app/api/items/end_attempt.robustness.feature
@@ -1,6 +1,6 @@
 Feature: End an attempt (itemAttemptEnd) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type                |
       | 101 | User                |
       | 102 | Team                |
@@ -8,11 +8,11 @@ Feature: End an attempt (itemAttemptEnd) - robustness
       | 201 | ContestParticipants |
       | 202 | ContestParticipants |
       | 203 | ContestParticipants |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | expires_at          |
       | 102             | 101            | 9999-12-31 23:59:59 |
       | 201             | 101            | 9999-12-31 23:59:59 |
@@ -24,24 +24,24 @@ Feature: End an attempt (itemAttemptEnd) - robustness
       | 203             | 102            | 2019-12-31 23:59:59 |
       | 203             | 111            | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | participants_group_id | default_language_tag |
       | 10 | null                                                                    | Chapter | 0                        | 201                   | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 0                        | 202                   | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | 203                   | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 60      | content                  |
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id | allows_submissions_until | ended_at            |
       | 0  | 101            | 10           | null              | 9999-12-31 23:59:59      | null                |
       | 0  | 102            | 10           | null              | 9999-12-31 23:59:59      | null                |

--- a/app/api/items/enter.feature
+++ b/app/api/items/enter.feature
@@ -1,6 +1,6 @@
 Feature: Enters a contest as a group (user self or team) (contestEnter)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name         | type                | root_activity_id |
       | 10 | Class        | Class               | 10               |
       | 11 | Team 2       | Team                | 60               |
@@ -10,31 +10,31 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 51 | jack         | User                | null             |
       | 98 | item60-group | ContestParticipants | null             |
       | 99 | item50-group | ContestParticipants | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 31       | John        | Doe       |
       | jane  | 41       | Jane        | null      |
       | jack  | 51       | Jack        | Daniel    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 31             |
       | 11              | 31             |
       | 11              | 41             |
       | 11              | 51             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 10 | fr                   |
       | 20 | fr                   |
       | 30 | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 20               | 30            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 20             | 30            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 30      | content            |
       | 31       | 30      | content            |
@@ -42,11 +42,11 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 98       | 20      | info               |
       | 99       | 10      | info               |
       | 99       | 20      | info               |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 11             | 2019-05-30 11:00:00 |
       | 0  | 31             | 2019-05-30 11:00:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 0          | 11             | 30      | null                |
       | 0          | 31             | 10      | 2019-05-30 11:00:00 |
@@ -54,25 +54,25 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
     And the DB time now is "3019-10-10 10:10:10"
 
   Scenario: Enter an individual contest
-    Given the database table 'items' has also the following row:
+    Given the database table "items" has also the following row:
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | participants_group_id | default_language_tag | entering_time_min   | entering_time_max   |
       | 50 | 01:01:01 | 1                       | User                   | None                             | 99                    | fr                   | 2007-01-01 00:00:00 | 5000-01-01 00:00:00 |
-    And the database table 'items_ancestors' has also the following row:
+    And the database table "items_ancestors" has also the following row:
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database table 'items_items' has also the following row:
+    And the database table "items_items" has also the following row:
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 1           |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | can_enter_from      | can_enter_until     | source_group_id |
       | 11       | 50      | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 | 11              |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 10      | content                  |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 50      | 02:02:02        |
     And I am the user with id "31"
@@ -122,23 +122,23 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 99                | 99             | 1       | 9999-12-31 23:59:59 |
 
   Scenario: Enter a team-only contest
-    Given the database table 'items' has also the following row:
+    Given the database table "items" has also the following row:
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 05:05:05 | 1                       | Team                   | Half                             | 3                   | 98                    | fr                   |
-    And the database table 'items_ancestors' has also the following row:
+    And the database table "items_ancestors" has also the following row:
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
-    And the database table 'items_items' has also the following row:
+    And the database table "items_items" has also the following row:
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | content                  |
       | 21       | 60      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 60      | 01:01:01        |
       | 31       | 60      | 02:02:02        |
@@ -192,26 +192,26 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 99                | 99             | 1       | 9999-12-31 23:59:59 |
 
   Scenario: Reenter a contest as a team
-    Given the database table 'items' has also the following row:
+    Given the database table "items" has also the following row:
       | id | duration | requires_explicit_entry | entry_participant_type | allows_multiple_attempts | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 01:01:01 | 1                       | Team                   | 1                        | None                             | 10                  | 99                    | fr                   |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id | expires_at          |
       | 99              | 11             | 2019-05-30 11:00:00 |
-    And the database table 'permissions_granted' has also the following rows:
+    And the database table "permissions_granted" has also the following rows:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | solution                 |
       | 31       | 60      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 60      | 02:02:02        |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until |
       | 1  | 11             | 2019-05-29 11:00:00 | 31         | 0                 | 60           | 2019-05-30 11:00:00      |
-    And the database table 'results' has also the following row:
+    And the database table "results" has also the following row:
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 11             | 60      | 2019-05-29 11:00:00 |
     And I am the user with id "31"
@@ -264,18 +264,18 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       | 99                | 99             | 1       | 9999-12-31 23:59:59 |
 
   Scenario: Enter a contest that doesn't have items.participants_group_id set
-    Given the database table 'items' has also the following row:
+    Given the database table "items" has also the following row:
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | default_language_tag |
       | 50 | 01:01:01 | 1                       | User                   | None                             | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 50      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated       |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 50      | 02:02:02        |
     And I am the user with id "31"
@@ -312,24 +312,24 @@ Feature: Enters a contest as a group (user self or team) (contestEnter)
       """
 
   Scenario: Enter a contest with empty duration
-    Given the database table 'items' has also the following row:
+    Given the database table "items" has also the following row:
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | participants_group_id | default_language_tag |
       | 50 | null     | 1                       | User                   | None                             | 99                    | fr                   |
-    And the database table 'items_ancestors' has also the following row:
+    And the database table "items_ancestors" has also the following row:
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database table 'items_items' has also the following row:
+    And the database table "items_items" has also the following row:
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 1           |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 50      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database table 'permissions_generated' has also the following rows:
+    And the database table "permissions_generated" has also the following rows:
       | group_id | item_id | can_view_generated       |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 50      | 02:02:02        |
     And I am the user with id "31"

--- a/app/api/items/enter.robustness.feature
+++ b/app/api/items/enter.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Enters a contest as a group (user self or team) (contestEnter) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name         | type                | root_activity_id |
       | 9  | Class        | Class               | 50               |
       | 10 | Team 1       | Team                | null             |
@@ -10,13 +10,13 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
       | 41 | jane         | User                | null             |
       | 51 | jack         | User                | null             |
       | 99 | item50-group | ContestParticipants | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 31       | John        | Doe       |
       | jane  | 41       | Jane        | null      |
       | jack  | 51       | Jack        | Daniel    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 9               | 31             |
       | 10              | 31             |
@@ -56,10 +56,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
 
   Scenario: The item is not visible to the team
     Given I am the user with id "31"
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | default_language_tag |
       | 50 | 1                       | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 31       | 50      | content            |
     When I send a POST request to "/items/50/enter?as_team_id=11&parent_attempt_id=0"
@@ -71,7 +71,7 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
 
   Scenario: The item is visible, but it doesn't exist
     Given I am the user with id "31"
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 31       | 50      | content            |
     When I send a POST request to "/items/50/enter?parent_attempt_id=0"
@@ -82,10 +82,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: The item is not visible to the user (can_view = none)
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | default_language_tag |
       | 50 | 1                       | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 31       | 50      | none               |
     And I am the user with id "31"
@@ -97,10 +97,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: The item is visible, but it's not a contest
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
@@ -113,10 +113,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: as_team_id is given while the item's entry_participant_type = User
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 50 | 1                       | User                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
@@ -129,10 +129,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: as_team_id is not a team related to the item while the item's entry_participant_type = Team
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 60 | 1                       | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -145,10 +145,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: as_team_id is not given while the item's entry_participant_type = Team
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 60 | 1                       | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
     And I am the user with id "31"
@@ -160,10 +160,10 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: The current user is not a member of as_team_id while the item's entry_participant_type = Team
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 60 | 1                       | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -176,19 +176,19 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario: The contest is not ready
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | default_language_tag |
       | 60 | 1                       | Team                   | All                              | 3                   | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 11              | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 51       | 60      | 51              | 2007-01-01 10:21:21 | 2008-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
-    Given the database has the following table 'groups_contest_items':
+    Given the database has the following table "groups_contest_items":
       | group_id | item_id |
       | 11       | 60      |
       | 41       | 60      |
@@ -202,27 +202,27 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     And the table "attempts" should be empty
 
   Scenario Outline: Reenter a non-team contest
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | participants_group_id | default_language_tag |
       | 50 | 01:01:01 | 1                       | User                   | None                             | 99                    | fr                   |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id | expires_at   |
       | 99              | 31             | <expires_at> |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 31       | 50      | 31              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 31       | 50      | 02:02:02        |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id |
       | 1  | 31             | 2019-05-29 11:00:00 | 31         | 0                 | 50           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 31             | 50      | 2019-05-29 11:00:00 |
     And I am the user with id "31"
@@ -238,26 +238,26 @@ Feature: Enters a contest as a group (user self or team) (contestEnter) - robust
     | 9999-12-31 23:59:59 |
 
   Scenario: Reenter an already entered (not expired) contest as a team
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 01:01:01 | 1                       | Team                   | None                             | 10                  | 99                    | fr                   |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 99              | 11             |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | solution                 |
       | 31       | 60      | content_with_descendants |
-    And the database has the following table 'groups_contest_items':
+    And the database has the following table "groups_contest_items":
       | group_id | item_id | additional_time |
       | 11       | 60      | 02:02:02        |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id |
       | 1  | 11             | 2019-05-29 11:00:00 | 31         | 0                 | 60           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 11             | 60      | 2019-05-29 11:00:00 |
     And I am the user with id "31"

--- a/app/api/items/generate_task_token.feature
+++ b/app/api/items/generate_task_token.feature
@@ -1,27 +1,27 @@
 Feature: Generate a task token with a refreshed attempt for an item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type |
       | 101 | User |
       | 102 | Team |
       | 111 | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | hints_allowed | text_id | supported_lang_prog | default_language_tag |
       | 10 | null                                                                    | Chapter | 0                        | 0             | null    | null                | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 0                        | 1             | task1   | null                | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | 0             | null    | c,python            | fr                   |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 101      | 60      | solution                 |
@@ -31,12 +31,12 @@ Feature: Generate a task token with a refreshed attempt for an item
 
   Scenario: User is able to fetch a task token
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 0  | 102            |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at        | hints_requested | hints_cached |
       | 0          | 101            | 50      | 2017-05-29 06:38:38 | null                | 0              | null              | 2019-05-30 11:00:00 | null            | 0            |
       | 0          | 101            | 51      | 2019-04-29 06:38:38 | null                | 0              | null              | null                | null            | 0            |
@@ -80,12 +80,12 @@ Feature: Generate a task token with a refreshed attempt for an item
 
   Scenario: User is able to fetch a task token as a team
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 0  | 102            |
       | 1  | 102            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at | hints_requested | hints_cached |
       | 0          | 101            | 60      | 2019-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
       | 0          | 102            | 60      | 2017-05-29 06:38:38 | null                | 0              | null              | null         | null            | 0            |
@@ -129,12 +129,12 @@ Feature: Generate a task token with a refreshed attempt for an item
 
   Scenario: bAccessSolutions is true when the item is validated
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 0  | 102            |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at        | hints_requested | hints_cached |
       | 0          | 101            | 50      | 2017-05-29 06:38:38 | null                | 0              | null              | null                | null            | 0            |
       | 0          | 101            | 51      | 2019-04-29 06:38:38 | null                | 0              | null              | null                | null            | 0            |

--- a/app/api/items/generate_task_token.robustness.feature
+++ b/app/api/items/generate_task_token.robustness.feature
@@ -1,25 +1,25 @@
 Feature: Generate a task token with a refreshed attempt for an item - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  |
       | 101 | User  |
       | 102 | Team  |
       | 103 | Class |
       | 104 | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 103             | 101            |
       | 104             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | entry_participant_type | default_language_tag |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | User                   | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | Team                   | fr                   |
       | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Chapter | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | info               |
       | 101      | 60      | content            |
@@ -29,7 +29,7 @@ Feature: Generate a task token with a refreshed attempt for an item - robustness
       | 102      | 60      | content            |
       | 103      | 60      | content            |
       | 104      | 60      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | allows_submissions_until |
       | 0  | 101            | 2017-05-29 05:38:38 | 9999-12-31 23:59:59      |
       | 0  | 102            | 2017-05-29 05:38:38 | 9999-12-31 23:59:59      |
@@ -37,7 +37,7 @@ Feature: Generate a task token with a refreshed attempt for an item - robustness
       | 0  | 104            | 2017-05-29 05:38:38 | 9999-12-31 23:59:59      |
       | 1  | 101            | 2017-05-29 05:38:38 | 2019-05-30 11:00:00      |
       | 2  | 101            | 2017-05-29 05:38:38 | 9999-12-31 23:59:59      |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | started_at          | score_computed | score_obtained_at | validated_at |
       | 0          | 101            | 50      | 2018-05-29 06:38:38 | 2017-05-29 06:38:38 | 0              | null              | null         |
       | 0          | 101            | 90      | 2018-05-29 06:38:38 | 2017-05-29 06:38:38 | 0              | null              | null         |

--- a/app/api/items/get_activity_log.feature
+++ b/app/api/items/get_activity_log.feature
@@ -6,19 +6,19 @@ Feature: Get activity log
       | user  | 0         | 11       | John        | Doe       | en               |
       | jane  | 0         | 31       | Jane        | Doe       | en               |
       | paul  | 0         | 41       | Paul        | Smith     | en               |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type  | name       |
       | 13 | Class | Our Class  |
       | 20 | Other | Some Group |
       | 30 | Team  | Our Team   |
       | 40 | Club  | Our Club   |
       | 50 | Club  | Team Club  |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 11       | 31         | true              |
       | 13       | 21         | true              |
       | 31       | 31         | true              |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 13              | 11             | 2019-05-30 11:00:00            |
       | 13              | 41             | 2019-05-30 11:00:00            |
@@ -27,11 +27,11 @@ Feature: Get activity log
       | 40              | 21             | null                           |
       | 50              | 30             | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 11             |
       | 1  | 11             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | item_id | participant_id | started_at          | validated_at        | latest_submission_at |
       | 0          | 200     | 11             | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 | 2020-05-29 06:38:38  |
       | 0          | 200     | 30             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
@@ -46,7 +46,7 @@ Feature: Get activity log
       | 1          | 201     | 11             | null                | 2017-05-29 06:38:38 | 2020-05-29 06:38:38  |
       | 1          | 202     | 11             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
       | 1          | 203     | 11             | 2017-05-29 06:38:00 | 2017-05-30 12:00:00 | 2020-05-29 06:38:38  |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | author_id | participant_id | attempt_id | item_id | type       | state   | created_at          |
       | 1  | 11        | 11             | 0          | 201     | Submission | State1  | 2017-05-29 06:38:38 |
       | 4  | 11        | 11             | 1          | 201     | Saved      | State4  | 2017-05-30 06:38:38 |
@@ -77,7 +77,7 @@ Feature: Get activity log
       | 37 | 31        | 11             | 0          | 203     | Submission | State37 | 2017-05-29 06:38:38 |
       | 38 | 31        | 11             | 1          | 203     | Submission | State38 | 2017-05-30 06:38:38 |
       | 39 | 31        | 11             | 1          | 204     | Submission | State39 | 2017-05-30 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | graded_at           | score |
       | 2         | 2017-05-29 06:38:38 | 100   |
       | 1         | 2017-05-29 06:38:38 | 99    |
@@ -87,14 +87,14 @@ Feature: Get activity log
       | 6         | 2017-05-29 06:38:38 | 100   |
       | 7         | 2017-05-29 06:38:38 | 98    |
       | 8         | 2017-05-30 06:38:38 | 100   |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | no_score | default_language_tag |
       | 200 | Task    | false    | fr                   |
       | 201 | Chapter | false    | fr                   |
       | 202 | Chapter | false    | fr                   |
       | 203 | Chapter | false    | fr                   |
       | 204 | Task    | false    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_watch_generated |
       | 20       | 200     | none               | result              |
       | 21       | 200     | info               | none                | # user 21 is in group 20, so he has can_watch=result on item 200
@@ -110,12 +110,12 @@ Feature: Get activity log
       | 31       | 203     | content            | none                |
       | 40       | 201     | content            | answer              |
       | 50       | 204     | content            | answer              |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 200              | 201           |
       | 200              | 203           |
       | 200              | 204           |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title      | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Task 1     | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 200     | fr           | Tache 1    | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
@@ -125,7 +125,7 @@ Feature: Get activity log
       | 202     | fr           | Chapitre 2 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
       | 203     | en           | Chapter 3  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 203     | fr           | Chapitre 3 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
 

--- a/app/api/items/get_activity_log.robustness.feature
+++ b/app/api/items/get_activity_log.robustness.feature
@@ -5,42 +5,42 @@ Feature: Get activity log - robustness
       | someone | 0         | 21       | Bill        | Clinton   |
       | user    | 0         | 11       | John        | Doe       |
       | owner   | 0         | 23       | Jean-Michel | Blanquer  |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type  |
       | 13 | Class |
       | 30 | Team  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 30              | 23             |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 21         | false             |
       | 13       | 23         | true              |
     And the groups ancestors are computed
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 11             |
       | 1  | 11             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | item_id | participant_id |
       | 0          | 200     | 11             |
       | 1          | 200     | 11             |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id | author_id | participant_id | attempt_id | item_id | type       | state  | created_at          |
       | 1  | 11        | 11             | 0          | 200     | Submission | State1 | 2017-05-29 06:38:38 |
       | 2  | 11        | 11             | 1          | 200     | Submission | State2 | 2017-05-29 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | graded_at           | score |
       | 1         | 2017-05-29 06:38:38 | 100   |
       | 2         | 2017-05-29 06:38:38 | 100   |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | no_score | default_language_tag |
       | 200 | Chapter | false    | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 21       | 200     | content_with_descendants |
       | 23       | 200     | none                     |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 200              | 200           |
 

--- a/app/api/items/get_breadcrumbs.feature
+++ b/app/api/items/get_breadcrumbs.feature
@@ -1,20 +1,20 @@
 Feature: Get item breadcrumbs
 
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  | root_activity_id | root_skill_id |
     | 11 | jdoe    | -2    | User  | 22               | null          |
     | 13 | Group B | -2    | Class | 21               | null          |
     | 14 | Team B  | -2    | Team  | 23               | 25            |
     | 15 | Group C | -2    | Class | 21               | null          |
-  And the database has the following table 'languages':
+  And the database has the following table "languages":
     | tag |
     | en  |
     | fr  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | group_id | default_language |
     | jdoe  | 11       | fr               |
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id | type    | default_language_tag | allows_multiple_attempts |
     | 21 | Task    | en                   | 0                        |
     | 22 | Chapter | en                   | 1                        |
@@ -22,7 +22,7 @@ Background:
     | 24 | Task    | fr                   | 0                        |
     | 25 | Chapter | en                   | 1                        |
     | 26 | Chapter | en                   | 1                        |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title            |
     | 21      | en           | Graph: Methods   |
     | 21      | fr           | Graphe: Methodes |
@@ -30,7 +30,7 @@ Background:
     | 23      | en           | Reduce Graph     |
     | 25      | en           | BFS              |
     | 26      | en           | Trees            |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 14              | 11             |
@@ -38,21 +38,21 @@ Background:
   And the groups ancestors are computed
 
 Scenario: Full access on all the breadcrumbs (as a user)
-  Given the database has the following table 'permissions_generated':
+  Given the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 21      | content_with_descendants |
     | 13       | 22      | content_with_descendants |
     | 13       | 23      | content_with_descendants |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 21             | 22            | 1           |
     | 22             | 23            | 1           |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | participant_id | id | parent_attempt_id | root_item_id |
     | 11             | 0  | null              | null         |
     | 11             | 1  | 0                 | 22           |
     | 11             | 2  | 0                 | 22           |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | participant_id | attempt_id | item_id | started_at          |
     | 11             | 0          | 21      | 2019-05-30 11:00:00 |
     | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -72,21 +72,21 @@ Scenario: Full access on all the breadcrumbs (as a user)
   """
 
 Scenario: 'Content' access on all the breadcrumbs (as a team)
-  Given the database has the following table 'permissions_generated':
+  Given the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated |
     | 14       | 21      | content            |
     | 14       | 22      | content            |
     | 14       | 23      | content            |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 21             | 22            | 1           |
     | 22             | 23            | 1           |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | participant_id | id | parent_attempt_id | root_item_id |
     | 14             | 0  | null              | null         |
     | 14             | 1  | 0                 | 22           |
     | 14             | 2  | 0                 | 22           |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | participant_id | attempt_id | item_id | started_at          |
     | 14             | 0          | 21      | 2019-05-30 11:00:00 |
     | 14             | 1          | 22      | 2019-05-29 11:00:00 |
@@ -106,20 +106,20 @@ Scenario: 'Content' access on all the breadcrumbs (as a team)
     """
 
 Scenario: Content access to all items except for last for which we have info access
-  Given the database has the following table 'permissions_generated':
+  Given the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated |
     | 13       | 21      | content            |
     | 13       | 22      | content            |
     | 13       | 23      | info               |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 21             | 22            | 1           |
     | 22             | 23            | 1           |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | participant_id | id | parent_attempt_id | root_item_id |
     | 11             | 0  | null              | null         |
     | 11             | 1  | 0                 | 22           |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | participant_id | attempt_id | item_id | started_at          |
     | 11             | 0          | 21      | 2019-05-30 11:00:00 |
     | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -136,7 +136,7 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_activity_id of some participant's ancestor
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 23      | info               |
     And I am the user with id "11"
@@ -150,7 +150,7 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_skill_id of some participant's ancestor
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 25      | info               |
     And I am the user with id "11"
@@ -164,13 +164,13 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_activity_id of a managed group
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 26      | info               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id |
       | 14         | 16       |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | name    | root_activity_id |
       | 16 | Managed | 26               |
     And the groups ancestors are computed
@@ -185,13 +185,13 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_skill_id of a managed group
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 26      | info               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id |
       | 14         | 16       |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | name    | root_skill_id |
       | 16 | Managed | 26            |
     And the groups ancestors are computed
@@ -206,17 +206,17 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_activity_id of a group managed by the participant's ancestor
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 26      | info               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id |
       | 15         | 16       |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | name     | root_activity_id |
       | 16 | Ancestor | null             |
       | 17 | Managed  | 26               |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 16              | 17             |
     And the groups ancestors are computed
@@ -231,17 +231,17 @@ Scenario: Content access to all items except for last for which we have info acc
     """
 
   Scenario: Allows the first item to be root_skill_id of a group managed by the participant's ancestor
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 14       | 26      | info               |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id |
       | 15         | 16       |
-    And the database table 'groups' has also the following row:
+    And the database table "groups" has also the following row:
       | id | name     | root_skill_id |
       | 16 | Ancestor | null          |
       | 17 | Managed  | 26            |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 16              | 17             |
     And the groups ancestors are computed

--- a/app/api/items/get_breadcrumbs.robustness.feature
+++ b/app/api/items/get_breadcrumbs.robustness.feature
@@ -1,44 +1,44 @@
 Feature: Get item breadcrumbs - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | grade | type  |
       | 11 | jdoe    | -2    | User  |
       | 13 | Group B | -2    | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | no_score | type    | default_language_tag |
       | 21 | false    | Task    | fr                   |
       | 22 | false    | Task    | fr                   |
       | 23 | false    | Chapter | fr                   |
       | 24 | false    | Task    | fr                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title            |
       | 21      | en           | Graph: Methods   |
       | 22      | en           | DFS              |
       | 23      | en           | Reduce Graph     |
       | 21      | fr           | Graphe: Methodes |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
     And the groups ancestors are computed
 
   Scenario: Should fail when breadcrumb hierarchy is corrupt (one parent-child link missing), but user has full access to all
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 21      | content_with_descendants |
       | 13       | 22      | content_with_descendants |
       | 13       | 23      | content_with_descendants |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 22             | 23            | 1           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | parent_attempt_id | root_item_id |
       | 11             | 0  | null              | null         |
       | 11             | 1  | 0                 | 22           |
       | 11             | 2  | 0                 | 22           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 11             | 0          | 21      | 2019-05-30 11:00:00 |
       | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -51,22 +51,22 @@ Feature: Get item breadcrumbs - robustness
     And the response error message should contain "Item ids hierarchy is invalid or insufficient access rights"
 
   Scenario: Should fail when breadcrumb hierarchy is corrupt (one parent-child link missing at the end), but user has full access to all
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 21      | content_with_descendants |
       | 13       | 22      | content_with_descendants |
       | 13       | 23      | content_with_descendants |
       | 13       | 24      | content_with_descendants |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 21             | 22            | 1           |
       | 22             | 23            | 1           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | parent_attempt_id | root_item_id |
       | 11             | 0  | null              | null         |
       | 11             | 1  | 0                 | 22           |
       | 11             | 2  | 0                 | 22           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 11             | 0          | 21      | 2019-05-30 11:00:00 |
       | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -79,21 +79,21 @@ Feature: Get item breadcrumbs - robustness
     And the response error message should contain "Item ids hierarchy is invalid or insufficient access rights"
 
   Scenario: Should fail when breadcrumb hierarchy is corrupt (one item missing), and user has full access to all
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 21      | content_with_descendants |
       | 13       | 22      | content_with_descendants |
       | 13       | 24      | content_with_descendants |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 21             | 22            | 1           |
       | 22             | 23            | 1           |
       | 23             | 24            | 1           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | parent_attempt_id | root_item_id |
       | 11             | 0  | null              | null         |
       | 11             | 1  | 0                 | 22           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 11             | 0          | 21      | 2019-05-30 11:00:00 |
       | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -104,19 +104,19 @@ Feature: Get item breadcrumbs - robustness
     And the response error message should contain "Item ids hierarchy is invalid or insufficient access rights"
 
   Scenario: Should fail when the first item of hierarchy is not a root item, and user has full access to all
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 22      | content_with_descendants |
       | 13       | 23      | content_with_descendants |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 22             | 23            | 1           |
       | 23             | 24            | 1           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | parent_attempt_id | root_item_id |
       | 11             | 0  | null              | null         |
       | 11             | 1  | 0                 | 22           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 11             | 0          | 21      | 2019-05-30 11:00:00 |
       | 11             | 1          | 22      | 2019-05-30 11:00:00 |
@@ -127,19 +127,19 @@ Feature: Get item breadcrumbs - robustness
     And the response error message should contain "Item ids hierarchy is invalid or insufficient access rights"
 
   Scenario: Should fail when the user has 'info' access to middle element, 'content' access to the rest
-    Given the database has the following table 'permissions_generated':
+    Given the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 13       | 21      | content            |
       | 13       | 22      | info               |
       | 13       | 23      | content            |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 22             | 23            | 1           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id | parent_attempt_id | root_item_id |
       | 11             | 0  | null              | null         |
       | 11             | 1  | 0                 | 22           |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | started_at          |
       | 11             | 0          | 21      | 2019-05-30 11:00:00 |
       | 11             | 1          | 22      | 2019-05-30 11:00:00 |

--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -1,6 +1,6 @@
 Feature: Find all breadcrumbs to an item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |
       | 91  | Other | 50               | null          |
@@ -10,11 +10,11 @@ Feature: Find all breadcrumbs to an item
       | 101 | User  | null             | null          |
       | 102 | Team  | 100              | 60            |
       | 111 | User  | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | default_language |
       | john  | 101      | en               |
       | jane  | 111      | fr               |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 90              | 111            |
       | 90              | 102            |
@@ -22,12 +22,12 @@ Feature: Find all breadcrumbs to an item
       | 94              | 93             |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 91         | 90       | true              |
       | 91         | 94       | false             |
       | 111        | 92       | false             |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | url                    | type    | default_language_tag | text_id               | requires_explicit_entry |
       | 10  | null                   | Chapter | en                   | id10                  | false                   |
       | 50  | http://taskplatform/50 | Task    | en                   | -_ '#&?:=/\.,+%¤€aéàd | false                   |
@@ -37,7 +37,7 @@ Feature: Find all breadcrumbs to an item
       | 90  | null                   | Chapter | en                   | id90                  | false                   |
       | 100 | null                   | Chapter | en                   | id100                 | false                   |
       | 101 | null                   | Task    | en                   | id101                 | true                    |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title                                         |
       | 10      | fr           | Graphe: Methodes                              |
       | 10      | en           | Graph: Methods                                |
@@ -48,20 +48,20 @@ Feature: Find all breadcrumbs to an item
       | 90      | en           | Queues                                        |
       | 100     | en           | Chapter Containing Explicit Entry Not Started |
       | 101     | en           | Explicit Entry Not Started                    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
       | 80             | 90            | 1           |
       | 100            | 101           | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
       | 80               | 90            |
       | 100              | 101           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 102      | 60      | none                     |
       | 111      | 10      | content_with_descendants |
@@ -72,7 +72,7 @@ Feature: Find all breadcrumbs to an item
       | 111      | 90      | info                     |
       | 111      | 100     | content                  |
       | 111      | 101     | content                  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |
       | 0  | 102            | null         | null              |
@@ -81,7 +81,7 @@ Feature: Find all breadcrumbs to an item
       | 1  | 102            | 10           | null              |
       | 2  | 102            | 10           | null              |
       | 3  | 102            | 60           | 1                 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 102            | 10      | 2020-01-01 00:00:00 |
       | 2          | 102            | 60      | 2020-01-01 00:00:00 |
@@ -111,35 +111,35 @@ Feature: Find all breadcrumbs to an item
     | /items/by-text-id/id90/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
 
   Scenario: Should return a breadcrumb when there are missing results, like path-from-root
-    Given the database has the following table 'users':
+    Given the database has the following table "users":
       | login | group_id | default_language |
       | user  | 1000     | en               |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id   | type  | root_activity_id |
       | 1000 | User  | null             |
       | 1001 | Class | 1010             |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1001            | 1000           |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | url                      | type    | default_language_tag | text_id |
       | 1010 | null                     | Chapter | en                   | id1010  |
       | 1011 | null                     | Chapter | en                   | id1011  |
       | 1012 | null                     | Chapter | en                   | id1012  |
       | 1020 | http://taskplatform/1020 | Task    | en                   | id1020  |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title     |
       | 1010    | en           | Chapter 1 |
       | 1011    | en           | Chapter 2 |
       | 1012    | en           | Chapter 3 |
       | 1020    | en           | Item      |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 1010           | 1011          | 1           |
       | 1011           | 1012          | 1           |
       | 1012           | 1020          | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 1010             | 1011          |
       | 1010             | 1012          |
@@ -147,16 +147,16 @@ Feature: Find all breadcrumbs to an item
       | 1011             | 1012          |
       | 1011             | 1020          |
       | 1012             | 1020          |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 1000     | 1010    | content_with_descendants |
       | 1000     | 1011    | content_with_descendants |
       | 1000     | 1012    | content_with_descendants |
       | 1000     | 1020    | content                  |
-      And the database has the following table 'attempts':
+      And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 1000           | null         | null              |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 0          | 1000           | 1010    | 2020-01-01 00:00:00 |
     And I am the user with id "1000"

--- a/app/api/items/get_breadcrumbs_from_roots.robustness.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.robustness.feature
@@ -1,53 +1,53 @@
 Feature: Find all breadcrumbs to an item - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |
       | 91  | Other | 50               | null          |
       | 101 | User  | null             | null          |
       | 102 | Team  | 60               | null          |
       | 111 | User  | null             | null          |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | default_language |
       | john  | 101      | en               |
       | jane  | 111      | fr               |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 90              | 102            |
       | 91              | 111            |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 91         | 90       | true              |
       | 111        | 111      | false             |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                    | type    | default_language_tag | requires_explicit_entry | text_id |
       | 10 | null                   | Chapter | en                   | false                   | id10    |
       | 60 | http://taskplatform/60 | Task    | en                   | false                   | id60    |
       | 70 | http://taskplatform/70 | Task    | fr                   | false                   | id70    |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title            |
       | 10      | fr           | Graphe: Methodes |
       | 10      | en           | Graph: Methods   |
       | 60      | en           | Reduce Graph     |
       | 70      | fr           | null             |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 2           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 102      | 60      | info               |
       | 111      | 10      | info               |
       | 111      | 60      | none               |
       | 111      | 70      | none               |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |
       | 0  | 102            | null         | null              |
@@ -56,7 +56,7 @@ Feature: Find all breadcrumbs to an item - robustness
       | 2  | 102            | 10           | null              |
       | 3  | 102            | 10           | null              |
       | 4  | 102            | 10           | null              |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          |
       | 1          | 102            | 10      | 2020-01-01 00:00:00 |
       | 2          | 102            | 10      | 2020-01-01 00:00:00 |

--- a/app/api/items/get_children.feature
+++ b/app/api/items/get_children.feature
@@ -1,6 +1,6 @@
 Feature: Get item children
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -9,13 +9,13 @@ Feature: Get item children
       | 17 | fr         | -2    | User  |
       | 22 | info       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url                    | uses_api | hints_allowed |
       | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl         | true     | true          |
       | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null                   | true     | true          |
@@ -24,7 +24,7 @@ Feature: Get item children
       | 300 | Skill   | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/300 | true     | true          |
       | 301 | Skill   | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/301 | true     | true          |
       | 302 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/302 | true     | true          |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title        | image_url                  | subtitle     | description     | edu_comment    |
       | 200     | en           | Category 1   | http://example.com/my0.jpg | Subtitle 0   | Description 0   | Some comment   |
       | 210     | en           | Chapter A    | http://example.com/my1.jpg | Subtitle 1   | Description 1   | Some comment   |
@@ -36,7 +36,7 @@ Feature: Get item children
       | 300     | en           | Skill Parent | http://example.com/300.jpg | Subtitle 300 | Description 300 | Comment 300    |
       | 301     | en           | Skill Child  | http://example.com/301.jpg | Subtitle 301 | Description 301 | Comment 301    |
       | 302     | en           | Task Child   | http://example.com/302.jpg | Subtitle 302 | Description 302 | Comment 302    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -45,22 +45,22 @@ Feature: Get item children
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | category  | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation | request_help_propagation |
       | 200            | 210           | 2           | Discovery | 1            | none                     | use_content_view_propagation  | true                   | false             | true             | true                     |
       | 200            | 220           | 1           | Discovery | 2            | as_info                  | as_content_with_descendants   | false                  | true              | false            | false                    |
       | 200            | 230           | 3           | Discovery | 2            | as_info                  | as_content_with_descendants   | false                  | true              | false            | false                    |
       | 300            | 301           | 1           | Discovery | 1            | as_info                  | as_content_with_descendants   | false                  | true              | false            | false                    |
       | 300            | 302           | 2           | Discovery | 1            | as_info                  | as_content_with_descendants   | false                  | true              | false            | false                    |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | grant_content_view |
       | 210     | 200               | false              |
       | 210     | 210               | true               |
       | 200     | 220               | false              |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | none               | none                | true               |
@@ -81,10 +81,10 @@ Feature: Get item children
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 11             | 2019-05-30 10:00:00 |
       | 0  | 13             | 2019-05-30 10:00:00 |
@@ -93,7 +93,7 @@ Feature: Get item children
       | 1  | 11             | 2019-05-30 11:00:00 |
       | 1  | 13             | 2019-05-30 11:00:00 |
       | 1  | 17             | 2019-05-30 10:00:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 200     | 2019-05-30 11:00:00 | 2019-05-30 11:00:01 | 11.1           | null                |
       | 0          | 11             | 210     | null                | 2018-05-30 11:00:01 | 12.2           | null                |

--- a/app/api/items/get_children.robustness.feature
+++ b/app/api/items/get_children.robustness.feature
@@ -1,44 +1,44 @@
 Feature: Get item children - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | Team    | -2    | Team  |
     | 15 | Team2   | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 15              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Task    | false    | fr                   |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 200            | 210           | 1           |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | info                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content_with_descendants |
     | 15       | 200     | info                     |
     | 15       | 210     | content_with_descendants |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      | image_url         |
     | 200     | en           | Category 1 | http://my/img.png |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
     | 0  | 15             | 2019-01-30 08:26:41 | null         | null              | null                |
     | 1  | 15             | 2019-01-30 08:26:41 | 200          | 0                 | null                |
     | 2  | 15             | 2019-01-30 08:26:41 | 230          | 0                 | 2019-01-30 09:26:48 |
     | 3  | 15             | 2019-01-30 08:26:41 | 210          | 0                 | 2019-01-30 09:26:48 |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
     | 0          | 11             | 190     | 91             | 11          | 2019-01-30 09:26:42 | null                | 2019-01-30 09:36:41 |
     | 0          | 15             | 200     | 91             | 11          | 2019-01-30 09:26:42 | null                | 2019-01-30 09:36:41 |
@@ -129,7 +129,7 @@ Background:
 
   Scenario: Should fail when the current user doesn't have 'can_watch_members' permission on watched_group_id
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
     When I send a GET request to "/items/210/children?as_team_id=15&attempt_id=2&watched_group_id=13"

--- a/app/api/items/get_dependencies.feature
+++ b/app/api/items/get_dependencies.feature
@@ -1,7 +1,7 @@
 Feature: Get item dependencies
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -11,19 +11,19 @@ Feature: Get item dependencies
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
       | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
       | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
       | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 210     | en           | Chapter B   | http://example.com/my2.jpg | Subtitle 2   | Description 2 | Some comment   |
@@ -31,7 +31,7 @@ Feature: Get item dependencies
       | 200     | fr           | Catégorie 1 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
       | 210     | fr           | Chapitre B  | http://example.com/mf2.jpg | Sous-titre 2 | texte 2       | Un commentaire |
       | 220     | fr           | Chapitre A  | http://example.com/mf1.jpg | Sous-titre 1 | texte 1       | Un commentaire |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -40,14 +40,14 @@ Feature: Get item dependencies
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 200     | 210               | 20    | true               |
       | 200     | 220               | 30    | false              |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | none               | none                | true               |
@@ -66,10 +66,10 @@ Feature: Get item dependencies
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id |
       | 0  | 11             | 2019-05-30 10:00:00 | null         | null              |
       | 0  | 13             | 2019-05-30 10:00:00 | null         | null              |
@@ -78,7 +78,7 @@ Feature: Get item dependencies
       | 1  | 11             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 13             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 17             | 2019-05-30 10:00:00 | 200          | 0                 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 200     | null                | 2019-05-30 11:00:01 | 11.1           | null                |
       | 0          | 11             | 210     | null                | 2018-05-30 11:00:01 | 12.2           | null                |

--- a/app/api/items/get_dependencies.robustness.feature
+++ b/app/api/items/get_dependencies.robustness.feature
@@ -1,35 +1,35 @@
 Feature: Get item dependencies - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | Team    | -2    | Team  |
     | 15 | Team2   | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 15              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Task    | false    | fr                   |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 210            | 200           | 1           |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content_with_descendants |
     | 15       | 200     | none                     |
     | 15       | 210     | content_with_descendants |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      |
     | 200     | en           | Category 1 |
 
@@ -89,7 +89,7 @@ Background:
 
   Scenario: Should fail when the current user doesn't have 'can_watch_members' permission on watched_group_id
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
     When I send a GET request to "/items/210/dependencies?as_team_id=15&watched_group_id=13"

--- a/app/api/items/get_entry_state.feature
+++ b/app/api/items/get_entry_state.feature
@@ -1,6 +1,6 @@
 Feature: Get entry state (itemGetEntryState)
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name   | type  | frozen_membership |
       | 10 | Team 1 | Team  | 1                 |
       | 11 | Team 2 | Team  | 0                 |
@@ -12,14 +12,14 @@ Feature: Get entry state (itemGetEntryState)
       | 41 | jane   | User  | 0                 |
       | 51 | jack   | User  | 0                 |
       | 61 | mark   | User  | 0                 |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 31       | John        | Doe       |
       | jane  | 41       | Jane        | null      |
       | jack  | 51       | Jack        | Daniel    |
       | mark  | 61       | Mark        | Moe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 10              | 31             | null                           |
       | 10              | 41             | null                           |
@@ -36,15 +36,15 @@ Feature: Get entry state (itemGetEntryState)
       | 14              | 41             | null                           |
       | 14              | 61             | 2019-05-30 11:00:00            |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 13       | 14         |
 
   Scenario Outline: Individual contest without can_enter_from & can_enter_until
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | default_language_tag |
       | 50 | 00:00:00 | 1                       | User                   | <entry_min_admitted_members_ratio> | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 31       | 50      | content_with_descendants |
     And I am the user with id "31"
@@ -69,13 +69,13 @@ Feature: Get entry state (itemGetEntryState)
     | One                              | not_ready      |
 
   Scenario Outline: State is ready for an individual contest
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | default_language_tag |
       | 50 | 00:00:00 | 1                       | User                   | <entry_min_admitted_members_ratio> | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 31       | 50      | 31              | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 31       | 50      | content_with_descendants |
     And I am the user with id "31"
@@ -100,10 +100,10 @@ Feature: Get entry state (itemGetEntryState)
       | One                              |
 
   Scenario Outline: Team-only contest when no one can enter
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 3                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -147,13 +147,13 @@ Feature: Get entry state (itemGetEntryState)
       | One                              | not_ready      |
 
   Scenario Outline: entry_min_admitted_members_ratio is ignored when the team itself can enter the contest (depending on entering_time_* & can_enter_*)
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | default_language_tag | entering_time_min   | entering_time_max   |
       | 60 | 00:00:00 | 1                       | Team                   | All                              | 3                   | fr                   | <entering_time_min> | <entering_time_max> |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 31              | <can_enter_from>    | <can_enter_until>   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -198,15 +198,15 @@ Feature: Get entry state (itemGetEntryState)
     | 2007-01-01 10:21:21 | 3008-01-01 10:21:21 | 2007-12-31 23:59:59 | 2008-12-31 23:59:59 | not_ready      | false           |
 
   Scenario Outline: Team-only contest when one member can enter
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 3                   | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 11              | 9999-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 51       | 60      | 51              | 2007-01-01 10:21:21 | 2008-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -250,14 +250,14 @@ Feature: Get entry state (itemGetEntryState)
       | One                              | ready          |
 
   Scenario Outline: Team-only contest when half of members can enter
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 3                   | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 31       | 60      | 31              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -301,15 +301,15 @@ Feature: Get entry state (itemGetEntryState)
       | One                              | ready          |
 
   Scenario Outline: Team-only contest when all members can enter
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 3                   | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 31       | 60      | 31              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 51       | 60      | 51              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -353,15 +353,15 @@ Feature: Get entry state (itemGetEntryState)
       | One                              |
 
   Scenario Outline: Team-only contest when all members can enter, but the team is too large
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 2                   | fr                   |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 31       | 60      | 31              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 51       | 60      | 51              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -405,16 +405,16 @@ Feature: Get entry state (itemGetEntryState)
       | One                              |
 
   Scenario Outline: Team-only contest ignores size of the team when the team itself can enter the contest (depending on entering_time_* & can_enter_*)
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | default_language_tag | entering_time_min   | entering_time_max   |
       | 60 | 00:00:00 | 1                       | Team                   | None                             | 2                   | fr                   | <entering_time_min> | <entering_time_max> |
-    And the database table 'permissions_granted' has also the following row:
+    And the database table "permissions_granted" has also the following row:
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 60      | 31              | <can_enter_from>    | <can_enter_until>   |
       | 31       | 60      | 31              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 41       | 60      | 41              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
       | 51       | 60      | 51              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
@@ -459,22 +459,22 @@ Feature: Get entry state (itemGetEntryState)
     | 2007-01-01 10:21:21 | 3008-01-01 10:21:21 | 2007-12-31 23:59:59 | 2008-12-31 23:59:59 | not_ready      | false           |
 
   Scenario Outline: State is already_started for an individual contest
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | participants_group_id | default_language_tag |
       | 50 | 00:00:00 | 1                       | User                   | <entry_min_admitted_members_ratio> | 0                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 10       | 50      | content                  |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id |
       | 1  | 31             | 2019-05-30 15:00:00 | 31         | 0                 | 50           |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 100             | 31             |
     And I am the user with id "31"
@@ -499,20 +499,20 @@ Feature: Get entry state (itemGetEntryState)
       | One                              |
 
   Scenario Outline: State is already_started for a team-only contest
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio   | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 00:00:00 | 1                       | Team                   | <entry_min_admitted_members_ratio> | 0                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id |
       | 1  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 100             | 11             |
     And I am the user with id "31"
@@ -555,22 +555,22 @@ Feature: Get entry state (itemGetEntryState)
       | One                              |
 
   Scenario: State is not_ready for an individual contest because the participation has expired
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 50 | 00:00:00 | 1                       | User                   | None                             | 0                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 10       | 50      | content                  |
       | 11       | 50      | none                     |
       | 21       | 50      | solution                 |
       | 31       | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until |
       | 1  | 31             | 2019-05-30 15:00:00 | 31         | 0                 | 50           | 2019-05-30 20:00:00      |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id | expires_at          |
       | 100             | 31             | 2019-05-30 20:00:00 |
     And I am the user with id "31"
@@ -589,20 +589,20 @@ Feature: Get entry state (itemGetEntryState)
     """
 
   Scenario: State is ready for a team-only contest because the participation has expired
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 00:00:00 | 1                       | 1                        | Team                   | None                             | 3                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until |
       | 1  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id | expires_at          |
       | 100             | 11             | 2019-05-30 20:00:00 |
     And I am the user with id "31"
@@ -639,22 +639,22 @@ Feature: Get entry state (itemGetEntryState)
     """
 
   Scenario: State is ready for a team-only contest because the all its started attempts has expired
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 00:00:00 | 1                       | 1                        | Team                   | None                             | 3                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until |
       | 1  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
       | 2  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
       | 3  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 100             | 11             |
     And I am the user with id "31"
@@ -691,25 +691,25 @@ Feature: Get entry state (itemGetEntryState)
     """
 
   Scenario: State is not ready for a team-only contest because the team's users have a conflicting participation
-    Given the database table 'groups' has also the following row:
+    Given the database table "groups" has also the following row:
       | id  | type                |
       | 100 | ContestParticipants |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | participants_group_id | default_language_tag |
       | 60 | 00:00:00 | 1                       | 1                        | Team                   | None                             | 3                   | 100                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | allows_submissions_until |
       | 1  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
       | 2  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
       | 3  | 11             | 2019-05-30 15:00:00 | 31         | 0                 | 60           | 2019-05-30 20:00:00      |
-    And the database table 'groups_groups' has also the following row:
+    And the database table "groups_groups" has also the following row:
       | parent_group_id | child_group_id |
       | 100             | 11             |
-    And the database table 'attempts' has also the following row:
+    And the database table "attempts" has also the following row:
       | participant_id | id | root_item_id |
       | 10             | 1  | 60           |
     And I am the user with id "31"
@@ -746,13 +746,13 @@ Feature: Get entry state (itemGetEntryState)
     """
 
   Scenario Outline: The user cannot enter because of entering_time_min/entering_time_max
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | default_language_tag | entering_time_min   | entering_time_max   |
       | 50 | 00:00:00 | 1                       | User                   | None                             | fr                   | <entering_time_min> | <entering_time_max> |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
       | 11       | 50      | 11              | 2007-01-01 10:21:21 | 9999-12-31 23:59:59 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 31       | 50      | content_with_descendants |
     And I am the user with id "31"
@@ -775,10 +775,10 @@ Feature: Get entry state (itemGetEntryState)
     | 2007-12-31 23:59:59 | 2008-12-31 23:59:59 |
 
   Scenario: entry_frozen_teams is ignored for non-team contests
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | duration | requires_explicit_entry | entry_participant_type | entry_min_admitted_members_ratio | default_language_tag | entry_frozen_teams |
       | 50 | 00:00:00 | 1                       | User                   | None                             | fr                   | 1                  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 31       | 50      | content_with_descendants |
     And I am the user with id "31"
@@ -797,10 +797,10 @@ Feature: Get entry state (itemGetEntryState)
     """
 
   Scenario Outline: State depends on frozen_membership when items.entry_frozen_teams = 1
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | entry_min_admitted_members_ratio | entry_max_team_size | default_language_tag | entry_frozen_teams |
       | 60 | 00:00:00 | 1                       | 1                        | Team                   | None                             | 3                   | fr                   | 1                  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id  | item_id | can_view_generated       |
       | <team_id> | 60      | info                     |
       | 21        | 60      | content_with_descendants |
@@ -842,10 +842,10 @@ Feature: Get entry state (itemGetEntryState)
     | 11      | false                  | not_ready |
 
   Scenario: Hides personal info for users who haven't give the approval
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | duration | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | entry_min_admitted_members_ratio | default_language_tag |
       | 60 | 00:00:00 | 1                       | 1                        | Team                   | None                             | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id  | item_id | can_view_generated       |
       | 12        | 60      | info                     |
       | 21        | 60      | content_with_descendants |

--- a/app/api/items/get_entry_state.robustness.feature
+++ b/app/api/items/get_entry_state.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get entry state (itemGetEntryState) - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name   | type |
       | 10 | Team 1 | Team |
       | 11 | Team 2 | Team |
@@ -8,13 +8,13 @@ Feature: Get entry state (itemGetEntryState) - robustness
       | 31 | john   | User |
       | 41 | jane   | User |
       | 51 | jack   | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name  | last_name |
       | owner | 21       | Jean-Michel | Blanquer  |
       | john  | 31       | John        | Doe       |
       | jane  | 41       | Jane        | null      |
       | jack  | 51       | Jack        | Daniel    |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 31             |
       | 10              | 41             |
@@ -38,10 +38,10 @@ Feature: Get entry state (itemGetEntryState) - robustness
 
   Scenario: The item is not visible to the current user (can_view = none)
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | requires_explicit_entry | default_language_tag |
       | 50 | 1                       | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 21       | 50      | none               |
     When I send a GET request to "/items/50/entry-state"
@@ -50,7 +50,7 @@ Feature: Get entry state (itemGetEntryState) - robustness
 
   Scenario: The item is not visible to the current user (no permissions)
     Given I am the user with id "21"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | requires_explicit_entry | default_language_tag |
       | 50 | 1                       | fr                   |
     When I send a GET request to "/items/50/entry-state"
@@ -58,10 +58,10 @@ Feature: Get entry state (itemGetEntryState) - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: The item is visible, but it's not a contest
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | default_language_tag |
       | 50 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 21       | 50      | info               |
     And I am the user with id "31"
@@ -70,10 +70,10 @@ Feature: Get entry state (itemGetEntryState) - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: as_team_id is given while the item's entry_participant_type = User
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 50 | 1                       | User                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 10       | 50      | content                  |
       | 21       | 50      | solution                 |
@@ -84,10 +84,10 @@ Feature: Get entry state (itemGetEntryState) - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: as_team_id is not given while the item's entry_participant_type = Team
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 50 | 1                       | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 10       | 50      | content                  |
       | 11       | 50      | none                     |
@@ -99,10 +99,10 @@ Feature: Get entry state (itemGetEntryState) - robustness
     And the response error message should contain "Insufficient access rights"
 
   Scenario: The current user is not a member of as_team_id while the item's entry_participant_type = 'Team'
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | requires_explicit_entry | entry_participant_type | default_language_tag |
       | 60 | 1                       | Team                   | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 11       | 60      | info                     |
       | 21       | 60      | content_with_descendants |

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -1,6 +1,6 @@
 Feature: Get item view information
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -11,18 +11,18 @@ Feature: Get item view information
       | 26 | team       | -2    | Team  |
       | 27 | Group D    | -2    | Class |
       | 28 | Group E    | -2    | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | text_id  | display_details_in_parent | validation_type | requires_explicit_entry | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | entry_participant_type | duration | prompt_to_join_group_by_code | title_bar_visible | read_only | full_screen | children_layout | show_user_infos | url            | options | uses_api | hints_allowed |
       | 200 | Task    | en                   | true     | Task_30c | true                      | All             | true                    | All                              | false              | 10                  | true                     | Team                   | 10:20:30 | true                         | true              | true      | forceYes    | List            | true            | http://someurl | {}      | true     | true          |
       | 210 | Chapter | en                   | true     | null     | true                      | All             | false                   | All                              | false              | 10                  | true                     | User                   | 10:20:31 | true                         | true              | true      | forceYes    | List            | true            | null           | null    | true     | true          |
       | 220 | Chapter | en                   | true     | Task_30e | true                      | All             | false                   | All                              | false              | 10                  | true                     | Team                   | 10:20:32 | true                         | true              | true      | forceYes    | List            | true            | null           | null    | true     | true          |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 210     | en           | Chapter A   | http://example.com/my1.jpg | Subtitle 1   | Description 1 | Some comment   |
@@ -30,7 +30,7 @@ Feature: Get item view information
       | 200     | fr           | Catégorie 1 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
       | 210     | fr           | Chapitre A  | http://example.com/mf1.jpg | Sous-titre 1 | texte 1       | Un commentaire |
       | 220     | fr           | Chapitre B  | http://example.com/mf2.jpg | Sous-titre 2 | texte 2       | Un commentaire |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -41,11 +41,11 @@ Feature: Get item view information
       | 27              | 11             |
       | 28              | 15             |
     And the groups ancestors are computed
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | category  | content_view_propagation |
       | 200            | 210           | 2           | Discovery | as_info                  |
       | 200            | 220           | 1           | Discovery | as_info                  |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | none               | none                | false              |
@@ -63,15 +63,15 @@ Feature: Get item view information
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
       | 28       | 220     | content_with_descendants | solution_with_grant      | all                | answer              | true               |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 11             | 2019-05-30 10:00:00 |
       | 0  | 13             | 2019-05-30 10:00:00 |
       | 1  | 13             | 2019-05-30 10:00:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | score_computed |
       | 0          | 11             | 200     | 2019-05-30 11:00:00 | 0              |
       | 0          | 11             | 210     | null                | 10             |
@@ -478,11 +478,11 @@ Feature: Get item view information
 
   Scenario Outline: With watched_group_id
     Given I am the user with id "11"
-    And the database table 'group_managers' has also the following row:
+    And the database table "group_managers" has also the following row:
       | manager_id | group_id | can_watch_members | can_grant_group_access            |
       | 11         | 15       | false             | <can_grant_group_access>          |
       | 27         | 28       | true              | <can_grant_group_access_ancestor> |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated | can_grant_view_generated            | can_edit_generated | can_watch_generated   | is_owner_generated |
       | 11       | 220     | solution           | <can_grant_view_generated>          | none               | <can_watch_generated> | false              |
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
@@ -565,11 +565,11 @@ Feature: Get item view information
 
   Scenario Outline: With watched_group_id and as_team_id
     Given I am the user with id "11"
-    And the database table 'group_managers' has also the following row:
+    And the database table "group_managers" has also the following row:
       | manager_id | group_id | can_watch_members | can_grant_group_access            |
       | 11         | 15       | false             | <can_grant_group_access>          |
       | 27         | 28       | true              | <can_grant_group_access_ancestor> |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated | can_grant_view_generated            | can_edit_generated | can_watch_generated   | is_owner_generated |
       | 11       | 220     | solution           | <can_grant_view_generated>          | none               | <can_watch_generated> | false              |
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |

--- a/app/api/items/get_item.robustness.feature
+++ b/app/api/items/get_item.robustness.feature
@@ -1,34 +1,34 @@
 Feature: Get item view information - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | info    | -2    | Class |
     | 16 | Group C | -2    | Class |
     | 17 | Team    | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
     | info  | 0         | 14       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 16              | 14             |
     | 17              | 14             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 16       | 190     | info                     |
     | 16       | 200     | content_with_descendants |
     | 17       | 190     | info                     |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      |
     | 200     | fr           | Category 1 |
 

--- a/app/api/items/get_item_can_request_help_to_groups.feature
+++ b/app/api/items/get_item_can_request_help_to_groups.feature
@@ -8,7 +8,7 @@ Feature: Get permissions can_request_help for an item
       | @ClassParent        |         | @Class                |
       | @ClassAnotherParent |         | @Class                |
       | @Class              | @School | @Student,@HelperGroup |
-    And @Teacher is a manager of the group @ClassAnotherParent and can watch its members
+    And the group @Teacher is a manager of the group @ClassAnotherParent and can watch for submissions from the group and its descendants
     And there are the following items:
       | item                          | type    |
       | @Chapter1                     | Chapter |

--- a/app/api/items/get_navigation.feature
+++ b/app/api/items/get_navigation.feature
@@ -1,6 +1,6 @@
 Feature: Get navigation for an item
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name      | grade | type  |
       | 1  | all       | -2    | Base  |
       | 11 | jdoe      | -2    | User  |
@@ -10,16 +10,16 @@ Feature: Get navigation for an item
       | 16 | info_mid  | -2    | User  |
       | 18 | french    | -2    | User  |
       | 19 | Group C   | -2    | Team  |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login     | temp_user | group_id | default_language |
       | jdoe      | 0         | 11       |                  |
       | info_root | 0         | 14       |                  |
       | info_mid  | 0         | 16       |                  |
       | fr_user   | 0         | 18       | fr               |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 1               | 12             |
       | 1               | 13             |
@@ -31,11 +31,11 @@ Feature: Get navigation for an item
       | 13              | 11             |
       | 19              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 12         | 1        | true              |
       | 12         | 19       | true              |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
       | 200 | Task    | en                   | false    | false                   | User                   |
       | 210 | Chapter | en                   | false    | false                   | User                   |
@@ -45,7 +45,7 @@ Feature: Get navigation for an item
       | 231 | Task    | en                   | false    | false                   | User                   |
       | 232 | Task    | en                   | false    | false                   | User                   |
       | 250 | Task    | en                   | false    | false                   | User                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
       | 11       | 200     | solution                 | solution_with_grant      | none                | none               | true               |
@@ -89,7 +89,7 @@ Feature: Get navigation for an item
       | 19       | 200     | content                  | none                     | none                | none               | false              |
       | 19       | 210     | content                  | none                     | none                | none               | false              |
       | 19       | 211     | content                  | none                     | none                | none               | false              |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | content_view_propagation |
       | 200            | 210           | 3           | none                     |
       | 200            | 220           | 2           | as_info                  |
@@ -97,7 +97,7 @@ Feature: Get navigation for an item
       | 210            | 211           | 1           | none                     |
       | 230            | 231           | 2           | none                     |
       | 230            | 232           | 1           | none                     |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       |
       | 200     | en           | Category 1  |
       | 210     | en           | Chapter A   |
@@ -110,14 +110,14 @@ Feature: Get navigation for an item
       | 210     | fr           | Chapitre A  |
       | 230     | fr           | Chapitre C  |
       | 211     | fr           | Tâche 1     |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
       | 0  | 11             | 2019-01-30 08:26:41 | null         | null              | null                |
       | 1  | 11             | 2019-01-30 08:26:41 | 200          | 0                 | null                |
       | 2  | 11             | 2019-01-30 08:26:41 | 230          | 0                 | 2019-01-30 09:26:48 |
       | 0  | 13             | 2018-01-30 09:26:42 | null         | null              | null                |
       | 0  | 19             | 2018-01-30 09:26:42 | null         | null              | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
       | 0          | 11             | 200     | 91             | 11          | 2019-01-30 09:26:41 | null                | 2019-01-30 09:36:41 |
       | 0          | 11             | 210     | 92             | 12          | 2019-01-30 09:26:42 | 2019-01-31 09:26:42 | 2019-01-30 09:36:42 |
@@ -222,14 +222,14 @@ Feature: Get navigation for an item
       """
 
   Scenario: Should only return Skills and compute has_visible children on Skills only when we get navigation on a Skill
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id   | name | type |
       | 1000 | user | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | user  | 0         | 1000     |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
       | 1000 | Skill   | en                   | false    | false                   | User                   |
       | 1100 | Skill   | en                   | false    | false                   | User                   |
@@ -241,7 +241,7 @@ Feature: Get navigation for an item
       | 1300 | Skill   | en                   | false    | false                   | User                   |
       | 1400 | Chapter | en                   | false    | false                   | User                   |
       | 1500 | Task    | en                   | false    | false                   | User                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1000     | 1000    | solution           | solution_with_grant      | none                | none               | false              |
       | 1000     | 1100    | solution           | solution_with_grant      | none                | none               | false              |
@@ -253,7 +253,7 @@ Feature: Get navigation for an item
       | 1000     | 1300    | solution           | solution_with_grant      | none                | none               | false              |
       | 1000     | 1400    | solution           | solution_with_grant      | none                | none               | false              |
       | 1000     | 1500    | solution           | solution_with_grant      | none                | none               | false              |
-      And the database has the following table 'items_items':
+      And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | content_view_propagation |
       | 1000           | 1100          | 1           | none                     |
       | 1100           | 1110          | 1           | none                     |
@@ -264,7 +264,7 @@ Feature: Get navigation for an item
       | 1000           | 1300          | 3           | as_content               |
       | 1000           | 1400          | 4           | as_content               |
       | 1000           | 1500          | 5           | as_content               |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title              |
       | 1000    | en           | Parent Skill       |
       | 1100    | en           | Child lvl1 Skill 1 |
@@ -276,10 +276,10 @@ Feature: Get navigation for an item
       | 1300    | en           | Child lvl1 Skill 3 |
       | 1400    | en           | Child lvl1 Chapter |
       | 1500    | en           | Child lvl1 Task    |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at |
       | 0  | 1000           | 2020-01-01 00:00:00 | null         | null              | null     |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
       | 0          | 1000           | 1000    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |
       | 0          | 1000           | 1100    | 100            | 1           | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 | 2020-01-01 00:00:00 |

--- a/app/api/items/get_navigation.robustness.feature
+++ b/app/api/items/get_navigation.robustness.feature
@@ -1,44 +1,44 @@
 Feature: Get item navigation - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | Team    | -2    | Team  |
     | 15 | Team2   | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 15              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Task    | false    | fr                   |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 200            | 210           | 1           |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content_with_descendants |
     | 15       | 200     | none                     |
     | 15       | 210     | content_with_descendants |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      |
     | 200     | en           | Category 1 |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
     | 0  | 15             | 2019-01-30 08:26:41 | null         | null              | null                |
     | 1  | 15             | 2019-01-30 08:26:41 | 200          | 0                 | null                |
     | 2  | 15             | 2019-01-30 08:26:41 | 230          | 0                 | 2019-01-30 09:26:48 |
     | 3  | 15             | 2019-01-30 08:26:41 | 210          | 0                 | 2019-01-30 09:26:48 |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
     | 0          | 15             | 200     | 91             | 11          | null                | null                | 2019-01-30 09:36:41 |
     | 1          | 15             | 200     | 92             | 12          | 2019-01-30 09:26:42 | 2019-01-31 09:26:42 | 2019-01-30 09:36:42 |
@@ -152,7 +152,7 @@ Background:
 
   Scenario: Should fail when the current user doesn't have 'can_watch_members' permission on watched_group_id
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
     When I send a GET request to "/items/210/navigation?as_team_id=15&attempt_id=0&watched_group_id=13"

--- a/app/api/items/get_parents.feature
+++ b/app/api/items/get_parents.feature
@@ -1,7 +1,7 @@
 Feature: Get item parents
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -10,18 +10,18 @@ Feature: Get item parents
       | 17 | fr         | -2    | User  |
       | 22 | info       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
       | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
       | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
       | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 210     | en           | Chapter A   | http://example.com/my1.jpg | Subtitle 1   | Description 1 | Some comment   |
@@ -29,7 +29,7 @@ Feature: Get item parents
       | 200     | fr           | Catégorie 1 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
       | 210     | fr           | Chapitre A  | http://example.com/mf1.jpg | Sous-titre 1 | texte 1       | Un commentaire |
       | 220     | fr           | Chapitre B  | http://example.com/mf2.jpg | Sous-titre 2 | texte 2       | Un commentaire |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -38,14 +38,14 @@ Feature: Get item parents
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order | category  |
       | 210            | 200           | 2           | Discovery |
       | 220            | 200           | 1           | Discovery |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | none               | none                | true               |
@@ -63,10 +63,10 @@ Feature: Get item parents
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id |
       | 0  | 11             | 2019-05-30 10:00:00 | null         | null              |
       | 0  | 13             | 2019-05-30 10:00:00 | null         | null              |
@@ -75,7 +75,7 @@ Feature: Get item parents
       | 1  | 11             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 13             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 17             | 2019-05-30 10:00:00 | 200          | 0                 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 200     | null                | 2019-05-30 11:00:01 | 11.1           | null                |
       | 0          | 11             | 210     | null                | 2018-05-30 11:00:01 | 12.2           | null                |

--- a/app/api/items/get_parents.robustness.feature
+++ b/app/api/items/get_parents.robustness.feature
@@ -1,44 +1,44 @@
 Feature: Get item parents - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | Team    | -2    | Team  |
     | 15 | Team2   | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 15              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Task    | false    | fr                   |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 210            | 200           | 1           |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content_with_descendants |
     | 15       | 200     | none                     |
     | 15       | 210     | content_with_descendants |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      |
     | 200     | en           | Category 1 |
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id | created_at          | root_item_id | parent_attempt_id | ended_at            |
     | 0  | 15             | 2019-01-30 08:26:41 | null         | null              | null                |
     | 1  | 15             | 2019-01-30 08:26:41 | 200          | 0                 | null                |
     | 2  | 15             | 2019-01-30 08:26:41 | 230          | 0                 | 2019-01-30 09:26:48 |
     | 3  | 15             | 2019-01-30 08:26:41 | 210          | 0                 | 2019-01-30 09:26:48 |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id | score_computed | submissions | started_at          | validated_at        | latest_activity_at  |
     | 0          | 11             | 190     | 91             | 11          | 2019-01-30 09:26:42 | null                | 2019-01-30 09:36:41 |
     | 0          | 15             | 200     | 91             | 11          | 2019-01-30 09:26:42 | null                | 2019-01-30 09:36:41 |
@@ -117,7 +117,7 @@ Background:
 
   Scenario: Should fail when the current user doesn't have 'can_watch_members' permission on watched_group_id
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
     When I send a GET request to "/items/210/parents?as_team_id=15&attempt_id=2&watched_group_id=13"

--- a/app/api/items/get_prerequisites.feature
+++ b/app/api/items/get_prerequisites.feature
@@ -1,7 +1,7 @@
 Feature: Get item prerequisites
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | grade | type  |
       | 11 | jdoe       | -2    | User  |
       | 13 | Group B    | -2    | Team  |
@@ -11,19 +11,19 @@ Feature: Get item prerequisites
       | 22 | info       | -2    | User  |
       | 23 | jane       | -2    | User  |
       | 26 | team       | -2    | Team  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login      | temp_user | group_id | default_language |
       | jdoe       | 0         | 11       |                  |
       | nosolution | 0         | 14       |                  |
       | fr         | 0         | 17       | fr               |
       | info       | 0         | 22       |                  |
       | jane       | 0         | 23       |                  |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
       | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
       | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
       | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
       | 210     | en           | Chapter B   | http://example.com/my2.jpg | Subtitle 2   | Description 2 | Some comment   |
@@ -31,7 +31,7 @@ Feature: Get item prerequisites
       | 200     | fr           | Catégorie 1 | http://example.com/mf0.jpg | Sous-titre 0 | texte 0       | Un commentaire |
       | 210     | fr           | Chapitre B  | http://example.com/mf2.jpg | Sous-titre 2 | texte 2       | Un commentaire |
       | 220     | fr           | Chapitre A  | http://example.com/mf1.jpg | Sous-titre 1 | texte 1       | Un commentaire |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 17             |
@@ -40,14 +40,14 @@ Feature: Get item prerequisites
       | 26              | 11             |
       | 26              | 22             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id | can_watch_members |
       | 22         | 15       | true              |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score | grant_content_view |
       | 210     | 200               | 20    | true               |
       | 220     | 200               | 30    | false              |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
       | 11       | 210     | solution                 | none                     | none               | none                | true               |
@@ -66,10 +66,10 @@ Feature: Get item prerequisites
       | 26       | 200     | solution                 | none                     | none               | none                | false              |
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | fr  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | root_item_id | parent_attempt_id |
       | 0  | 11             | 2019-05-30 10:00:00 | null         | null              |
       | 0  | 13             | 2019-05-30 10:00:00 | null         | null              |
@@ -78,7 +78,7 @@ Feature: Get item prerequisites
       | 1  | 11             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 13             | 2019-05-30 11:00:00 | null         | null              |
       | 1  | 17             | 2019-05-30 10:00:00 | 200          | 0                 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  | score_computed | validated_at        |
       | 0          | 11             | 200     | null                | 2019-05-30 11:00:01 | 11.1           | null                |
       | 0          | 11             | 210     | null                | 2018-05-30 11:00:01 | 12.2           | null                |

--- a/app/api/items/get_prerequisites.robustness.feature
+++ b/app/api/items/get_prerequisites.robustness.feature
@@ -1,35 +1,35 @@
 Feature: Get item prerequisites - robustness
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name    | grade | type  |
     | 11 | jdoe    | -2    | User  |
     | 13 | Group B | -2    | Class |
     | 14 | Team    | -2    | Team  |
     | 15 | Team2   | -2    | Team  |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 13              | 11             |
     | 15              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id  | type    | no_score | default_language_tag |
     | 190 | Chapter | false    | fr                   |
     | 200 | Chapter | false    | fr                   |
     | 210 | Task    | false    | fr                   |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 210            | 200           | 1           |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       |
     | 13       | 190     | none                     |
     | 13       | 200     | content_with_descendants |
     | 13       | 210     | content_with_descendants |
     | 15       | 200     | none                     |
     | 15       | 210     | content_with_descendants |
-  And the database has the following table 'items_strings':
+  And the database has the following table "items_strings":
     | item_id | language_tag | title      |
     | 200     | en           | Category 1 |
 
@@ -89,7 +89,7 @@ Background:
 
   Scenario: Should fail when the current user doesn't have 'can_watch_members' permission on watched_group_id
     Given I am the user with id "11"
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 13       | 11         | false             |
     When I send a GET request to "/items/210/prerequisites?as_team_id=15&watched_group_id=13"

--- a/app/api/items/list_attempts.feature
+++ b/app/api/items/list_attempts.feature
@@ -1,6 +1,6 @@
 Feature: List attempts for current user and item_id
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 11 | jdoe    | User  |
       | 13 | Group B | Class |
@@ -8,12 +8,12 @@ Feature: List attempts for current user and item_id
       | 23 | Group C | Team  |
       | 24 | jane    | User  |
       | 25 | Group D | Club  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
       | other | 21       | George     | Bush      |
       | jane  | 24       | Jane       | Joe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 13              | 11             | null                           |
       | 13              | 21             | null                           |
@@ -21,30 +21,30 @@ Feature: List attempts for current user and item_id
       | 23              | 24             | null                           |
       | 23              | 31             | null                           |
       | 25              | 24             | 2019-05-30 11:00:00            |
-    And the database has the following table 'group_pending_requests':
+    And the database has the following table "group_pending_requests":
       | group_id | member_id | personal_info_view_approved |
       | 25       | 21        | true                        |
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id |
       | 25       | 13         |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 200 | 0                        | fr                   |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 200     | content                  |
       | 13       | 210     | info                     |
       | 23       | 210     | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | ended_at            |
       | 1  | 11             | 2018-05-29 05:38:38 | 21         | 0                 | 210          | 2018-05-29 05:38:38 |
       | 2  | 11             | 2018-05-29 05:38:38 | 11         | 1                 | 200          | 2018-05-29 05:38:38 |
       | 0  | 11             | 2018-05-29 05:38:38 | null       | null              | null         | null                |
       | 0  | 23             | 2019-05-29 05:38:38 | 11         | null              | null         | null                |
       | 1  | 23             | 2019-05-29 05:38:38 | 24         | 0                 | 210          | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | validated_at        | started_at          | latest_activity_at  | help_requested |
       | 0          | 11             | 200     | 99             | null                | 2018-05-29 06:38:38 | 2018-05-29 06:38:39 | false          |
       | 0          | 23             | 210     | 99             | 2018-05-29 08:00:00 | 2019-05-29 06:38:38 | 2019-05-29 06:38:39 | true           |

--- a/app/api/items/list_attempts.robustness.feature
+++ b/app/api/items/list_attempts.robustness.feature
@@ -4,26 +4,26 @@ Feature: List attempts for current user and item_id - robustness
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
       | jane  | 12       | Jane       | Doe       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | type  |
       | 13 | Team  |
       | 14 | Class |
       | 15 | Team  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 12             |
       | 14              | 12             |
       | 15              | 12             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 210     | content            |
       | 13       | 210     | info               |
       | 15       | 210     | solution           |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | ended_at |
       | 0  | 11             | 2018-05-29 05:38:38 | null       | null              | null     |
       | 1  | 13             | 2018-05-29 05:38:38 | null       | null              | null     |

--- a/app/api/items/list_official_sessions.feature
+++ b/app/api/items/list_official_sessions.feature
@@ -1,6 +1,6 @@
 Feature: List official sessions for item_id
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name          | description | type    | is_official_session | is_public | root_activity_id | require_lock_membership_approval_until | require_personal_info_access_approval | require_watch_approval | require_members_to_join_parent | open_activity_when_joining | expected_start      | organizer              | address_city | address_country | address_line1               | address_line2        | address_postcode |
       | 11 | jdoe          | null        | User    | false               | false     | null             | null                                   | none                                  | false                  | false                          | false                      | null                | null                   | null         | null            | null                        | null                 | null             |
       | 13 | Group B       | null        | Class   | false               | false     | null             | null                                   | none                                  | false                  | false                          | false                      | null                | null                   | null         | null            | null                        | null                 | null             |
@@ -16,11 +16,11 @@ Feature: List official sessions for item_id
       | 72 | Parent        | null        | Club    | false               | false     | null             | null                                   | none                                  | false                  | false                          | false                      | null                | null                   | null         | null            | null                        | null                 | null             |
       | 73 | Parent2       | null        | Friends | false               | false     | null             | null                                   | none                                  | false                  | false                          | false                      | null                | null                   | null         | null            | null                        | null                 | null             |
       | 80 | Group         | null        | Friends | false               | false     | null             | null                                   | none                                  | false                  | false                          | false                      | null                | null                   | null         | null            | null                        | null                 | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
       | other | 21       | George     | Bush      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
       | 13              | 21             |
@@ -34,14 +34,14 @@ Feature: List official sessions for item_id
       | 73              | 50             |
       | 80              | 71             |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | manager_id | group_id |
       | 13         | 80       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 200 | 0                        | fr                   |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 200     | info                     |
       | 13       | 210     | content                  |

--- a/app/api/items/list_official_sessions.robustness.feature
+++ b/app/api/items/list_official_sessions.robustness.feature
@@ -1,21 +1,21 @@
 Feature: List official sessions for item_id - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    |
       | 11 | jdoe    |
       | 13 | Group B |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 13              | 11             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 200 | 0                        | fr                   |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 13       | 200     | none                     |
       | 13       | 210     | info                     |

--- a/app/api/items/path_from_root.feature
+++ b/app/api/items/path_from_root.feature
@@ -1,39 +1,39 @@
 Feature: Find an item path
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id |
       | 90  | Class | 10               |
       | 91  | Other | 50               |
       | 101 | User  | null             |
       | 102 | Team  | 60               |
       | 111 | User  | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 90              | 111            |
       | 90              | 102            |
       | 91              | 111            |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | default_language_tag |
       | 10 | null                                                                    | Chapter | 1                        | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 10      | content                  |
@@ -41,7 +41,7 @@ Feature: Find an item path
       | 102      | 70      | content                  |
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | created_at          | ended_at            | allows_submissions_until |
       | 0  | 101            | null         | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
       | 0  | 102            | null         | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
@@ -49,7 +49,7 @@ Feature: Find an item path
       | 1  | 102            | 10           | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
       | 2  | 102            | 10           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | 9999-12-31 23:59:59      |
       | 3  | 102            | 10           | 2019-05-30 11:00:00 | null                | 2019-05-30 11:00:00      |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
       | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
@@ -85,7 +85,7 @@ Feature: Find an item path
 
   Scenario: Finds a path with started result
     Given I am the user with id "101"
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a GET request to "/items/60/path-from-root?as_team_id=102"

--- a/app/api/items/path_from_root.robustness.feature
+++ b/app/api/items/path_from_root.robustness.feature
@@ -1,37 +1,37 @@
 Feature: Find an item path - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 101 | User  | 70               | null          |
       | 102 | Team  | null             | null          |
       | 103 | Class | 50               | 90            |
       | 104 | Team  | 50               | 90            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 103             | 101            |
       | 104             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type  | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 0                        | fr                   | false                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | false                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | true                    |
       | 71 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task  | 1                        | fr                   | false                   |
       | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill | 1                        | fr                   | false                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 70             | 71            | 1           |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | none               |
       | 101      | 60      | content            |
       | 101      | 70      | content            |
       | 101      | 71      | content            |
       | 101      | 90      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id |
       | 101            | 0  |
 

--- a/app/api/items/publish_result.feature
+++ b/app/api/items/publish_result.feature
@@ -1,35 +1,35 @@
 Feature: Publish a result to LTI
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  |
       | 21  | User  |
       | 31  | User  |
       | 99  | Class |
       | 100 | Team  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 99              | 21             |
       | 100             | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 123 | fr                   |
       | 124 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 21       | 123     | content                  |
       | 99       | 124     | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id  | participant_id |
       | 0   | 21             |
       | 1   | 21             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed |
       | 0          | 21             | 123     | 12.3           |
       | 1          | 21             | 123     | 15.6           |
       | 1          | 21             | 124     | 20.1           |
       | 1          | 31             | 123     | 9.5            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | temp_user | login | group_id | login_id |
       | 0         | john  | 21       | 1234567  |
       | 1         | jane  | 31       | null     |

--- a/app/api/items/publish_result.robustness.feature
+++ b/app/api/items/publish_result.robustness.feature
@@ -1,36 +1,36 @@
 Feature: Publish a result to LTI - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  |
       | 21  | User  |
       | 31  | User  |
       | 99  | Class |
       | 100 | Team  |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 99              | 21             |
       | 100             | 21             |
       | 100             | 31             |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 123 | fr                   |
       | 124 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 21       | 123     | content            |
       | 99       | 124     | info               |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id  | participant_id |
       | 0   | 21             |
       | 1   | 21             |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed |
       | 0          | 21             | 123     | 12.3           |
       | 1          | 21             | 123     | 15.6           |
       | 1          | 21             | 124     | 20.1           |
       | 1          | 31             | 123     | 9.5            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | temp_user | login | group_id | login_id |
       | 0         | john  | 21       | 1234567  |
       | 1         | jane  | 31       | null     |

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -3,36 +3,36 @@ Feature: Save grading result
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | name | type |
       | 201 | team | Team |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
       | 201             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'platforms':
+    And the database has the following table "platforms":
       | id | regexp                                             | priority | public_key                |
       | 10 | http://taskplatform.mblockelet.info/task.html\?.*  | 2        | {{taskPlatformPublicKey}} |
       | 20 | http://taskplatform1.mblockelet.info/task.html\?.* | 1        | null                      |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | platform_id | url                                                                     | validation_type | default_language_tag |
       | 50 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | All             | fr                   |
       | 60 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183937 | All             | fr                   |
       | 10 | null        | null                                                                    | AllButOne       | fr                   |
       | 70 | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721839  | All             | fr                   |
-    And the database has the following table 'item_dependencies':
+    And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score |
       | 60      | 50                | 98    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 0           |
       | 10             | 60            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
       | 10               | 60            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
       | 101      | 60      | content            |
@@ -44,16 +44,16 @@ Feature: Save grading result
 
   Scenario: User is able to save the grading result with a high score and attempt_id
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | hints_requested        |
       | 0          | 101            | 10      | 2019-05-30 11:00:00 | null                   |
       | 0          | 101            | 50      | 2019-05-30 11:00:00 | [0,  1, "hint" , null] |
       | 1          | 101            | 60      | 2019-05-29 11:00:00 | [0,  1, "hint" , null] |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
       | 124 | 101       | 101            | 0          | 60      | 2017-05-29 06:38:38 |
@@ -99,16 +99,16 @@ Feature: Save grading result
 
   Scenario: User is able to save the grading result for a team (participant_id is the first integer in idAttempt in the score token)
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 201            |
       | 1  | 201            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | latest_activity_at  | hints_requested        |
       | 0          | 201            | 10      | 2019-05-30 11:00:00 | null                   |
       | 0          | 201            | 50      | 2019-05-30 11:00:00 | [0,  1, "hint" , null] |
       | 1          | 201            | 60      | 2019-05-29 11:00:00 | [0,  1, "hint" , null] |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 201            | 0          | 50      | 2017-05-29 06:38:38 |
       | 124 | 101       | 201            | 0          | 60      | 2017-05-29 06:38:38 |
@@ -154,16 +154,16 @@ Feature: Save grading result
 
   Scenario Outline: User is able to save the grading result with a low score and idAttempt
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        | latest_activity_at  | score_edit_rule   | score_edit_value   |
       | 0          | 101            | 10      | null                   | 2019-05-30 11:00:00 | null              | null               |
       | 0          | 101            | 50      | [0,  1, "hint" , null] | 2019-05-30 11:00:00 | <score_edit_rule> | <score_edit_value> |
       | 1          | 101            | 60      | [0,  1, "hint" , null] | 2019-05-29 11:00:00 | null              | null               |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
       | 124 | 101       | 101            | 1          | 60      | 2017-05-29 06:38:38 |
@@ -217,15 +217,15 @@ Feature: Save grading result
 
   Scenario: User is able to save the grading result with a low score, but still obtaining a key (with idAttempt)
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_obtained_at   | latest_activity_at  |
       | 0          | 101            | 50      | 2017-04-29 06:38:38 | 2019-05-30 11:00:00 |
       | 1          | 101            | 60      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
       | 124 | 101       | 101            | 1          | 60      | 2017-05-29 06:38:38 |
@@ -270,19 +270,19 @@ Feature: Save grading result
 
   Scenario Outline: Should keep previous score if it is greater
     Given I am the user with id "101"
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 10      | 2018-05-29 06:38:38 |
       | 124 | 101       | 101            | 0          | 50      | 2018-05-29 06:38:38 |
       | 125 | 101       | 101            | 0          | 10      | 2018-05-29 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | score | graded_at           |
       | 123       | 5     | 2018-05-29 06:38:38 |
       | 125       | 20    | 2018-05-29 06:38:38 |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | participant_id | attempt_id | item_id | score_computed | score_obtained_at   | score_edit_rule   | score_edit_value   |
       | 101            | 0          | 10      | 20             | 2018-05-29 06:38:38 | null              | null               |
       | 101            | 0          | 50      | 20             | 2018-05-29 06:38:38 | <score_edit_rule> | <score_edit_value> |
@@ -333,15 +333,15 @@ Feature: Save grading result
 
   Scenario: Should keep previous validated_at if it is earlier
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 0          | 101            | 10      | 2016-05-29 06:38:37 |
       | 0          | 101            | 50      | 2016-05-29 06:38:37 |
       | 0          | 101            | 60      | 2015-05-29 06:38:37 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
       | 124 | 101       | 101            | 0          | 60      | 2017-05-29 06:38:38 |
@@ -382,13 +382,13 @@ Feature: Save grading result
 
   Scenario: Should set bAccessSolutions=1 if the task has been validated
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 0          | 101            | 50      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 100        | 50      | 2017-05-29 06:38:38 |
     And "scoreToken" is a token signed by the task platform with the following payload:
@@ -422,13 +422,13 @@ Feature: Save grading result
 
   Scenario: Should set bAccessSolutions=1 if the previous task task token had bAccessSolutions=1
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 0          | 101            | 50      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 100        | 50      | 2017-05-29 06:38:38 |
     And "scoreToken" is a token signed by the task platform with the following payload:
@@ -462,13 +462,13 @@ Feature: Save grading result
 
   Scenario: Platform doesn't support tokens
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 1          | 101            | 70      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 125 | 101       | 101            | 100        | 70      | 2017-05-29 06:38:38 |
     And "answerToken" is a token signed by the app with the following payload:
@@ -506,13 +506,13 @@ Feature: Save grading result
 
   Scenario: Platform doesn't support tokens for team (participant_id is the first integer in idAttempt in the answer token)
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 201            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 1          | 201            | 70      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 125 | 101       | 201            | 100        | 70      | 2017-05-29 06:38:38 |
     And "answerToken" is a token signed by the app with the following payload:
@@ -550,13 +550,13 @@ Feature: Save grading result
 
   Scenario: Should ignore score_token when provided if the platform doesn't have a key. Make sure the right score is used.
     Given I am the user with id "101"
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 1  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 1          | 101            | 70      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 125 | 101       | 101            | 100        | 70      | 2017-05-29 06:38:38 |
     And "answerToken" is a token signed by the app with the following payload:

--- a/app/api/items/save_grade.robustness.feature
+++ b/app/api/items/save_grade.robustness.feature
@@ -3,38 +3,38 @@ Feature: Save grading result - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |
     And the groups ancestors are computed
-    And the database has the following table 'platforms':
+    And the database has the following table "platforms":
       | id | regexp                                             | priority | public_key                |
       | 10 | http://taskplatform.mblockelet.info/task.html\?.*  | 2        | {{taskPlatformPublicKey}} |
       | 20 | http://taskplatform1.mblockelet.info/task.html\?.* | 1        | null                      |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | platform_id | url                                                                     | read_only | validation_type | default_language_tag |
       | 50 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | 1         | All             | fr                   |
       | 70 | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721839  | 0         | All             | fr                   |
       | 80 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183937 | 0         | All             | fr                   |
       | 10 | null        | null                                                                    | 0         | AllButOne       | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 50            | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 50            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | content            |
       | 101      | 70      | content            |
       | 101      | 80      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id |
       | 0  | 101            |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | hints_requested        |
       | 0          | 101            | 50      | [0,  1, "hint" , null] |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 123 | 101       | 101            | 100        | 50      | 2017-05-29 06:38:38 |
     And time is frozen
@@ -270,16 +270,16 @@ Feature: Save grading result - robustness
     And the table "attempts" should stay unchanged
 
   Scenario: The answer has been already graded
-    Given the database table 'attempts' has also the following row:
+    Given the database table "attempts" has also the following row:
       | id | participant_id |
       | 1  | 101            |
-    And the database table 'results' has also the following row:
+    And the database table "results" has also the following row:
       | attempt_id | participant_id | item_id | validated_at        |
       | 1          | 101            | 80      | 2018-05-29 06:38:38 |
-    And the database has the following table 'answers':
+    And the database has the following table "answers":
       | id  | author_id | participant_id | attempt_id | item_id | created_at          |
       | 124 | 101       | 101            | 105        | 80      | 2017-05-29 06:38:38 |
-    And the database has the following table 'gradings':
+    And the database has the following table "gradings":
       | answer_id | score | graded_at           |
       | 124       | 0     | 2017-05-29 06:38:38 |
     And "scoreToken" is a token signed by the task platform with the following payload:

--- a/app/api/items/search_for_items.feature
+++ b/app/api/items/search_for_items.feature
@@ -1,6 +1,6 @@
 Feature: Search for items
   Background:
-    Given the database has the following table 'items':
+    Given the database has the following table "items":
       | id | type    | default_language_tag |
       | 1  | Chapter | en                   |
       | 2  | Task    | en                   |
@@ -30,7 +30,7 @@ Feature: Search for items
       | 29 | Chapter | en                   |
       | 30 | Chapter | en                   |
       | 31 | Chapter | en                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title                                     |
       | 1       | fr           | amazing Chapter                           |
       | 2       | fr           | amazing Task                              |
@@ -66,7 +66,7 @@ Feature: Search for items
       | login | default_language | temp_user | group_id | first_name  | last_name | grade |
       | owner | fr               | 0         | 21       | Jean-Michel | Blanquer  | 3     |
     And the groups ancestors are computed
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 22       | 1       | info                     |
       | 21       | 2       | content                  |

--- a/app/api/items/start_result.feature
+++ b/app/api/items/start_result.feature
@@ -2,41 +2,41 @@ Feature: Start a result for an item
   Background:
     Given time is frozen
     And the DB time now is "{{currentTimeDB()}}"
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 90  | Class | 10               | null          |
       | 91  | Other | 50               | null          |
       | 101 | User  | null             | null          |
       | 102 | Team  | 60               | null          |
       | 111 | User  | null             | 80            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 90              | 111            |
       | 90              | 102            |
       | 91              | 111            |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | default_language_tag |
       | 10 | null                                                                    | Chapter | 1                        | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 80 | null                                                                    | Skill   | 0                        | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 10      | content                  |
@@ -45,13 +45,13 @@ Feature: Start a result for an item
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
       | 111      | 80      | content                  |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          |
       | 0  | 101            | 2019-05-30 11:00:00 |
       | 0  | 102            | 2019-05-30 11:00:00 |
       | 0  | 111            | 2019-05-30 11:00:00 |
       | 1  | 102            | 2019-05-30 11:00:00 |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
 
@@ -152,7 +152,7 @@ Feature: Start a result for an item
 
   Scenario: Keeps the previous started_at value
     Given I am the user with id "101"
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result?as_team_id=102&attempt_id=1"
@@ -185,7 +185,7 @@ Feature: Start a result for an item
 
   Scenario: Sets started_at of an existing result
     Given I am the user with id "101"
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | started_at | latest_activity_at  |
       | 1          | 102            | 60      | null       | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result?as_team_id=102&attempt_id=1"

--- a/app/api/items/start_result.robustness.feature
+++ b/app/api/items/start_result.robustness.feature
@@ -1,32 +1,32 @@
 Feature: Start a result for an item - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 101 | User  | 70               | null          |
       | 102 | Team  | null             | null          |
       | 103 | Class | 50               | 90            |
       | 104 | Team  | 50               | 90            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 103             | 101            |
       | 104             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type   | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 0                        | fr                   | false                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | false                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | true                    |
       | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill  | 1                        | fr                   | false                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | info               |
       | 101      | 60      | content            |
       | 101      | 70      | content            |
       | 101      | 90      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id |
       | 101            | 0  |
 
@@ -94,7 +94,7 @@ Feature: Start a result for an item - robustness
 
   Scenario: Not enough permissions for the last item in the path
     Given I am the user with id "101"
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated |
       | 104      | 50      | info               |
     When I send a POST request to "/items/50/start-result?as_team_id=104&attempt_id=0"

--- a/app/api/items/start_result_path.feature
+++ b/app/api/items/start_result_path.feature
@@ -1,39 +1,39 @@
 Feature: Start results for an item path
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id |
       | 90  | Class | 10               |
       | 91  | Other | 50               |
       | 101 | User  | null             |
       | 102 | Team  | 60               |
       | 111 | User  | null             |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
       | jane  | 111      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 90              | 111            |
       | 90              | 102            |
       | 91              | 111            |
       | 102             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type    | allows_multiple_attempts | default_language_tag |
       | 10 | null                                                                    | Chapter | 1                        | fr                   |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task    | 1                        | fr                   |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 10             | 60            | 1           |
       | 60             | 70            | 1           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 10               | 60            |
       | 10               | 70            |
       | 60               | 70            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
       | 101      | 50      | content                  |
       | 102      | 10      | content                  |
@@ -41,7 +41,7 @@ Feature: Start results for an item path
       | 102      | 70      | content                  |
       | 111      | 10      | content_with_descendants |
       | 111      | 50      | content_with_descendants |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | root_item_id | created_at          | ended_at            | allows_submissions_until |
       | 0  | 101            | null         | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
       | 0  | 102            | null         | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
@@ -49,7 +49,7 @@ Feature: Start results for an item path
       | 1  | 102            | 10           | 2019-05-30 11:00:00 | null                | 9999-12-31 23:59:59      |
       | 2  | 102            | 10           | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 | 9999-12-31 23:59:59      |
       | 3  | 102            | 10           | 2019-05-30 11:00:00 | null                | 2019-05-30 11:00:00      |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
       | 2          | 102            | 10      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
@@ -139,7 +139,7 @@ Feature: Start results for an item path
 
   Scenario: Keeps the previous started_at value
     Given I am the user with id "101"
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
       | 1          | 102            | 60      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
     When I send a POST request to "/items/10/60/start-result-path?as_team_id=102"

--- a/app/api/items/start_result_path.robustness.feature
+++ b/app/api/items/start_result_path.robustness.feature
@@ -1,32 +1,32 @@
 Feature: Start results for an item path - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | type  | root_activity_id | root_skill_id |
       | 101 | User  | 70               | null          |
       | 102 | Team  | null             | null          |
       | 103 | Class | 50               | 90            |
       | 104 | Team  | 50               | 90            |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id |
       | john  | 101      |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 103             | 101            |
       | 104             | 101            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | url                                                                     | type   | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
       | 50 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 0                        | fr                   | false                   |
       | 60 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | false                   |
       | 70 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Task   | 1                        | fr                   | true                    |
       | 90 | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183936 | Skill  | 1                        | fr                   | false                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 101      | 50      | info               |
       | 101      | 60      | content            |
       | 101      | 70      | content            |
       | 101      | 90      | content            |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | participant_id | id |
       | 101            | 0  |
 

--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -1,54 +1,54 @@
 Feature: Update item
 Background:
-  Given the database has the following table 'groups':
+  Given the database has the following table "groups":
     | id | name | type |
     | 10 | Club | Club |
     | 11 | jdoe | User |
-  And the database has the following table 'users':
+  And the database has the following table "users":
     | login | temp_user | group_id |
     | jdoe  | 0         | 11       |
-  And the database has the following table 'items':
+  And the database has the following table "items":
     | id | type    | url                  | options   | default_language_tag | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
     | 21 | Chapter | http://someurl1.com/ | {"opt":1} | en                   | 1        | Task1   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
     | 50 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task2   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
     | 60 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task3   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
     | 70 | Skill   | http://someurl3.com/ | {"opt":3} | en                   | 0        | null    | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
-  And the database has the following table 'items_items':
+  And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 21             | 60            | 0           |
     | 50             | 21            | 0           |
-  And the database has the following table 'items_ancestors':
+  And the database has the following table "items_ancestors":
     | ancestor_item_id | child_item_id |
     | 21               | 60            |
     | 50               | 21            |
     | 50               | 60            |
-  And the database has the following table 'permissions_generated':
+  And the database has the following table "permissions_generated":
     | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | is_owner_generated |
     | 10       | 50      | content_with_descendants | solution_with_grant      | all                | true               |
     | 11       | 21      | content                  | none                     | children           | false              |
     | 11       | 50      | none                     | none                     | none               | false              |
     | 11       | 60      | solution                 | solution_with_grant      | all_with_grant     | true               |
     | 11       | 70      | content                  | solution_with_grant      | all_with_grant     | true               |
-  And the database has the following table 'permissions_granted':
+  And the database has the following table "permissions_granted":
     | group_id | item_id | can_view | is_owner | source_group_id | latest_update_at    |
     | 10       | 50      | none     | true     | 11              | 2019-05-30 11:00:00 |
     | 11       | 21      | content  | false    | 11              | 2019-05-30 11:00:00 |
     | 11       | 50      | none     | false    | 11              | 2019-05-30 11:00:00 |
     | 11       | 60      | none     | true     | 11              | 2019-05-30 11:00:00 |
     | 11       | 70      | none     | true     | 11              | 2019-05-30 11:00:00 |
-  And the database has the following table 'groups_groups':
+  And the database has the following table "groups_groups":
     | parent_group_id | child_group_id |
     | 10              | 11             |
   And the groups ancestors are computed
-  And the database has the following table 'attempts':
+  And the database has the following table "attempts":
     | id | participant_id |
     | 0  | 11             |
-  And the database has the following table 'results':
+  And the database has the following table "results":
     | attempt_id | participant_id | item_id | score_computed |
     | 0          | 11             | 21      | 1              |
     | 0          | 11             | 50      | 10             |
     | 0          | 11             | 70      | 20             |
-  And the database has the following table 'languages':
+  And the database has the following table "languages":
     | tag |
     | en  |
     | sl  |
@@ -96,22 +96,22 @@ Background:
 
   Scenario: Valid (all the fields are set)
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
       | 134 | fr                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | language_tag | item_id |
       | sl           | 50      |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 11       | 112     | solution           | content                  | answer              | all                | false              |
       | 11       | 134     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view | can_watch | can_edit | is_owner | source_group_id | latest_update_at    |
       | 11       | 112     | solution | content        | answer    | all      | false    | 11              | 2019-05-30 11:00:00 |
       | 11       | 134     | none     | none           | none      | none     | true     | 11              | 2019-05-30 11:00:00 |
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | score_computed |
       | 0          | 11             | 112     | 50             |
       | 0          | 11             | 134     | 60             |
@@ -200,22 +200,22 @@ Background:
 
   Scenario: Valid (with skill items)
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag | type    |
       | 112 | fr                   | Skill   |
       | 134 | fr                   | Chapter |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | language_tag | item_id |
       | sl           | 50      |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 11       | 112     | solution           | content                  | answer              | all                | false              |
       | 11       | 134     | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view | can_watch | can_edit | is_owner | source_group_id | latest_update_at    |
       | 11       | 112     | solution | content        | answer    | all      | false    | 11              | 2019-05-30 11:00:00 |
       | 11       | 134     | none     | none           | none      | none     | true     | 11              | 2019-05-30 11:00:00 |
-    And the database table 'results' has also the following rows:
+    And the database table "results" has also the following rows:
       | attempt_id | participant_id | item_id | score_computed |
       | 0          | 11             | 112     | 50             |
       | 0          | 11             | 134     | 60             |
@@ -272,13 +272,13 @@ Background:
 
   Scenario: Should set content_view_propagation to 'none' by default if can_grant_view = 'none' for the parent item
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 11       | 112     | solution           | content                  | answer              | all                | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view | can_watch | can_edit | is_owner | source_group_id | latest_update_at    |
       | 11       | 112     | solution | content        | answer    | all      | false    | 11              | 2019-05-30 11:00:00 |
     When I send a PUT request to "/items/21" with the following body:
@@ -450,13 +450,13 @@ Background:
 
   Scenario Outline: Sets default values of items_items.content_view_propagation/upper_view_levels_propagation/grant_view_propagation correctly for each can_grant_view
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_grant_view_generated |
       | 11       | 112     | info               | <can_grant_view>         |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_grant_view   | source_group_id |
       | 11       | 112     | info     | <can_grant_view> | 11              |
     When I send a PUT request to "/items/21" with the following body:
@@ -480,10 +480,10 @@ Background:
 
   Scenario Outline: Sets default values of items_items.watch_propagation/edit_propagation correctly
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | <parent_permission_column> |
       | 11       | 112     | info               | <parent_permission_value>  |
     When I send a PUT request to "/items/21" with the following body:
@@ -509,10 +509,10 @@ Background:
 
   Scenario Outline: Sets items_items.content_view_propagation/upper_view_levels_propagation/grant_view_propagation correctly
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 11       | 112     | info               | <can_grant_view>         | none                | none               | 0                  |
     When I send a PUT request to "/items/21" with the following body:
@@ -564,10 +564,10 @@ Background:
 
   Scenario Outline: Sets items_items.watch_propagation/edit_propagation correctly
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated | <parent_permission_column> |
       | 11       | 112     | info               | <parent_permission_value>  |
     When I send a PUT request to "/items/21" with the following body:
@@ -599,7 +599,7 @@ Background:
 
   Scenario: Sets items_items.request_help_propagation correctly
     Given I am the user with id "11"
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | default_language_tag |
       | 112 | fr                   |
       | 113 | fr                   |
@@ -617,7 +617,7 @@ Background:
       | 125 | fr                   |
       | 126 | fr                   |
       | 127 | fr                   |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_grant_view_generated | can_view_generated |
       | 11       | 112     | content                  | content            |
       | 11       | 113     | content                  | content            |
@@ -721,13 +721,13 @@ Background:
 
   Scenario Outline: Allows setting items_items.content_view_propagation/upper_view_levels_propagation/grant_view_propagation/watch_propagation/edit_propagation to the same of a lower value
     Given I am the user with id "11"
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database table 'items_items' has also the following rows:
+    And the database table "items_items" has also the following rows:
       | parent_item_id | child_item_id | child_order | <field_name> |
       | 21             | 112           | 1           | <old_value>  |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | can_view_generated |
       | 11       | 112     | info               |
     When I send a PUT request to "/items/21" with the following body:
@@ -757,10 +757,10 @@ Background:
 
   Scenario: Allows keeping old values in items_items
     Given I am the user with id "11"
-    And the database table 'items' has also the following rows:
+    And the database table "items" has also the following rows:
       | id  | default_language_tag |
       | 112 | fr                   |
-    And the database table 'items_items' has also the following rows:
+    And the database table "items_items" has also the following rows:
       | parent_item_id | child_item_id | child_order | category  | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation |
       | 21             | 112           | 1           | Challenge | 2            | as_content               | as_is                         | true                   | true              | true             |
     When I send a PUT request to "/items/21" with the following body:

--- a/app/api/items/update_item.robustness.feature
+++ b/app/api/items/update_item.robustness.feature
@@ -3,7 +3,7 @@ Feature: Update item - robustness
     Given the database has the following users:
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag | type    | requires_explicit_entry | duration | text_id |
       | 4  | fr                   | Chapter | 0                       | null     | id4     |
       | 20 | fr                   | Chapter | 0                       | null     | id20    |
@@ -16,15 +16,15 @@ Feature: Update item - robustness
       | 60 | fr                   | Chapter | 0                       | null     | id60    |
       | 70 | fr                   | Skill   | 0                       | null     | id70    |
       | 80 | fr                   | Task    | 0                       | null     | id80    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | child_order |
       | 4              | 21            | 0           |
       | 21             | 50            | 0           |
-    And the database has the following table 'items_ancestors':
+    And the database has the following table "items_ancestors":
       | ancestor_item_id | child_item_id |
       | 4                | 21            |
       | 21               | 50            |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_edit_generated | is_owner_generated |
       | 11       | 4       | solution           | none               | false              |
       | 11       | 20      | info               | all                | false              |
@@ -36,7 +36,7 @@ Feature: Update item - robustness
       | 11       | 50      | solution           | all                | false              |
       | 11       | 70      | solution           | all                | false              |
       | 11       | 80      | solution           | all                | false              |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | item_id | can_view | can_edit | is_owner | source_group_id |
       | 11       | 4       | solution | none     | false    | 11              |
       | 11       | 20      | info     | all      | false    | 11              |
@@ -48,7 +48,7 @@ Feature: Update item - robustness
       | 11       | 70      | solution | all      | false    | 11              |
       | 11       | 80      | solution | all      | false    | 11              |
     And the groups ancestors are computed
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | sl  |
 
@@ -317,10 +317,10 @@ Feature: Update item - robustness
 
   Scenario Outline: Not enough permissions for setting propagation in items_items
     Given I am the user with id "11"
-    And the database table 'items' has also the following row:
+    And the database table "items" has also the following row:
       | id | default_language_tag |
       | 90 | fr                   |
-    And the database table 'permissions_generated' has also the following row:
+    And the database table "permissions_generated" has also the following row:
       | group_id | item_id | <permission_column> | can_view_generated |
       | 11       | 90      | <permission_value>  | info               |
     When I send a PUT request to "/items/50" with the following body:

--- a/app/api/items/update_item_string.feature
+++ b/app/api/items/update_item_string.feature
@@ -1,28 +1,28 @@
 Feature: Update an item string entry
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name | type |
       | 11 | jdoe | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 21 | en                   |
       | 50 | en                   |
       | 60 | sl                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title  | image_url                  | subtitle        | description        |
       | 50      | en           | Item 2 | http://myurl.com/item2.jpg | Item 2 Subtitle | Item 2 Description |
       | 50      | sl           | Item 3 | http://myurl.com/item3.jpg | Item 3 Subtitle | Item 3 Description |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_edit_generated | is_owner_generated |
       | 11       | 21      | content            | none               | false              |
       | 11       | 50      | solution           | all                | true               |
       | 11       | 60      | content            | all                | true               |
     And the groups ancestors are computed
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | en  |
       | sl  |

--- a/app/api/items/update_item_string.robustness.feature
+++ b/app/api/items/update_item_string.robustness.feature
@@ -1,29 +1,29 @@
 Feature: Update an item string entry - robustness
 
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name | type |
       | 11 | jdoe | User |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | temp_user | group_id |
       | jdoe  | 0         | 11       |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 21 | en                   |
       | 22 | en                   |
       | 50 | en                   |
       | 60 | sl                   |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title  | image_url                  | subtitle        | description        |
       | 50      | en           | Item 2 | http://myurl.com/item2.jpg | Item 2 Subtitle | Item 2 Description |
       | 50      | sl           | Item 3 | http://myurl.com/item3.jpg | Item 3 Subtitle | Item 3 Description |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated | can_edit_generated | is_owner_generated |
       | 11       | 21      | solution           | children           | false              |
       | 11       | 22      | info               | all                | false              |
       | 11       | 50      | solution           | all                | true               |
     And the groups ancestors are computed
-    And the database has the following table 'languages':
+    And the database has the following table "languages":
       | tag |
       | en  |
       | sl  |

--- a/app/api/items/update_result.feature
+++ b/app/api/items/update_result.feature
@@ -1,6 +1,6 @@
 Feature: Update an attempt result
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 11 | jdoe    | User  |
       | 13 | Group B | Class |
@@ -8,12 +8,12 @@ Feature: Update an attempt result
       | 23 | Group C | Team  |
       | 24 | jane    | User  |
       | 25 | Group D | Club  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
       | other | 21       | George     | Bush      |
       | jane  | 24       | Jane       | Joe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 13              | 11             | null                           |
       | 13              | 21             | null                           |
@@ -22,18 +22,18 @@ Feature: Update an attempt result
       | 23              | 31             | null                           |
       | 25              | 24             | 2019-05-30 11:00:00            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 200 | 0                        | fr                   |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | ended_at            |
       | 1  | 11             | 2018-05-29 05:38:38 | 21         | 0                 | 210          | 2018-05-29 05:38:38 |
       | 2  | 11             | 2018-05-29 05:38:38 | 11         | 1                 | 200          | 2018-05-29 05:38:38 |
       | 0  | 11             | 2018-05-29 05:38:38 | null       | null              | null         | null                |
       | 0  | 23             | 2019-05-29 05:38:38 | 11         | null              | null         | null                |
       | 1  | 23             | 2019-05-29 05:38:38 | 24         | 0                 | 210          | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | validated_at        | started_at          | latest_activity_at  | help_requested |
       | 0          | 11             | 200     | 99             | null                | 2018-05-29 06:38:38 | 2018-05-29 06:38:39 | false          |
       | 0          | 23             | 210     | 99             | 2018-05-29 08:00:00 | 2019-05-29 06:38:38 | 2019-05-29 06:38:39 | true           |

--- a/app/api/items/update_result.robustness.feature
+++ b/app/api/items/update_result.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Update an attempt result - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 11 | jdoe    | User  |
       | 13 | Group B | Class |
@@ -8,12 +8,12 @@ Feature: Update an attempt result - robustness
       | 23 | Group C | Team  |
       | 24 | jane    | User  |
       | 25 | Group D | Club  |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login | group_id | first_name | last_name |
       | jdoe  | 11       | John       | Doe       |
       | other | 21       | George     | Bush      |
       | jane  | 24       | Jane       | Joe       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 13              | 11             | null                           |
       | 13              | 21             | null                           |
@@ -22,18 +22,18 @@ Feature: Update an attempt result - robustness
       | 23              | 31             | null                           |
       | 25              | 24             | 2019-05-30 11:00:00            |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id  | allows_multiple_attempts | default_language_tag |
       | 200 | 0                        | fr                   |
       | 210 | 1                        | fr                   |
-    And the database has the following table 'attempts':
+    And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | ended_at            |
       | 1  | 11             | 2018-05-29 05:38:38 | 21         | 0                 | 210          | 2018-05-29 05:38:38 |
       | 2  | 11             | 2018-05-29 05:38:38 | 11         | 1                 | 200          | 2018-05-29 05:38:38 |
       | 0  | 11             | 2018-05-29 05:38:38 | null       | null              | null         | null                |
       | 0  | 23             | 2019-05-29 05:38:38 | 11         | null              | null         | null                |
       | 1  | 23             | 2019-05-29 05:38:38 | 24         | 0                 | 210          | null                |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | score_computed | validated_at        | started_at          | latest_activity_at  | help_requested |
       | 0          | 11             | 200     | 99             | null                | 2018-05-29 06:38:38 | 2018-05-29 06:38:39 | false          |
       | 0          | 23             | 210     | 99             | 2018-05-29 08:00:00 | 2019-05-29 06:38:38 | 2019-05-29 06:38:39 | true           |

--- a/app/api/threads/get_thread.feature
+++ b/app/api/threads/get_thread.feature
@@ -1,6 +1,6 @@
 Feature: Get thread
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | type  |
       | 1  | john       | User  |
       | 2  | manager    | User  |
@@ -8,17 +8,17 @@ Feature: Get thread
       | 4  | helper     | User  |
       | 10 | Group      | Class |
       | 20 | Help Group | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | john    | 1        |
       | manager | 2        |
       | jack    | 3        |
       | helper  | 4        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 20              | 4              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 10 | en                   |
       | 20 | en                   |
@@ -27,16 +27,16 @@ Feature: Get thread
       | 30 | en                   |
       | 40 | en                   |
       | 50 | en                   |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 0          | 4              | 40      | 2020-01-01 00:00:00 |
       | 0          | 4              | 50      | 2020-01-01 00:00:00 |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_watch_generated |
       | 1        | 10      | content                  | none                |
       | 1        | 21      | content_with_descendants | none                |
       | 2        | 30      | none                     | answer              |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | item_id | participant_id | status                  | helper_group_id | latest_update_at    |
       | 10      | 2              | closed                  | 2               | 2019-01-01 00:00:00 |
       | 20      | 1              | closed                  | 10              | 2019-01-01 00:00:00 |

--- a/app/api/threads/get_thread.robustness.feature
+++ b/app/api/threads/get_thread.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Get thread - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name       | type  |
       | 1  | john       | User  |
       | 2  | manager    | User  |
@@ -8,17 +8,17 @@ Feature: Get thread - robustness
       | 4  | helper     | User  |
       | 10 | Group      | Class |
       | 20 | Help group | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | john    | 1        |
       | manager | 2        |
       | jack    | 3        |
       | helper  | 4        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 20              | 4              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | default_language_tag |
       | 10 | en                   |
       | 20 | en                   |
@@ -27,18 +27,18 @@ Feature: Get thread - robustness
       | 60 | en                   |
       | 70 | en                   |
       | 80 | en                   |
-    And the database has the following table 'results':
+    And the database has the following table "results":
       | attempt_id | participant_id | item_id | validated_at        |
       | 0          | 4              | 20      | 2020-01-01 00:00:00 |
       | 0          | 4              | 40      | null                |
       | 0          | 4              | 60      | 2020-01-01 00:00:00 |
       | 0          | 4              | 70      | 2020-01-01 00:00:00 |
       | 0          | 4              | 80      | null                |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 1        | 10      | info               |
       | 2        | 10      | content            |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | item_id | participant_id | status                  | helper_group_id | latest_update_at    |
       | 10      | 1              | waiting_for_trainer     | 10              | 2020-01-01 00:00:00 |
       | 20      | 3              | closed                  | 20              | 2020-01-05 00:00:00 |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -60,7 +60,7 @@ Feature: List threads
       | @A_UniversityManagerCanWatch_CanViewInfo        | @A_UniversityManagerCanWatch | info                     |           |
       | @Item1                                          | @A_UniversityManagerCanWatch | content                  |           |
       | @Item2                                          | @A_UniversityManagerCanWatch | content                  |           |
-    And there are the following results:
+    And there are the following validated results:
       | item                              | participant         | validated |
       | @B_UniversityMember_HasValidated1 | @B_UniversityMember | 1         |
       | @B_UniversityMember_HasValidated2 | @B_UniversityMember | 1         |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -10,7 +10,7 @@ Feature: List threads
       | @A_Class      | @A_Section    | @A_ClassMember1,@A_ClassMember2                       |
       | @B_Class      | @B_Section    |                                                       |
       | @OtherGroup   |               | @OtherGroupMember                                     |
-    And @A_UniversityManagerCanWatch is a manager of the group @A_UniversityParent and can watch its members
+    And the group @A_UniversityManagerCanWatch is a manager of the group @A_UniversityParent and can watch for submissions from the group and its descendants
     And the group @A_University is a child of the group @A_UniversityParent
     And there are the following tasks:
       | item                                            |
@@ -96,7 +96,7 @@ Feature: List threads
 
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am @LaboratoryManagerCanWatch
-    And I am a manager of the group @LaboratoryParent and can watch its members
+    And I am a manager of the group @LaboratoryParent and can watch for submissions from the group and its descendants
     And the group @Laboratory is a child of the group @LaboratoryParent
     And there are the following users:
       | user                                                 | first_name            | last_name            |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -106,20 +106,20 @@ Feature: List threads
     And @LaboratoryMember_WithApprovedAccessPersonalInfo is a member of the group @Laboratory who has approved access to his personal info
     And @LaboratoryMember_WithoutApprovedAccessPersonalInfo is a member of the group @Laboratory
     And @LaboratoryMember_WithApprovedAccessPersonalInfoNull is a member of the group @Laboratory who has approved access to his personal info
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id | type | default_language_tag |
       | 1  | Task | fr                   |
       | 2  | Task | en                   |
-    And the database has the following table 'permissions_generated':
+    And the database has the following table "permissions_generated":
       | group_id                   | item_id | can_view_generated |
       | @LaboratoryManagerCanWatch | 1       | content            |
       | @LaboratoryManagerCanWatch | 2       | content            |
-    And the database has the following table 'items_strings':
+    And the database has the following table "items_strings":
       | item_id | language_tag | title      |
       | 1       | en           | Beginning  |
       | 1       | fr           | Debut      |
       | 2       | en           | Experiment |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | item_id | participant_id                                       | status                  | message_count | latest_update_at    | helper_group_id |
       | 1       | @LaboratoryMember_WithApprovedAccessPersonalInfo     | waiting_for_trainer     | 0             | 2023-01-01 00:00:01 | @Laboratory     |
       | 2       | @LaboratoryMember_WithApprovedAccessPersonalInfoNull | waiting_for_participant | 1             | 2023-01-01 00:00:02 | @Laboratory     |

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -11,7 +11,7 @@ Feature: List threads
       | @B_Class      | @B_Section    |                                                       |
       | @OtherGroup   |               | @OtherGroupMember                                     |
     And @A_UniversityManagerCanWatch is a manager of the group @A_UniversityParent and can watch its members
-    And @A_University is a child of the group @A_UniversityParent
+    And the group @A_University is a child of the group @A_UniversityParent
     And there are the following tasks:
       | item                                            |
       | @B_SectionMember2_CanViewInfo                   |
@@ -97,7 +97,7 @@ Feature: List threads
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am @LaboratoryManagerCanWatch
     And I am a manager of the group @LaboratoryParent and can watch its members
-    And @Laboratory is a child of the group @LaboratoryParent
+    And the group @Laboratory is a child of the group @LaboratoryParent
     And there are the following users:
       | user                                                 | first_name            | last_name            |
       | @LaboratoryMember_WithApprovedAccessPersonalInfo     | FirstName_Approved    | LastName_Approved    |

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -42,7 +42,7 @@ Feature: List threads - robustness
   Scenario Outline: Should not have watched_group_id and is_mine set a the same time
     Given I am @John
     And there is a group @Classroom
-    And I am a manager of the group @ClassroomParent and can watch its members
+    And I am a manager of the group @ClassroomParent and can watch for submissions from the group and its descendants
     And the group @Classroom is a child of the group @ClassroomParent
     When I send a GET request to "/threads?watched_group_id=@Classroom&is_mine=<is_mine>"
     Then the response code should be 400

--- a/app/api/threads/list_threads.robustness.feature
+++ b/app/api/threads/list_threads.robustness.feature
@@ -28,7 +28,7 @@ Feature: List threads - robustness
     Given I am @John
     And there is a group @Classroom
     And I am a manager of the group @ClassroomParent
-    And @Classroom is a child of the group @ClassroomParent
+    And the group @Classroom is a child of the group @ClassroomParent
     When I send a GET request to "/threads?watched_group_id=@Classroom"
     Then the response code should be 403
     And the response error message should contain "No rights to watch for watched_group_id"
@@ -43,7 +43,7 @@ Feature: List threads - robustness
     Given I am @John
     And there is a group @Classroom
     And I am a manager of the group @ClassroomParent and can watch its members
-    And @Classroom is a child of the group @ClassroomParent
+    And the group @Classroom is a child of the group @ClassroomParent
     When I send a GET request to "/threads?watched_group_id=@Classroom&is_mine=<is_mine>"
     Then the response code should be 400
     And the response error message should contain "Must not provide watched_group_id and is_mine at the same time"

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -114,7 +114,7 @@ Feature: Update thread
   Scenario: Can write to thread condition (2) when status is not set
     Given I am the user with id "2"
     And there is a thread with "item_id=20,participant_id=3"
-    And I can watch answer on item with id "20"
+    And I have the watch permission set to "answer" on the item 20
     And I can watch the participant with id "3"
     When I send a PUT request to "/items/20/participant/3/thread" with the following body:
       """
@@ -132,7 +132,7 @@ Feature: Update thread
     Given I am the user with id "2"
     And there is a thread with "item_id=30,participant_id=3"
     And I am part of the helper group of the thread
-    And I can watch answer on item with id "30"
+    And I have the watch permission set to "answer" on the item 30
     When I send a PUT request to "/items/30/participant/3/thread" with the following body:
       """
       {
@@ -215,7 +215,7 @@ Feature: Update thread
   Scenario Outline: Participant of a thread can always switch the thread from open to any other status
     Given I am the user with id "3"
     And there is a thread with "item_id=<item_id>,participant_id=3,status=<old_status>"
-    And I can watch none on item with id "<item_id>"
+    And I have the watch permission set to "none" on the item <item_id>
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
       {
@@ -236,7 +236,7 @@ Feature: Update thread
 
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread exists
     Given I am the user with id "2"
-    And I can watch answer on item with id "<item_id>"
+    And I have the watch permission set to "answer" on the item <item_id>
     And I can watch the participant with id "3"
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -260,7 +260,7 @@ Feature: Update thread
 
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread doesn't exists
     Given I am the user with id "2"
-    And I can watch answer on item with id "<item_id>"
+    And I have the watch permission set to "answer" on the item <item_id>
     And I can watch the participant with id "3"
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -282,7 +282,7 @@ Feature: Update thread
 
   Scenario Outline: Can switch to open if part of the group the participant has requested help to AND can_watch>=answer on the item
     Given I am the user with id "4"
-    And I can watch answer on item with id "<item_id>"
+    And I have the watch permission set to "answer" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=<old_status>,helper_group_id=50"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -324,7 +324,7 @@ Feature: Update thread
 
   Scenario: If status is open and not provided (no change): update helper_group_id
     Given I am the user with id "2"
-    And I can watch answer on item with id "260"
+    And I have the watch permission set to "answer" on the item 260
     And there is a thread with "item_id=260,participant_id=3,helper_group_id=10"
     When I send a PUT request to "/items/260/participant/3/thread" with the following body:
       """
@@ -339,7 +339,7 @@ Feature: Update thread
 
   Scenario Outline: Participant of a thread can switch from non-open to open status when allowed to request help on the item
     Given I am the user with id "3"
-    And I can watch none on item with id "<item_id>"
+    And I have the watch permission set to "none" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed,helper_group_id=<old_helper_group_id>"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -362,7 +362,7 @@ Feature: Update thread
 
   Scenario Outline: Participant of a thread can switch from non-open to open status when allowed to request help on the item when thread doesn't exists
     Given I am the user with id "3"
-    And I can watch none on item with id "<item_id>"
+    And I have the watch permission set to "none" on the item <item_id>
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -1,6 +1,6 @@
 Feature: Update thread
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id | name    | type  |
       | 1  | john    | User  |
       | 2  | manager | User  |
@@ -15,14 +15,14 @@ Feature: Update thread
       | 50 | Group   | Class |
       | 51 | Group   | Class |
       | 60 | Group   | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login   | group_id |
       | john    | 1        |
       | manager | 2        |
       | jack    | 3        |
       | jess    | 4        |
       | owner   | 5        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 10              | 2              |
       | 10              | 3              |
@@ -38,7 +38,7 @@ Feature: Update thread
       | 51              | 4              |
       | 60              | 5              |
     And the groups ancestors are computed
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag | type    |
       | 2000 | en                   | Task    |
       | 2001 | en                   | Task    |
@@ -52,7 +52,7 @@ Feature: Update thread
       | 3005 | en                   | Chapter |
       | 3006 | en                   | Chapter |
       | 3010 | en                   | Task    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | request_help_propagation | child_order |
       | 3004           | 3005          | 1                        | 1           |
       | 3004           | 2007          | 1                        | 2           |
@@ -60,7 +60,7 @@ Feature: Update thread
       | 3005           | 2008          | 1                        | 2           |
       | 3006           | 2009          | 1                        | 1           |
       | 3006           | 2010          | 1                        | 2           |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | source_group_id | item_id | can_request_help_to | is_owner |
       | 3        | 11              | 2000    | 12                  | 0        |
       | 3        | 11              | 2001    | 12                  | 0        |
@@ -68,7 +68,7 @@ Feature: Update thread
       | 11       | 11              | 2002    | 12                  | 0        |
       | 11       | 11              | 2003    | 12                  | 0        |
       | 12       | 11              | 3004    | 12                  | 0        |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | item_id | participant_id | status | helper_group_id | latest_update_at |
     And the time now is "2022-01-01T00:00:00Z"
 

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -115,7 +115,7 @@ Feature: Update thread
     Given I am the user with id "2"
     And there is a thread with "item_id=20,participant_id=3"
     And I have the watch permission set to "answer" on the item 20
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     When I send a PUT request to "/items/20/participant/3/thread" with the following body:
       """
       {
@@ -237,7 +237,7 @@ Feature: Update thread
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread exists
     Given I am the user with id "2"
     And I have the watch permission set to "answer" on the item <item_id>
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -261,7 +261,7 @@ Feature: Update thread
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread doesn't exists
     Given I am the user with id "2"
     And I have the watch permission set to "answer" on the item <item_id>
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -115,7 +115,7 @@ Feature: Update thread
     Given I am the user with id "2"
     And there is a thread with "item_id=20,participant_id=3"
     And I have the watch permission set to "answer" on the item 20
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     When I send a PUT request to "/items/20/participant/3/thread" with the following body:
       """
       {
@@ -237,7 +237,7 @@ Feature: Update thread
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread exists
     Given I am the user with id "2"
     And I have the watch permission set to "answer" on the item <item_id>
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -261,7 +261,7 @@ Feature: Update thread
   Scenario Outline: A user who has can_watch>=answer on the item AND can_watch_members on the participant can always switch to an open status when thread doesn't exists
     Given I am the user with id "2"
     And I have the watch permission set to "answer" on the item <item_id>
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -149,7 +149,7 @@ Feature: Update thread
     Given I am the user with id "4"
     And there is a thread with "item_id=40,participant_id=3"
     And I am part of the helper group of the thread
-    And I have validated the item with id "40"
+    And I have a validated result on the item 40
     When I send a PUT request to "/items/40/participant/3/thread" with the following body:
       """
       {
@@ -303,7 +303,7 @@ Feature: Update thread
 
   Scenario Outline: Can switch to open if part of the group the participant has requested help to AND have validated the item
     Given I am the user with id "4"
-    And I have validated the item with id "<item_id>"
+    And I have a validated result on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=<old_status>,helper_group_id=50"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -189,7 +189,7 @@ Feature: Update thread - robustness
   "can write to thread" condition (2) is not met: can_watch>=answer not met
     Given I am the user with id "2"
     And there is a thread with "item_id=20,participant_id=3"
-    And I can watch result on item with id "20"
+    And I have the watch permission set to "result" on the item 20
     When I send a PUT request to "/items/20/participant/3/thread" with the following body:
       """
       {
@@ -203,7 +203,7 @@ Feature: Update thread - robustness
   Should return access error when the status is not set and not part of the helper group
   "can write to thread" condition (2) is not met: can_watch_members of the participant
     Given I am the user with id "4"
-    And I can watch answer on item with id "30"
+    And I have the watch permission set to "answer" on the item 30
     And there is a thread with "item_id=30,participant_id=3"
     When I send a PUT request to "/items/30/participant/3/thread" with the following body:
       """
@@ -219,7 +219,7 @@ Feature: Update thread - robustness
   "can write to thread" condition (3) is not met: user is not part of the help group
     Given I am the user with id "1"
     And I have validated the item with id "40"
-    And I can watch answer on item with id "40"
+    And I have the watch permission set to "answer" on the item 40
     And there is a thread with "item_id=40,participant_id=3"
     When I send a PUT request to "/items/40/participant/3/thread" with the following body:
       """
@@ -291,7 +291,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Participant of a thread should not be able to switch from non-open to open if not allowed to request help on the item when thread exists
     Given I am the user with id "3"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed,helper_group_id=10"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -322,7 +322,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Participant of a thread should not be able to switch from non-open to open if not allowed to request help on the item when thread doesn't exists
     Given I am the user with id "3"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -353,7 +353,7 @@ Feature: Update thread - robustness
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread exists
     Given I am the user with id "2"
     And I can watch the participant with id "3"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -372,7 +372,7 @@ Feature: Update thread - robustness
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread doesn't exists
     Given I am the user with id "2"
     And I can watch the participant with id "3"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -390,7 +390,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch>=answer but cannot watch_members on the participant when thread exists
     Given I am the user with id "4"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -408,7 +408,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch>=answer but cannot watch_members on the participant when thread doesn't exists
     Given I am the user with id "4"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
       {
@@ -425,7 +425,7 @@ Feature: Update thread - robustness
 
   Scenario: Cannot switch between open status if only can_watch>answer but not a part of the helper group, and cannot watch participant
     Given I am the user with id "1"
-    And I can watch answer on item with id "150"
+    And I have the watch permission set to "answer" on the item 150
     And there is a thread with "item_id=150,participant_id=3,status=waiting_for_participant"
     When I send a PUT request to "/items/150/participant/3/thread" with the following body:
       """
@@ -599,7 +599,7 @@ Feature: Update thread - robustness
 
   Scenario: A user who can_watch >= answer on the item and can_watch the participant should not be able to close a thread
     Given I am the user with id "2"
-    And I can watch answer on item with id "320"
+    And I have the watch permission set to "answer" on the item 320
     And there is a thread with "item_id=320,participant_id=3"
     When I send a PUT request to "/items/320/participant/3/thread" with the following body:
       """
@@ -612,7 +612,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: A user not part of the helper group with can_watch >= answer on the item cannot switch a thread to an open status
     Given I am the user with id "4"
-    And I can watch <can_watch> on item with id "<item_id>"
+    And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,helper_group_id=20,status=<old_status>"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """
@@ -676,7 +676,7 @@ Feature: Update thread - robustness
 
   Scenario: If participant is the user and helper_group_id is given, it must be a descendant or a group he "can_request_help_to"
     Given I am the user with id "3"
-    And I can watch answer_with_grant on item with id "430"
+    And I have the watch permission set to "answer_with_grant" on the item 430
     And I have validated the item with id "430"
     And there is a thread with "item_id=430,participant_id=3"
     When I send a PUT request to "/items/430/participant/3/thread" with the following body:

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -1,6 +1,6 @@
 Feature: Update thread - robustness
   Background:
-    Given the database has the following table 'groups':
+    Given the database has the following table "groups":
       | id  | name           | type  |
       | 1   | john           | User  |
       | 2   | manager        | User  |
@@ -18,7 +18,7 @@ Feature: Update thread - robustness
       | 100 | Group          | Class |
       | 300 | Group          | Class |
       | 310 | Group          | Class |
-    And the database has the following table 'users':
+    And the database has the following table "users":
       | login          | group_id |
       | john           | 1        |
       | manager        | 2        |
@@ -26,7 +26,7 @@ Feature: Update thread - robustness
       | managernowatch | 4        |
       | jess           | 5        |
       | owner          | 6        |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 12              | 11             |
       | 11              | 10             |
@@ -44,10 +44,10 @@ Feature: Update thread - robustness
       | 300             | 1              |
       | 310             | 3              |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members |
       | 12       | 4          | false             |
-    And the database has the following table 'items':
+    And the database has the following table "items":
       | id   | default_language_tag | type    |
       | 110  | en                   | Task    |
       | 120  | en                   | Task    |
@@ -68,7 +68,7 @@ Feature: Update thread - robustness
       | 3002 | en                   | Chapter |
       | 3003 | en                   | Chapter |
       | 3010 | en                   | Task    |
-    And the database has the following table 'items_items':
+    And the database has the following table "items_items":
       | parent_item_id | child_item_id | request_help_propagation | child_order |
       | 3000           | 3001          | 1                        | 1           |
       | 3000           | 1004          | 1                        | 2           |
@@ -79,7 +79,7 @@ Feature: Update thread - robustness
       | 3003           | 2004          | 0                        | 1           |
       | 2004           | 1007          | 1                        | 1           |
       | 2004           | 1008          | 0                        | 2           |
-    And the database has the following table 'permissions_granted':
+    And the database has the following table "permissions_granted":
       | group_id | source_group_id | item_id | can_request_help_to | is_owner |
       | 100      | 100             | 240     | 100                 | 0        |
       | 100      | 100             | 250     | 100                 | 0        |
@@ -88,7 +88,7 @@ Feature: Update thread - robustness
       | 12       | 3               | 3000    | 10                  | 0        |
       | 12       | 3               | 3001    | 12                  | 0        |
       | 6        | 6               | 3010    | null                | 1        |
-    And the database has the following table 'threads':
+    And the database has the following table "threads":
       | item_id | participant_id | status | helper_group_id | latest_update_at |
 
   Scenario: Should be logged in

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -352,7 +352,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread exists
     Given I am the user with id "2"
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -371,7 +371,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread doesn't exists
     Given I am the user with id "2"
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -632,7 +632,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: A user with can_watch_members on the participant cannot switch a thread to an open status
     Given I am the user with id "2"
-    And I can watch the participant with id "3"
+    And I can watch for submissions from the group 3 and its descendants
     And there is a thread with "item_id=<item_id>,participant_id=3,status=<old_status>"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -218,7 +218,7 @@ Feature: Update thread - robustness
   Should return access error when the status is not set and
   "can write to thread" condition (3) is not met: user is not part of the help group
     Given I am the user with id "1"
-    And I have validated the item with id "40"
+    And I have a validated result on the item 40
     And I have the watch permission set to "answer" on the item 40
     And there is a thread with "item_id=40,participant_id=3"
     When I send a PUT request to "/items/40/participant/3/thread" with the following body:
@@ -438,7 +438,7 @@ Feature: Update thread - robustness
 
   Scenario: Cannot switch between open status if only item validated but not a part of the helper group, and cannot watch participant
     Given I am the user with id "1"
-    And I have validated the item with id "160"
+    And I have a validated result on the item 160
     And there is a thread with "item_id=160,participant_id=3,status=waiting_for_trainer"
     When I send a PUT request to "/items/160/participant/3/thread" with the following body:
       """
@@ -677,7 +677,7 @@ Feature: Update thread - robustness
   Scenario: If participant is the user and helper_group_id is given, it must be a descendant or a group he "can_request_help_to"
     Given I am the user with id "3"
     And I have the watch permission set to "answer_with_grant" on the item 430
-    And I have validated the item with id "430"
+    And I have a validated result on the item 430
     And there is a thread with "item_id=430,participant_id=3"
     When I send a PUT request to "/items/430/participant/3/thread" with the following body:
       """

--- a/app/api/threads/update_thread.robustness.feature
+++ b/app/api/threads/update_thread.robustness.feature
@@ -352,7 +352,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread exists
     Given I am the user with id "2"
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is a thread with "item_id=<item_id>,participant_id=3,status=closed"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -371,7 +371,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: Should not switch to open if can_watch_members on the participant but can_watch<answer when thread doesn't exists
     Given I am the user with id "2"
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     And I have the watch permission set to "<can_watch>" on the item <item_id>
     And there is no thread with "item_id=<item_id>,participant_id=3"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
@@ -632,7 +632,7 @@ Feature: Update thread - robustness
 
   Scenario Outline: A user with can_watch_members on the participant cannot switch a thread to an open status
     Given I am the user with id "2"
-    And I can watch for submissions from the group 3 and its descendants
+    And I am a manager of the group 3 and can watch for submissions from the group and its descendants
     And there is a thread with "item_id=<item_id>,participant_id=3,status=<old_status>"
     When I send a PUT request to "/items/<item_id>/participant/3/thread" with the following body:
       """

--- a/app/api/users/generate_profile_edit_token.feature
+++ b/app/api/users/generate_profile_edit_token.feature
@@ -63,7 +63,7 @@ Feature: Generate Profile Edit Token
     And the time now is "2020-01-01T00:00:00Z"
     And I am @Manager
     And I am a manager of the group @CityParent
-    And @City is a child of the group @CityParent
+    And the group @City is a child of the group @CityParent
     When I send a POST request to "/users/@User/generate-profile-edit-token"
     Then the response code should be 200
     And the response at $.token should be the base64 of an AES-256-GCM encrypted JSON object containing:

--- a/app/api/users/get_user.feature
+++ b/app/api/users/get_user.feature
@@ -6,18 +6,18 @@ Feature: Get user info
       | 3        | 1         | jane  | null       | null      | fr               | null      | null       |
       | 4        | 0         | john  | null       | null      | fr               | null      | null       |
       | 5        | 0         | paul  | null       | null      | fr               | null      | null       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name          |
       | 10 | Some group    |
       | 11 | Another group |
       | 12 | Friends       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 11              | 4              | null                           |
       | 10              | 2              | 2019-05-30 11:00:00            |
       | 12              | 5              | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members | can_grant_group_access |
       | 10       | 11         | false             | false                  |
       | 12       | 4          | true              | false                  |

--- a/app/api/users/get_user_by_login.feature
+++ b/app/api/users/get_user_by_login.feature
@@ -6,18 +6,18 @@ Feature: Get user info by login
       | 3        | 1         | jane  | null       | null      | fr               | null      | null       |
       | 4        | 0         | john  | null       | null      | fr               | null      | null       |
       | 5        | 0         | paul  | null       | null      | fr               | null      | null       |
-    And the database has the following table 'groups':
+    And the database has the following table "groups":
       | id | name          |
       | 10 | Some group    |
       | 11 | Another group |
       | 12 | Friends       |
-    And the database has the following table 'groups_groups':
+    And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | personal_info_view_approved_at |
       | 11              | 4              | null                           |
       | 10              | 2              | 2019-05-30 11:00:00            |
       | 12              | 5              | null                           |
     And the groups ancestors are computed
-    And the database has the following table 'group_managers':
+    And the database has the following table "group_managers":
       | group_id | manager_id | can_watch_members | can_grant_group_access |
       | 10       | 11         | false             | false                  |
       | 12       | 4          | true              | false                  |

--- a/testhelpers/app_language_group_pending_requests.go
+++ b/testhelpers/app_language_group_pending_requests.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cucumber/godog"
+	messages "github.com/cucumber/messages/go/v21"
 )
 
 // registerFeaturesForGroupMembershipChanges registers the Gherkin features related to group membership changes.
@@ -26,8 +27,8 @@ func (ctx *TestContext) registerFeaturesForGroupPendingRequests(s *godog.Scenari
 }
 
 // getGroupPendingRequestPrimaryKey returns the primary key of a group pending request.
-func (ctx *TestContext) getGroupPendingRequestPrimaryKey(groupID, memberID int64) string {
-	return strconv.FormatInt(groupID, 10) + "," + strconv.FormatInt(memberID, 10)
+func (ctx *TestContext) getGroupPendingRequestPrimaryKey(groupID, memberID int64) map[string]string {
+	return map[string]string{"group_id": strconv.FormatInt(groupID, 10), "member_id": strconv.FormatInt(memberID, 10)}
 }
 
 // addGroup adds a group to the database.
@@ -38,13 +39,25 @@ func (ctx *TestContext) addGroupPendingRequest(group, member, requestType string
 	primaryKey := ctx.getGroupPendingRequestPrimaryKey(groupID, memberID)
 
 	if !ctx.isInDatabase("group_pending_requests", primaryKey) {
-		ctx.addToDatabase("group_pending_requests", primaryKey, map[string]interface{}{
-			"group_id":  groupID,
-			"member_id": memberID,
-			"type":      requestType,
-			// All the other fields are set to default values.
-			"at": time.Now(),
+		err := ctx.DBHasTable("group_pending_requests", &godog.Table{
+			Rows: []*messages.PickleTableRow{
+				{
+					Cells: []*messages.PickleTableCell{
+						{Value: "group_id"}, {Value: "member_id"}, {Value: "type"}, {Value: "at"},
+					},
+					// All the other fields are set to default values.
+				},
+				{Cells: []*messages.PickleTableCell{
+					{Value: strconv.FormatInt(groupID, 10)},
+					{Value: strconv.FormatInt(memberID, 10)},
+					{Value: requestType},
+					{Value: time.Now().UTC().Format(time.DateTime)},
+				}},
+			},
 		})
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -18,7 +18,7 @@ func (ctx *TestContext) registerFeaturesForGroups(s *godog.ScenarioContext) {
 	s.Step(`^I am a member of the group (@\w+)$`, ctx.IAmAMemberOfTheGroup)
 	s.Step(`^I am a member of the group with id "([^"]*)"$`, ctx.IAmAMemberOfTheGroupWithID)
 	s.Step(`^(@\w+) is a member of the group (@\w+)$`, ctx.UserIsAMemberOfTheGroup)
-	s.Step(`^(@\w+) is a child of the group (@\w+)$`, ctx.GroupIsAChildOfTheGroup)
+	s.Step(`^the group (@\w+) is a child of the group (@\w+)$`, ctx.GroupIsAChildOfTheGroup)
 	s.Step(
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -146,7 +146,7 @@ func (ctx *TestContext) IAmAMemberOfTheGroupWithID(group string) error {
 		return err
 	}
 
-	ctx.IsAMemberOfTheGroup(
+	ctx.GroupIsAMemberOfTheGroup(
 		ctx.user,
 		group,
 	)
@@ -166,7 +166,7 @@ func (ctx *TestContext) GroupIsAChildOfTheGroup(childGroup, parentGroup string) 
 		return err
 	}
 
-	ctx.IsAMemberOfTheGroup(childGroup, parentGroup)
+	ctx.GroupIsAMemberOfTheGroup(childGroup, parentGroup)
 
 	return nil
 }
@@ -273,8 +273,8 @@ func (ctx *TestContext) theGroupIsADescendantOfTheGroup(descendant, parent, midd
 		}
 	}
 
-	ctx.IsAMemberOfTheGroup(middle, parent)
-	ctx.IsAMemberOfTheGroup(descendant, middle)
+	ctx.GroupIsAMemberOfTheGroup(middle, parent)
+	ctx.GroupIsAMemberOfTheGroup(descendant, middle)
 
 	return nil
 }

--- a/testhelpers/app_language_sessions.go
+++ b/testhelpers/app_language_sessions.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
-
+	"github.com/cucumber/godog"
+	messages "github.com/cucumber/messages/go/v21"
 	"github.com/jinzhu/gorm"
 
-	"github.com/cucumber/godog"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 )
 
 // registerFeaturesForSessions registers the Gherkin features related to sessions and access tokens.
@@ -32,33 +32,44 @@ func (ctx *TestContext) addSession(session, user, refreshToken string) {
 	sessionID := ctx.getIDOfReference(session)
 	userID := ctx.getIDOfReference(user)
 
-	ctx.addToDatabase("sessions", strconv.FormatInt(sessionID, 10), map[string]interface{}{
-		"session_id":    sessionID,
-		"user_id":       userID,
-		"refresh_token": refreshToken,
+	err := ctx.DBHasTable("sessions", &godog.Table{
+		Rows: []*messages.PickleTableRow{
+			{Cells: []*messages.PickleTableCell{
+				{Value: "session_id"}, {Value: "user_id"}, {Value: "refresh_token"},
+			}},
+			{Cells: []*messages.PickleTableCell{
+				{Value: strconv.FormatInt(sessionID, 10)}, {Value: strconv.FormatInt(userID, 10)}, {Value: refreshToken},
+			}},
+		},
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 // addAccessToken adds an access token to the database.
 func (ctx *TestContext) addAccessToken(session, token, issuedAt, expiresAt string) {
 	sessionID := ctx.getIDOfReference(session)
 
-	issuedAtDate, err := time.Parse(time.DateTime, issuedAt)
+	_, err := time.Parse(time.DateTime, issuedAt)
 	if err != nil {
 		panic(err)
 	}
 
-	expiresAtDate, err := time.Parse(time.DateTime, expiresAt)
+	_, err = time.Parse(time.DateTime, expiresAt)
 	if err != nil {
 		panic(err)
 	}
 
-	ctx.addToDatabase("access_tokens", token, map[string]interface{}{
-		"session_id": sessionID,
-		"token":      token,
-		"issued_at":  issuedAtDate,
-		"expires_at": expiresAtDate,
+	err = ctx.DBHasTable("access_tokens", &godog.Table{
+		Rows: []*messages.PickleTableRow{
+			{Cells: []*messages.PickleTableCell{{Value: "session_id"}, {Value: "token"}, {Value: "issued_at"}, {Value: "expires_at"}}},
+			{Cells: []*messages.PickleTableCell{{Value: strconv.FormatInt(sessionID, 10)}, {Value: token}, {Value: issuedAt}, {Value: expiresAt}}},
+		},
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 // IAm Sets the current user.

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -62,7 +62,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
 		ctx.ICanViewOnItemWithID)
-	s.Step(`^I can watch (none|result|answer|answer_with_grant) on item with id "([^"]*)"$`, ctx.ICanWatchOnItemWithID)
+	s.Step(`^I have the watch permission set to "(none|result|answer|answer_with_grant)" on the item (.+)$`, ctx.ICanWatchOnItemWithID)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
 

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -26,8 +26,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^the template constant "([^"]+)" is "(.*)"$`, ctx.TheTemplateConstantIsString)
 	s.Step(`^the template constant "([^"]+)" is:$`, ctx.TheTemplateConstantIsDocString)
 
-	s.Step(`^the database has the following table \'([\w\-_]*)\':$`, ctx.DBHasTable)
-	s.Step(`^the database table \'([\w\-_]*)\' has also the following rows?:$`, ctx.DBHasTable)
+	s.Step(`^the database has the following table "([^"]+)":$`, ctx.DBHasTable)
+	s.Step(`^the database table "([^"]+)" has also the following rows?:$`, ctx.DBHasTable)
 	s.Step(`^the database has the following users:$`, ctx.DBHasUsers)
 	s.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
 

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -74,7 +74,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^I have a validated result on the item (.+)$`, ctx.IHaveValidatedResultOnItem)
 
 	s.Step(`^there are the following threads:$`, ctx.ThereAreTheFollowingThreads)
-	s.Step(`^there is a thread with "([^"]*)"$`, ctx.ThereIsAThreadWith)
+	s.Step(`^there is a thread with "(.*)"$`, ctx.ThereIsAThreadWith)
 	s.Step(`^there is no thread with "([^"]*)"$`, ctx.ThereIsNoThreadWith)
 	s.Step(`^I am part of the helper group of the thread$`, ctx.IAmPartOfTheHelperGroupOfTheThread)
 

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -58,8 +58,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
 	s.Step(`^there are the following item relations:$`, ctx.ThereAreTheFollowingItemRelations)
-	s.Step(`^I can watch the group (@\w+)$`, ctx.ICanWatchGroup)
-	s.Step(`^I can watch the participant with id "([^"]*)"$`, ctx.ICanWatchGroupWithID)
+	s.Step(`^I can watch for submissions from the group (.+) and its descendants$`, ctx.ICanWatchGroupWithID)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
 		ctx.ICanViewOnItemWithID)
 	s.Step(`^I have the watch permission set to "(none|result|answer|answer_with_grant)" on the item (.+)$`, ctx.ICanWatchOnItemWithID)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -47,14 +47,14 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmAManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)
 	s.Step(`^I am a manager of the group (.+) and can watch for submissions from the group and its descendants$`,
-		ctx.ICanWatchGroupWithID)
+		ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^the group (@\w+) is a manager of the group (@\w+) and can watch for submissions from the group and its descendants$`,
-		ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
+		ctx.GroupIsAManagerOfTheGroupAndCanWatchItsMembers)
 	s.Step(`^the group (@\w+) is a manager of the group (@\w+) and can grant group access`,
-		ctx.UserIsAManagerOfTheGroupAndCanGrantGroupAccess)
+		ctx.GroupIsAManagerOfTheGroupAndCanGrantGroupAccess)
 	s.Step(
 		`^the group (@\w+) is a manager of the group (@\w+) and can can manage memberships and the group`,
-		ctx.UserIsAManagerOfTheGroupAndCanManageMembershipsAndGroup,
+		ctx.GroupIsAManagerOfTheGroupAndCanManageMembershipsAndGroup,
 	)
 
 	s.Step(`^there are the following items:$`, ctx.ThereAreTheFollowingItems)
@@ -62,8 +62,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
 	s.Step(`^there are the following item relations:$`, ctx.ThereAreTheFollowingItemRelations)
 	s.Step(`^I can view (none|info|content|content_with_descendants|solution) of the item (.+)$`,
-		ctx.ICanViewOnItemWithID)
-	s.Step(`^I have the watch permission set to "(none|result|answer|answer_with_grant)" on the item (.+)$`, ctx.ICanWatchOnItemWithID)
+		ctx.IHaveViewPermissionOnItem)
+	s.Step(`^I have the watch permission set to "(none|result|answer|answer_with_grant)" on the item (.+)$`, ctx.IHaveWatchPermissionOnItem)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,
 		ctx.ICanRequestHelpToTheGroupWithIDOnTheItemWithID)
 

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -69,7 +69,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	ctx.registerFeaturesForGroupPendingRequests(s)
 
 	s.Step(`^there are the following results:$`, ctx.ThereAreTheFollowingResults)
-	s.Step(`^I have validated the item with id "([^"]*)"$`, ctx.IHaveValidatedItemWithID)
+	s.Step(`^I have a validated result on the item (.+)$`, ctx.IHaveValidatedResultOnItem)
 
 	s.Step(`^there are the following threads:$`, ctx.ThereAreTheFollowingThreads)
 	s.Step(`^there is a thread with "([^"]*)"$`, ctx.ThereIsAThreadWith)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -46,11 +46,14 @@ func InitializeScenario(s *godog.ScenarioContext) {
 
 	s.Step(`^I am a manager of the group with id "([^"]*)"$`, ctx.IAmAManagerOfTheGroupWithID)
 	s.Step(`^I am a manager of the group (@\w+)$`, ctx.IAmAManagerOfTheGroup)
-	s.Step(`^(@\w+) is a manager of the group (@\w+) and can watch its members$`, ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
-	s.Step(`^I am a manager of the group (@\w+) and can watch its members$`, ctx.IAmAManagerOfTheGroupAndCanWatchItsMembers)
-	s.Step(`(@\w+) is a manager of the group (@\w+) and can grant group access`, ctx.UserIsAManagerOfTheGroupAndCanGrantGroupAccess)
+	s.Step(`^I am a manager of the group (.+) and can watch for submissions from the group and its descendants$`,
+		ctx.ICanWatchGroupWithID)
+	s.Step(`^the group (@\w+) is a manager of the group (@\w+) and can watch for submissions from the group and its descendants$`,
+		ctx.UserIsAManagerOfTheGroupAndCanWatchItsMembers)
+	s.Step(`^the group (@\w+) is a manager of the group (@\w+) and can grant group access`,
+		ctx.UserIsAManagerOfTheGroupAndCanGrantGroupAccess)
 	s.Step(
-		`(@\w+) is a manager of the group (@\w+) and can manage memberships and group`,
+		`^the group (@\w+) is a manager of the group (@\w+) and can can manage memberships and the group`,
 		ctx.UserIsAManagerOfTheGroupAndCanManageMembershipsAndGroup,
 	)
 
@@ -58,8 +61,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^there are the following tasks:$`, ctx.ThereAreTheFollowingTasks)
 	s.Step(`^there are the following item permissions:$`, ctx.ThereAreTheFollowingItemPermissions)
 	s.Step(`^there are the following item relations:$`, ctx.ThereAreTheFollowingItemRelations)
-	s.Step(`^I can watch for submissions from the group (.+) and its descendants$`, ctx.ICanWatchGroupWithID)
-	s.Step(`^I can view (none|info|content|content_with_descendants|solution) on item with id "([^"]*)"$`,
+	s.Step(`^I can view (none|info|content|content_with_descendants|solution) of the item (.+)$`,
 		ctx.ICanViewOnItemWithID)
 	s.Step(`^I have the watch permission set to "(none|result|answer|answer_with_grant)" on the item (.+)$`, ctx.ICanWatchOnItemWithID)
 	s.Step(`^I can request help to the group with id "([^"]*)" on the item with id "([^"]*)"$`,

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -70,7 +70,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	ctx.registerFeaturesForGroupMembershipChanges(s)
 	ctx.registerFeaturesForGroupPendingRequests(s)
 
-	s.Step(`^there are the following results:$`, ctx.ThereAreTheFollowingResults)
+	s.Step(`^there are the following validated results:$`, ctx.ThereAreTheFollowingValidatedResults)
 	s.Step(`^I have a validated result on the item (.+)$`, ctx.IHaveValidatedResultOnItem)
 
 	s.Step(`^there are the following threads:$`, ctx.ThereAreTheFollowingThreads)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -662,8 +662,8 @@ func (ctx *TestContext) GroupHasValidatedResultOnItem(group, item string) error 
 	return nil
 }
 
-// ThereAreTheFollowingResults creates validated results described in the given Godog table.
-func (ctx *TestContext) ThereAreTheFollowingResults(results *godog.Table) error {
+// ThereAreTheFollowingValidatedResults creates validated results described in the given Godog table.
+func (ctx *TestContext) ThereAreTheFollowingValidatedResults(results *godog.Table) error {
 	for i := 1; i < len(results.Rows); i++ {
 		result := ctx.getRowMap(i, results)
 

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -722,7 +722,7 @@ func (ctx *TestContext) UserCanRequestHelpToOnItemWithID(canRequestHelpTo, user,
 	return ctx.UserSetPermissionOnItemWithID("can_request_help_to", canRequestHelpTo, user, item)
 }
 
-func (ctx *TestContext) userHasAValidatedItemWithID(user, item string) error {
+func (ctx *TestContext) userHasValidatedResultOnItem(user, item string) error {
 	attemptID := rand.Int63()
 
 	ctx.addAttempt(item, user)
@@ -745,7 +745,7 @@ func (ctx *TestContext) ThereAreTheFollowingResults(results *godog.Table) error 
 			"item": result["item"],
 		})
 
-		err := ctx.userHasAValidatedItemWithID(result["participant"], result["item"])
+		err := ctx.userHasValidatedResultOnItem(result["participant"], result["item"])
 		if err != nil {
 			return err
 		}
@@ -754,9 +754,9 @@ func (ctx *TestContext) ThereAreTheFollowingResults(results *godog.Table) error 
 	return nil
 }
 
-// IHaveValidatedItemWithID states that user has validated an item.
-func (ctx *TestContext) IHaveValidatedItemWithID(item string) error {
-	return ctx.userHasAValidatedItemWithID(ctx.user, item)
+// IHaveValidatedResultOnItem states that the current user has a validated result on the item.
+func (ctx *TestContext) IHaveValidatedResultOnItem(item string) error {
+	return ctx.userHasValidatedResultOnItem(ctx.user, item)
 }
 
 // ThereAreTheFollowingThreads create threads.

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	referencePrefix = '@'
-	strTrue         = "true"
 )
 
 var (
@@ -27,8 +26,13 @@ var (
 
 // ctx.getParameterMap parses parameters in format key1=val1,key2=val2,... into a map.
 func (ctx *TestContext) getParameterMap(parameters string) map[string]string {
+	preprocessed, err := ctx.preprocessString(parameters)
+	if err != nil {
+		panic(err)
+	}
+
 	parameterMap := make(map[string]string)
-	arrayParameters := strings.Split(parameters, ",")
+	arrayParameters := strings.Split(preprocessed, ",")
 	for _, paramKeyValue := range arrayParameters {
 		keyVal := strings.Split(paramKeyValue, "=")
 

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -54,9 +54,9 @@ func (ctx *TestContext) replaceReferencesWithIDs(str string) string {
 	})
 }
 
-func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
-	jsonBody = ctx.replaceReferencesWithIDs(jsonBody)
-	tmpl, err := ctx.templateSet.Parse("template", jsonBody)
+func (ctx *TestContext) preprocessString(str string) (string, error) {
+	str = ctx.replaceReferencesWithIDs(str)
+	tmpl, err := ctx.templateSet.Parse("template", str)
 	if err != nil {
 		return "", err
 	}
@@ -65,9 +65,9 @@ func (ctx *TestContext) preprocessString(jsonBody string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	jsonBody = buffer.String()
+	str = buffer.String()
 
-	return jsonBody, nil
+	return str, nil
 }
 
 func (ctx *TestContext) constructTemplateSet() *jet.Set {

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -44,8 +44,7 @@ type TestContext struct {
 	requestHeaders       map[string][]string
 	referenceToIDMap     map[string]int64
 	idToReferenceMap     map[int64]string
-	dbTables             map[string]map[string]map[string]interface{}
-	currentThreadKey     string
+	currentThreadKey     map[string]string
 	allUsersGroup        string
 	needPopulateDatabase bool
 }
@@ -70,7 +69,6 @@ func (ctx *TestContext) SetupTestContext(sc *godog.Scenario) {
 	ctx.db = ctx.openDB()
 	ctx.dbTableData = make(map[string]*godog.Table)
 	ctx.templateSet = ctx.constructTemplateSet()
-	ctx.dbTables = make(map[string]map[string]map[string]interface{})
 	ctx.needPopulateDatabase = false
 
 	ctx.initReferences(sc)


### PR DESCRIPTION
Here is some preparation before implementing #1042.

As the cucumber test of getAnswer service is very hard to maintain (it has common DB setup for all the scenarios and do not employ references at all), it's necessary to rewrite it. But first it's important to tidy up our cucumber test steps and test helpers:
1. Make all the cucumber test steps compatible with each other and make it possible to use any cucumber steps together.
2. Make cucumber test steps style a bit more consistent.
3. Rename incorrectly/misleadingly named test steps.

The PR may seem to be huge, but it consists of independent commits, making it easier to review one by one.