### PR TITLE
Move&rename testhelpers/SuppressOutputIfPasses(), suppress output of more tests

### DIFF
--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/auth"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-chi/chi"
@@ -22,6 +23,8 @@ import (
 )
 
 func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	expectedClientID := "1234"
 	expectedClientSecret := "secret"
 	loginModuleStubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func Test_checkPreconditionsForGroupRequests(t *testing.T) {
@@ -184,7 +185,7 @@ func Test_checkPreconditionsForGroupRequests(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(tt.fixture)
 			defer func() { _ = db.Close() }()

--- a/app/api/groups/create_invitations_integration_test.go
+++ b/app/api/groups/create_invitations_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/groups"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func Test_filterOtherTeamsMembersOut(t *testing.T) {
@@ -243,7 +244,7 @@ func Test_filterOtherTeamsMembersOut(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(tt.fixture)
 			defer func() { _ = db.Close() }()

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/items"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func Test_FindItemPath(t *testing.T) {
@@ -811,7 +812,7 @@ func Test_FindItemPath(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/items"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func Test_getDataForResultPathStart(t *testing.T) {
@@ -438,7 +439,7 @@ func Test_getDataForResultPathStart(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()

--- a/app/database/answer_store_integration_test.go
+++ b/app/database/answer_store_integration_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestAnswerStore_SubmitNewAnswer(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 121}]
 		users: [{group_id: 121}]
@@ -34,6 +37,8 @@ func TestAnswerStore_SubmitNewAnswer(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			newID, err := answerStore.SubmitNewAnswer(test.authorID, test.participantID, test.attemptID, test.itemID, test.answer)
 
 			assert.NoError(t, err)

--- a/app/database/attempt_store_integration_test.go
+++ b/app/database/attempt_store_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type resultType struct {
@@ -31,6 +32,8 @@ type attemptType struct {
 }
 
 func TestAttemptStore_CreateNew_CreatesNewAttempt(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups:
 			- {id: 10}

--- a/app/database/badges_integration_test.go
+++ b/app/database/badges_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGroupStore_StoreBadges(t *testing.T) {
@@ -268,6 +269,8 @@ func TestGroupStore_StoreBadges(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups: [{id: 5}]
 				users: [{group_id: 5}]` + tt.fixture)
@@ -379,6 +382,8 @@ func TestGroupStore_StoreBadges(t *testing.T) {
 }
 
 func TestGroupStore_StoreBadge_PropagatesResults(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 				groups: [{id: 1, text_id: badge_url}, {id: 5}, {id: 6}]
 				users: [{group_id: 5, login: john}, {group_id: 6, login: jane}]

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDataStore_WithForeignKeyChecksDisabled(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	rawDB, err := testhelpers.OpenRawDBConnection()
 	if err != nil {
 		assert.FailNow(t, err.Error())

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDataStore_StoreConstructorsSetTablesCorrectly(t *testing.T) {
@@ -54,6 +55,8 @@ func TestDataStore_StoreConstructorsSetTablesCorrectly(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 			mock.ExpectQuery("SELECT \\* FROM " + tt.wantTable).
@@ -114,6 +117,8 @@ func TestDataStore_StoreConstructorsReturnObjectsOfRightTypes(t *testing.T) {
 }
 
 func TestDataStore_ByID(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -138,6 +143,8 @@ func TestDataStore_ByID_ForAbstractDataStore(t *testing.T) {
 }
 
 func TestDataStore_InTransaction_NoErrors(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -166,6 +173,8 @@ func TestDataStore_InTransaction_NoErrors(t *testing.T) {
 }
 
 func TestDataStore_InTransaction_DBError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -190,6 +199,8 @@ func TestDataStore_InTransaction_DBError(t *testing.T) {
 }
 
 func TestDataStore_InTransaction_ContextAndTxOptions(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	var callsCount int
 
 	type ctxKey string
@@ -217,6 +228,8 @@ func TestDataStore_InTransaction_ContextAndTxOptions(t *testing.T) {
 }
 
 func TestDataStore_InTransaction_ForcesTransactionRetryingForTestingPurposes(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -238,6 +251,8 @@ func TestDataStore_InTransaction_ForcesTransactionRetryingForTestingPurposes(t *
 }
 
 func TestDataStore_InTransaction_ForcesTransactionRetryingForTestingPurposes_Hooks(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -271,6 +286,8 @@ func TestDataStore_InTransaction_ForcesTransactionRetryingForTestingPurposes_Hoo
 }
 
 func TestDataStore_WithForeignKeyChecksDisabled_DBErrorOnStartingTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -291,6 +308,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_DBErrorOnStartingTransaction(t *
 }
 
 func TestDataStore_WithForeignKeyChecksDisabled_WithTxOptions(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	var callsCount int
 	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
 	patch := patchBeginTxWithVerifier(t, &callsCount, txOptions, nil)
@@ -315,6 +334,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_WithTxOptions(t *testing.T) {
 }
 
 func TestDataStore_WithForeignKeyChecksDisabled_DBErrorOnCommittingTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -337,6 +358,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_DBErrorOnCommittingTransaction(t
 }
 
 func TestDataStore_WithForeignKeyChecksDisabled_DBErrorInsideTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -357,6 +380,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_DBErrorInsideTransaction(t *test
 }
 
 func TestDataStore_WithForeignKeyChecksDisabled_DBErrorWithoutTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -379,6 +404,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_DBErrorWithoutTransaction(t *tes
 }
 
 func TestDataStore_WithNamedLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	lockName := "some lock name"
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -417,6 +444,8 @@ func assertNamedLockMethod(t *testing.T, expectedLockName string, expectedTimeou
 }
 
 func TestDataStore_RetryOnDuplicatePrimaryKeyError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -438,6 +467,8 @@ func TestDataStore_RetryOnDuplicatePrimaryKeyError(t *testing.T) {
 }
 
 func TestDataStore_RetryOnDuplicateKeyError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -460,6 +491,8 @@ func TestDataStore_RetryOnDuplicateKeyError(t *testing.T) {
 }
 
 func TestDataStore_InsertMap(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -475,6 +508,8 @@ func TestDataStore_InsertMap(t *testing.T) {
 }
 
 func TestDataStore_InsertOrUpdateMap(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -492,6 +527,8 @@ func TestDataStore_InsertOrUpdateMap(t *testing.T) {
 }
 
 func TestDataStore_InsertOrUpdateMaps(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -512,6 +549,8 @@ func TestDataStore_InsertOrUpdateMaps(t *testing.T) {
 }
 
 func TestDataStore_WithSharedWriteLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -543,6 +582,8 @@ func TestDataStore_WithSharedWriteLock_PanicsWhenNotInTransaction(t *testing.T) 
 }
 
 func TestDataStore_WithCustomWriteLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -592,6 +633,8 @@ func TestDataStore_PropagationsSchedules_MustBeInTransaction(t *testing.T) {
 }
 
 func TestProhibitResultsPropagation(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/db_enums_test.go
+++ b/app/database/db_enums_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDB_getFromEnumUnderLock_WipesOutAllMapsOnError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 const someName = "some name"
@@ -49,6 +50,8 @@ func TestDB_inTransaction_NoErrors(t *testing.T) {
 }
 
 func TestDB_inTransaction_DBErrorOnBegin(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -65,6 +68,8 @@ func TestDB_inTransaction_DBErrorOnBegin(t *testing.T) {
 }
 
 func TestDB_inTransaction_DBError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -83,6 +88,8 @@ func TestDB_inTransaction_DBError(t *testing.T) {
 }
 
 func TestDB_inTransaction_Panic(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -103,6 +110,8 @@ func TestDB_inTransaction_Panic(t *testing.T) {
 }
 
 func TestDB_inTransaction_PanicWithString(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -120,6 +129,8 @@ func TestDB_inTransaction_PanicWithString(t *testing.T) {
 }
 
 func TestDB_inTransaction_ErrorOnRollback(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -141,6 +152,8 @@ func TestDB_inTransaction_ErrorOnRollback(t *testing.T) {
 }
 
 func TestDB_inTransaction_ErrorOnCommit(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -161,6 +174,8 @@ func TestDB_inTransaction_ErrorOnCommit(t *testing.T) {
 func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutErrors(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -196,6 +211,8 @@ func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutErrors(t *testing.T
 func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutErrorsAndPanicsOnRollbackError(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -224,6 +241,8 @@ func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutErrorsAndPanicsOnRo
 func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutPanic(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -273,6 +292,8 @@ func patchBeginTxWithVerifier(
 }
 
 func TestDB_inTransaction_RetriesOnDeadLockPanic_WithTxOptions(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	var calledCount int
 	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
 	patch := patchBeginTxWithVerifier(t, &calledCount, txOptions, nil)
@@ -303,6 +324,8 @@ func TestDB_inTransaction_RetriesOnDeadLockPanic_WithTxOptions(t *testing.T) {
 }
 
 func TestDB_inTransaction_RetriesOnDeadLockError_WithTxOptions(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	var calledCount int
 	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
 	patch := patchBeginTxWithVerifier(t, &calledCount, txOptions, nil)
@@ -334,6 +357,8 @@ func TestDB_inTransaction_RetriesOnDeadLockError_WithTxOptions(t *testing.T) {
 func TestDB_inTransaction_RetriesOnDeadockAndLockWaitTimeoutPanicAndPanicsOnRollbackError(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -363,6 +388,8 @@ func TestDB_inTransaction_RetriesOnDeadockAndLockWaitTimeoutPanicAndPanicsOnRoll
 func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Panic(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -395,6 +422,8 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Panic(t *testing.T) {
 func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Error(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -426,6 +455,8 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Error(t *testing.T) {
 func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Panic(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -455,6 +486,8 @@ func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Panic(t *testing.T) 
 func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Error(t *testing.T) {
 	for _, errorNumber := range []uint16{1213, 1205} {
 		t.Run(fmt.Sprintf("error%d", errorNumber), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -564,6 +597,8 @@ func TestDB_QueryConstructors(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -603,6 +638,8 @@ func TestDB_With_Duplicate(t *testing.T) {
 }
 
 func TestDB_Count(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -622,6 +659,8 @@ func TestDB_Count(t *testing.T) {
 }
 
 func TestDB_Count_DoesNothingIfDBContainsError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -640,6 +679,8 @@ func TestDB_Count_DoesNothingIfDBContainsError(t *testing.T) {
 }
 
 func TestDB_Take(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -660,6 +701,8 @@ func TestDB_Take(t *testing.T) {
 }
 
 func TestDB_HasRows(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -677,6 +720,8 @@ func TestDB_HasRows(t *testing.T) {
 }
 
 func TestDB_HasRows_NoRows(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -694,6 +739,8 @@ func TestDB_HasRows_NoRows(t *testing.T) {
 }
 
 func TestDB_HasRows_Error(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -712,6 +759,8 @@ func TestDB_HasRows_Error(t *testing.T) {
 }
 
 func TestDB_Pluck(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -731,6 +780,8 @@ func TestDB_Pluck(t *testing.T) {
 }
 
 func TestDB_Pluck_DoesNothingIfErrorIsSet(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -744,6 +795,8 @@ func TestDB_Pluck_DoesNothingIfErrorIsSet(t *testing.T) {
 }
 
 func TestDB_Pluck_WipesOldData(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -788,6 +841,8 @@ func TestDB_Pluck_NonPointer(t *testing.T) {
 }
 
 func TestDB_PluckFirst(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -807,6 +862,8 @@ func TestDB_PluckFirst(t *testing.T) {
 }
 
 func TestDB_PluckFirst_NotFound(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -825,6 +882,8 @@ func TestDB_PluckFirst_NotFound(t *testing.T) {
 }
 
 func TestDB_PluckFirst_Error(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -844,6 +903,8 @@ func TestDB_PluckFirst_Error(t *testing.T) {
 }
 
 func TestDB_Scan(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -867,6 +928,8 @@ func TestDB_Scan(t *testing.T) {
 }
 
 func TestDB_Scan_WipesOldData(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -920,6 +983,8 @@ func TestDB_Scan_NonPointer(t *testing.T) {
 }
 
 func TestDB_RowsAffected(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -936,6 +1001,8 @@ func TestDB_RowsAffected(t *testing.T) {
 }
 
 func TestDB_Delete(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -956,6 +1023,8 @@ func TestDB_Delete(t *testing.T) {
 }
 
 func TestDB_Exec(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -973,6 +1042,8 @@ func TestDB_Exec(t *testing.T) {
 }
 
 func TestDB_insertMaps(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -988,6 +1059,8 @@ func TestDB_insertMaps(t *testing.T) {
 }
 
 func TestDB_insertMaps_MultipleRows(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1014,6 +1087,8 @@ func TestDB_insertMaps_WithEmptyArray(t *testing.T) {
 }
 
 func TestDB_insertOrUpdateMaps(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1038,6 +1113,8 @@ func TestDB_insertOrUpdateMaps_WithEmptyArray(t *testing.T) {
 }
 
 func TestDB_ScanIntoSlices(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1061,6 +1138,8 @@ func TestDB_ScanIntoSlices(t *testing.T) {
 }
 
 func TestDB_ScanIntoSlices_DoesNothingIfErrorIsSet(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1076,6 +1155,8 @@ func TestDB_ScanIntoSlices_DoesNothingIfErrorIsSet(t *testing.T) {
 }
 
 func TestDB_ScanIntoSlices_WipesOldData(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1096,6 +1177,8 @@ func TestDB_ScanIntoSlices_WipesOldData(t *testing.T) {
 }
 
 func TestDB_ScanIntoSlices_RowsError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1114,6 +1197,8 @@ func TestDB_ScanIntoSlices_RowsError(t *testing.T) {
 }
 
 func TestDB_ScanIntoSlices_ErrorOnScan(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1134,6 +1219,8 @@ func TestDB_ScanIntoSlices_ErrorOnScan(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1158,6 +1245,8 @@ func TestDB_ScanIntoSliceOfMaps(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps_DoesNothingIfErrorIsSet(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1173,6 +1262,8 @@ func TestDB_ScanIntoSliceOfMaps_DoesNothingIfErrorIsSet(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps_WipesOldData(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1196,6 +1287,8 @@ func TestDB_ScanIntoSliceOfMaps_WipesOldData(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps_RowsError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1214,6 +1307,8 @@ func TestDB_ScanIntoSliceOfMaps_RowsError(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps_ErrorOnGettingColumns(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1234,6 +1329,8 @@ func TestDB_ScanIntoSliceOfMaps_ErrorOnGettingColumns(t *testing.T) {
 }
 
 func TestDB_ScanIntoSliceOfMaps_ErrorOnScan(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1254,6 +1351,8 @@ func TestDB_ScanIntoSliceOfMaps_ErrorOnScan(t *testing.T) {
 }
 
 func TestDB_ScanAndHandleMaps_FailsIfHandlerReturnsError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1272,6 +1371,8 @@ func TestDB_ScanAndHandleMaps_FailsIfHandlerReturnsError(t *testing.T) {
 }
 
 func TestDB_Updates(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1290,6 +1391,8 @@ func TestDB_Updates(t *testing.T) {
 }
 
 func TestDB_UpdateColumn(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1308,6 +1411,8 @@ func TestDB_UpdateColumn(t *testing.T) {
 }
 
 func TestDB_Set(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1332,6 +1437,8 @@ func TestOpenRawDBConnection(t *testing.T) {
 }
 
 func TestOpen_DSN(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, err := Open("/db")
 	assert.Error(t, err) // we want an error since dsn is wrong, but other things should be ok
 	assert.NotNil(t, db)
@@ -1363,6 +1470,8 @@ func assertRawDBIsOK(t *testing.T, rawDB *sql.DB) {
 }
 
 func TestDB_isInTransaction_ReturnsTrue(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1385,6 +1494,8 @@ func TestDB_isInTransaction_ReturnsFalse(t *testing.T) {
 }
 
 func TestDB_mustBeInTransaction_DoesNothingInTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1462,8 +1573,11 @@ func Test_recoverPanics_PanicsOnRecoveringValueOfNonErrorType(t *testing.T) {
 }
 
 func TestDB_withNamedLock_ReturnsErrLockWaitTimeoutExceededWhenGetLockTimeouts(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := "lock name"
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1480,8 +1594,11 @@ func TestDB_withNamedLock_ReturnsErrLockWaitTimeoutExceededWhenGetLockTimeouts(t
 }
 
 func TestDB_withNamedLock_ReturnsErrorWhenDBFails(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := someName
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1499,8 +1616,11 @@ func TestDB_withNamedLock_ReturnsErrorWhenDBFails(t *testing.T) {
 }
 
 func TestDB_withNamedLock_ReleasesLockOnSuccess(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := someName
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1519,8 +1639,11 @@ func TestDB_withNamedLock_ReleasesLockOnSuccess(t *testing.T) {
 }
 
 func TestDB_withNamedLock_ReleasesLockOnError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := someName
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1540,8 +1663,11 @@ func TestDB_withNamedLock_ReleasesLockOnError(t *testing.T) {
 }
 
 func TestDB_withNamedLock_ReleasesLockOnPanic(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := someName
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1562,8 +1688,11 @@ func TestDB_withNamedLock_ReleasesLockOnPanic(t *testing.T) {
 }
 
 func TestDB_withNamedLock_ReturnsReleaseError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, dbMock := NewDBMock()
 	defer func() { _ = db.Close() }()
+
 	lockName := someName
 	timeout := 1234 * time.Millisecond
 	expectedTimeout := int(timeout.Round(time.Second).Seconds())
@@ -1584,6 +1713,8 @@ func TestDB_withNamedLock_ReturnsReleaseError(t *testing.T) {
 }
 
 func TestDB_WithExclusiveWriteLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1617,6 +1748,8 @@ func TestDB_WithExclusiveWriteLock_PanicsWhenNotInTransaction(t *testing.T) {
 var retryOnDuplicatePrimaryKeyErrorExpectedQueryRegexp = "^" + regexp.QuoteMeta("INSERT INTO users (id) VALUES (?)") + "$"
 
 func TestDB_retryOnDuplicatePrimaryKeyError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1637,6 +1770,8 @@ func TestDB_retryOnDuplicatePrimaryKeyError(t *testing.T) {
 }
 
 func TestDB_retryOnDuplicatePrimaryKeyError_ErrorsWhenLimitExceeded(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -1671,6 +1806,8 @@ func TestDB_retryOnDuplicatePrimaryKeyError_ReturnsOtherErrors(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -1724,6 +1861,8 @@ func TestDB_InsertIgnoreMaps_WithEmptyArray(t *testing.T) {
 }
 
 func TestDB_InsertIgnoreMaps(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/group_group_store_ancestors_integration_test.go
+++ b/app/database/group_group_store_ancestors_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type groupAncestorsResultRow struct {
@@ -27,7 +28,7 @@ type groupPropagateResultRow struct {
 var maxExpiresAt = "9999-12-31 23:59:59"
 
 func TestGroupGroupStore_CreateNewAncestors_Concurrent(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
@@ -67,7 +68,7 @@ func TestGroupGroupStore_CreateNewAncestors_Concurrent(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_Cyclic(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common", "group_group_store/ancestors/cyclic")
 	defer func() { _ = db.Close() }()
@@ -99,7 +100,7 @@ func TestGroupGroupStore_CreateNewAncestors_Cyclic(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_IgnoresDoneGroups(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
@@ -139,7 +140,7 @@ func TestGroupGroupStore_CreateNewAncestors_IgnoresDoneGroups(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_ProcessesOnlyDirectRelationsOrAcceptedRequestsAndInvitations(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
@@ -177,7 +178,7 @@ func TestGroupGroupStore_CreateNewAncestors_ProcessesOnlyDirectRelationsOrAccept
 }
 
 func TestGroupGroupStore_CreateNewAncestors_PropagatesExpiresAt(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
@@ -226,7 +227,7 @@ func TestGroupGroupStore_CreateNewAncestors_PropagatesExpiresAt(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_IgnoresExpiredRelations(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("group_group_store/ancestors/_common")
 	defer func() { _ = db.Close() }()

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGroupGroupStore_DeleteRelation(t *testing.T) {
@@ -168,6 +169,8 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixture("group_group_store/delete_relation/" + tt.fixture)
 			defer func() { _ = db.Close() }()
 			dataStore := database.NewDataStore(db)
@@ -383,6 +386,8 @@ func TestGroupGroupStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) 
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(groupGroupMarksResultsAsChangedFixture)
 			defer func() { _ = db.Close() }()
 
@@ -469,6 +474,8 @@ func TestGroupGroupStore_TriggerAfterUpdate_MarksResultsAsChanged(t *testing.T) 
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			expiresAt := "2019-05-30 11:00:00"
 			if test.doNotSetExpired {
 				expiresAt = maxDateTime
@@ -501,6 +508,8 @@ func TestGroupGroupStore_TriggerAfterUpdate_MarksResultsAsChanged(t *testing.T) 
 }
 
 func TestGroupGroupStore_TriggerBeforeUpdate_RefusesToModifyParentGroupIDOrChildGroupIDOrIsTeamMembership(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}]
 		groups_groups: [{parent_group_id: 1, child_group_id: 2}]
@@ -574,7 +583,7 @@ func queryResultsAndStatesForTests(t *testing.T, s *database.ResultStore, result
 }
 
 func TestGroupGroupStore_TriggerBeforeDelete(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}, {id: 3, type: Team}, {id: 4}]

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -9,6 +9,8 @@ import (
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGroupGroupStore_WhereUserIsMember(t *testing.T) {
@@ -32,6 +34,8 @@ func TestGroupGroupStore_WhereUserIsMember(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.tableName, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := NewDBMock()
 			defer func() { _ = db.Close() }()
 
@@ -49,6 +53,8 @@ func TestGroupGroupStore_WhereUserIsMember(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateRelation(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -113,6 +119,8 @@ func TestGroupGroupStore_CreateRelation_MustBeRunInTransaction(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateRelation_PreventsRelationCycles(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -137,6 +145,8 @@ func TestGroupGroupStore_CreateRelation_PreventsRelationCycles(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateRelationsWithoutChecking(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -206,6 +216,8 @@ func TestGroupGroupStore_DeleteRelation_MustBeRunInTransaction(t *testing.T) {
 }
 
 func TestGroupGroupStore_createRelation(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	const (
 		parentGroupID = 1
 		childGroupID  = 2
@@ -243,6 +255,8 @@ func TestGroupGroupStore_CreateNewAncestors_MustBeInTransaction(t *testing.T) {
 }
 
 func TestGroupGroupStore_CreateNewAncestors_HandlesErrorOfCreateNewAncestors(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	expectedError := errors.New("some error")
 
 	db, dbMock := NewDBMock()
@@ -259,6 +273,8 @@ func TestGroupGroupStore_CreateNewAncestors_HandlesErrorOfCreateNewAncestors(t *
 }
 
 func TestGroupGroupStore_TeamGroupForTeamItemAndUser(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type groupGroup struct {
@@ -800,6 +801,8 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixture("group_group_store/transition/")
 			defer func() { _ = db.Close() }()
 			dataStore := database.NewDataStore(db)
@@ -1008,6 +1011,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestsOnAcceptingJoin
 	for _, tt := range generateApprovalsTests(expectedTime) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(fmt.Sprintf(`
 				groups:
 					- {id: 3}
@@ -1077,6 +1082,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestIfJoinRequestExi
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups:
 					- {id: 3}
@@ -1113,6 +1120,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestIfJoinRequestExi
 func TestGroupGroupStore_Transition_ReplacesJoinRequestByInvitationWhenNotNotEnoughApprovalsInJoinRequestOnCreatingInvitation(
 	t *testing.T,
 ) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups:
 			- {id: 3}
@@ -1154,6 +1163,8 @@ func TestGroupGroupStore_Transition_ChecksApprovalsFromParametersOnAcceptingInvi
 	for _, tt := range generateApprovalsTests(expectedTime) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(fmt.Sprintf(`
 				groups:
 					- {id: 3}

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGroupStore_CreateNew(t *testing.T) {
@@ -23,6 +24,8 @@ func TestGroupStore_CreateNew(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.groupType, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString()
 			defer func() { _ = db.Close() }()
 
@@ -324,12 +327,16 @@ func TestGroupStore_CheckIfEntryConditionsStillSatisfiedForAllActiveParticipatio
 		},
 	}
 	for _, tt := range tests {
+		testoutput.SuppressIfPasses(t)
+
 		tt := tt
 		db := testhelpers.SetupDBWithFixtureString(mainFixture, tt.fixture)
 		defer func() { _ = db.Close() }()
 		for _, withLock := range []bool{true, false} {
 			withLock := withLock
 			t.Run(tt.name+fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
+				testoutput.SuppressIfPasses(t)
+
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					if err := store.GroupGroups().CreateNewAncestors(); err != nil {
 						return err
@@ -351,6 +358,8 @@ func TestGroupStore_CheckIfEntryConditionsStillSatisfiedForAllActiveParticipatio
 }
 
 func Test_GroupStore_DeleteGroup(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`groups: [{id: 1234}]`)
 	defer func() { _ = db.Close() }()
 	groupStore := database.NewDataStore(db).Groups()
@@ -365,7 +374,7 @@ func Test_GroupStore_DeleteGroup(t *testing.T) {
 }
 
 func TestGroupStore_TriggerBeforeUpdate_RefusesToModifyType(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`groups: [{id: 1}]`)
 	defer func() { _ = db.Close() }()

--- a/app/database/group_store_test.go
+++ b/app/database/group_store_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGroupStore_ManagedBy(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -30,6 +34,8 @@ func TestGroupStore_ManagedBy(t *testing.T) {
 }
 
 func TestGroupStore_TeamGroupForUser(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -49,6 +55,8 @@ func TestGroupStore_TeamGroupForUser(t *testing.T) {
 }
 
 func TestGroupStore_CreateNew_MustBeRunInTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -59,6 +67,8 @@ func TestGroupStore_CreateNew_MustBeRunInTransaction(t *testing.T) {
 }
 
 func TestGroupStore_DeleteGroup_MustBeRunInTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -70,6 +80,8 @@ func TestGroupStore_DeleteGroup_MustBeRunInTransaction(t *testing.T) {
 }
 
 func TestGroupStore_DeleteGroup_HandlesErrorOfInnerMethod(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/groups_integration_test.go
+++ b/app/database/groups_integration_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDataStore_GetGroupJoiningByCodeInfoByCode(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	tests := []struct {
 		name     string
 		code     string
@@ -96,6 +99,8 @@ func TestDataStore_GetGroupJoiningByCodeInfoByCode(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			store := database.NewDataStore(db)
 			var got *database.GroupJoiningByCodeInfo
 			var err error

--- a/app/database/groups_test.go
+++ b/app/database/groups_test.go
@@ -5,9 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDataStore_GetGroupJoiningByCodeInfoByCode_WithLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -22,6 +26,8 @@ func TestDataStore_GetGroupJoiningByCodeInfoByCode_WithLock(t *testing.T) {
 }
 
 func TestDataStore_GetGroupJoiningByCodeInfoByCode_Error(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type itemAncestorsResultRow struct {
@@ -23,7 +24,7 @@ type itemPropagateResultRow struct {
 }
 
 func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common")
 	defer func() { _ = db.Close() }()
@@ -58,7 +59,7 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 }
 
 func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common", "item_item_store/ancestors/cyclic")
 	defer func() { _ = db.Close() }()
@@ -86,7 +87,7 @@ func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
 }
 
 func TestItemItemStore_CreateNewAncestors_IgnoresDoneItems(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("item_item_store/ancestors/_common")
 	defer func() { _ = db.Close() }()

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(groupGroupMarksResultsAsChangedFixture)
 	defer func() { _ = db.Close() }()
 

--- a/app/database/item_item_store_test.go
+++ b/app/database/item_item_store_test.go
@@ -9,9 +9,13 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestItemItemStore_ChildrenOf(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -60,6 +64,8 @@ func TestItemItemStore_PropagationEnums(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, _ := NewDBMock()
 			defer func() { _ = db.Close() }()
 			itemItemStore := NewDataStore(db).ItemItems()
@@ -95,6 +101,8 @@ func TestItemItemStore_PropagationEnums(t *testing.T) {
 }
 
 func TestItemItemStore_UpperViewLevelsPropagationIndexByName_Load(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, sqlMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -108,6 +116,8 @@ func TestItemItemStore_UpperViewLevelsPropagationIndexByName_Load(t *testing.T) 
 }
 
 func TestItemItemStore_ContentViewPropagationIndexByName_Load(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, sqlMock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -121,6 +131,8 @@ func TestItemItemStore_ContentViewPropagationIndexByName_Load(t *testing.T) {
 }
 
 func TestItemItemStore_WithItemsRelationsLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	assertNamedLockMethod(t, "items_items", int(itemsRelationsLockTimeout.Seconds()), "items_items",
 		func(store *DataStore) func(func(store *DataStore) error) error {
 			return func(txFunc func(store *DataStore) error) error {
@@ -141,6 +153,8 @@ func TestItemItemStore_CreateNewAncestors_MustBeInTransaction(t *testing.T) {
 }
 
 func TestItemItemStore_CreateNewAncestors_HandlesErrorOfCreateNewAncestors(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	expectedError := errors.New("some error")
 
 	db, dbMock := NewDBMock()

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func setupDB() *database.DB {
@@ -31,7 +32,7 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.methodToCall, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := setupDB()
 			defer func() { _ = db.Close() }()
@@ -56,7 +57,7 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 }
 
 func TestItemStore_CheckSubmissionRights(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("item_store/check_submission_rights")
 	defer func() { _ = db.Close() }()
@@ -87,7 +88,7 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				hasAccess, reason, err := store.Items().CheckSubmissionRights(test.participantID, test.itemID)
@@ -102,7 +103,7 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 }
 
 func TestItemStore_GetItemIDFromTextID(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [
@@ -133,7 +134,7 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				itemID, err := store.Items().GetItemIDFromTextID(test.textID)
@@ -146,7 +147,7 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 }
 
 func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_BreadcrumbsHierarchyForParentAttempt(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -571,7 +572,7 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 		tt := tt
 		testEachWriteLockMode(t, tt.name+": is valid", func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
-				testhelpers.SuppressOutputIfPasses(t)
+				testoutput.SuppressIfPasses(t)
 
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					got, err := store.Items().IsValidParticipationHierarchyForParentAttempt(
@@ -584,7 +585,7 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 		})
 		testEachWriteLockMode(t, tt.name+": breadcrumbs hierarchy", func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
-				testhelpers.SuppressOutputIfPasses(t)
+				testoutput.SuppressIfPasses(t)
 
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForParentAttempt(
@@ -607,7 +608,7 @@ func assertBreadcrumbsHierarchy(t *testing.T,
 }
 
 func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -1019,7 +1020,7 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 		tt := tt
 		testEachWriteLockMode(t, tt.name, func(writeLock bool) func(*testing.T) {
 			return func(t *testing.T) {
-				testhelpers.SuppressOutputIfPasses(t)
+				testoutput.SuppressIfPasses(t)
 
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForAttempt(
@@ -1058,7 +1059,7 @@ func TestItemStore_TriggerBeforeInsert_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
@@ -1111,7 +1112,7 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
@@ -1169,7 +1170,7 @@ func TestItemStore_PlatformsTriggerAfterInsert_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
@@ -1235,7 +1236,7 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				platforms:
@@ -1266,7 +1267,7 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 }
 
 func Test_ItemStore_DeleteItem(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		languages: [{tag: fr}]

--- a/app/database/mock_db_test.go
+++ b/app/database/mock_db_test.go
@@ -10,9 +10,13 @@ import (
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestNewDBMock_ExitsOnGettingErrorFromSQLMockNew(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	someError := errors.New("some error")
 
 	var patch *monkey.PatchGuard
@@ -41,6 +45,8 @@ func TestNewDBMock_ExitsOnGettingErrorFromSQLMockNew(t *testing.T) {
 }
 
 func TestNewDBMock_ExitsOnGettingErrorFromOpen(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	someError := errors.New("some error")
 
 	monkey.Patch(Open, func(interface{}) (*DB, error) { return nil, someError })

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestPermissionGeneratedStore_MatchingUserAncestors(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}]
@@ -97,7 +98,7 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(groupGroupMarksResultsAsChangedFixture)
 			defer func() { _ = db.Close() }()
@@ -193,7 +194,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			fixures := make([]string, 0, 2)
 			if !test.updateExisting {
@@ -225,7 +226,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 }
 
 func TestPermissionGeneratedStore_TriggerBeforeUpdate_RefusesToModifyGroupIDOrItemID(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}]

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type permissionsGeneratedResultRow struct {
@@ -25,7 +26,7 @@ var expectedRow14 = permissionsGeneratedResultRow{
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()
@@ -99,7 +100,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *test
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()
@@ -177,7 +178,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 	for _, access := range []string{"solution", "content_with_descendants"} {
 		access := access
 		t.Run(access, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 			defer func() { _ = db.Close() }()
@@ -330,7 +331,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 	} {
 		testcase := testcase
 		t.Run(testcase.canView+" as "+testcase.expectedCanView, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -354,7 +355,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -383,7 +384,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanView(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -407,7 +408,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -427,7 +428,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanView(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanViewAsSolutionForOwners(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -447,7 +448,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanViewAsSolutionForO
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanGrantView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -478,7 +479,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanGrantV
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanGrantView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -501,7 +502,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanGrantView(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -521,7 +522,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanGrantV
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanGrantViewAsSolutionWithGrantForOwners(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -546,7 +547,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanGrantViewAsSolutio
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanWatch(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -577,7 +578,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanWatch(
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanWatch(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -600,7 +601,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanWatch(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -620,7 +621,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanWatch(
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanWatchAsAnswerWithGrantForOwners(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -640,7 +641,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanWatchAsAnswerWithG
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanEdit(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items:
@@ -671,7 +672,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsCanEdit(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrantedCanEdit(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -694,7 +695,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesMaxOfParentsAndGrante
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanEdit(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -714,7 +715,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesMaxOfGrantedCanEdit(t
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_AggregatesCanEditAsAllWithGrantForOwners(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, default_language_tag: fr}]
@@ -798,7 +799,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_Propagates(t *testing.T) {
 
 func testPropagates(t *testing.T, column, propagationColumn, valueForParent string, propagationMode bool, expectedValue string) {
 	t.Run(valueForParent+" as "+expectedValue, func(t *testing.T) {
-		testhelpers.SuppressOutputIfPasses(t)
+		testoutput.SuppressIfPasses(t)
 
 		grantViewPropagationString := fmt.Sprint(propagationMode)
 		db := testhelpers.SetupDBWithFixtureString(`

--- a/app/database/permission_granted_store_compute_all_access_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type groupItemsResultRow struct {
@@ -19,7 +20,7 @@ type groupItemsResultRow struct {
 }
 
 func TestPermissionGrantedStore_ComputeAllAccess_Concurrency(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
 	defer func() { _ = db.Close() }()

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 const joinsPermissionsForGroupToItemsFixture = `
@@ -34,7 +35,7 @@ const joinsPermissionsForGroupToItemsFixture = `
 				 can_edit_generated: children, is_owner_generated: 1}`
 
 func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
 	defer func() { _ = db.Close() }()
@@ -70,7 +71,7 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 	} {
 		test := test
 		t.Run(fmt.Sprintf("ids: %v", test.ids), func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			var result []map[string]interface{}
 			assert.NoError(t, itemStore.Select("items.id, permissions.*").
@@ -83,7 +84,7 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 }
 
 func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(joinsPermissionsForGroupToItemsFixture)
 	defer func() { _ = db.Close() }()
@@ -139,7 +140,7 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 	} {
 		test := test
 		t.Run(fmt.Sprintf("ids: %v, %s>=%s", test.ids, test.permissionKind, test.neededPermission), func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			var result []map[string]interface{}
 			assert.NoError(t, itemStore.Select("items.id, permissions.*").

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		attempts:
@@ -52,7 +53,7 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 				hintsInfo, err := store.Results().GetHintsInfoForActiveAttempt(test.participantID, test.attemptID, test.itemID)
@@ -65,7 +66,7 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 }
 
 func TestResultStore_Propagate(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	tests := []struct {
 		name    string
@@ -80,7 +81,7 @@ func TestResultStore_Propagate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			err := database.NewDataStore(db).InTransaction(func(s *database.DataStore) error {
 				s.ScheduleResultsPropagation()

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type aggregatesResultRow struct {
@@ -28,7 +29,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 	for _, markAllResultsAsToBePropagated := range []bool{false, true} {
 		markAllResultsAsToBePropagated := markAllResultsAsToBePropagated
 		t.Run(fmt.Sprintf("mark all as to_be_propagated=%v", markAllResultsAsToBePropagated), func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/aggregates")
 			defer func() { _ = db.Close() }()
@@ -113,7 +114,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 	defer func() { _ = db.Close() }()
@@ -137,7 +138,7 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 	defer func() { _ = db.Close() }()
@@ -180,7 +181,7 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixture("results_propagation/_common")
 			defer func() { _ = db.Close() }()

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type existingResultsRow struct {
@@ -142,7 +143,7 @@ func TestResultStore_Propagate_CreatesNew(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 			testResultStorePropagateCreatesNew(t, &test)
 		})
 	}

--- a/app/database/result_store_propagate_recomputes_items_integration_test.go
+++ b/app/database/result_store_propagate_recomputes_items_integration_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestResultStore_Propagate_RecomputesResultsForItemsFromTableResultsRecomputeForItems(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1}, {id: 2}, {id: 3}]

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type unlocksResultRow struct {
@@ -23,7 +24,7 @@ type unlocksResultRow struct {
 }
 
 func TestResultStore_Propagate_Unlocks(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
@@ -32,7 +33,7 @@ func TestResultStore_Propagate_Unlocks(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Unlocks_UpdatesOldRecords(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture(
 		"results_propagation/_common",
@@ -44,7 +45,7 @@ func TestResultStore_Propagate_Unlocks_UpdatesOldRecords(t *testing.T) {
 }
 
 func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture(
 		"results_propagation/_common",
@@ -98,7 +99,7 @@ func generateGrantedPermissionsRow(itemID, canView, canEnterFrom, canEnterUntil,
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
@@ -108,7 +109,7 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry(t *testing.T)
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHasBeenSetAlready(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()
@@ -140,7 +141,7 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHas
 }
 
 func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_CanEnterFromIsInTheFuture(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/unlocks")
 	defer func() { _ = db.Close() }()

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type validationDateResultRow struct {
@@ -34,7 +35,7 @@ func constructExpectedResultsForValidatedAtTests(t11, t12, t13, t14, t23, t24 *t
 }
 
 func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValidatedAts(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
@@ -77,7 +78,7 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_NoSuitableChildren(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
@@ -110,7 +111,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategoriesAreNotValidated(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
@@ -145,7 +146,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithCategoryValidation_IfAllAreValidated(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()
@@ -185,7 +186,7 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfChildrenWithCategoryValidation_IgnoresNoScoreItems(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture("results_propagation/_common", "results_propagation/validated_at")
 	defer func() { _ = db.Close() }()

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 type validatedResultRow struct {
@@ -31,7 +32,7 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	validationType string,
 	prepareFunc func(*testing.T, *database.ResultStore), expectedResults []validatedResultRow,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixture(fixtures...)
 	defer func() { _ = db.Close() }()
@@ -66,7 +67,7 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			testResultStorePropagateValidated(t,
 				[]string{"results_propagation/_common"},
@@ -85,7 +86,7 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhenThereIsAtLeastOneValidatedChild(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
@@ -102,7 +103,7 @@ func TestResultStore_Propagate_ValidatedWithValidationTypeOneBecomesValidatedWhe
 func TestResultStore_Propagate_ValidatedWithValidationTypeOneStaysNonValidatedWhenThereAreNoValidatedChildren(
 	t *testing.T,
 ) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	testResultStorePropagateValidated(t,
 		[]string{"results_propagation/_common", "results_propagation/validated/one"},
@@ -255,7 +256,7 @@ func TestResultStore_Propagate_Validated(t *testing.T) {
 	for _, testCase := range tests {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 			testResultStorePropagateValidated(t, testCase.fixtures,
 				testCase.validationType, testCase.prepareFunc, testCase.expectedResults)
 		})

--- a/app/database/user_integration_test.go
+++ b/app/database/user_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestUser_CanSeeAnswer(t *testing.T) {
@@ -72,7 +73,7 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups: [{id: 101}, {id: 102}, {id: 111}, {id: 121}]

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
@@ -39,7 +40,7 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := setupDBForDeleteWithTrapsTests(t, currentTime)
 			defer func() { _ = db.Close() }()
@@ -53,7 +54,7 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 }
 
 func TestUserStore_DeleteWithTraps(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	currentTime := time.Now().UTC().Truncate(time.Second)
 	testhelpers.MockDBTime(currentTime.Format(time.DateTime))
@@ -70,7 +71,7 @@ func TestUserStore_DeleteWithTraps(t *testing.T) {
 }
 
 func TestUserStore_DeleteWithTrapsByScope(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	currentTime := time.Now().UTC().Truncate(time.Second)
 	testhelpers.MockDBTime(currentTime.Format(time.DateTime))

--- a/app/database/users_integration_test.go
+++ b/app/database/users_integration_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	tests := []struct {
 		name   string
@@ -94,7 +95,7 @@ func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(
 		for _, withLock := range []bool{true, false} {
 			withLock := withLock
 			t.Run(tt.name+fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
-				testhelpers.SuppressOutputIfPasses(t)
+				testoutput.SuppressIfPasses(t)
 
 				store := database.NewDataStore(db)
 				var got bool

--- a/app/database/users_test.go
+++ b/app/database/users_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDB_WhereUsersAreDescendantsOfGroup(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -28,6 +32,8 @@ func TestDB_WhereUsersAreDescendantsOfGroup(t *testing.T) {
 }
 
 func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships_WithLock(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 
@@ -42,6 +48,8 @@ func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships_
 }
 
 func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships_Error(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db, mock := NewDBMock()
 	defer func() { _ = db.Close() }()
 

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestStructuredDBLogger_Print_SQL(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
@@ -44,6 +47,8 @@ func TestStructuredDBLogger_Print_SQL(t *testing.T) {
 }
 
 func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
@@ -65,6 +70,8 @@ func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 }
 
 func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
@@ -97,6 +104,8 @@ func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 }
 
 func TestStructuredDBLogger_Print_RawSQLWithDuration(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger.Logger, hook = test.NewNullLogger()

--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestGetParticipantIDFromRequest(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1, type: Class}, {id: 2, type: Team}, {id: 3, type: Team}, {id: 4, type: User}, {id: 5, type: User}]
@@ -61,7 +62,7 @@ func TestGetParticipantIDFromRequest(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		testhelpers.SuppressOutputIfPasses(t)
+		testoutput.SuppressIfPasses(t)
 
 		test := test
 		participantID, apiError := service.GetParticipantIDFromRequest(

--- a/app/service/propagation_integration_test.go
+++ b/app/service/propagation_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestSchedulePropagation(t *testing.T) {
@@ -64,7 +65,7 @@ func TestSchedulePropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(`
 				groups:

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestBase_ResolveWatchedGroupID(t *testing.T) {
-	testhelpers.SuppressOutputIfPasses(t)
+	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(`
 		groups: [{id: 1, type: Class}, {id: 2, type: Team}, {id: 3, type: Other}, {id: 4, type: User}, {id: 5, type: User}, {id: 6, type: Team}]
@@ -60,7 +61,7 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			testhelpers.SuppressOutputIfPasses(t)
+			testoutput.SuppressIfPasses(t)
 
 			req, _ := http.NewRequest("GET", tt.url, http.NoBody)
 			watchedGroupID, watchedGroupIDIsSet, apiError := srv.ResolveWatchedGroupID(req)

--- a/app/token/token_integration_test.go
+++ b/app/token/token_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/tokentest"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestToken_UnmarshalDependingOnItemPlatform(t *testing.T) {
@@ -125,6 +126,8 @@ func TestToken_UnmarshalDependingOnItemPlatform(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db := testhelpers.SetupDBWithFixtureString(tt.fixtures...)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)

--- a/testhelpers/testoutput/suppress.go
+++ b/testhelpers/testoutput/suppress.go
@@ -1,4 +1,5 @@
-package testhelpers
+// Package testoutput provides SuppressIfPasses function that mutes output of the test.
+package testoutput
 
 import (
 	"testing"
@@ -6,7 +7,7 @@ import (
 	"github.com/zenovich/flowmingo"
 )
 
-// SuppressOutputIfPasses immediately mutes output (to both STDOUT and STDERR) of the test
+// SuppressIfPasses immediately mutes output (to both STDOUT and STDERR) of the test
 // so that the output will only be shown if the test fails.
 // The cleanup part is scheduled to be run automatically,
 // no need to clean up manually.
@@ -17,7 +18,7 @@ import (
 // After the output is suppressed, t.Parallel() for the test will panic.
 //
 // Note: This function does nothing if the test is run in verbose mode.
-func SuppressOutputIfPasses(t *testing.T) { //nolint:gocritic
+func SuppressIfPasses(t *testing.T) { //nolint:gocritic
 	if testing.Verbose() {
 		return
 	}


### PR DESCRIPTION
1. Move and rename testhelpers/SuppressOutputIfPasses() to testhelpers/testoutput/SuppressIfPasses() to allow using it from unit tests without creating dependency cycles
2. Suppress output of even more tests.