### PR TITLE
Handle the failed asserts of httpmock stubs properly, do not panic on them

### DIFF
--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -143,7 +143,10 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		ctx.TheLoginModuleLTIResultSendEndpointForUserIDContentIDScoreReturns)
 
 	s.After(func(contextCtx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-		ctx.ScenarioTeardown(sc, err)
+		tearDownErr := ctx.ScenarioTeardown(sc, err)
+		if err == nil {
+			err = tearDownErr
+		}
 		if restoreFunc != nil { // If we captured the output, restore it
 			restoreFunc(err != nil) // Pass through the output if the test failed
 		}
@@ -153,6 +156,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 				*parentOutputRestorerFunc = nil
 			}
 		}
-		return contextCtx, nil
+		return contextCtx, tearDownErr
 	})
 }

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -157,19 +157,18 @@ func (ctx *TestContext) tearDownApp() {
 }
 
 // ScenarioTeardown is called after each scenario to remove stubs.
-func (ctx *TestContext) ScenarioTeardown(*godog.Scenario, error) {
+func (ctx *TestContext) ScenarioTeardown(*godog.Scenario, error) (err error) {
 	RestoreDBTime()
 	monkey.UnpatchAll()
 	ctx.logsRestoreFunc()
 
 	defer func() {
-		if err := httpmock.AllStubsCalled(); err != nil {
-			panic(err) // godog doesn't allow to return errors from handlers (see https://github.com/cucumber/godog/issues/88)
-		}
+		err = httpmock.AllStubsCalled()
 		httpmock.DeactivateAndReset()
 	}()
 
 	ctx.tearDownApp()
+	return nil
 }
 
 // openDB opens a connection to the database.


### PR DESCRIPTION
Otherwise, it kills the whole test run skipping running next tests.