### PR TITLE
Do not run groups ancestors propagation in currentUserDeletion & userBatchRemove services and delete-temp-users command + Schedule permissions propagations when needed in currentUserDeletion & userBatchRemove

### DIFF
--- a/app/api/currentuser/delete.go
+++ b/app/api/currentuser/delete.go
@@ -28,13 +28,14 @@ import (
 //							 3. [`permissions_granted`, `permissions_generated`, `attempts`]
 //									having `group_id` = `users.group_id`;
 //
-//							 4. `groups_groups` having `parent_group_id` or `child_group_id` equal to `users.group_id`;
-//							 5. `group_pending_requests`/`group_membership_changes` having `group_id` or `member_id` equal
+//							 4. `permissions_granted` having `source_group_id` = `users.group_id`;
+//							 5. `groups_groups` having `parent_group_id` or `child_group_id` equal to `users.group_id`;
+//							 6. `group_pending_requests`/`group_membership_changes` having `group_id` or `member_id` equal
 //									to `users.group_id`;
-//							 6. `groups_ancestors` having `ancestor_group_id` or `child_group_id` equal
+//							 7. `groups_ancestors` having `ancestor_group_id` or `child_group_id` equal
 //									to `users.group_id`;
-//							 7. [`groups_propagate`, `groups`] having `id` equal to `users.group_id`;
-//							 8. `users` having `group_id` = `users.group_id`.
+//							 8. [`groups_propagate`, `groups`] having `id` equal to `users.group_id`;
+//							 9. `users` having `group_id` = `users.group_id`.
 //
 //
 //							 The deletion is rejected if the user is a member of at least one group with
@@ -70,7 +71,7 @@ func (srv *Service) delete(w http.ResponseWriter, r *http.Request) service.APIEr
 		service.MustNotBeError(store.Users().ByID(user.GroupID).
 			PluckFirst("login_id", &loginID).Error())
 	}
-	service.MustNotBeError(store.Users().DeleteWithTraps(user))
+	service.MustNotBeError(store.Users().DeleteWithTraps(user, user.IsTempUser))
 
 	if !user.IsTempUser {
 		var result bool

--- a/app/api/groups/remove_user_batch.go
+++ b/app/api/groups/remove_user_batch.go
@@ -120,7 +120,7 @@ func (srv *Service) removeUserBatch(w http.ResponseWriter, r *http.Request) serv
 	}
 	service.MustNotBeError(store.Users().DeleteWithTrapsByScope(func(store *database.DataStore) *database.DB {
 		return store.Users().Where("login LIKE CONCAT(?, '\\_', ?, '\\_%')", groupPrefix, customPrefix)
-	}))
+	}, false))
 	service.MustNotBeError(
 		store.UserBatches().
 			Where("group_prefix = ?", groupPrefix).

--- a/app/database/user_store.go
+++ b/app/database/user_store.go
@@ -41,28 +41,31 @@ func (s *UserStore) DeleteTemporaryWithTraps(delay time.Duration) (err error) {
 				uint64(delay.Round(time.Second)/time.Second)).
 			Where("access_tokens.session_id IS NULL").
 			Where("temp_user = 1")
-		return store.Users().deleteWithTraps(userScope)
+		return store.Users().deleteWithTraps(userScope, true)
 	})
 	return nil
 }
 
 // DeleteWithTraps deletes a given user. It also removes linked rows in the same way as DeleteTemporaryWithTraps.
