### PR TITLE
Make groups&items propagations twice faster, do not join groups table to determine group memberships, do not mark new items for propagation, run/schedule propagations in GroupGroupStore.Transition() only when needed + testing-related fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - image: circleci/mysql:8.0.28
         command: --default-authentication-plugin=mysql_native_password --max-allowed-packet=10485760
         environment:
-          MYSQL_USER: franceioi
+          MYSQL_USER: algorea
           MYSQL_PASSWORD: dummy_password
           MYSQL_DATABASE: algorea_example
           MYSQL_ROOT_PASSWORD: root

--- a/app/api/answers/create_answer.robustness.feature
+++ b/app/api/answers/create_answer.robustness.feature
@@ -4,8 +4,9 @@ Feature: Create a 'saved' answer - robustness
       | login | group_id |
       | john  | 101      |
     And the database table "groups" also has the following row:
-      | id | type |
-      | 13 | Team |
+      | id | type  |
+      | 13 | Team  |
+      | 22 | Class |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |

--- a/app/api/answers/get_answer.go
+++ b/app/api/answers/get_answer.go
@@ -63,8 +63,8 @@ func (srv *Service) getAnswer(rw http.ResponseWriter, httpReq *http.Request) ser
 	userAndHisTeamsQuery := store.Raw("SELECT id FROM ? `teams` UNION ALL SELECT ?",
 		store.ActiveGroupGroups().
 			WhereUserIsMember(user).
-			Joins("JOIN `groups` ON groups.id = groups_groups_active.parent_group_id AND groups.type='Team'").
-			Select("groups.id").SubQuery(),
+			Where("groups_groups_active.is_team_membership = 1").
+			Select("groups_groups_active.parent_group_id AS id").SubQuery(),
 		user.GroupID)
 
 	// a participant should have at least 'content' access to the answers.item_id
@@ -77,7 +77,7 @@ func (srv *Service) getAnswer(rw http.ResponseWriter, httpReq *http.Request) ser
 		Joins("JOIN `groups_ancestors_active` ON groups_ancestors_active.ancestor_group_id = permissions.group_id").
 		Joins("JOIN `groups_groups_active` ON groups_groups_active.parent_group_id = groups_ancestors_active.child_group_id").
 		Where("groups_groups_active.child_group_id = ?", user.GroupID).
-		Joins("JOIN `groups` ON groups.id = groups_groups_active.parent_group_id AND groups.type='Team'").
+		Where("groups_groups_active.is_team_membership = 1").
 		WherePermissionIsAtLeast("view", "content").
 		Where("permissions.item_id = answers.item_id").
 		Select("1").Limit(1).SubQuery()

--- a/app/api/answers/submit.feature
+++ b/app/api/answers/submit.feature
@@ -6,10 +6,6 @@ Feature: Submit a new answer
     And the database has the following table "groups":
       | id  | name | type |
       | 201 | team | Team |
-    And the database has the following table "groups_groups":
-      | parent_group_id | child_group_id |
-      | 22              | 13             |
-      | 201             | 101            |
     And the groups ancestors are computed
     And the database has the following table "items":
       | id | default_language_tag |

--- a/app/api/answers/submit.robustness.feature
+++ b/app/api/answers/submit.robustness.feature
@@ -3,9 +3,6 @@ Feature: Submit a new answer - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table "groups_groups":
-      | parent_group_id | child_group_id |
-      | 22              | 13             |
     And the groups ancestors are computed
     And the database has the following table "items":
       | id | read_only | default_language_tag |

--- a/app/api/answers/update_current.robustness.feature
+++ b/app/api/answers/update_current.robustness.feature
@@ -3,6 +3,10 @@ Feature: Update participant's current answer
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
+    And the database has the following table "groups":
+      | id  |
+      | 13  |
+      | 22  |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 22              | 13             |

--- a/app/api/currentuser/get_dump.feature
+++ b/app/api/currentuser/get_dump.feature
@@ -95,28 +95,32 @@ Feature: Export the short version of the current user's data
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Our Team", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Our Team", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 1
         },
         {
           "child_group_id": "11", "parent_group_id": "5",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Other people", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Other people", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         },
         {
           "child_group_id": "11", "parent_group_id": "6",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Another Class", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Another Class", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         },
         {
           "child_group_id": "11", "parent_group_id": "9",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Some other friends", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Some other friends", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         }
       ],
       "group_managers": [

--- a/app/api/currentuser/get_full_dump.feature
+++ b/app/api/currentuser/get_full_dump.feature
@@ -136,35 +136,40 @@ Feature: Export the current user's data
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Our Team", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Our Team", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 1
         },
         {
           "child_group_id": "11", "parent_group_id": "5",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Other people", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Other people", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         },
         {
           "child_group_id": "11", "parent_group_id": "6",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Another Class", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Another Class", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         },
         {
           "child_group_id": "11", "parent_group_id": "9",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Some other friends", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Some other friends", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         },
         {
           "child_group_id": "11", "parent_group_id": "10",
           "lock_membership_approved_at": null, "lock_membership_approved": 0,
           "personal_info_view_approved_at": null, "personal_info_view_approved": 0,
           "watch_approved_at": null, "watch_approved": 0,
-          "name": "Secret group", "expires_at": "9999-12-31T23:59:59Z"
+          "name": "Secret group", "expires_at": "9999-12-31T23:59:59Z",
+          "is_team_membership": 0
         }
       ],
       "group_managers": [

--- a/app/api/currentuser/get_full_dump.go
+++ b/app/api/currentuser/get_full_dump.go
@@ -272,7 +272,7 @@ func buildQueryForGettingAttemptsOrResults(store *database.DataStore, user *data
 				Select(columns).
 				Where("participant_id IN (?)",
 					store.GroupGroups().WhereUserIsMember(user).
-						Select("`groups`.id").
-						Joins("JOIN `groups` ON `groups`.id = groups_groups.parent_group_id AND `groups`.type = 'Team'").
+						Where("groups_groups.is_team_membership = 1").
+						Select("groups_groups.parent_group_id AS id").
 						QueryExpr()))
 }

--- a/app/api/currentuser/get_full_dump.go
+++ b/app/api/currentuser/get_full_dump.go
@@ -85,6 +85,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 			service.MustNotBeError(store.Sessions().
 				Where("user_id = ?", user.GroupID).
 				Select(columns + ", '***' AS refresh_token").
+				Order("session_id").
 				ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 
@@ -95,6 +96,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 				Joins("JOIN sessions ON sessions.session_id = access_tokens.session_id").
 				Where("sessions.user_id = ?", user.GroupID).
 				Select(columns + ", '***' AS token").
+				Order("session_id").
 				ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 	}
