### PR TITLE
Suppress output of passing integration tests in app/service

### DIFF
--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestGetParticipantIDFromRequest(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1, type: Class}, {id: 2, type: Team}, {id: 3, type: Team}, {id: 4, type: User}, {id: 5, type: User}]
 		users: [{group_id: 4, login: john}, {group_id: 5, login: jane}]
@@ -59,6 +61,8 @@ func TestGetParticipantIDFromRequest(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		testhelpers.SuppressOutputIfPasses(t)
+
 		test := test
 		participantID, apiError := service.GetParticipantIDFromRequest(
 			&http.Request{URL: &url.URL{RawQuery: test.query}}, &database.User{GroupID: 4}, store)

--- a/app/service/propagation_integration_test.go
+++ b/app/service/propagation_integration_test.go
@@ -64,6 +64,8 @@ func TestSchedulePropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups:
 					- {id: 1, type: Class}

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestBase_ResolveWatchedGroupID(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1, type: Class}, {id: 2, type: Team}, {id: 3, type: Other}, {id: 4, type: User}, {id: 5, type: User}, {id: 6, type: Team}]
 		groups_groups:
@@ -58,6 +60,8 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testhelpers.SuppressOutputIfPasses(t)
+
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
 			watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(req)
 			assert.Equal(t, tt.wantWatchedGroupID, watchedGroupID)


### PR DESCRIPTION
Otherwise it's hard to find output of failed tests.