### PR TITLE
Store the DB time instead of the server time in threads.latest_update_at and compare its value with the DB time instead of the server time as well

### DIFF
--- a/app/api/threads/get_thread.robustness.feature
+++ b/app/api/threads/get_thread.robustness.feature
@@ -47,7 +47,7 @@ Feature: Get thread - robustness
       | 60      | 3              | closed                  | 10              | 2020-01-20 00:00:00 |
       | 70      | 3              | waiting_for_trainer     | 10              | 2020-01-20 00:00:00 |
       | 80      | 3              | waiting_for_participant | 20              | 2020-01-20 00:00:00 |
-    And the server time now is "2020-01-20T00:00:00Z"
+    And the DB time now is "2020-01-20 00:00:00"
 
   Scenario: Should be logged
     When I send a GET request to "/items/10/participant/1/thread"

--- a/app/api/threads/list_threads.feature
+++ b/app/api/threads/list_threads.feature
@@ -92,7 +92,7 @@ Feature: List threads
       | @B_SectionMember3   | @B_SectionMember2_CanViewContent2               |               |                         |                     | 18            | @B_SectionMember2 is_mine=1 -> notok: not the participant                                                                     |
       | @B_SectionMember2   | @B_SectionMember2_CanViewContentWithDescendants |               |                         |                     | 19            | @B_SectionMember2 is_mine=1 -> ok: can_view >= content                                                                        |
       | @OtherGroupMember   | @Item2                                          |               |                         |                     | 20            |                                                                                                                               |
-    And the server time now is "2022-01-01T00:00:00Z"
+    And the DB time now is "2022-01-01 00:00:00"
 
   Scenario: Should have all the fields properly set, including first_name and last_name when the access is approved
     Given I am @LaboratoryManagerCanWatch

--- a/app/api/threads/update_thread.feature
+++ b/app/api/threads/update_thread.feature
@@ -70,7 +70,7 @@ Feature: Update thread
       | 12       | 11              | 3004    | 12                  | 0        |
     And the database has the following table "threads":
       | item_id | participant_id | status | helper_group_id | latest_update_at |
-    And the server time now is "2022-01-01T00:00:00Z"
+    And the DB time now is "2022-01-01 00:00:00"
 
   Scenario: Create a thread if it doesn't exist
     Given I am the user with id "3"

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -3,7 +3,6 @@ package threads
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/France-ioi/validator"
 	"github.com/go-chi/render"
@@ -197,7 +196,7 @@ func computeNewThreadData(
 	if len(threadData) > 0 {
 		threadData["item_id"] = itemID
 		threadData["participant_id"] = participantID
-		threadData["latest_update_at"] = time.Now()
+		threadData["latest_update_at"] = database.Now()
 
 		if _, ok := threadData["helper_group_id"]; !ok {
 			threadData["helper_group_id"] = oldHelperGroupID

--- a/app/database/thread_store.go
+++ b/app/database/thread_store.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"time"
-
 	"github.com/jinzhu/gorm"
 )
 
@@ -193,14 +191,11 @@ func (s *ThreadStore) WhereUserCanHelp(user *User) *ThreadStore {
 	// the thread is either open (=waiting_for_participant or =waiting_for_trainer), or closed for less than 2 weeks
 	// the current-user has validated the item
 
-	now := time.Now()
-	twoWeeksAgo := now.AddDate(0, 0, -14)
-
 	return s.NewThreadStore(
 		s.Joins("JOIN results ON results.item_id = threads.item_id AND results.participant_id = ?", user.GroupID).
 			Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", user.GroupID).
 			Where("threads.helper_group_id = groups_ancestors_active.ancestor_group_id").
-			Where("threads.status != 'closed' OR threads.latest_update_at > ?", twoWeeksAgo).
+			Where("threads.status != 'closed' OR threads.latest_update_at > NOW() - INTERVAL 2 WEEK").
 			Where("results.validated"),
 	)
 }


### PR DESCRIPTION
For the sake of consistency with other services, the thread-related services should store the DB time in threads.latest_update_at (not the server time). Also they should compare threads.latest_update_at with the DB time (not the server time).