@@ -121,6 +123,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 		writeComma(w)
 		writeJSONObjectArrayElement("answers", w, func(writer io.Writer) {
 			service.MustNotBeError(store.Answers().Where("author_id = ?", user.GroupID).
+				Order("id").
 				ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 
@@ -144,6 +147,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 			Where("child_group_id = ?", user.GroupID).
 			Joins("JOIN `groups` ON `groups`.id = parent_group_id").
 			Select(columns + ", `groups`.name").
+			Order("parent_group_id").
 			ScanAndHandleMaps(streamerFunc(w)).Error())
 	})
 
@@ -154,6 +158,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 			Where("manager_id = ?", user.GroupID).
 			Joins("JOIN `groups` ON `groups`.id = group_id").
 			Select(columns + ", `groups`.name").
+			Order("group_id").
 			ScanAndHandleMaps(streamerFunc(w)).Error())
 	})
 
@@ -176,6 +181,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 				Where("member_id = ?", user.GroupID).
 				Joins("JOIN `groups` ON `groups`.id = group_id").
 				Select(columns + ", `groups`.name").
+				Order("group_id").
 				ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 	}

--- a/app/api/currentuser/get_group_activities.robustness.feature
+++ b/app/api/currentuser/get_group_activities.robustness.feature
@@ -2,6 +2,7 @@ Feature: Get root activities for a participant group - robustness
   Background:
     Given the database has the following table "groups":
       | id | name      | type  | root_activity_id | created_at          |
+      | 1  | Class     | Class | null             | 2019-01-30 08:26:46 |
       | 11 | jdoe      | User  | null             | 2019-01-30 08:26:48 |
       | 13 | Group B   | Team  | 230              | 2019-01-30 08:26:46 |
       | 14 | Group C   | Team  | 230              | 2019-01-30 08:26:46 |

--- a/app/api/currentuser/get_group_skills.robustness.feature
+++ b/app/api/currentuser/get_group_skills.robustness.feature
@@ -2,6 +2,7 @@ Feature: Get root skills for a participant group - robustness
   Background:
     Given the database has the following table "groups":
       | id | name      | type  | root_activity_id | created_at          |
+      | 1  | Class     | Class | null             | 2019-01-30 08:26:46 |
       | 13 | Group B   | Team  | 230              | 2019-01-30 08:26:46 |
       | 14 | Group C   | Team  | 230              | 2019-01-30 08:26:46 |
     And the database has the following table "languages":

--- a/app/api/currentuser/get_managed_groups.feature
+++ b/app/api/currentuser/get_managed_groups.feature
@@ -1,11 +1,14 @@
 Feature: List groups managed by the current user
   Background:
     Given the database has the following table "groups":
-      | id | name          | type  | description |
-      | 5  | Group         | Class | null        |
-      | 13 | Our Class     | Class | null        |
-      | 14 | Our Friends   | Other | null        |
-      | 15 | Another Group | Other | Super Group |
+      | id | name          | type    | description |
+      | 1  | Friends       | Friends | null        |
+      | 5  | Group         | Class   | null        |
+      | 6  | Club          | Club    | null        |
+      | 9  | Other         | Other   | null        |
+      | 13 | Our Class     | Class   | null        |
+      | 14 | Our Friends   | Other   | null        |
+      | 15 | Another Group | Other   | Super Group |
     And the database has the following users:
       | group_id | login |
       | 21       | owner |

