### PR TITLE
Add missing call to testhelpers.SuppressOutputIfPasses() in integration tests

### DIFF
--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -185,6 +185,7 @@ func Test_checkPreconditionsForGroupRequests(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(tt.fixture)
 			defer func() { _ = db.Close() }()
 

--- a/app/api/groups/create_invitations_integration_test.go
+++ b/app/api/groups/create_invitations_integration_test.go
@@ -244,6 +244,7 @@ func Test_filterOtherTeamsMembersOut(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(tt.fixture)
 			defer func() { _ = db.Close() }()
 

--- a/app/database/group_group_store_ancestors_integration_test.go
+++ b/app/database/group_group_store_ancestors_integration_test.go
@@ -27,6 +27,8 @@ type groupPropagateResultRow struct {
 var maxExpiresAt = "9999-12-31 23:59:59"
 
 func TestGroupGroupStore_CreateNewAncestors_Concurrent(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 
@@ -67,6 +69,8 @@ func TestGroupGroupStore_CreateNewAncestors_Concurrent(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_Cyclic(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common", "group_group_store/ancestors/cyclic")
 	defer func() { _ = db.Close() }()
 
@@ -96,6 +100,8 @@ func TestGroupGroupStore_CreateNewAncestors_Cyclic(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_IgnoresDoneGroups(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 
@@ -133,6 +139,8 @@ func TestGroupGroupStore_CreateNewAncestors_IgnoresDoneGroups(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_ProcessesOnlyDirectRelationsOrAcceptedRequestsAndInvitations(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 
@@ -171,6 +179,8 @@ func TestGroupGroupStore_CreateNewAncestors_ProcessesOnlyDirectRelationsOrAccept
 }
 
 func TestGroupGroupStore_CreateNewAncestors_PropagatesExpiresAt(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 
@@ -220,6 +230,8 @@ func TestGroupGroupStore_CreateNewAncestors_PropagatesExpiresAt(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_IgnoresExpiredRelations(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -23,6 +23,8 @@ type itemPropagateResultRow struct {
 }
 
 func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 
@@ -58,6 +60,8 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 }
 
 func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common", "item_item_store/ancestors/cyclic")
 	defer func() { _ = db.Close() }()
 
@@ -85,6 +89,8 @@ func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
 }
 
 func TestItemItemStore_CreateNewAncestors_IgnoresDoneItems(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
 

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -31,6 +31,8 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.methodToCall, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := setupDB()
 			defer func() { _ = db.Close() }()
 
@@ -54,6 +56,8 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 }
 
 func TestItemStore_CheckSubmissionRights(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("item_store/check_submission_rights")
 	defer func() { _ = db.Close() }()
 
@@ -83,6 +87,8 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				hasAccess, reason, err := store.Items().CheckSubmissionRights(test.participantID, test.itemID)
 				assert.Equal(t, test.wantHasAccess, hasAccess)
@@ -96,6 +102,8 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 }
 
 func TestItemStore_GetItemIDFromTextID(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [
 			{id: 11, text_id: "id11", default_language_tag: fr},
@@ -125,6 +133,8 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				itemID, err := store.Items().GetItemIDFromTextID(test.textID)
 				assert.Equal(t, test.wantItemID, itemID)
@@ -136,6 +146,8 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 }
 
 func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_BreadcrumbsHierarchyForParentAttempt(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr, allows_multiple_attempts: 1}
@@ -560,6 +572,8 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 		tt := tt
 		testEachWriteLockMode(t, tt.name+": is valid", func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
+				testhelpers.SuppressOutputIfPasses(t)
+
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					got, err := store.Items().IsValidParticipationHierarchyForParentAttempt(
 						tt.args.ids, tt.args.groupID, tt.args.parentAttemptID, tt.args.requireContentAccessToTheLastItem, writeLock)
@@ -571,6 +585,8 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 		})
 		testEachWriteLockMode(t, tt.name+": breadcrumbs hierarchy", func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
+				testhelpers.SuppressOutputIfPasses(t)
+
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForParentAttempt(
 						tt.args.ids, tt.args.groupID, tt.args.parentAttemptID, writeLock)
@@ -592,6 +608,8 @@ func assertBreadcrumbsHierarchy(t *testing.T,
 }
 
 func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr, allows_multiple_attempts: 1}
@@ -1003,6 +1021,8 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 		tt := tt
 		testEachWriteLockMode(t, tt.name, func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
+				testhelpers.SuppressOutputIfPasses(t)
+
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForAttempt(
 						tt.args.ids, tt.args.groupID, tt.args.attemptID, writeLock)
@@ -1040,6 +1060,8 @@ func TestItemStore_TriggerBeforeInsert_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
 					- {id: 3, regexp: "^1.*", priority: 1}
@@ -1091,6 +1113,8 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
 					- {id: 1, regexp: "^4.*", priority: 4}
@@ -1147,6 +1171,8 @@ func TestItemStore_PlatformsTriggerAfterInsert_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
 					- {id: 3, regexp: "^1.*", priority: 1}
@@ -1211,6 +1237,8 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
 					- {id: 3, regexp: "^1.*", priority: 1}
@@ -1240,6 +1268,8 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 }
 
 func Test_ItemStore_DeleteItem(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		languages: [{tag: fr}]
 		items: [{id: 1234, default_language_tag: fr},{id: 1235, default_language_tag: fr}]

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestPermissionGeneratedStore_MatchingUserAncestors(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}]
 		users: [{group_id: 5}]
@@ -100,6 +102,8 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(groupGroupMarksResultsAsChangedFixture)
 			defer func() { _ = db.Close() }()
 
@@ -195,6 +199,8 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			fixures := make([]string, 0, 2)
 			if !test.updateExisting {
 				fixures = append(fixures,
@@ -226,6 +232,8 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 }
 
 func TestPermissionGeneratedStore_TriggerBeforeUpdate_RefusesToModifyGroupIDOrItemID(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}]
 		items: [{id: 2, default_language_tag: 2}]

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -25,6 +25,8 @@ var expectedRow14 = permissionsGeneratedResultRow{
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()
 
@@ -97,6 +99,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *test
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()
 
@@ -173,6 +177,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 	for _, access := range []string{"solution", "content_with_descendants"} {
 		access := access
 		t.Run(access, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 			defer func() { _ = db.Close() }()
 
@@ -324,6 +330,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 	} {
 		testcase := testcase
 		t.Run(testcase.canView+" as "+testcase.expectedCanView, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 				groups: [{id: 1}]
@@ -346,6 +354,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr}
@@ -373,6 +383,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanView(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -395,6 +407,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -413,6 +427,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanView(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanViewAsSolutionForOwners(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -431,6 +447,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanViewAsSolutionForO
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanGrantView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr}
@@ -460,6 +478,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanGrantV
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanGrantView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -481,6 +501,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanGrantView(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}]
@@ -499,6 +521,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanGrantV
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanGrantViewAsSolutionWithGrantForOwners(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}, {id: 3}]
@@ -522,6 +546,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanGrantViewAsSolutio
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanWatch(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr}
@@ -551,6 +577,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanWatch(
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanWatch(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -572,6 +600,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanWatch(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -590,6 +620,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanWatch(
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanWatchAsAnswerWithGrantForOwners(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -608,6 +640,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanWatchAsAnswerWithG
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanEdit(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
 			- {id: 1, default_language_tag: fr}
@@ -637,6 +671,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanEdit(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanEdit(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -658,6 +694,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanEdit(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -676,6 +714,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanEdit(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanEditAsAllWithGrantForOwners(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
 		groups: [{id: 1}, {id: 2}]
@@ -758,6 +798,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_Propagates(t *testing.T) {
 
 func testPropagates(t *testing.T, column, propagationColumn, valueForParent string, propagationMode bool, expectedValue string) {
 	t.Run(valueForParent+" as "+expectedValue, func(t *testing.T) {
+		testhelpers.SuppressOutputIfPasses(t)
+
 		grantViewPropagationString := fmt.Sprint(propagationMode)
 		db := testhelpers.SetupDBWithFixtureString(`
 				items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]

--- a/app/database/permission_granted_store_compute_all_access_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_integration_test.go
@@ -19,6 +19,8 @@ type groupItemsResultRow struct {
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_Concurrency(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()
 

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -39,6 +39,8 @@ const joinsPermissionsForGroupToItemsFixture = `
 				 can_edit_generated: children, is_owner_generated: 1}`
 
 func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
 	defer func() { _ = db.Close() }()
 
@@ -73,6 +75,8 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 	} {
 		test := test
 		t.Run(fmt.Sprintf("ids: %v", test.ids), func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			var result []map[string]interface{}
 			assert.NoError(t, itemStore.Select("items.id, permissions.*").
 				JoinsPermissionsForGroupToItems(5).
@@ -84,6 +88,8 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 }
 
 func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
 	defer func() { _ = db.Close() }()
 
@@ -138,6 +144,8 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 	} {
 		test := test
 		t.Run(fmt.Sprintf("ids: %v, %s>=%s", test.ids, test.permissionKind, test.neededPermission), func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			var result []map[string]interface{}
 			assert.NoError(t, itemStore.Select("items.id, permissions.*").
 				JoinsPermissionsForGroupToItemsWherePermissionAtLeast(5, test.permissionKind, test.neededPermission).

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		attempts:
 			- {participant_id: 11, id: 1, root_item_id: 112, allows_submissions_until: 3019-05-30 12:00:00}
@@ -50,6 +52,8 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				hintsInfo, err := store.Results().GetHintsInfoForActiveAttempt(test.participantID, test.attemptID, test.itemID)
 				assert.Equal(t, test.wantHintsInfo, hintsInfo)
@@ -61,6 +65,8 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 }
 
 func TestResultStore_Propagate(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	tests := []struct {
 		name    string
 		wantErr bool
@@ -74,6 +80,8 @@ func TestResultStore_Propagate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			err := database.NewDataStore(db).InTransaction(func(s *database.DataStore) error {
 				s.ScheduleResultsPropagation()
 				return nil

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -28,6 +28,8 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 	for _, markAllResultsAsToBePropagated := range []bool{false, true} {
 		markAllResultsAsToBePropagated := markAllResultsAsToBePropagated
 		t.Run(fmt.Sprintf("mark all as to_be_propagated=%v", markAllResultsAsToBePropagated), func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/aggregates")
 			defer func() { _ = db.Close() }()
 
@@ -111,6 +113,8 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 	defer func() { _ = db.Close() }()
 
@@ -133,6 +137,8 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 	defer func() { _ = db.Close() }()
 
@@ -174,6 +180,8 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 			defer func() { _ = db.Close() }()
 

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -146,6 +146,7 @@ func TestResultStore_Propagate_CreatesNew(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
 			testResultStorePropagateCreatesNew(t, &test)
 		})
 	}

--- a/app/database/result_store_propagate_recomputes_items_integration_test.go
+++ b/app/database/result_store_propagate_recomputes_items_integration_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestResultStore_Propagate_RecomputesResultsForItemsFromTableResultsRecomputeForItems(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}, {id: 3}]
 		items:

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -23,6 +23,8 @@ type unlocksResultRow struct {
 }
 
 func TestResultStore_Propagate_Unlocks(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
 
@@ -30,6 +32,8 @@ func TestResultStore_Propagate_Unlocks(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Unlocks_UpdatesOldRecords(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture(
 		"results_propagation/_common",
 		"results_propagation/unlocks",
@@ -40,6 +44,8 @@ func TestResultStore_Propagate_Unlocks_UpdatesOldRecords(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture(
 		"results_propagation/_common",
 		"results_propagation/unlocks")
@@ -92,6 +98,8 @@ func generateGrantedPermissionsRow(itemID, canView, canEnterFrom, canEnterUntil,
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
 	assert.NoError(t, db.Exec("UPDATE items SET requires_explicit_entry=1").Error())
@@ -100,6 +108,8 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry(t *testing.T)
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHasBeenSetAlready(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
 	assert.NoError(t, db.Exec("UPDATE items SET requires_explicit_entry=1").Error())
@@ -130,6 +140,8 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHas
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_CanEnterFromIsInTheFuture(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
 	assert.NoError(t, db.Exec("UPDATE items SET requires_explicit_entry=1").Error())

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -34,6 +34,8 @@ func constructExpectedResultsForValidatedAtTests(t11, t12, t13, t14, t23, t24 *t
 }
 
 func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValidatedAts(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -75,6 +77,8 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_NoSuitableChildren(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -106,6 +110,8 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategoriesAreNotValidated(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -139,6 +145,8 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithCategoryValidation_IfAllAreValidated(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 
@@ -177,6 +185,8 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_IgnoresNoScoreItems(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
 

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -31,6 +31,8 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	validationType string,
 	prepareFunc func(*testing.T, *database.ResultStore), expectedResults []validatedResultRow,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixture(fixtures...)
 	defer func() { _ = db.Close() }()
 
@@ -64,6 +66,8 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			testResultStorePropagateValidated(t,
 				[]string{"results_propagation/_common"},
 				tt.name,
@@ -81,6 +85,8 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhenThereIsAtLeastOneValidatedChild(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
 		"One",
@@ -96,6 +102,8 @@ func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhe
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneStaysNonValidatedWhenThereAreNoValidatedChildren(
 	t *testing.T,
 ) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
 		"One",
@@ -247,6 +255,7 @@ func TestResultStore_Propagate_Validated(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
 			testResultStorePropagateValidated(t, testCase.fixtures,
 				testCase.validationType, testCase.prepareFunc, testCase.expectedResults)
 		})

--- a/app/database/user_integration_test.go
+++ b/app/database/user_integration_test.go
@@ -72,6 +72,8 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups: [{id: 101}, {id: 111}, {id: 121}]
 				users:

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -39,6 +39,8 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := setupDBForDeleteWithTrapsTests(t, currentTime)
 			defer func() { _ = db.Close() }()
 
@@ -51,6 +53,8 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 }
 
 func TestUserStore_DeleteWithTraps(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	currentTime := time.Now().UTC().Truncate(time.Second)
 	testhelpers.MockDBTime(currentTime.Format("2006-01-02T15:04:05"))
 	defer testhelpers.RestoreDBTime()
@@ -66,6 +70,8 @@ func TestUserStore_DeleteWithTraps(t *testing.T) {
 }
 
 func TestUserStore_DeleteWithTrapsByScope(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	currentTime := time.Now().UTC().Truncate(time.Second)
 	testhelpers.MockDBTime(currentTime.Format("2006-01-02T15:04:05"))
 	defer testhelpers.RestoreDBTime()

--- a/app/database/users_integration_test.go
+++ b/app/database/users_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	tests := []struct {
 		name   string
 		teamID int64
@@ -92,6 +94,8 @@ func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(
 		for _, withLock := range []bool{true, false} {
 			withLock := withLock
 			t.Run(tt.name+fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
+				testhelpers.SuppressOutputIfPasses(t)
+
 				store := database.NewDataStore(db)
 				var got bool
 				var err error


### PR DESCRIPTION
Otherwise, it's hard to find which test has failed.