### PR TITLE
Always mock the DB time with a UTC timestamp

### DIFF
--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -31,7 +31,7 @@ func (ctx *TestContext) TimeNow(timeStr string) error {
 	if err := ctx.ServerTimeNow(timeStr); err != nil {
 		return err
 	}
-	MockDBTime(time.Now().Format(time.DateTime + ".999999999"))
+	MockDBTime(time.Now().UTC().Format(time.DateTime + ".999999999"))
 	return nil
 }
 
@@ -54,7 +54,7 @@ func (ctx *TestContext) TimeIsFrozen() error {
 	if err := ctx.ServerTimeIsFrozen(); err != nil {
 		return err
 	}
-	MockDBTime(time.Now().Format(time.DateTime + ".999999999"))
+	MockDBTime(time.Now().UTC().Format(time.DateTime + ".999999999"))
 	return nil
 }
 


### PR DESCRIPTION
Otherwise, tests fail sometimes depending on success of previous tests.