### PR TITLE
Make all the services compatible with transactions retrying and cover this feature with tests for all services + make error messages related to JSON parsing clearer

### DIFF
--- a/app/api/currentuser/refresh.go
+++ b/app/api/currentuser/refresh.go
@@ -30,9 +30,10 @@ func (srv *Service) refresh(w http.ResponseWriter, r *http.Request) service.APIE
 
 	userProfile, err := loginmodule.NewClient(srv.AuthConfig.GetString("loginModuleURL")).GetUserProfile(r.Context(), accessToken)
 	service.MustNotBeError(err)
+	badges := userProfile["badges"].([]database.Badge)
 
 	service.MustNotBeError(srv.GetStore(r).InTransaction(func(store *database.DataStore) error {
-		service.MustNotBeError(store.Groups().StoreBadges(userProfile["badges"].([]database.Badge), user.GroupID, false))
+		service.MustNotBeError(store.Groups().StoreBadges(badges, user.GroupID, false))
 		userProfile["latest_activity_at"] = database.Now()
 		userProfile["latest_profile_sync_at"] = database.Now()
 		delete(userProfile, "default_language")

--- a/app/api/groups/create_manager.robustness.feature
+++ b/app/api/groups/create_manager.robustness.feature
@@ -42,7 +42,7 @@ Feature: Make a user a group manager (groupManagerCreate) - robustness
       {
       """
     Then the response code should be 400
-    And the response error message should contain "Unexpected EOF"
+    And the response error message should contain "Invalid input JSON: unexpected EOF"
     And the table "group_managers" should stay unchanged
 
   Scenario: manager_id doesn't exist

--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -183,7 +183,9 @@ func (srv *Service) updateGroup(w http.ResponseWriter, r *http.Request) service.
 		}
 		service.MustNotBeError(err)
 
-		groupHasParticipants := groupStore.HasParticipants(groupID)
+		var groupHasParticipants bool
+		groupHasParticipants, err = groupStore.HasParticipants(groupID)
+		service.MustNotBeError(err)
 
 		var formData *formdata.FormData
 		formData, err = validateUpdateGroupInput(r, groupHasParticipants, &currentGroupData, s)

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -2,8 +2,6 @@ package groups
 
 import (
 	"errors"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -19,15 +17,15 @@ import (
 func Test_validateUpdateGroupInput(t *testing.T) {
 	tests := []struct {
 		name    string
-		json    string
+		jsonMap map[string]interface{}
 		wantErr bool
 	}{
-		{"code_lifetime=2147483647", `{"code_lifetime":2147483647}`, false},
-		{"code_lifetime=0", `{"code_lifetime":0}`, false},
-		{"code_lifetime=null", `{"code_lifetime":null}`, false},
+		{"code_lifetime=2147483647", map[string]interface{}{"code_lifetime": 2147483647}, false},
+		{"code_lifetime=0", map[string]interface{}{"code_lifetime": 0}, false},
+		{"code_lifetime=null", map[string]interface{}{"code_lifetime": nil}, false},
 
-		{"code_lifetime=2147483648", `{"code_lifetime":2147483648}`, true},
-		{"code_lifetime=", `{"code_lifetime":""}`, true},
+		{"code_lifetime=2147483648", map[string]interface{}{"code_lifetime": 2147483648}, true},
+		{"code_lifetime=", map[string]interface{}{"code_lifetime": ""}, true},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -39,8 +37,7 @@ func Test_validateUpdateGroupInput(t *testing.T) {
 			defer database.ClearAllDBEnums()
 
 			store := database.NewDataStore(db)
-			r, _ := http.NewRequest("PUT", "/", strings.NewReader(tt.json))
-			_, err := validateUpdateGroupInput(r, true, &groupUpdateInput{
+			_, err := validateUpdateGroupInput(tt.jsonMap, true, &groupUpdateInput{
 				CanManageValue: store.GroupManagers().CanManageIndexByName("memberships_and_group"),
 			}, store)
 			if (err != nil) != tt.wantErr {

--- a/app/api/groups/update_manager.robustness.feature
+++ b/app/api/groups/update_manager.robustness.feature
@@ -42,7 +42,7 @@ Feature: Update the group manager's permissions (groupManagerEdit) - robustness
       {
       """
     Then the response code should be 400
-    And the response error message should contain "Unexpected EOF"
+    And the response error message should contain "Invalid input JSON: unexpected EOF"
     And the table "group_managers" should stay unchanged
 
   Scenario: manager_id doesn't exist

--- a/app/api/items/update_result.go
+++ b/app/api/items/update_result.go
@@ -79,6 +79,10 @@ func (srv *Service) updateResult(w http.ResponseWriter, r *http.Request) service
 
 	input := resultUpdateRequest{}
 	formData := formdata.NewFormData(&input)
+	err = formData.ParseJSONRequestData(r)
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
 
 	apiError := service.NoError
 	err = srv.GetStore(r).InTransaction(func(store *database.DataStore) error {
@@ -92,12 +96,6 @@ func (srv *Service) updateResult(w http.ResponseWriter, r *http.Request) service
 		if !found {
 			apiError = service.InsufficientAccessRightsError
 			return apiError.Error // rollback
-		}
-
-		err = formData.ParseJSONRequestData(r)
-		if err != nil {
-			apiError = service.ErrInvalidRequest(err)
-			return err // rollback
 		}
 
 		data := formData.ConstructMapForDB()

--- a/app/api/items/update_result.robustness.feature
+++ b/app/api/items/update_result.robustness.feature
@@ -66,7 +66,12 @@ Feature: Update an attempt result - robustness
 
   Scenario: No result with given participant_id, attempt_id, item_id
     Given I am the user with id "11"
-    When I send a PUT request to "/items/200/attempts/3"
+    When I send a PUT request to "/items/200/attempts/3" with the following body:
+      """
+      {
+        "help_requested": true
+      }
+      """
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
 

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -114,7 +114,9 @@ func (srv *Service) updateThread(w http.ResponseWriter, r *http.Request) service
 		return service.ErrInvalidRequest(err)
 	}
 
-	apiError := service.NoError
+	rawRequestData, apiError := service.ResolveJSONBodyIntoMap(r)
+	service.MustBeNoError(apiError)
+
 	err = srv.GetStore(r).InTransaction(func(store *database.DataStore) error {
 		var oldThread struct {
 			Status        string
@@ -152,7 +154,7 @@ func (srv *Service) updateThread(w http.ResponseWriter, r *http.Request) service
 		formData.RegisterTranslation("can_request_help_to_when_own_thread",
 			"the group must be descendant of a group the participant can request help to")
 
-		err = formData.ParseJSONRequestData(r)
+		err = formData.ParseMapData(rawRequestData)
 		if err != nil {
 			apiError = service.ErrInvalidRequest(err)
 			return apiError.Error

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -109,9 +109,7 @@ func (conn *DB) inTransactionWithCount(txFunc func(*DB) error, count int64, txOp
 		return errors.New("transaction retries limit exceeded")
 	}
 
-	if count > 0 {
-		time.Sleep(time.Duration(float64(transactionDelayBetweenRetries) * (1.0 + (rand.Float64()-0.5)*0.1))) // ±5%
-	}
+	conn.sleepBeforeStartingTransactionIfNeeded(count)
 
 	txOpts := &sql.TxOptions{}
 	if len(txOptions) > 0 {
@@ -147,6 +145,12 @@ func (conn *DB) inTransactionWithCount(txFunc func(*DB) error, count int64, txOp
 	}()
 	err = txFunc(newDB(conn.ctx, txDB, nil))
 	return err
+}
+
+func (conn *DB) sleepBeforeStartingTransactionIfNeeded(count int64) {
+	if count > 0 && conn.ctx.Value(retryEachTransactionContextKey) == nil {
+		time.Sleep(time.Duration(float64(transactionDelayBetweenRetries) * (1.0 + (rand.Float64()-0.5)*0.1))) // ±5%
+	}
 }
 
 func (conn *DB) handleDeadlockAndLockWaitTimeout(txFunc func(*DB) error, count int64, errToHandle interface{}, rollbackErr error,

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -101,7 +101,7 @@ func (conn *DB) inTransaction(txFunc func(*DB) error, txOptions ...*sql.TxOption
 
 const (
 	transactionRetriesLimit        = 30
-	transactionDelayBetweenRetries = 1000 * time.Millisecond
+	transactionDelayBetweenRetries = 50 * time.Millisecond
 )
 
 func (conn *DB) inTransactionWithCount(txFunc func(*DB) error, count int64, txOptions ...*sql.TxOptions) (err error) {

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -257,18 +257,17 @@ func (s *GroupStore) GetDirectParticipantIDsOf(groupID int64) (participantIDs []
 }
 
 // HasParticipants checks whether a group has participants.
-func (s *GroupStore) HasParticipants(groupID int64) bool {
-	hasParticipants, err := s.
+// Must be called inside a transaction.
+func (s *GroupStore) HasParticipants(groupID int64) (hasParticipants bool, err error) {
+	return s.
 		Joins("JOIN groups_groups ON groups_groups.parent_group_id = groups.id").
 		Joins("JOIN `groups` AS participants ON participants.id = groups_groups.child_group_id").
 		Where("groups.id = ?", groupID).
 		Where("participants.type = 'User' OR participants.type = 'Team'").
+		WithSharedWriteLock().
 		Select("1").
 		Limit(1).
 		HasRows()
-	mustNotBeError(err)
-
-	return hasParticipants
 }
 
 // PossibleSubgroupsBySearchString returns a query for searching for possible subgroups of a user.

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -221,7 +221,7 @@ func (f *FormData) decodeRequestJSONDataIntoStruct(r *http.Request) error {
 	defer func() { _, _ = io.Copy(ioutil.Discard, r.Body) }()
 	err := json.NewDecoder(r.Body).Decode(&rawData)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid input JSON: %v", err)
 	}
 	f.decodeMapIntoStruct(rawData)
 	return nil

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -127,6 +127,7 @@ func (f *FormData) AllowUnknownFields() {
 }
 
 // ParseJSONRequestData parses and validates JSON from the request according to the structure definition.
+// As it reads out the request body, it should be called only once.
 func (f *FormData) ParseJSONRequestData(r *http.Request) error {
 	if err := f.decodeRequestJSONDataIntoStruct(r); err != nil {
 		return err

--- a/app/formdata/form_data_integration_test.go
+++ b/app/formdata/form_data_integration_test.go
@@ -40,7 +40,7 @@ func TestFormData_ParseJSONRequestData(t *testing.T) {
 			"invalid JSON",
 			&struct{}{},
 			`{id:123, name:"John"}`,
-			"invalid character 'i' looking for beginning of object key string",
+			"invalid input JSON: invalid character 'i' looking for beginning of object key string",
 			nil,
 		},
 		{

--- a/app/rand/rand_test.go
+++ b/app/rand/rand_test.go
@@ -52,3 +52,19 @@ func TestString(t *testing.T) {
 	Seed(1)
 	assert.Equal(t, "BpLnfgDsc2W", String(11))
 }
+
+func TestGetSource_SetSource(t *testing.T) {
+	Seed(1)
+	Int63()
+	Float64()
+	oldSource := GetSource()
+	values := make([]interface{}, 0, 4)
+	values = append(values, Float64(), Int63(), Float64(), Int63())
+	SetSource(oldSource)
+	newValues := make([]interface{}, 0, 4)
+	newValues = append(newValues, Float64(), Int63(), Float64(), Int63())
+	assert.Equal(t, values, newValues)
+	SetSource(oldSource)
+	newValues = []interface{}{Float64(), Int63(), Float64(), Int63()}
+	assert.Equal(t, values, newValues)
+}

--- a/app/service/parameters.go
+++ b/app/service/parameters.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -210,4 +212,16 @@ func ResolveURLQueryPathInt64SliceFieldWithLimit(r *http.Request, paramName stri
 		return nil, fmt.Errorf("no more than %d %s expected", limit, paramName)
 	}
 	return ids, nil
+}
+
+// ResolveJSONBodyIntoMap reads the request body and parses it as JSON into a map.
+// As it reads out the body, it can only be called once.
+func ResolveJSONBodyIntoMap(r *http.Request) (map[string]interface{}, APIError) {
+	var rawRequestData map[string]interface{}
+	defer func() { _, _ = io.Copy(io.Discard, r.Body) }()
+	err := json.NewDecoder(r.Body).Decode(&rawRequestData)
+	if err != nil {
+		return nil, ErrInvalidRequest(fmt.Errorf("invalid input JSON: %v", err))
+	}
+	return rawRequestData, NoError
 }

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -17,7 +17,6 @@ import (
 	"github.com/thingful/httpmock"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app"
-	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	log "github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/rand"
@@ -63,14 +62,6 @@ func (ctx *TestContext) SetupTestContext(sc *godog.Scenario) {
 	var logHook *test.Hook
 	logHook, ctx.logsRestoreFunc = log.MockSharedLoggerHook()
 	ctx.logsHook = &loggingtest.Hook{Hook: logHook}
-	database.SetOnStartOfTransactionToBeRetriedForcefullyHook(func() {
-		ctx.previousGeneratedGroupCodeIndex = ctx.generatedGroupCodeIndex
-		ctx.previousRandSource = rand.GetSource()
-	})
-	database.SetOnForcefulRetryOfTransactionHook(func() {
-		ctx.generatedGroupCodeIndex = ctx.previousGeneratedGroupCodeIndex
-		rand.SetSource(ctx.previousRandSource)
-	})
 
 	ctx.setupApp()
 	ctx.userID = 0 // not set

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -29,24 +29,26 @@ type dbquery struct {
 
 // TestContext implements context for tests.
 type TestContext struct {
-	application          *app.Application // do NOT call it directly, use `app()`
-	userID               int64            // userID that will be used for the next requests
-	user                 string           // user reference of the logged user
-	featureQueries       []dbquery
-	lastResponse         *http.Response
-	lastResponseBody     string
-	logsHook             *loggingtest.Hook
-	logsRestoreFunc      func()
-	inScenario           bool
-	db                   *sql.DB
-	dbTableData          map[string]*godog.Table
-	templateSet          *jet.Set
-	requestHeaders       map[string][]string
-	referenceToIDMap     map[string]int64
-	idToReferenceMap     map[int64]string
-	currentThreadKey     map[string]string
-	allUsersGroup        string
-	needPopulateDatabase bool
+	application                     *app.Application // do NOT call it directly, use `app()`
+	userID                          int64            // userID that will be used for the next requests
+	user                            string           // user reference of the logged user
+	featureQueries                  []dbquery
+	lastResponse                    *http.Response
+	lastResponseBody                string
+	logsHook                        *loggingtest.Hook
+	logsRestoreFunc                 func()
+	inScenario                      bool
+	db                              *sql.DB
+	dbTableData                     map[string]*godog.Table
+	templateSet                     *jet.Set
+	requestHeaders                  map[string][]string
+	referenceToIDMap                map[string]int64
+	idToReferenceMap                map[int64]string
+	currentThreadKey                map[string]string
+	allUsersGroup                   string
+	needPopulateDatabase            bool
+	previousGeneratedGroupCodeIndex int
+	generatedGroupCodeIndex         int
 }
 
 const (


### PR DESCRIPTION
1. Make cucumber tests implicitly verify that all the services work fine when their transactions are retried.
2. Fix all the services failing when their transactions are retried.
3. Sleep 50ms instead of 1s on average before retrying a transaction.
4. Make error responses a bit more clear when JSON input is broken.
5. Add some obvious improvements related to row locking.

Fixes #1196 