### PR TITLE
Allow passing DB transaction options + pass the context for transactions

### DIFF
--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -289,10 +289,10 @@ func (s *DataStore) SchedulePermissionsPropagation() {
 
 // WithForeignKeyChecksDisabled executes the given function with foreign keys checking disabled
 // (wraps it up in a transaction if no transaction started).
-func (s *DataStore) WithForeignKeyChecksDisabled(blockFunc func(*DataStore) error) error {
+func (s *DataStore) WithForeignKeyChecksDisabled(blockFunc func(*DataStore) error, txOptions ...*sql.TxOptions) error {
 	return s.withForeignKeyChecksDisabled(func(db *DB) error {
 		return blockFunc(NewDataStoreWithTable(db, s.tableName))
-	})
+	}, txOptions...)
 }
 
 // IsInTransaction returns true if the store operates in a DB transaction at the moment.

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/rand"
@@ -219,14 +220,14 @@ const (
 // InTransaction executes the given function in a transaction and commits.
 // If a propagation is scheduled, it will be run after the transaction commit,
 // so we can run each step of the propagation in a separate transaction.
-func (s *DataStore) InTransaction(txFunc func(*DataStore) error) error {
+func (s *DataStore) InTransaction(txFunc func(*DataStore) error, txOptions ...*sql.TxOptions) error {
 	s.DB.ctx = context.WithValue(s.DB.ctx, awaitingPropagationsContextKey, &propagationsBitField{})
 	err := s.inTransaction(func(db *DB) error {
 		dataStore := NewDataStoreWithTable(db, s.tableName)
 		err := txFunc(dataStore)
 
 		return err
-	})
+	}, txOptions...)
 	if err != nil {
 		return err
 	}

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -228,6 +229,86 @@ func TestDB_inTransaction_RetriesOnDeadLockPanic(t *testing.T) {
 	}))
 	assert.InEpsilon(t, transactionDelayBetweenRetries, duration, 0.05)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func patchBeginTxWithVerifier(
+	t *testing.T, callsCount *int, expectedTxOptions *sql.TxOptions, expectedContextVars map[interface{}]interface{},
+) (patch *monkey.PatchGuard) {
+	patch = monkey.PatchInstanceMethod(reflect.TypeOf(&gorm.DB{}), "BeginTx",
+		func(db *gorm.DB, ctx context.Context, opts *sql.TxOptions) *gorm.DB {
+			*callsCount++
+			assert.Equal(t, expectedTxOptions, opts)
+			if len(expectedContextVars) > 0 {
+				assert.NotNil(t, ctx)
+				for key, value := range expectedContextVars {
+					assert.Equal(t, value, ctx.Value(key), "Wrong context value for key %#v", key)
+				}
+			}
+
+			defer patch.Restore()
+			patch.Unpatch()
+			return db.BeginTx(ctx, opts)
+		})
+	return patch
+}
+
+func TestDB_inTransaction_RetriesOnDeadLockPanic_WithTxOptions(t *testing.T) {
+	var calledCount int
+	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
+	patch := patchBeginTxWithVerifier(t, &calledCount, txOptions, nil)
+	defer patch.Unpatch()
+
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	monkey.Patch(time.Sleep, func(d time.Duration) {})
+	defer monkey.UnpatchAll()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT 1").
+		WillReturnError(&mysql.MySQLError{Number: 1213})
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT 1").
+		WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectCommit()
+
+	assert.NoError(t, db.inTransaction(func(db *DB) error {
+		var result []interface{}
+		mustNotBeError(db.Raw("SELECT 1").Scan(&result).Error())
+		return nil
+	}, txOptions))
+	assert.NoError(t, mock.ExpectationsWereMet())
+	assert.Equal(t, 2, calledCount)
+}
+
+func TestDB_inTransaction_RetriesOnDeadLockError_WithTxOptions(t *testing.T) {
+	var calledCount int
+	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
+	patch := patchBeginTxWithVerifier(t, &calledCount, txOptions, nil)
+	defer patch.Unpatch()
+
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	monkey.Patch(time.Sleep, func(d time.Duration) {})
+	defer monkey.UnpatchAll()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT 1").
+		WillReturnError(&mysql.MySQLError{Number: 1213})
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT 1").
+		WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectCommit()
+
+	assert.NoError(t, db.inTransaction(func(db *DB) error {
+		var result []interface{}
+		return db.Raw("SELECT 1").Scan(&result).Error()
+	}, txOptions))
+	assert.NoError(t, mock.ExpectationsWereMet())
+	assert.Equal(t, 2, calledCount)
 }
 
 func TestDB_inTransaction_RetriesOnDeadLockPanicAndPanicsOnRollbackError(t *testing.T) {


### PR DESCRIPTION
1. Allow passing transaction options to DataStore.InTransaction(). This may be useful for having read-only transactions and changing the transaction isolation level.
2. Pass the context for transactions (may be useful for cancelling DB queries run inside transactions to eliminate issues like the one described in #1048).
3. Add tests.