### PR TITLE
Try calculating code coverage normally (per-package) is it had been done before

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ PWD=$(shell pwd)
 VERSION_FETCHING_CMD=git describe --always --dirty
 GOBUILD_VERSION_INJECTION=-ldflags="-X main.version=$(shell $(VERSION_FETCHING_CMD))"
 
-# Don't cover the packages ending by test, and separate the packages by a comma
-COVER_PACKAGES=$(shell $(GOLIST) ./app/... | grep -v "test$$" | tr '\n' ',')
-
 # Filter for tests
 ifdef FILTER
 	TEST_FILTER=-run $(FILTER)
@@ -85,7 +82,7 @@ test: $(TEST_REPORT_DIR)
 	$(Q)# Warning: DIRECTORY must be a directory, it will fail if it is a file
 	$(Q)# add FILTER=functionToTest to only test a certain function. functionToTest is a Regex.
 
-	$(Q)$(GOTEST) -gcflags=all=-l -race -coverpkg=$(COVER_PACKAGES) -coverprofile=$(TEST_REPORT_DIR)/coverage.txt -covermode=atomic -v $(TEST_DIR) -p 1 -parallel 1 $(TEST_FILTER)
+	$(Q)$(GOTEST) -gcflags=all=-l -race -coverprofile=$(TEST_REPORT_DIR)/coverage.txt -covermode=atomic -v $(TEST_DIR) -p 1 -parallel 1 $(TEST_FILTER)
 test-unit:
 	$(GOTEST) -gcflags=all=-l -race -cover -v -tags=unit $(TEST_DIR) $(TEST_FILTER)
 test-bdd:


### PR DESCRIPTION
Otherwise the coverage of a package depends on tests in other packages which can lead to situations where modifying a test of one package leads to having to add tests in other packages. Also, computing the code coverage for the whole project as a monolith contradicts the idea of the packages as separate libraries.

Also, there is a technical decision made in March 2019 stating the code coverage should be computed per-package (https://github.com/France-ioi/algorea-devdoc/pull/60/files#diff-36f14a930e1574edebba78bb847f62fb08ae10745ffe74ae65deed384d213285R71).