--- a/app/api/groups/get_current_user_team_by_item.go
+++ b/app/api/groups/get_current_user_team_by_item.go
@@ -54,7 +54,8 @@ func (srv *Service) getCurrentUserTeamByItem(w http.ResponseWriter, r *http.Requ
 
 	var teamID int64
 	user := srv.GetUser(r)
-	err = srv.GetStore(r).Groups().TeamGroupForTeamItemAndUser(itemID, user).PluckFirst("groups.id", &teamID).Error()
+	err = srv.GetStore(r).ActiveGroupGroups().TeamGroupForTeamItemAndUser(itemID, user).
+		PluckFirst("groups_groups_active.parent_group_id", &teamID).Error()
 	if gorm.IsRecordNotFoundError(err) {
 		return service.ErrNotFound(errors.New("no team for this item"))
 	}

--- a/app/api/groups/get_user_progress.go
+++ b/app/api/groups/get_user_progress.go
@@ -206,10 +206,9 @@ func joinUserProgressResults(db *database.DB, userID interface{}) *database.DB {
 	return db.
 		Joins(`
 			LEFT JOIN LATERAL (
-				SELECT STRAIGHT_JOIN groups.id
+				SELECT STRAIGHT_JOIN groups_groups_active.parent_group_id AS id
 				FROM groups_groups_active
-				JOIN `+"`groups`"+` ON groups.id = groups_groups_active.parent_group_id
-				WHERE groups.type = 'Team' AND groups_groups_active.child_group_id = ?
+				WHERE groups_groups_active.is_team_membership = 1 AND groups_groups_active.child_group_id = ?
 			) teams ON 1`, userID).
 		Joins(`
 			LEFT JOIN LATERAL (

--- a/app/api/groups/get_user_progress_csv.go
+++ b/app/api/groups/get_user_progress_csv.go
@@ -266,10 +266,9 @@ func joinUserProgressResultsForCSV(db *database.DB, userID interface{}) *databas
 	return db.
 		Joins(`
 			LEFT JOIN LATERAL (
-				SELECT STRAIGHT_JOIN groups.id
+				SELECT STRAIGHT_JOIN groups_groups_active.parent_group_id AS id
 				FROM groups_groups_active
-				JOIN `+"`groups`"+` ON groups.id = groups_groups_active.parent_group_id
-				WHERE groups.type = 'Team' AND groups_groups_active.child_group_id = ?
+				WHERE groups_groups_active.is_team_membership = 1 AND groups_groups_active.child_group_id = ?
 			) teams ON 1`, userID).
 		Joins(`
 			LEFT JOIN LATERAL (

--- a/app/api/items/ask_hint.feature
+++ b/app/api/items/ask_hint.feature
@@ -8,7 +8,6 @@ Feature: Ask for a hint
       | 201 | team | Team |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
-      | 22              | 13             |
       | 201             | 101            |
     And the groups ancestors are computed
     And the database has the following table "platforms":

--- a/app/api/items/ask_hint.robustness.feature
+++ b/app/api/items/ask_hint.robustness.feature
@@ -3,10 +3,6 @@ Feature: Ask for a hint - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table "groups_groups":
-      | parent_group_id | child_group_id |
-      | 22              | 13             |
-    And the groups ancestors are computed
     And the database has the following table "platforms":
       | id | regexp                     | public_key                | priority |
       | 10 | https://platformwithkey    | {{taskPlatformPublicKey}} | 0        |

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -264,8 +264,6 @@ func validateAndInsertItem(srv *Service, r *http.Request) (itemID int64, apiErro
 
 		setNewItemAsRootActivityOrSkill(store, formData, &input, itemID)
 
-		service.MustNotBeError(store.ItemItems().CreateNewAncestors())
-
 		return nil
 	})
 	if err == nil {
@@ -617,6 +615,8 @@ func (srv *Service) insertItem(store *database.DataStore, user *database.User, f
 		parentChildSpec = append(parentChildSpec,
 			constructItemsItemsForChildren(newItemRequest.Children, itemID)...)
 		insertItemItems(store, parentChildSpec)
+
+		service.MustNotBeError(store.ItemItems().CreateNewAncestors())
 	}
 
 	return itemID, service.NoError

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -8,7 +8,6 @@ Feature: Save grading result
       | 201 | team | Team |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
-      | 22              | 13             |
       | 201             | 101            |
     And the groups ancestors are computed
     And the database has the following table "platforms":

--- a/app/api/items/save_grade.robustness.feature
+++ b/app/api/items/save_grade.robustness.feature
@@ -3,10 +3,6 @@ Feature: Save grading result - robustness
     Given the database has the following users:
       | login | group_id |
       | john  | 101      |
-    And the database has the following table "groups_groups":
-      | parent_group_id | child_group_id |
-      | 22              | 13             |
-    And the groups ancestors are computed
     And the database has the following table "platforms":
       | id | regexp                                             | priority | public_key                |
       | 10 | http://taskplatform.mblockelet.info/task.html\?.*  | 2        | {{taskPlatformPublicKey}} |

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -13,7 +13,7 @@ const groups = "groups"
 //
 // Note: rows in *_propagate tables with `ancestors_computation_state`="todo"
 // are added in the database in SQL triggers:
-// - after_insert_items/groups
+// - after_insert_items
 // - after_update_groups_groups
 // - before_insert_items_items/groups_groups
 // - before_delete_items_items/groups_groups.
@@ -34,39 +34,46 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 
 	mustNotBeError(s.db.Exec(query).Error)
 
-	hasChanges := true
+	createTemporaryTableQuery := "CREATE TEMPORARY TABLE " + objectName + "_propagate_processing (id BIGINT NOT NULL)"
+	dropTemporaryTableQuery := "DROP TEMPORARY TABLE IF EXISTS " + objectName + "_propagate_processing"
+	mustNotBeError(s.db.Exec(createTemporaryTableQuery).Error)
+	defer func() {
+		mustNotBeError(s.db.Exec(dropTemporaryTableQuery).Error)
+	}()
 
 	relationsTable := objectName + "_" + objectName
 
-	var additionalJoin, additionalLocking string
+	additionalRelationCondition := "1"
 	if objectName == groups {
-		additionalJoin = " JOIN `groups` AS parent ON parent.id = groups_groups.parent_group_id AND parent.type != 'Team' "
-		additionalLocking = " FOR SHARE OF parent "
+		additionalRelationCondition = "groups_groups.is_team_membership = 0"
 	}
 	// Next queries will be executed in the loop
 
-	// We mark as "processing" all objects that were marked as 'todo' and that have no parents not marked as 'done'
+	// We mark as processing all objects that were marked as 'todo' and that have no parents not marked as 'done'.
 	// This way we prevent infinite looping as we never process objects that are descendants of themselves
 
 	/* #nosec */
 	markAsProcessingQuery := `
-		UPDATE ` + objectName + `_propagate AS children
-		SET children.ancestors_computation_state='processing'
-		WHERE children.ancestors_computation_state = 'todo' AND NOT EXISTS (
-			SELECT 1 FROM (
+		INSERT INTO ` + objectName + `_propagate_processing (id)
+		SELECT id
+		FROM ` + objectName + `_propagate AS children
+		WHERE children.ancestors_computation_state = 'todo' AND
+			NOT EXISTS (
 				SELECT 1
 				FROM ` + relationsTable + `
 					JOIN ` + objectName + `_propagate
 						ON ` + objectName + `_propagate.id = ` + relationsTable + `.parent_` + singleObjectName + `_id AND
-							 ` + objectName + `_propagate.ancestors_computation_state <> 'done'
-					` + additionalJoin + `
-				WHERE ` + relationsTable + `.child_` + singleObjectName + `_id = children.id
+							 ` + objectName + `_propagate.ancestors_computation_state = 'todo'
+				WHERE ` + relationsTable + `.child_` + singleObjectName + `_id = children.id AND ` + additionalRelationCondition + `
+				LIMIT 1
 				FOR SHARE OF ` + relationsTable + `
 				FOR UPDATE OF ` + objectName + `_propagate
-				` + additionalLocking + `
-			) has_undone_parents
-		)`
+			)
+		FOR UPDATE OF children` // #nosec
 
+	createTemporaryTable, err := s.db.CommonDB().Prepare(createTemporaryTableQuery)
+	mustNotBeError(err)
+	defer func() { mustNotBeError(createTemporaryTable.Close()) }()
 	markAsProcessing, err := s.db.CommonDB().Prepare(markAsProcessingQuery)
 	mustNotBeError(err)
 	defer func() { mustNotBeError(markAsProcessing.Close()) }()
@@ -77,18 +84,17 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 
 	if objectName == groups {
 		expiresAtColumn = ", expires_at"
-		expiresAtValueJoin = ", LEAST(groups_ancestors_join.expires_at, groups_groups.expires_at)"
+		expiresAtValueJoin = ", MAX(LEAST(groups_ancestors_join.expires_at, groups_groups.expires_at)) AS max_expires_at"
 		ignore = ""
 	}
 
-	// For every object marked as 'processing', we compute all its ancestors
+	// For every object marked as processing, we compute all its ancestors
 	recomputeQueries := make([]string, 0, 3)
 	recomputeQueries = append(recomputeQueries, `
 		DELETE `+objectName+`_ancestors
 		FROM `+objectName+`_ancestors
-			JOIN `+objectName+`_propagate
-				ON `+objectName+`_propagate.id = `+objectName+`_ancestors.child_`+singleObjectName+`_id
-		WHERE `+objectName+`_propagate.ancestors_computation_state = 'processing'`, `
+			JOIN `+objectName+`_propagate_processing
+				ON `+objectName+`_propagate_processing.id = `+objectName+`_ancestors.child_`+singleObjectName+`_id`, `
 		INSERT `+ignore+` INTO `+objectName+`_ancestors
 		(
 			ancestor_`+singleObjectName+`_id,
@@ -100,39 +106,35 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 			`+relationsTable+`.child_`+singleObjectName+`_id
 			`+expiresAtValueJoin+`
 		FROM `+relationsTable+` AS `+relationsTable+`
-		`+additionalJoin+`
 		JOIN `+objectName+`_ancestors AS `+objectName+`_ancestors_join ON (
 			`+objectName+`_ancestors_join.child_`+singleObjectName+`_id = `+relationsTable+`.parent_`+singleObjectName+`_id
 		)
-		JOIN `+objectName+`_propagate ON (
-			`+relationsTable+`.child_`+singleObjectName+`_id = `+objectName+`_propagate.id
+		JOIN `+objectName+`_propagate_processing ON (
+			`+relationsTable+`.child_`+singleObjectName+`_id = `+objectName+`_propagate_processing.id
 		)
-		WHERE
-			`+objectName+`_propagate.ancestors_computation_state = 'processing'`) // #nosec
+		WHERE `+additionalRelationCondition) // #nosec
 	if objectName == groups {
 		recomputeQueries[0] += `
 			AND groups_ancestors.ancestor_group_id != groups_ancestors.child_group_id` // do not delete group ancestors with is_self=1
 		recomputeQueries[1] += `
-				AND NOW() < groups_groups.expires_at AND
-				NOW() < LEAST(groups_ancestors_join.expires_at, groups_groups.expires_at)
-			FOR UPDATE OF ` + objectName + `_propagate
+				AND NOW() < groups_groups.expires_at
+				AND NOW() < groups_ancestors_join.expires_at
+			GROUP BY groups_groups.child_group_id, groups_ancestors_join.ancestor_group_id
+			HAVING NOW() < max_expires_at
+			FOR UPDATE OF ` + objectName + `_propagate_processing
 			FOR SHARE OF ` + objectName + `_ancestors_join
-			FOR SHARE OF ` + relationsTable + `
-			FOR SHARE OF parent
-			ON DUPLICATE KEY UPDATE
-				expires_at = GREATEST(groups_ancestors.expires_at, LEAST(groups_ancestors_join.expires_at, groups_groups.expires_at))`
+			FOR SHARE OF ` + relationsTable
 	} else {
 		recomputeQueries[1] += `
-			FOR UPDATE OF ` + objectName + `_propagate
+			FOR UPDATE OF ` + objectName + `_propagate_processing
 			FOR SHARE OF ` + objectName + `_ancestors_join
 			FOR SHARE OF ` + relationsTable
 		recomputeQueries = append(recomputeQueries, `
 			INSERT IGNORE INTO items_ancestors (ancestor_item_id, child_item_id)
 			SELECT items_items.parent_item_id, items_items.child_item_id
 			FROM items_items
-			JOIN items_propagate ON items_items.child_item_id = items_propagate.id
-			WHERE items_propagate.ancestors_computation_state = 'processing'
-			FOR UPDATE OF items_propagate
+			JOIN items_propagate_processing ON items_items.child_item_id = items_propagate_processing.id
+			FOR UPDATE OF items_propagate_processing
 			FOR SHARE OF items_items`) // #nosec
 	}
 
@@ -144,16 +146,20 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 		defer func(i int) { mustNotBeError(recomputeAncestors[i].Close()) }(i)
 	}
 
-	// Objects marked as 'processing' are now marked as 'done'
+	// Objects marked as processing are now marked as 'done'
 	markAsDoneQuery := `
 		UPDATE ` + objectName + `_propagate
-		SET ancestors_computation_state = 'done'
-		WHERE ancestors_computation_state = 'processing'` // #nosec
+		JOIN ` + objectName + `_propagate_processing
+			ON ` + objectName + `_propagate.id = ` + objectName + `_propagate_processing.id
+		SET ancestors_computation_state = 'done'` // #nosec
 	markAsDone, err := s.db.CommonDB().Prepare(markAsDoneQuery)
 	mustNotBeError(err)
 	defer func() { mustNotBeError(markAsDone.Close()) }()
+	dropTemporaryTable, err := s.db.CommonDB().Prepare(dropTemporaryTableQuery)
+	mustNotBeError(err)
+	defer func() { mustNotBeError(dropTemporaryTable.Close()) }()
 
-	for hasChanges {
+	for {
 		_, err = markAsProcessing.Exec()
 		mustNotBeError(err)
 		for i := 0; i < len(recomputeAncestors); i++ {
@@ -167,6 +173,14 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 		var rowsAffected int64
 		rowsAffected, err = result.RowsAffected()
 		mustNotBeError(err)
-		hasChanges = rowsAffected > 0
+		if rowsAffected == 0 {
+			break
+		}
+
+		_, err = dropTemporaryTable.Exec()
+		mustNotBeError(err)
+
+		_, err = createTemporaryTable.Exec()
+		mustNotBeError(err)
 	}
 }

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -13,7 +13,6 @@ const groups = "groups"
 //
 // Note: rows in *_propagate tables with `ancestors_computation_state`="todo"
 // are added in the database in SQL triggers:
-// - after_insert_items
 // - after_update_groups_groups
 // - before_insert_items_items/groups_groups
 // - before_delete_items_items/groups_groups.

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -257,3 +257,23 @@ func TestGroupGroupStore_CreateNewAncestors_HandlesErrorOfCreateNewAncestors(t *
 
 	assert.NoError(t, dbMock.ExpectationsWereMet())
 }
+
+func TestGroupGroupStore_TeamGroupForTeamItemAndUser(t *testing.T) {
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	mockUser := &User{GroupID: 2, DefaultLanguage: "fr"}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT `groups_groups_active`.* FROM `groups_groups_active` "+
+		"JOIN attempts ON attempts.participant_id = groups_groups_active.parent_group_id AND attempts.root_item_id = ? AND "+
+		"NOW() < attempts.allows_submissions_until "+
+		"WHERE (groups_groups_active.is_team_membership = 1) AND (groups_groups_active.child_group_id = ?) "+
+		"ORDER BY groups_groups_active.parent_group_id LIMIT 1")).
+		WithArgs(1234, 2).
+		WillReturnRows(mock.NewRows([]string{"id"}))
+
+	var result []interface{}
+	err := NewDataStore(db).ActiveGroupGroups().TeamGroupForTeamItemAndUser(1234, mockUser).Scan(&result).Error()
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -169,10 +169,14 @@ func TestGroupGroupStore_CreateRelationsWithoutChecking(t *testing.T) {
 
 func setMockExpectationsForCreateNewAncestors(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectPrepare("")
 	mock.ExpectPrepare("")
 	mock.ExpectPrepare("")
 	mock.ExpectPrepare("")
+	mock.ExpectPrepare("")
+	mock.ExpectPrepare("")
+	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -28,24 +28,6 @@ func (s *GroupStore) ManagedBy(user *User) *DB {
 					user_ancestors.child_group_id = ?`, user.GroupID)
 }
 
-// TeamGroupForTeamItemAndUser returns a composable query for getting a team that
-//  1. the given user is a member of
-//  2. has an unexpired attempt with root_item_id = `itemID`.
-//
-// If more than one team is found (which should be impossible), the one with the smallest `groups.id` is returned.
-func (s *GroupStore) TeamGroupForTeamItemAndUser(itemID int64, user *User) *DB {
-	return s.
-		Joins(`JOIN groups_groups_active
-			ON groups_groups_active.parent_group_id = groups.id AND
-				groups_groups_active.child_group_id = ?`, user.GroupID).
-		Joins(`
-			JOIN attempts ON attempts.participant_id = groups.id AND
-				attempts.root_item_id = ? AND NOW() < attempts.allows_submissions_until`, itemID).
-		Where("groups.type = 'Team'").
-		Order("groups.id").
-		Limit(1) // The current API doesn't allow users to join multiple teams working on the same item
-}
-
 // TeamGroupForUser returns a composable query for getting team group of the given user with given id.
 func (s *GroupStore) TeamGroupForUser(teamGroupID int64, user *User) *DB {
 	return s.

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -363,3 +363,16 @@ func Test_GroupStore_DeleteGroup(t *testing.T) {
 	assert.NoError(t, groupStore.Table("groups_propagate").Pluck("id", &ids).Error())
 	assert.Empty(t, ids)
 }
+
+func TestGroupStore_TriggerBeforeUpdate_RefusesToModifyType(t *testing.T) {
+	testhelpers.SuppressOutputIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixtureString(`groups: [{id: 1}]`)
+	defer func() { _ = db.Close() }()
+
+	const expectedErrorMessage = "Error 1644: Unable to change immutable groups.type"
+
+	groupGroupStore := database.NewDataStore(db).Groups()
+	result := groupGroupStore.ByID(1).UpdateColumn("type", "Team")
+	assert.EqualError(t, result.Error(), expectedErrorMessage)
+}

--- a/app/database/group_store_test.go
+++ b/app/database/group_store_test.go
@@ -29,27 +29,6 @@ func TestGroupStore_ManagedBy(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGroupStore_TeamGroupForTeamItemAndUser(t *testing.T) {
-	db, mock := NewDBMock()
-	defer func() { _ = db.Close() }()
-
-	mockUser := &User{GroupID: 2, DefaultLanguage: "fr"}
-
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT `groups`.* FROM `groups` "+
-		"JOIN groups_groups_active ON groups_groups_active.parent_group_id = groups.id AND "+
-		"groups_groups_active.child_group_id = ? "+
-		"JOIN attempts ON attempts.participant_id = groups.id AND attempts.root_item_id = ? AND "+
-		"NOW() < attempts.allows_submissions_until "+
-		"WHERE (groups.type = 'Team') ORDER BY `groups`.`id` LIMIT 1")).
-		WithArgs(2, 1234).
-		WillReturnRows(mock.NewRows([]string{"id"}))
-
-	var result []interface{}
-	err := NewDataStore(db).Groups().TeamGroupForTeamItemAndUser(1234, mockUser).Scan(&result).Error()
-	assert.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
 func TestGroupStore_TeamGroupForUser(t *testing.T) {
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -51,7 +51,6 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 	var propagateResult []itemPropagateResultRow
 	assert.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
 	assert.Equal(t, []itemPropagateResultRow{
-		{ID: 1, AncestorsComputationState: "done"},
 		{ID: 2, AncestorsComputationState: "done"},
 		{ID: 3, AncestorsComputationState: "done"},
 		{ID: 4, AncestorsComputationState: "done"},

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -29,5 +29,6 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 		{106, 1, 2},
 		{107, 1, 2},
 		{108, 1, 2},
+		{109, 1, 2},
 	})
 }

--- a/app/database/user_integration_test.go
+++ b/app/database/user_integration_test.go
@@ -75,7 +75,7 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 			testhelpers.SuppressOutputIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
-				groups: [{id: 101}, {id: 111}, {id: 121}]
+				groups: [{id: 101}, {id: 102}, {id: 111}, {id: 121}]
 				users:
 					- {login: "john", group_id: 101}
 					- {login: "jane", group_id: 111}
@@ -84,7 +84,6 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 					- {parent_group_id: 102, child_group_id: 101}
 				groups_ancestors:
 					- {ancestor_group_id: 102, child_group_id: 101}
-					- {ancestor_group_id: 102, child_group_id: 102}
 				languages: [{tag: fr}]
 				items:
 					- {id: 10, default_language_tag: fr}

--- a/db/migrations/2410230158_add_column_groups_groups_is_team_membership.sql
+++ b/db/migrations/2410230158_add_column_groups_groups_is_team_membership.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `groups_groups` ADD COLUMN `is_team_membership` TINYINT(1) NOT NULL DEFAULT 0
+  COMMENT 'true if the parent group is a team'
+  AFTER `expires_at`;
+
+-- +migrate Down
+ALTER TABLE `groups_groups` DROP COLUMN `is_team_membership`;

--- a/db/migrations/2410230202_initialize_column_groups_groups_is_team_membership.sql
+++ b/db/migrations/2410230202_initialize_column_groups_groups_is_team_membership.sql
@@ -1,0 +1,4 @@
+-- +migrate Up
+UPDATE `groups_groups` SET `is_team_membership` = 1 WHERE `parent_group_id` IN (SELECT `id` FROM `groups` WHERE `type` = 'Team');
+
+-- +migrate Down

--- a/db/migrations/2410260221_modify_trigger_before_insert_groups_groups_to_set_is_team_membership.sql
+++ b/db/migrations/2410260221_modify_trigger_before_insert_groups_groups_to_set_is_team_membership.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+DROP TRIGGER IF EXISTS `before_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_insert_groups_groups` BEFORE INSERT ON `groups_groups` FOR EACH ROW BEGIN
+  SET NEW.is_team_membership = (SELECT type = 'Team' FROM `groups` WHERE id = NEW.parent_group_id FOR SHARE);
+  IF NOT NEW.is_team_membership THEN
+    INSERT IGNORE INTO `groups_propagate` (id, ancestors_computation_state) VALUES (NEW.child_group_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `before_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_insert_groups_groups` BEFORE INSERT ON `groups_groups` FOR EACH ROW BEGIN INSERT IGNORE INTO `groups_propagate` (id, ancestors_computation_state) VALUES (NEW.child_group_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo' ; END
+-- +migrate StatementEnd

--- a/db/migrations/2410281951_modify_trigger_before_update_groups_groups_to_disallow_modifying_of_is_team_membership.sql
+++ b/db/migrations/2410281951_modify_trigger_before_update_groups_groups_to_disallow_modifying_of_is_team_membership.sql
@@ -1,0 +1,19 @@
+-- +migrate Up
+DROP TRIGGER `before_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_groups_groups` BEFORE UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.`parent_group_id` != NEW.`parent_group_id` OR OLD.`child_group_id` != NEW.`child_group_id` OR OLD.`is_team_membership` != NEW.`is_team_membership` THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Unable to change immutable columns of groups_groups (parent_group_id/child_group_id/is_team_membership)';
+    END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `before_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_groups_groups` BEFORE UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.`parent_group_id` != NEW.`parent_group_id` OR OLD.`child_group_id` != NEW.`child_group_id` THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Unable to change immutable groups_groups.parent_group_id and/or groups_groups.child_group_id';
+    END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2410282058_modify_trigger_after_insert_groups_groups_to_ignore_team_memberships.sql
+++ b/db/migrations/2410282058_modify_trigger_after_insert_groups_groups_to_ignore_team_memberships.sql
@@ -1,0 +1,98 @@
+-- +migrate Up
+DROP TRIGGER `after_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_groups_groups` AFTER INSERT ON `groups_groups` FOR EACH ROW BEGIN
+    IF NEW.`expires_at` > NOW() AND NOT NEW.`is_team_membership` THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `results`.`item_id`, 'to_be_propagated' AS `state`
+        FROM (
+                 SELECT `item_id`
+                 FROM (
+                          SELECT DISTINCT `item_id`
+                          FROM `results`
+                                   JOIN `groups_ancestors_active`
+                                        ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                           `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+                          FOR SHARE
+                      ) AS `result_items`
+                 WHERE EXISTS(
+                         SELECT 1
+                         FROM `permissions_generated`
+                                  JOIN `groups_ancestors_active` AS `grand_ancestors`
+                                       ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                                          `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                  JOIN `items_ancestors`
+                                       ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                         WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                           AND `permissions_generated`.`can_view_generated` != 'none'
+                         FOR SHARE
+                     )
+                   AND NOT EXISTS(
+                         SELECT 1
+                         FROM `permissions_generated`
+                                  JOIN `groups_ancestors_active` AS `child_ancestors`
+                                       ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                                          `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                  JOIN `items_ancestors`
+                                       ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                         WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                           AND `permissions_generated`.`can_view_generated` != 'none'
+                         FOR SHARE
+                     )
+                 FOR SHARE
+             ) AS `result_items_filtered`
+        JOIN `results` ON `results`.`item_id` = `result_items_filtered`.`item_id`
+        JOIN `groups_ancestors_active`
+          ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+             `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+        FOR SHARE;
+    END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_insert_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_groups_groups` AFTER INSERT ON `groups_groups` FOR EACH ROW BEGIN
+    IF NEW.`expires_at` > NOW() THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `results`.`item_id`, 'to_be_propagated' AS `state`
+        FROM (
+                 SELECT `item_id`
+                 FROM (
+                          SELECT DISTINCT `item_id`
+                          FROM `results`
+                                   JOIN `groups_ancestors_active`
+                                        ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                           `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+                      ) AS `result_items`
+                 WHERE EXISTS(
+                         SELECT 1
+                         FROM `permissions_generated`
+                                  JOIN `groups_ancestors_active` AS `grand_ancestors`
+                                       ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                                          `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                  JOIN `items_ancestors`
+                                       ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                         WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                           AND `permissions_generated`.`can_view_generated` != 'none'
+                     )
+                   AND NOT EXISTS(
+                         SELECT 1
+                         FROM `permissions_generated`
+                                  JOIN `groups_ancestors_active` AS `child_ancestors`
+                                       ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                                          `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                  JOIN `items_ancestors`
+                                       ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                         WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                           AND `permissions_generated`.`can_view_generated` != 'none'
+                     )
+             ) AS `result_items_filtered`
+                 JOIN `results` ON `results`.`item_id` = `result_items_filtered`.`item_id`
+                 JOIN `groups_ancestors_active`
+                      ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                         `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`;
+    END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2410282314_modify_trigger_after_update_groups_groups_to_ignore_team_memberships.sql
+++ b/db/migrations/2410282314_modify_trigger_after_update_groups_groups_to_ignore_team_memberships.sql
@@ -1,0 +1,111 @@
+-- +migrate Up
+DROP TRIGGER `after_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_groups_groups` AFTER UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.expires_at != NEW.expires_at AND NOT NEW.`is_team_membership` THEN
+        IF NEW.`expires_at` > NOW() THEN
+            INSERT IGNORE INTO `results_propagate`
+            SELECT `participant_id`, `attempt_id`, `results`.`item_id`, 'to_be_propagated' AS `state`
+            FROM (
+                     SELECT `item_id`
+                     FROM (
+                              SELECT DISTINCT `item_id`
+                              FROM `results`
+                                       JOIN `groups_ancestors_active`
+                                            ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+                              FOR SHARE
+                          ) AS `result_items`
+                     WHERE EXISTS(
+                             SELECT 1
+                             FROM `permissions_generated`
+                                      JOIN `groups_ancestors_active` AS `grand_ancestors`
+                                           ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                                              `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                      JOIN `items_ancestors`
+                                           ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                             WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                               AND `permissions_generated`.`can_view_generated` != 'none'
+                             FOR SHARE
+                         )
+                       AND NOT EXISTS(
+                             SELECT 1
+                             FROM `permissions_generated`
+                                      JOIN `groups_ancestors_active` AS `child_ancestors`
+                                           ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                                              `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                      JOIN `items_ancestors`
+                                           ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                             WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                               AND `permissions_generated`.`can_view_generated` != 'none'
+                             FOR SHARE
+                         )
+                     FOR SHARE
+                 ) AS `result_items_filtered`
+            JOIN `results` ON `results`.`item_id` = `result_items_filtered`.`item_id`
+            JOIN `groups_ancestors_active`
+              ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                 `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+            FOR SHARE;
+        END IF;
+
+        INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (NEW.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+    END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_update_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_groups_groups` AFTER UPDATE ON `groups_groups` FOR EACH ROW BEGIN
+    IF OLD.expires_at != NEW.expires_at THEN
+        IF NEW.`expires_at` > NOW() THEN
+            INSERT IGNORE INTO `results_propagate`
+            SELECT `participant_id`, `attempt_id`, `results`.`item_id`, 'to_be_propagated' AS `state`
+            FROM (
+                     SELECT `item_id`
+                     FROM (
+                              SELECT DISTINCT `item_id`
+                              FROM `results`
+                                       JOIN `groups_ancestors_active`
+                                            ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`
+                          ) AS `result_items`
+                     WHERE EXISTS(
+                             SELECT 1
+                             FROM `permissions_generated`
+                                      JOIN `groups_ancestors_active` AS `grand_ancestors`
+                                           ON `grand_ancestors`.`child_group_id` = NEW.`parent_group_id` AND
+                                              `grand_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                      JOIN `items_ancestors`
+                                           ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                             WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                               AND `permissions_generated`.`can_view_generated` != 'none'
+                         )
+                       AND NOT EXISTS(
+                             SELECT 1
+                             FROM `permissions_generated`
+                                      JOIN `groups_ancestors_active` AS `child_ancestors`
+                                           ON `child_ancestors`.`child_group_id` = NEW.`child_group_id` AND
+                                              `child_ancestors`.`ancestor_group_id` = `permissions_generated`.`group_id`
+                                      JOIN `items_ancestors`
+                                           ON `items_ancestors`.`ancestor_item_id` = `permissions_generated`.`item_id`
+                             WHERE `items_ancestors`.`child_item_id` = `result_items`.`item_id`
+                               AND `permissions_generated`.`can_view_generated` != 'none'
+                         )
+                 ) AS `result_items_filtered`
+                     JOIN `results` ON `results`.`item_id` = `result_items_filtered`.`item_id`
+                     JOIN `groups_ancestors_active`
+                          ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                             `groups_ancestors_active`.`ancestor_group_id` = NEW.`child_group_id`;
+        END IF;
+
+        INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (OLD.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+        INSERT IGNORE INTO `groups_propagate` (id, ancestors_computation_state) VALUES (NEW.child_group_id, 'todo')
+        ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+    END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2410282327_modify_trigger_before_delete_groups_groups_to_ignore_team_memberships.sql
+++ b/db/migrations/2410282327_modify_trigger_before_delete_groups_groups_to_ignore_team_memberships.sql
@@ -1,0 +1,19 @@
+-- +migrate Up
+DROP TRIGGER `before_delete_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_groups_groups` BEFORE DELETE ON `groups_groups` FOR EACH ROW BEGIN
+  IF NOT OLD.`is_team_membership` THEN
+    INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (OLD.child_group_id, 'todo')
+    ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `before_delete_groups_groups`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_groups_groups` BEFORE DELETE ON `groups_groups` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `groups_propagate` (`id`, `ancestors_computation_state`) VALUES (OLD.child_group_id, 'todo')
+    ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+END
+-- +migrate StatementEnd

--- a/db/migrations/2410282334_add_trigger_before_update_groups_to_disallow_modifying_type.sql
+++ b/db/migrations/2410282334_add_trigger_before_update_groups_to_disallow_modifying_type.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- +migrate StatementBegin
+CREATE TRIGGER `before_update_groups` BEFORE UPDATE ON `groups` FOR EACH ROW BEGIN
+  IF OLD.`type` != NEW.`type` THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Unable to change immutable groups.type';
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `before_update_groups`;

--- a/db/migrations/2410282334_add_trigger_before_update_groups_to_disallow_modifying_type.sql
+++ b/db/migrations/2410282334_add_trigger_before_update_groups_to_disallow_modifying_type.sql
@@ -1,8 +1,8 @@
 -- +migrate Up
 -- +migrate StatementBegin
 CREATE TRIGGER `before_update_groups` BEFORE UPDATE ON `groups` FOR EACH ROW BEGIN
-  IF OLD.`type` != NEW.`type` THEN
-    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Unable to change immutable groups.type';
+  IF OLD.`type` != NEW.`type` AND (OLD.`type` IN ('User', 'Team') OR NEW.`type` IN ('User', 'Team')) THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Unable to change groups.type from/to User/Team';
   END IF;
 END
 -- +migrate StatementEnd

--- a/db/migrations/2410292333_remove_unnecessary_enum_values_from_groups_propagate_ancestors_computation_state.sql
+++ b/db/migrations/2410292333_remove_unnecessary_enum_values_from_groups_propagate_ancestors_computation_state.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `groups_propagate` MODIFY COLUMN `ancestors_computation_state` ENUM('todo', 'done') NOT NULL;
+
+-- +migrate Down
+ALTER TABLE `groups_propagate` MODIFY COLUMN `ancestors_computation_state` ENUM('todo', 'done', 'processing', '') NOT NULL;

--- a/db/migrations/2410292340_remove_unnecessary_enum_values_from_items_propagate_ancestors_computation_state.sql
+++ b/db/migrations/2410292340_remove_unnecessary_enum_values_from_items_propagate_ancestors_computation_state.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `items_propagate` MODIFY COLUMN `ancestors_computation_state` ENUM('todo', 'done') NOT NULL;
+
+-- +migrate Down
+ALTER TABLE `items_propagate` MODIFY COLUMN `ancestors_computation_state` ENUM('todo', 'done', 'processing', '') NOT NULL;

--- a/db/migrations/2411061620_create_index_child_group_id_is_team_membership_parent_group_id_expires_at_on_groups_groups.sql
+++ b/db/migrations/2411061620_create_index_child_group_id_is_team_membership_parent_group_id_expires_at_on_groups_groups.sql
@@ -3,4 +3,8 @@ ALTER TABLE `groups_groups` ADD INDEX `child_group_id_is_team_membership_parent_
   (`child_group_id`,`is_team_membership`,`parent_group_id`,`expires_at`);
 
 -- +migrate Down
-ALTER TABLE `groups_groups` DROP INDEX `child_group_id_is_team_membership_parent_group_id_expires_at`;
+ALTER TABLE `groups_groups`
+  DROP FOREIGN KEY `fk_groups_groups_child_group_id_groups_id`,
+  DROP INDEX `child_group_id_is_team_membership_parent_group_id_expires_at`;
+ALTER TABLE `groups_groups`
+  ADD CONSTRAINT `fk_groups_groups_child_group_id_groups_id` FOREIGN KEY (`child_group_id`) REFERENCES `groups` (`id`) ON DELETE CASCADE;

--- a/db/migrations/2411061620_create_index_child_group_id_is_team_membership_parent_group_id_expires_at_on_groups_groups.sql
+++ b/db/migrations/2411061620_create_index_child_group_id_is_team_membership_parent_group_id_expires_at_on_groups_groups.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+ALTER TABLE `groups_groups` ADD INDEX `child_group_id_is_team_membership_parent_group_id_expires_at`
+  (`child_group_id`,`is_team_membership`,`parent_group_id`,`expires_at`);
+
+-- +migrate Down
+ALTER TABLE `groups_groups` DROP INDEX `child_group_id_is_team_membership_parent_group_id_expires_at`;

--- a/db/migrations/2411070615_add_column_is_team_membership_to_groups_groups_active_view.sql
+++ b/db/migrations/2411070615_add_column_is_team_membership_to_groups_groups_active_view.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+DROP VIEW groups_groups_active;
+CREATE VIEW groups_groups_active AS SELECT * FROM groups_groups WHERE NOW() < expires_at;
+
+-- +migrate Down
+DROP VIEW groups_groups_active;
+CREATE VIEW `groups_groups_active` AS
+  SELECT `groups_groups`.`parent_group_id` AS `parent_group_id`,
+         `groups_groups`.`child_group_id` AS `child_group_id`,
+         `groups_groups`.`expires_at` AS `expires_at`,
+         `groups_groups`.`personal_info_view_approved_at` AS `personal_info_view_approved_at`,
+         `groups_groups`.`personal_info_view_approved` AS `personal_info_view_approved`,
+         `groups_groups`.`lock_membership_approved_at` AS `lock_membership_approved_at`,
+         `groups_groups`.`lock_membership_approved` AS `lock_membership_approved`,
+         `groups_groups`.`watch_approved_at` AS `watch_approved_at`,
+         `groups_groups`.`watch_approved` AS `watch_approved`
+  FROM `groups_groups` WHERE (NOW() < `groups_groups`.`expires_at`);

--- a/db/migrations/2411070848_drop_trigger_after_insert_items.sql
+++ b/db/migrations/2411070848_drop_trigger_after_insert_items.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+DROP TRIGGER `after_insert_items`;
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `after_insert_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items` AFTER INSERT ON `items` FOR EACH ROW BEGIN INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`) VALUES (NEW.`id`, 'todo') ; END
+-- +migrate StatementEnd

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -129,16 +129,16 @@ func (ctx *TestContext) ThereAreTheFollowingGroups(groups *godog.Table) error {
 }
 
 // ThereIsAGroup creates a new group (type=Class).
-func (ctx *TestContext) ThereIsAGroup(group string) error {
+func (ctx *TestContext) ThereIsAGroup(group string) (err error) {
+	defer recoverPanics(&err)
 	ctx.addGroup(group, "Class")
-
 	return nil
 }
 
 // ThereIsATeam creates a new team.
-func (ctx *TestContext) ThereIsATeam(group string) error {
+func (ctx *TestContext) ThereIsATeam(group string) (err error) {
+	defer recoverPanics(&err)
 	ctx.addGroup(group, "Team")
-
 	return nil
 }
 
@@ -202,15 +202,13 @@ func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonal
 }
 
 // AllUsersGroupIsDefinedAsTheGroup creates and sets the allUsersGroup.
-func (ctx *TestContext) AllUsersGroupIsDefinedAsTheGroup(group string) error {
-	err := ctx.ThereIsAGroup(group)
-	if err != nil {
-		return err
-	}
+func (ctx *TestContext) AllUsersGroupIsDefinedAsTheGroup(group string) (err error) {
+	defer recoverPanics(&err)
+
+	ctx.addGroup(group, "Base")
 
 	groupPrimaryKey := ctx.getGroupPrimaryKey(ctx.getIDOfReference(group))
 	ctx.setGroupFieldInDatabase(groupPrimaryKey, "name", "AllUsers")
-	ctx.setGroupFieldInDatabase(groupPrimaryKey, "type", "Base")
 
 	err = ctx.TheApplicationConfigIs(&godog.DocString{
 		Content: `

--- a/testhelpers/app_language_users.go
+++ b/testhelpers/app_language_users.go
@@ -81,14 +81,11 @@ func (ctx *TestContext) setUserFieldInDatabase(primaryKey map[string]string, fie
 }
 
 // ThereIsAUser create a user.
-func (ctx *TestContext) ThereIsAUser(name string) error {
+func (ctx *TestContext) ThereIsAUser(name string) (err error) {
+	defer recoverPanics(&err)
+
 	ctx.addUser(name)
-
-	err := ctx.ThereIsAGroup(name)
-	mustNotBeError(err)
-
-	groupPrimaryKey := ctx.getGroupPrimaryKey(ctx.getIDOfReference(name))
-	ctx.setGroupFieldInDatabase(groupPrimaryKey, "type", "User")
+	ctx.addGroup(name, "User")
 
 	return nil
 }

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"sort"
 
 	"bou.ke/monkey"
@@ -235,5 +236,18 @@ func (ctx *TestContext) initDB() error {
 func mustNotBeError(err error) {
 	if err != nil {
 		panic(err)
+	}
+}
+
+func recoverPanics(returnErr *error) {
+	if p := recover(); p != nil {
+		switch e := p.(type) {
+		case runtime.Error:
+			panic(e)
+		case error:
+			*returnErr = e
+		default:
+			panic(p)
+		}
 	}
 }


### PR DESCRIPTION
1. Make groups&items propagations twice faster:
- introduce a new column groups_groups.is_team_membership which equals to 1 when a parent group is a team, set its value automatically on groups_groups creation,
- move the 'processing' state into a new temporary table,
- always filter *_propagate tables by exact values of ancestors_propagation_state,
- perform covering index lookups on groups_groups instead of index lookups (create an index for this).
2. Do not join the groups table to determine if group memberships (use the new groups_groups.is_team_membership column instead).
3. Do not mark new items for propagation, only call the items propagation in itemCreate if at least one items_items row is created.
4. Disallow modifying groups.type and groups_groups.is_team_membership.
5. Change the DB username for migration-tests to match the definer of triggers in the dump file.
6. Sort all the data returned by currentUserDataExport & currentUserFullDataExport to make tests stable.
7. Do not run/schedule propagations in GroupGroupStore.Transition() when the parent group is a team, schedule the results propagation in GroupGroupStore.Transition() only if a new relation is inserted and the parent group is not a team.