-func (s *UserStore) DeleteWithTraps(user *User) (err error) {
+// For non-temporary users (when isTemporary is false), it also removes `permissions_granted`
+// having source_group_id = users.group_id and schedules the permissions propagation.
+func (s *UserStore) DeleteWithTraps(user *User, isTemporary bool) (err error) {
 	return s.InTransaction(func(store *DataStore) error {
-		deleteOneBatchOfUsers(store.DB, []int64{user.GroupID})
-		store.GroupGroups().createNewAncestors()
+		deleteOneBatchOfUsers(store.DB, []int64{user.GroupID}, isTemporary)
 		return nil
 	})
 }
 
 // DeleteWithTrapsByScope deletes users matching the given scope.
 // It also removes linked rows in the same way as DeleteTemporaryWithTraps.
-func (s *UserStore) DeleteWithTrapsByScope(scopeFunc func(store *DataStore) *DB) (err error) {
+// For non-temporary users (when isTemporary is false), it also removes `permissions_granted`
+// having source_group_id = users.group_id and schedules the permissions propagation.
+func (s *UserStore) DeleteWithTrapsByScope(scopeFunc func(store *DataStore) *DB, isTemporary bool) (err error) {
 	defer recoverPanics(&err)
 
 	s.executeBatchesInTransactions(func(store *DataStore) int {
 		scope := scopeFunc(store)
-		return store.Users().deleteWithTraps(scope)
+		return store.Users().deleteWithTraps(scope, isTemporary)
 	})
 	return nil
 }
@@ -82,7 +85,7 @@ func (s *UserStore) executeBatchesInTransactions(f func(store *DataStore) int) {
 
 // deleteWithTraps deletes the first deleteWithTrapsBatchSize users satisfying the scope's conditions
 // and all the users' stuff.
-func (s *UserStore) deleteWithTraps(userScope *DB) int {
+func (s *UserStore) deleteWithTraps(userScope *DB, isTemporary bool) int {
 	userScope.mustBeInTransaction()
 
 	userIDs := make([]int64, 0, deleteWithTrapsBatchSize)
@@ -95,17 +98,19 @@ func (s *UserStore) deleteWithTraps(userScope *DB) int {
 		return 0
 	}
 
-	deleteOneBatchOfUsers(userScope, userIDs)
-	s.GroupGroups().createNewAncestors()
+	deleteOneBatchOfUsers(userScope, userIDs, isTemporary)
 
 	return len(userIDs)
 }
 
-func deleteOneBatchOfUsers(db *DB, userIDs []int64) {
+func deleteOneBatchOfUsers(db *DB, userIDs []int64, isTemporary bool) {
 	db.mustBeInTransaction()
 
-	// we should delete from groups_groups explicitly in order to invoke triggers on groups_groups
-	executeDeleteQuery(db, "groups_groups", "WHERE parent_group_id IN (?)", userIDs)
+	// we should delete from permissions_granted explicitly in order to invoke triggers on permissions_granted
+	if !isTemporary && executeDeleteQuery(db, "permissions_granted", "WHERE source_group_id IN (?)", userIDs) > 0 {
+		NewDataStore(db).SchedulePermissionsPropagation()
+	}
+
 	// deleting from `groups` triggers deletion from
 	// `groups_propagate`, `groups_groups`, `groups_ancestors`, `group_pending_requests`, `group_membership_changes`,
 	// `permissions_granted`, `permissions_generated", `attempts`, `results`,
@@ -113,7 +118,8 @@ func deleteOneBatchOfUsers(db *DB, userIDs []int64) {
 	executeDeleteQuery(db, "groups", "WHERE id IN (?)", userIDs)
 }
 
-func executeDeleteQuery(s *DB, table, condition string, args ...interface{}) {
-	mustNotBeError(
-		s.Exec(fmt.Sprintf("DELETE %[1]s FROM %[1]s ", QuoteName(table))+condition, args...).Error())
+func executeDeleteQuery(s *DB, table, condition string, args ...interface{}) int64 {
+	result := s.Exec(fmt.Sprintf("DELETE %[1]s FROM %[1]s ", QuoteName(table))+condition, args...)
+	mustNotBeError(result.Error())
+	return result.RowsAffected()
 }

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
@@ -65,7 +66,7 @@ func TestUserStore_DeleteWithTraps(t *testing.T) {
 
 	store := database.NewDataStore(db)
 	assert.NoError(t, store.Users().DeleteWithTraps(
-		&database.User{GroupID: 5001}))
+		&database.User{GroupID: 5001}, false))
 
 	assertUserRelatedTablesAfterDeletingWithTraps(t, db, golang.NewSet[int64](5001), golang.NewSet[int64](2))
 }
@@ -83,7 +84,7 @@ func TestUserStore_DeleteWithTrapsByScope(t *testing.T) {
 	store := database.NewDataStore(db)
 	assert.NoError(t, store.Users().DeleteWithTrapsByScope(func(store *database.DataStore) *database.DB {
 		return store.Users().Where("group_id % 2 = 0")
-	}))
+	}, false))
 
 	assertUserRelatedTablesAfterDeletingWithTraps(t, db, golang.NewSet[int64](5000, 5002), golang.NewSet[int64](1, 3))
 }
@@ -161,6 +162,30 @@ func setupDBForDeleteWithTrapsTests(t *testing.T, currentTime time.Time) *databa
 		return nil
 	}))
 	return db
+}
+
+func TestUserStore_DeleteWithTrapsByScope_RecomputesAccessWhenPermissionIsRemovedViaSourceGroupID(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups: [{id: 1}, {id: 5000}, {id: 5001}]
+		users: [{group_id: 5000}]
+		items: [{id: 10, default_language_tag: fr}]
+		permissions_granted:
+			- {group_id: 1, item_id: 10, source_group_id: 5000, can_view: content}
+			- {group_id: 1, item_id: 10, source_group_id: 5001, can_view: info}
+		permissions_generated: [{group_id: 1, item_id: 10, can_view_generated: content}]`)
+	defer func() { _ = db.Close() }()
+
+	dataStore := database.NewDataStore(db)
+	require.NoError(t, dataStore.Users().DeleteWithTrapsByScope(func(store *database.DataStore) *database.DB {
+		return store.Users().Where("group_id = 5000")
+	}, false))
+
+	var newPermission string
+	require.NoError(t, dataStore.Permissions().Where("group_id = 1 AND item_id = 10").
+		PluckFirst("can_view_generated", &newPermission).Error())
+	assert.Equal(t, "info", newPermission)
 }
 
 func assertTableColumn(t *testing.T, db *database.DB, table, column string, expectedValues interface{}) {

--- a/app/database/user_store_test.go
+++ b/app/database/user_store_test.go
@@ -18,7 +18,7 @@ func TestUserStore_deleteWithTraps_DoesNothingWhenScopeReturnsNothing(t *testing
 
 	assert.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
 		userStore := store.Users()
-		cnt := userStore.deleteWithTraps(userStore.DB)
+		cnt := userStore.deleteWithTraps(userStore.DB, false)
 		assert.Zero(t, cnt)
 		return nil
 	}))


### PR DESCRIPTION
1. Do not run groups ancestors propagation in currentUserDeletion & userBatchRemove services and delete-temp-users command as users cannot have child groups.
2. Schedule permissions propagations when a removed user is a source_group_id for a granted permission in currentUserDeletion & userBatchRemove.