### PR TITLE
DB wrappers: handle DB request timeouts, log SQL queries everywhere, analyze SQL statement + rework named locking + add 408 status code + test-system improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,11 @@ jobs:
           name: Prepare for report
           command: |
             mkdir -p test-results
-            go get -u github.com/jstemmer/go-junit-report
-            go install github.com/jstemmer/go-junit-report
+            go install github.com/jstemmer/go-junit-report/v2@latest
       - run:
           name: Run tests (make verbosity disabled)
           no_output_timeout: 30m
-          command: NOECHO=1 make test 2>&1 | go-junit-report > test-results/junit.xml
+          command: NOECHO=1 make test 2>&1 | go-junit-report -iocopy -set-exit-code -out test-results/junit.xml
       - run:
           name: Upload test coverage results to Codecov
           command: bash <(curl -s https://codecov.io/bash)
@@ -78,11 +77,6 @@ jobs:
       - store_artifacts: *TESTPATH
       - store_artifacts:
           path: log
-      - run:
-          when: on_fail
-          name: On failure, run BDD tests with details
-          no_output_timeout: 30m
-          command: make test-bdd
   migration-tests:
     docker:
       - image: cimg/go:1.20.2

--- a/app/api/answers/create_answer.go
+++ b/app/api/answers/create_answer.go
@@ -56,6 +56,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) answerCreate(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/generate_task_token.go
+++ b/app/api/answers/generate_task_token.go
@@ -72,6 +72,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/answers/get_answer.go
+++ b/app/api/answers/get_answer.go
@@ -47,6 +47,8 @@ import (
 //				"$ref": "#/responses/unauthorizedResponse"
 //			"403":
 //				"$ref": "#/responses/forbiddenResponse"
+//			"408":
+//				"$ref": "#/responses/requestTimeoutResponse"
 //			"500":
 //				"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getAnswer(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/get_best.go
+++ b/app/api/answers/get_best.go
@@ -48,6 +48,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getBestAnswer(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/get_current.go
+++ b/app/api/answers/get_current.go
@@ -50,6 +50,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getCurrentAnswer(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/list_answers.go
+++ b/app/api/answers/list_answers.go
@@ -73,6 +73,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listAnswers(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -79,6 +79,8 @@ type answerSubmitResponse struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) submit(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/answers/update_current.go
+++ b/app/api/answers/update_current.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateCurrentAnswer(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -195,6 +195,8 @@ const parsedRequestData ctxKey = iota
 //			"$ref": "#/responses/badRequestResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -58,6 +58,8 @@ import (
 //				"$ref": "#/definitions/userCreateTmpResponse"
 //		"400":
 //			"$ref": "#/responses/badRequestResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createTempUser(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/auth/logout.go
+++ b/app/api/auth/logout.go
@@ -20,6 +20,8 @@ import (
 //			"$ref": "#/responses/successResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) logout(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/auth/refresh_access_token.go
+++ b/app/api/auth/refresh_access_token.go
@@ -17,7 +17,7 @@ import (
 
 type sessionIDsInProgressMap sync.Map
 
-func (m *sessionIDsInProgressMap) withLock(sessionID int64, r *http.Request, f func() error) error {
+func (m *sessionIDsInProgressMap) WithLock(sessionID int64, r *http.Request, f func() error) error {
 	sessionMutex := make(chan bool)
 	defer close(sessionMutex)
 	sessionMutexInterface, loaded := (*sync.Map)(m).LoadOrStore(sessionID, sessionMutex)
@@ -68,7 +68,7 @@ func (srv *Service) refreshAccessToken(w http.ResponseWriter, r *http.Request) s
 			// We should not allow concurrency in this part because the login module generates not only
 			// a new access token, but also a new refresh token and revokes the old one. We want to prevent
 			// usage of the old refresh token for that reason.
-			service.MustNotBeError(sessionIDsInProgress.withLock(sessionID, r, func() error {
+			service.MustNotBeError(sessionIDsInProgress.WithLock(sessionID, r, func() error {
 				newToken, expiresIn, apiError = srv.refreshTokens(r.Context(), store, user, sessionID)
 				return nil
 			}))

--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -102,7 +102,7 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 			defer func() { _ = response.Body.Close() }()
 		}
 		if timeout {
-			assert.Equal(t, 500, response.StatusCode)
+			assert.Equal(t, 408, response.StatusCode)
 			assert.Contains(t, logs, "The request is canceled: context deadline exceeded")
 		} else {
 			assert.Equal(t, 201, response.StatusCode)

--- a/app/api/contests/get_administered_list.go
+++ b/app/api/contests/get_administered_list.go
@@ -74,6 +74,8 @@ type contestAdminListRow struct {
 //					"$ref": "#/definitions/contestAdminListRow"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getAdministeredList(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/contests/get_group_by_name.go
+++ b/app/api/contests/get_group_by_name.go
@@ -59,6 +59,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupByName(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/contests/get_members_additional_times.go
+++ b/app/api/contests/get_members_additional_times.go
@@ -73,6 +73,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getMembersAdditionalTimes(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/contests/set_additional_time.go
+++ b/app/api/contests/set_additional_time.go
@@ -61,6 +61,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) setAdditionalTime(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/accept_group_invitation.go
+++ b/app/api/currentuser/accept_group_invitation.go
@@ -56,6 +56,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponseWithMissingApprovals"
 //		"500":

--- a/app/api/currentuser/check_login_id.go
+++ b/app/api/currentuser/check_login_id.go
@@ -33,6 +33,8 @@ type loginIDCheckData struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) checkLoginID(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/create_group_join_request.go
+++ b/app/api/currentuser/create_group_join_request.go
@@ -86,6 +86,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"409":
 //			"$ref": "#/responses/conflictResponse"
 //		"422":

--- a/app/api/currentuser/create_group_leave_request.go
+++ b/app/api/currentuser/create_group_leave_request.go
@@ -41,6 +41,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/currentuser/delete.go
+++ b/app/api/currentuser/delete.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) delete(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_dump.go
+++ b/app/api/currentuser/get_dump.go
@@ -31,6 +31,8 @@ import (
 //				type: file
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getDump(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_full_dump.go
+++ b/app/api/currentuser/get_full_dump.go
@@ -54,6 +54,8 @@ import (
 //					type: file
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getFullDump(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_group_activities.go
+++ b/app/api/currentuser/get_group_activities.go
@@ -125,6 +125,8 @@ type rootItem struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getRootActivities(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_group_invitations.go
+++ b/app/api/currentuser/get_group_invitations.go
@@ -102,6 +102,8 @@ type groupWithApprovals struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupInvitations(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_group_memberships.go
+++ b/app/api/currentuser/get_group_memberships.go
@@ -77,6 +77,8 @@ type membershipsViewResponseRow struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupMemberships(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_group_memberships_history.go
+++ b/app/api/currentuser/get_group_memberships_history.go
@@ -52,6 +52,8 @@ import (
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupMembershipsHistory(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_group_skills.go
+++ b/app/api/currentuser/get_group_skills.go
@@ -53,6 +53,8 @@ type skillsViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getRootSkills(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_info.go
+++ b/app/api/currentuser/get_info.go
@@ -101,6 +101,8 @@ type getInfoData struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getInfo(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/get_managed_groups.go
+++ b/app/api/currentuser/get_managed_groups.go
@@ -67,6 +67,8 @@ type managedGroupsGetResponseRow struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getManagedGroups(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/join_group_by_code.go
+++ b/app/api/currentuser/join_group_by_code.go
@@ -68,6 +68,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"409":
 //			"$ref": "#/responses/conflictResponse"
 //		"422":

--- a/app/api/currentuser/leave_group.go
+++ b/app/api/currentuser/leave_group.go
@@ -45,6 +45,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) leaveGroup(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/refresh.go
+++ b/app/api/currentuser/refresh.go
@@ -22,6 +22,8 @@ import (
 //			"$ref": "#/responses/updatedResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) refresh(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/reject_group_invitation.go
+++ b/app/api/currentuser/reject_group_invitation.go
@@ -35,6 +35,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/currentuser/search_for_available_groups.go
+++ b/app/api/currentuser/search_for_available_groups.go
@@ -79,6 +79,8 @@ const minSearchStringLength = 3
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) searchForAvailableGroups(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/update.go
+++ b/app/api/currentuser/update.go
@@ -30,6 +30,8 @@ type userDataUpdateRequest struct {
 //			"$ref": "#/responses/updatedResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) update(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/update_notifications_read_at.go
+++ b/app/api/currentuser/update_notifications_read_at.go
@@ -19,6 +19,8 @@ import (
 //			"$ref": "#/responses/updatedResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateNotificationsReadAt(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/currentuser/withdraw_group_join_request.go
+++ b/app/api/currentuser/withdraw_group_join_request.go
@@ -36,6 +36,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/currentuser/withdraw_group_leave_request.go
+++ b/app/api/currentuser/withdraw_group_leave_request.go
@@ -40,6 +40,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) withdrawGroupLeaveRequest(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/accept_join_requests.go
+++ b/app/api/groups/accept_join_requests.go
@@ -81,6 +81,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) acceptJoinRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/accept_leave_requests.go
+++ b/app/api/groups/accept_leave_requests.go
@@ -60,6 +60,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) acceptLeaveRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/add_child.go
+++ b/app/api/groups/add_child.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) addChild(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/check_code.go
+++ b/app/api/groups/check_code.go
@@ -88,6 +88,8 @@ type groupCodeCheckResponse struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) checkCode(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/create_code.go
+++ b/app/api/groups/create_code.go
@@ -77,7 +77,7 @@ func (srv *Service) createCode(w http.ResponseWriter, r *http.Request) service.A
 			newCode, err = GenerateGroupCode()
 			service.MustNotBeError(err)
 
-			err = store.Groups().Where("id = ?", groupID).Updates(map[string]interface{}{"code": newCode}).Error()
+			err = store.Groups().Where("id = ?", groupID).UpdateColumn(map[string]interface{}{"code": newCode}).Error()
 			if err != nil && strings.Contains(err.Error(), "Duplicate entry") {
 				continue
 			}

--- a/app/api/groups/create_code.go
+++ b/app/api/groups/create_code.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createCode(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/create_group.go
+++ b/app/api/groups/create_group.go
@@ -49,6 +49,8 @@ type createGroupRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createGroup(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/create_invitations.go
+++ b/app/api/groups/create_invitations.go
@@ -104,6 +104,8 @@ const maxAllowedLoginsToInvite = 100
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createGroupInvitations(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/create_manager.go
+++ b/app/api/groups/create_manager.go
@@ -55,6 +55,8 @@ type createGroupManagerRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createGroupManager(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/create_user_batch.go
+++ b/app/api/groups/create_user_batch.go
@@ -118,6 +118,8 @@ type subgroupApproval struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createUserBatch(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/delete_group.go
+++ b/app/api/groups/delete_group.go
@@ -51,6 +51,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) deleteGroup(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_breadcrumbs.go
+++ b/app/api/groups/get_breadcrumbs.go
@@ -58,6 +58,8 @@ type groupBreadcrumbsViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getBreadcrumbs(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -110,6 +110,8 @@ type groupChildrenViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getChildren(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_current_user_team_by_item.go
+++ b/app/api/groups/get_current_user_team_by_item.go
@@ -44,6 +44,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getCurrentUserTeamByItem(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -124,6 +124,8 @@ type grantedPermissionsViewResultRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_group.go
+++ b/app/api/groups/get_group.go
@@ -129,6 +129,8 @@ type groupGetResponse struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroup(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -116,6 +116,8 @@ type groupGroupProgressResponseTableCell struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupProgress(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_group_progress_csv.go
+++ b/app/api/groups/get_group_progress_csv.go
@@ -69,6 +69,8 @@ type idName struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getGroupProgressCSV(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_managers.go
+++ b/app/api/groups/get_managers.go
@@ -109,6 +109,8 @@ type groupManagersViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getManagers(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_members.go
+++ b/app/api/groups/get_members.go
@@ -83,6 +83,8 @@ type groupsMembersViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getMembers(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_navigation.go
+++ b/app/api/groups/get_navigation.go
@@ -80,6 +80,8 @@ type groupNavigationViewResponse struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getNavigation(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_parents.go
+++ b/app/api/groups/get_parents.go
@@ -78,6 +78,8 @@ type groupParentsViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getParents(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -168,6 +168,8 @@ type participantProgressParameters struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getParticipantProgress(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -165,6 +165,8 @@ type canRequestHelpToPermissionsRaw struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getPermissions(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_requests.go
+++ b/app/api/groups/get_requests.go
@@ -127,6 +127,8 @@ type groupRequestsViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_roots.go
+++ b/app/api/groups/get_roots.go
@@ -47,6 +47,8 @@ type groupRootsViewResponseRow struct {
 //					"$ref": "#/definitions/groupRootsViewResponseRow"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getRoots(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_team_descendants.go
+++ b/app/api/groups/get_team_descendants.go
@@ -56,6 +56,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getTeamDescendants(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_team_progress.go
+++ b/app/api/groups/get_team_progress.go
@@ -102,6 +102,8 @@ type groupTeamProgressResponseTableCell struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getTeamProgress(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_team_progress_csv.go
+++ b/app/api/groups/get_team_progress_csv.go
@@ -62,6 +62,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getTeamProgressCSV(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_batch_prefixes.go
+++ b/app/api/groups/get_user_batch_prefixes.go
@@ -69,6 +69,8 @@ type userBatchPrefix struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserBatchPrefixes(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_batches.go
+++ b/app/api/groups/get_user_batches.go
@@ -69,6 +69,8 @@ type userBatch struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserBatches(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_descendants.go
+++ b/app/api/groups/get_user_descendants.go
@@ -56,6 +56,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserDescendants(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_progress.go
+++ b/app/api/groups/get_user_progress.go
@@ -108,6 +108,8 @@ type groupUserProgressResponseTableCell struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserProgress(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_progress_csv.go
+++ b/app/api/groups/get_user_progress_csv.go
@@ -71,6 +71,8 @@ const csvExportBatchSize = 500
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserProgressCSV(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/get_user_requests.go
+++ b/app/api/groups/get_user_requests.go
@@ -121,6 +121,8 @@ type groupUserRequestsViewResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getUserRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/path_from_root.go
+++ b/app/api/groups/path_from_root.go
@@ -55,6 +55,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/reject_join_requests.go
+++ b/app/api/groups/reject_join_requests.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) rejectJoinRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/reject_leave_requests.go
+++ b/app/api/groups/reject_leave_requests.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) rejectLeaveRequests(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/remove_child.go
+++ b/app/api/groups/remove_child.go
@@ -63,6 +63,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) removeChild(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/remove_code.go
+++ b/app/api/groups/remove_code.go
@@ -33,6 +33,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) removeCode(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/remove_manager.go
+++ b/app/api/groups/remove_manager.go
@@ -40,6 +40,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) removeGroupManager(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/remove_members.go
+++ b/app/api/groups/remove_members.go
@@ -68,6 +68,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) removeMembers(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/remove_user_batch.go
+++ b/app/api/groups/remove_user_batch.go
@@ -61,6 +61,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/groups/search_for_possible_subgroups.go
+++ b/app/api/groups/search_for_possible_subgroups.go
@@ -79,6 +79,8 @@ const minSearchStringLength = 3
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) searchForPossibleSubgroups(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -231,7 +231,7 @@ func (srv *Service) updateGroup(w http.ResponseWriter, r *http.Request) service.
 			groupStore, groupID, user.GroupID, dbMap, &currentGroupData, approvalChangeAction))
 
 		// update the group
-		service.MustNotBeError(groupStore.Where("id = ?", groupID).Updates(dbMap).Error())
+		service.MustNotBeError(groupStore.Where("id = ?", groupID).UpdateColumns(dbMap).Error())
 
 		return nil // commit
 	})

--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -148,6 +148,8 @@ type groupUpdateInput struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateGroup(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/update_manager.go
+++ b/app/api/groups/update_manager.go
@@ -46,6 +46,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateGroupManager(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -121,6 +121,8 @@ type managerGeneratedPermissions struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updatePermissions(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/groups/withdraw_invitations.go
+++ b/app/api/groups/withdraw_invitations.go
@@ -47,6 +47,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) withdrawInvitations(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/apply_dependency.go
+++ b/app/api/items/apply_dependency.go
@@ -46,6 +46,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) applyDependency(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -80,6 +80,8 @@ import (
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) askHint(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/create_attempt.go
+++ b/app/api/items/create_attempt.go
@@ -61,6 +61,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/items/create_dependency.go
+++ b/app/api/items/create_dependency.go
@@ -64,6 +64,8 @@ type itemDependencyCreateRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -187,6 +187,8 @@ func (in *NewItemRequest) canCreateItemsRelationsWithoutCycles(store *database.D
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) createItem(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/delete_dependency.go
+++ b/app/api/items/delete_dependency.go
@@ -38,6 +38,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) deleteDependency(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/delete_item.go
+++ b/app/api/items/delete_item.go
@@ -43,6 +43,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"422":
 //			"$ref": "#/responses/unprocessableEntityResponse"
 //		"500":

--- a/app/api/items/end_attempt.go
+++ b/app/api/items/end_attempt.go
@@ -42,6 +42,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) endAttempt(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/enter.go
+++ b/app/api/items/enter.go
@@ -56,6 +56,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) enter(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/generate_task_token.go
+++ b/app/api/items/generate_task_token.go
@@ -81,6 +81,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) generateTaskToken(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -151,6 +151,8 @@ type itemActivityLogResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getActivityLogForItem(w http.ResponseWriter, r *http.Request) service.APIError {
@@ -240,6 +242,8 @@ func (srv *Service) getActivityLogForItem(w http.ResponseWriter, r *http.Request
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getActivityLogForAllItems(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -89,6 +89,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getBreadcrumbs(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -83,6 +83,8 @@ type breadcrumbElement struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getBreadcrumbsFromRootsByItemID(w http.ResponseWriter, r *http.Request) service.APIError {
@@ -130,6 +132,8 @@ func (srv *Service) getBreadcrumbsFromRootsByItemID(w http.ResponseWriter, r *ht
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getBreadcrumbsFromRootsByTextID(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -210,6 +210,8 @@ type rawListChildItem struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemChildren(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/get_dependencies.go
+++ b/app/api/items/get_dependencies.go
@@ -50,6 +50,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemDependencies(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/get_entry_state.go
+++ b/app/api/items/get_entry_state.go
@@ -131,6 +131,8 @@ type itemGetEntryStateResponse struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getEntryState(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -212,6 +212,8 @@ type itemResponse struct {
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItem(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/get_navigation.go
+++ b/app/api/items/get_navigation.go
@@ -123,6 +123,8 @@ type itemWatchedGroupStat struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemNavigation(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/get_parents.go
+++ b/app/api/items/get_parents.go
@@ -84,6 +84,8 @@ type parentItem struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemParents(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/get_prerequisites.go
+++ b/app/api/items/get_prerequisites.go
@@ -93,6 +93,8 @@ type rawPrerequisiteOrDependencyItem struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getItemPrerequisites(rw http.ResponseWriter, httpReq *http.Request) service.APIError {

--- a/app/api/items/list_attempts.go
+++ b/app/api/items/list_attempts.go
@@ -113,6 +113,8 @@ type attemptsListResponseRow struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listAttempts(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/list_official_sessions.go
+++ b/app/api/items/list_official_sessions.go
@@ -147,6 +147,8 @@ type rawOfficialSession struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listOfficialSessions(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -86,6 +86,8 @@ type rawItemPath struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/publish_result.go
+++ b/app/api/items/publish_result.go
@@ -49,6 +49,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) publishResult(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -80,6 +80,8 @@ import (
 //			"$ref": "#/responses/badRequestResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) saveGrade(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/search_for_items.go
+++ b/app/api/items/search_for_items.go
@@ -89,6 +89,8 @@ type itemSearchResponseRowRaw struct {
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) searchForItems(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -71,6 +71,8 @@ type updatedStartResultResponse struct { // nolint:unused
 //				"$ref": "#/responses/unauthorizedResponse"
 //			"403":
 //				"$ref": "#/responses/forbiddenResponse"
+//			"408":
+//				"$ref": "#/responses/requestTimeoutResponse"
 //			"500":
 //				"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -74,6 +74,8 @@ import (
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) startResultPath(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -108,6 +108,8 @@ func (in *updateItemRequest) checkItemsRelationsCycles(store *database.DataStore
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateItem(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/update_item_string.go
+++ b/app/api/items/update_item_string.go
@@ -63,6 +63,8 @@ type itemStringUpdateRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateItemString(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/items/update_result.go
+++ b/app/api/items/update_result.go
@@ -60,6 +60,8 @@ type resultUpdateRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateResult(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/threads/get_thread.go
+++ b/app/api/threads/get_thread.go
@@ -73,6 +73,8 @@ type threadGetResponse struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) getThread(rw http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -152,6 +152,8 @@ type listThreadParameters struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) listThreads(rw http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -101,6 +101,8 @@ type updateThreadRequest struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) updateThread(w http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/users/generate_profile_edit_token.go
+++ b/app/api/users/generate_profile_edit_token.go
@@ -80,6 +80,8 @@ type ProfileEditToken struct {
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":
 //			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 func (srv *Service) generateProfileEditToken(rw http.ResponseWriter, r *http.Request) service.APIError {

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -84,6 +84,8 @@ type userViewResponse struct {
 //			"$ref": "#/responses/forbiddenResponse"
 //		"404":
 //			"$ref": "#/responses/notFoundResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
 //		"500":
 //			"$ref": "#/responses/internalErrorResponse"
 

--- a/app/database/access_token_store_integration_test.go
+++ b/app/database/access_token_store_integration_test.go
@@ -1,0 +1,129 @@
+//go:build !unit
+
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+type tokenData struct {
+	SessionID int64
+	Token     string
+	ExpiresAt database.Time
+	IssuedAt  database.Time
+}
+
+func TestAccessTokenStore_InsertNewToken(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	timeNow, _ := time.Parse(time.DateTime, "2021-01-02 03:04:05")
+	testhelpers.MockDBTime(timeNow.Format(time.DateTime))
+	defer testhelpers.RestoreDBTime()
+
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups: [{id: 123}]
+		sessions: [{session_id: 456, user_id: 123, refresh_token: 'refresh_token'}]`)
+	defer func() { _ = db.Close() }()
+
+	accessTokenStore := database.NewDataStore(db).AccessTokens()
+	require.NoError(t, accessTokenStore.InsertNewToken(456, "token", 789))
+
+	var token tokenData
+	assert.NoError(t, accessTokenStore.Scan(&token).Error())
+	assert.Equal(t, tokenData{
+		SessionID: 456,
+		Token:     "token",
+		ExpiresAt: database.Time(timeNow.Add(789 * time.Second)),
+		IssuedAt:  database.Time(timeNow),
+	}, token)
+}
+
+func TestAccessTokenStore_GetMostRecentValidTokenForSession(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	timeNow, _ := time.Parse(time.DateTime, "2021-01-02 03:04:05")
+	testhelpers.MockDBTime(timeNow.Format(time.DateTime))
+	defer testhelpers.RestoreDBTime()
+
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups: [{id: 123}]
+		sessions:
+			- {session_id: 456, user_id: 123, refresh_token: 'refresh_token1'}
+			- {session_id: 457, user_id: 123, refresh_token: 'refresh_token2'}
+		access_tokens:
+			- {session_id: 456, token: 'token1', expires_at: '2021-01-02 03:09:06', issued_at: '2021-01-02 02:04:05'}
+			- {session_id: 456, token: 'token2', expires_at: '2021-01-02 03:09:07', issued_at: '2021-01-02 02:04:05'}
+			- {session_id: 457, token: 'token3', expires_at: '2021-01-02 03:09:08', issued_at: '2021-01-02 02:59:06'}`)
+	defer func() { _ = db.Close() }()
+
+	accessTokenStore := database.NewDataStore(db).AccessTokens()
+	token, err := accessTokenStore.GetMostRecentValidTokenForSession(456)
+	assert.NoError(t, err)
+	assert.Equal(t, database.MostRecentToken{
+		Token:              "token2",
+		SecondsUntilExpiry: 302,
+		TooNewToRefresh:    false,
+	}, token)
+
+	token, err = accessTokenStore.GetMostRecentValidTokenForSession(457)
+	assert.NoError(t, err)
+	assert.Equal(t, database.MostRecentToken{
+		Token:              "token3",
+		SecondsUntilExpiry: 303,
+		TooNewToRefresh:    true,
+	}, token)
+}
+
+func TestAccessTokenStore_DeleteExpiredTokensOfUser(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	timeNow, _ := time.Parse(time.DateTime, "2021-01-02 03:09:08")
+	testhelpers.MockDBTime(timeNow.Format(time.DateTime))
+	defer testhelpers.RestoreDBTime()
+
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups: [{id: 123}, {id: 124}]
+		sessions:
+			- {session_id: 456, user_id: 123, refresh_token: 'refresh_token1'}
+			- {session_id: 457, user_id: 123, refresh_token: 'refresh_token2'}
+			- {session_id: 458, user_id: 124, refresh_token: 'refresh_token3'}
+		access_tokens:
+			- {session_id: 456, token: 'token1', expires_at: '2021-01-02 03:09:06', issued_at: '2021-01-02 02:04:05'}
+			- {session_id: 456, token: 'token2', expires_at: '2021-01-02 03:09:07', issued_at: '2021-01-02 02:04:05'}
+			- {session_id: 457, token: 'token3', expires_at: '2021-01-02 03:09:08', issued_at: '2021-01-02 02:59:06'}
+			- {session_id: 457, token: 'token4', expires_at: '2021-01-02 03:09:09', issued_at: '2021-01-02 02:59:06'}
+			- {session_id: 458, token: 'token5', expires_at: '2021-01-02 03:09:05', issued_at: '2021-01-02 02:59:06'}`)
+	defer func() { _ = db.Close() }()
+
+	accessTokenStore := database.NewDataStore(db).AccessTokens()
+	assert.NoError(t, accessTokenStore.DeleteExpiredTokensOfUser(123))
+
+	var count int
+	assert.NoError(t, accessTokenStore.Count(&count).Error())
+	assert.Equal(t, 2, count)
+
+	_, err := accessTokenStore.GetMostRecentValidTokenForSession(456)
+	assert.EqualError(t, err, "record not found")
+	token, err := accessTokenStore.GetMostRecentValidTokenForSession(457)
+	assert.NoError(t, err)
+	assert.Equal(t, database.MostRecentToken{
+		Token:              "token4",
+		SecondsUntilExpiry: 1,
+		TooNewToRefresh:    false,
+	}, token)
+	token, err = accessTokenStore.GetMostRecentValidTokenForSession(458)
+	assert.NoError(t, err)
+	assert.Equal(t, database.MostRecentToken{
+		Token:              "token5",
+		SecondsUntilExpiry: -3,
+		TooNewToRefresh:    false,
+	}, token)
+}

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -33,11 +33,14 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 
 	mustNotBeError(s.db.Exec(query).Error)
 
-	createTemporaryTableQuery := "CREATE TEMPORARY TABLE " + objectName + "_propagate_processing (id BIGINT NOT NULL)"
 	dropTemporaryTableQuery := "DROP TEMPORARY TABLE IF EXISTS " + objectName + "_propagate_processing"
+	mustNotBeError(s.db.Exec(dropTemporaryTableQuery).Error)
+	createTemporaryTableQuery := "CREATE TEMPORARY TABLE " + objectName + "_propagate_processing (id BIGINT NOT NULL)"
 	mustNotBeError(s.db.Exec(createTemporaryTableQuery).Error)
 	defer func() {
-		mustNotBeError(s.db.Exec(dropTemporaryTableQuery).Error)
+		// As we start from dropping the temporary table, it's optional to delete it here.
+		// This means we can use a potentially canceled context and ignore the error.
+		s.db.Exec(dropTemporaryTableQuery)
 	}()
 
 	relationsTable := objectName + "_" + objectName

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -321,9 +321,9 @@ func (s *DataStore) IsInTransaction() bool {
 }
 
 // WithNamedLock wraps the given function in GET_LOCK/RELEASE_LOCK.
-func (s *DataStore) WithNamedLock(lockName string, timeout time.Duration, txFunc func(*DataStore) error) error {
+func (s *DataStore) WithNamedLock(lockName string, timeout time.Duration, funcToCall func(*DataStore) error) error {
 	return s.withNamedLock(lockName, timeout, func(db *DB) error {
-		return txFunc(NewDataStoreWithTable(db, s.tableName))
+		return funcToCall(NewDataStoreWithTable(db, s.tableName))
 	})
 }
 

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -24,11 +24,11 @@ func NewDataStore(conn *DB) *DataStore {
 }
 
 // NewDataStoreWithContext returns a new DataStore with the given context.
-func NewDataStoreWithContext(ctx context.Context, conn *DB) *DataStore {
-	newSQLDB := conn.db.CommonDB().(withContexter).withContext(ctx)
-	newGormDB := cloneGormDB(conn.db)
+func NewDataStoreWithContext(ctx context.Context, db *DB) *DataStore {
+	newSQLDB := db.db.CommonDB().(withContexter).withContext(ctx)
+	newGormDB := cloneGormDB(db.db)
 	replaceDBInGormDB(newGormDB, newSQLDB)
-	return &DataStore{DB: newDB(ctx, newGormDB, conn.ctes, conn.logConfig)}
+	return &DataStore{DB: cloneDBWithNewContext(ctx, db)}
 }
 
 // NewDataStoreWithTable returns a specialized DataStore.

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -25,7 +25,7 @@ func NewDataStore(conn *DB) *DataStore {
 
 // NewDataStoreWithContext returns a new DataStore with the given context.
 func NewDataStoreWithContext(ctx context.Context, conn *DB) *DataStore {
-	return &DataStore{DB: newDB(ctx, conn.db, conn.ctes)}
+	return &DataStore{DB: newDB(ctx, conn.db, conn.ctes, conn.logConfig)}
 }
 
 // NewDataStoreWithTable returns a specialized DataStore.

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -4,10 +4,14 @@ package database_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
@@ -16,13 +20,11 @@ func TestDataStore_WithForeignKeyChecksDisabled(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
 	rawDB, err := testhelpers.OpenRawDBConnection()
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
+	require.NoError(t, err)
 	db, err := database.Open(rawDB)
-	if err != nil {
-		assert.FailNow(t, err.Error())
-	}
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
 	s := database.NewDataStore(db)
 	assert.NoError(t, s.WithForeignKeyChecksDisabled(func(store *database.DataStore) error {
 		assertForeignKeysDBVars(t, store, 1, 0)
@@ -55,4 +57,35 @@ func assertForeignKeysDBVars(t *testing.T, store *database.DataStore, expectedSt
 			Scan(&result).Error())
 	assert.Equal(t, expectedStackCount, result.StackCount, "wrong @foreign_key_checks_stack_count")
 	assert.Equal(t, expectedForeignKeyChecks, result.ForeignKeyChecks, "wrong @@SESSION.foreign_key_checks")
+}
+
+func TestDataStore_WithNamedLock_WorksOutsideOfTransaction(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	testHook, restoreFunc := logging.MockSharedLoggerHook()
+	defer restoreFunc()
+	rawDB, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	db, err := database.OpenWithLogConfig(rawDB,
+		database.LogConfig{Logger: logging.NewStructuredDBLogger(), LogSQLQueries: false}, true)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	s := database.NewDataStore(db)
+	resultCh := make(chan struct{}, 100)
+	defer close(resultCh)
+	for i := 0; i < 100; i++ {
+		go func() {
+			assert.NoError(t, s.WithNamedLock("test", 1*time.Second, func(store *database.DataStore) error {
+				return nil
+			}))
+			resultCh <- struct{}{}
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-resultCh
+	}
+
+	logEntries := (&loggingtest.Hook{Hook: testHook}).GetAllStructuredLogs()
+	assert.Empty(t, logEntries)
 }

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -428,8 +428,8 @@ func assertNamedLockMethod(t *testing.T, expectedLockName string, expectedTimeou
 		WillReturnRows(sqlmock.NewRows([]string{"GET_LOCK(?, ?)"}).AddRow(int64(1)))
 	dbMock.ExpectQuery("SELECT 1 AS id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
-	dbMock.ExpectExec("^" + regexp.QuoteMeta("SELECT RELEASE_LOCK(?)") + "$").
-		WithArgs(expectedLockName).WillReturnResult(sqlmock.NewResult(-1, -1))
+	dbMock.ExpectQuery("^" + regexp.QuoteMeta("SELECT RELEASE_LOCK(?)") + "$").
+		WithArgs(expectedLockName).WillReturnRows(sqlmock.NewRows([]string{"RELEASE_LOCK(?)"}).AddRow(int64(1)))
 
 	store := NewDataStoreWithTable(db, "tableName")
 	err := funcToTestGenerator(store)(func(s *DataStore) error {

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -206,7 +206,7 @@ func TestDataStore_InTransaction_ContextAndTxOptions(t *testing.T) {
 	type ctxKey string
 
 	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
-	patch := patchBeginTxWithVerifier(t, &callsCount, txOptions, map[interface{}]interface{}{ctxKey("key"): "value"})
+	patch := patchGormBeginTxWithVerifier(t, &callsCount, txOptions, map[interface{}]interface{}{ctxKey("key"): "value"})
 	defer patch.Unpatch()
 
 	db, mock := NewDBMock()
@@ -312,7 +312,7 @@ func TestDataStore_WithForeignKeyChecksDisabled_WithTxOptions(t *testing.T) {
 
 	var callsCount int
 	txOptions := &sql.TxOptions{Isolation: sql.LevelReadCommitted}
-	patch := patchBeginTxWithVerifier(t, &callsCount, txOptions, nil)
+	patch := patchGormBeginTxWithVerifier(t, &callsCount, txOptions, nil)
 	defer patch.Unpatch()
 
 	db, mock := NewDBMock()
@@ -435,7 +435,7 @@ func assertNamedLockMethod(t *testing.T, expectedLockName string, expectedTimeou
 	err := funcToTestGenerator(store)(func(s *DataStore) error {
 		assert.Equal(t, expectedTableName, s.tableName)
 		assert.NotEqual(t, store, s)
-		assert.Equal(t, store.db.DB(), s.db.DB())
+		assert.Equal(t, store.db.CommonDB(), s.db.CommonDB())
 		var result []interface{}
 		return db.Raw("SELECT 1 AS id").Scan(&result).Error()
 	})

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -52,6 +52,14 @@ func newDB(ctx context.Context, db *gorm.DB, ctes []cte, logConfig *LogConfig) *
 	return &DB{db: db, ctx: ctx, ctes: ctes, logConfig: logConfig}
 }
 
+// cloneDBWithNewContext clones the current db connection replacing the context with the given one.
+func cloneDBWithNewContext(ctx context.Context, conn *DB) *DB {
+	newSQLDB := conn.db.CommonDB().(withContexter).withContext(ctx)
+	newGormDB := cloneGormDB(conn.db)
+	replaceDBInGormDB(newGormDB, newSQLDB)
+	return newDB(ctx, newGormDB, conn.ctes, conn.logConfig)
+}
+
 // Open connects to the database and tests the connection.
 func Open(source interface{}) (*DB, error) {
 	logger := log.SharedLogger.NewDBLogger()

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -297,9 +297,9 @@ func (conn *DB) Raw(query string, args ...interface{}) *DB {
 			Raw("").Joins(query, args...), nil)
 }
 
-// Updates update attributes with callbacks, refer: https://jinzhu.github.io/gorm/crud.html#update
-func (conn *DB) Updates(values interface{}, ignoreProtectedAttrs ...bool) *DB {
-	return newDB(conn.ctx, conn.toQuery().Updates(values, ignoreProtectedAttrs...), nil)
+// UpdateColumns is a synonym for UpdateColumn.
+func (conn *DB) UpdateColumns(attrs ...interface{}) *DB {
+	return conn.UpdateColumn(attrs...)
 }
 
 // UpdateColumn updates attributes without callbacks, refer: https://jinzhu.github.io/gorm/crud.html#update

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -614,6 +614,7 @@ func (conn *DB) insertOrUpdateMaps(tableName string, dataMaps []map[string]inter
 		for key := range dataMaps[0] {
 			updateColumns = append(updateColumns, key)
 		}
+		sort.Strings(updateColumns)
 	}
 
 	var builder strings.Builder

--- a/app/database/db_integration_test.go
+++ b/app/database/db_integration_test.go
@@ -9,23 +9,28 @@ import (
 
 	"github.com/luna-duclos/instrumentedsql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 )
 
 func Test_ConnectionOfWrappedDriverImplementsDriverSessionResetter(t *testing.T) {
-	rawDB, err := testhelpers.OpenRawDBConnection()
-	assert.NoError(t, err)
-	if err == nil {
-		defer func() { assert.NoError(t, rawDB.Close()) }()
-	}
+	appenv.ForceTestEnv()
+
+	// needs actual config for connection to DB
+	config := app.LoadConfig()
+	dbConfig, _ := app.DBConfig(config)
+	rawDB, err := database.OpenRawDBConnection(dbConfig.FormatDSN(), true)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, rawDB.Close()) }()
 
 	assert.IsType(t, (*instrumentedsql.WrappedDriver)(nil), rawDB.Driver())
 	connection, err := rawDB.Conn(context.Background())
-	assert.NoError(t, err)
-	if err == nil {
-		defer func() { assert.NoError(t, connection.Close()) }()
-	}
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, connection.Close()) }()
+
 	assert.NoError(t, connection.Raw(func(driverConn interface{}) error {
 		assert.Implements(t, (*driver.SessionResetter)(nil), driverConn)
 		return nil

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -1370,7 +1370,7 @@ func TestDB_ScanAndHandleMaps_FailsIfHandlerReturnsError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestDB_Updates(t *testing.T) {
+func TestDB_UpdateColumns(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
 	db, mock := NewDBMock()
@@ -1383,7 +1383,7 @@ func TestDB_Updates(t *testing.T) {
 	mock.ExpectCommit()
 
 	db = db.Table("myTable")
-	updateDB := db.Updates(map[string]interface{}{"id": 1, "name": someName})
+	updateDB := db.UpdateColumns(map[string]interface{}{"id": 1, "name": someName})
 	assert.NotEqual(t, updateDB, db)
 	assert.NoError(t, updateDB.Error())
 

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -1,0 +1,249 @@
+package database
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+)
+
+type cancelCtx struct {
+	context.Context
+	_     sync.Mutex
+	_     atomic.Value
+	_     map[interface{}]struct{}
+	err   error
+	cause error
+}
+
+type timerCtx struct {
+	*cancelCtx
+}
+
+type cancelCtxInterface struct {
+	t unsafe.Pointer
+	p *timerCtx
+}
+
+func Test_Deadline(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		timeoutHasPassed bool
+		funcToCall       func(*DataStore, context.CancelFunc) error
+		setupMock        func(sqlmock.Sqlmock)
+	}{
+		{
+			name:             "Before_Exec",
+			timeoutHasPassed: true,
+			funcToCall: func(s *DataStore, _ context.CancelFunc) error {
+				return s.Exec("INSERT INTO t1 (id) VALUES (1)").Error()
+			},
+		},
+		{
+			name:             "Before_Query",
+			timeoutHasPassed: true,
+			funcToCall: func(s *DataStore, _ context.CancelFunc) error {
+				var ids []int64
+				return s.Table("t1").Select("id").Scan(&ids).Error()
+			},
+		},
+		{
+			name:             "Before_QueryRow",
+			timeoutHasPassed: true,
+			funcToCall: func(s *DataStore, _ context.CancelFunc) error {
+				var cnt int64
+				return s.Table("t1").Count(&cnt).Error()
+			},
+		},
+		{
+			name:             "Before_Transaction",
+			timeoutHasPassed: true,
+			funcToCall: func(s *DataStore, _ context.CancelFunc) error {
+				return s.InTransaction(func(_ *DataStore) error {
+					return nil
+				})
+			},
+		},
+		{
+			name: "Before_Exec_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					return s.Exec("INSERT INTO t1 (id) VALUES (1)").Error()
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Prepare_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					_, err := s.Prepare("INSERT INTO t1 (id) VALUES (1)")
+					return err
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Query_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					var ids []int64
+					return s.Table("t1").Select("id").Scan(&ids).Error()
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_QueryRow_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					var cnt int64
+					return s.Table("t1").Count(&cnt).Error()
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Commit_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					return nil
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Rollback_InTransaction",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					cancel()
+					return s.db.Rollback().Error
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Stmt_ExecContext",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					stmt, err := s.Prepare("INSERT INTO t1 (id) VALUES (1)")
+					mustNotBeError(err)
+					defer func() { _ = stmt.Close() }()
+					cancel()
+					_, err = stmt.ExecContext(s.ctx)
+					return err
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectPrepare("^" + regexp.QuoteMeta("INSERT INTO t1 (id) VALUES (1)") + "$")
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Stmt_QueryContext",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					stmt, err := s.Prepare("SELECT * FROM t1")
+					mustNotBeError(err)
+					defer func() { _ = stmt.Close() }()
+					cancel()
+					rows, err := stmt.QueryContext(s.ctx)
+					if rows != nil {
+						_ = rows.Err() // ignore the error as err is expected to be non-nil
+						_ = rows.Close()
+					}
+					return err
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectPrepare("^" + regexp.QuoteMeta("SELECT * FROM t1") + "$")
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "Before_Stmt_QueryRowContext",
+			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
+				return s.InTransaction(func(s *DataStore) error {
+					stmt, err := s.Prepare("SELECT * FROM t1")
+					mustNotBeError(err)
+					defer func() { _ = stmt.Close() }()
+					cancel()
+					row := stmt.QueryRowContext(s.ctx)
+					return row.Err()
+				})
+			},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectPrepare("^" + regexp.QuoteMeta("SELECT * FROM t1") + "$")
+				mock.ExpectRollback()
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			db, mock := NewDBMock()
+			defer func() { _ = db.Close() }()
+			logHook, logRestoreFunc := logging.MockSharedLoggerHook()
+			defer logRestoreFunc()
+
+			if test.setupMock != nil {
+				test.setupMock(mock)
+			}
+			ctx, cancel := context.WithDeadline(context.Background(),
+				time.Now().Add(golang.IfElse(test.timeoutHasPassed, 0, 1*time.Hour)))
+			defer cancel()
+			dataStore := NewDataStoreWithContext(ctx, db)
+
+			err := test.funcToCall(dataStore, func() {
+				cancel()
+				(*cancelCtxInterface)(unsafe.Pointer(&ctx)).p.err = context.DeadlineExceeded
+				(*cancelCtxInterface)(unsafe.Pointer(&ctx)).p.cause = nil
+			})
+
+			assert.EqualError(t, err, context.DeadlineExceeded.Error())
+
+			assert.Eventually(t, func() bool {
+				return mock.ExpectationsWereMet() == nil
+			}, 1*time.Second, 10*time.Millisecond)
+			assert.NoError(t, mock.ExpectationsWereMet())
+
+			logs := (&loggingtest.Hook{Hook: logHook}).GetAllStructuredLogs()
+			assert.Contains(t, logs, "context deadline exceeded")
+		})
+	}
+}

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -180,6 +180,7 @@ func TestGroupGroupStore_CreateRelationsWithoutChecking(t *testing.T) {
 func setMockExpectationsForCreateNewAncestors(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectPrepare("")
 	mock.ExpectPrepare("")
 	mock.ExpectPrepare("")

--- a/app/database/logging_test.go
+++ b/app/database/logging_test.go
@@ -1,0 +1,726 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func expectAnalyzeForQuery(mock sqlmock.Sqlmock, query string, err error, withAnalyze bool) {
+	if !withAnalyze {
+		return
+	}
+	expectation := mock.ExpectQuery("^" + regexp.QuoteMeta("EXPLAIN ANALYZE "+query) + "$")
+	if err != nil {
+		expectation.WillReturnError(err)
+	} else {
+		expectation.WillReturnRows(sqlmock.NewRows([]string{"QUERY PLAN"}).AddRow("plan"))
+	}
+}
+
+const (
+	updateQueryForTesting = "UPDATE users SET name = 'John' WHERE id = 1"
+	selectQueryForTesting = "SELECT id FROM users"
+)
+
+type funcToRunInSQLQueryLoggingTests func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+	expectedQuery string, expectedAffectedRows *int64, expectedError error,
+)
+
+type sqlQueryLoggingTest struct {
+	name                         string
+	funcToRun                    funcToRunInSQLQueryLoggingTests
+	skipAnalyzeSQLQueriesTesting bool
+}
+
+var sqlQueryLoggingTests = []sqlQueryLoggingTest{
+	{
+		name: "sqlDBWrapper.Exec with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectExec("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			result, err := db.db.CommonDB().(*sqlDBWrapper).Exec(expectedQuery)
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.Exec with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+			expectedAffectedRows = golang.Ptr(int64(1))
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectExec("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnResult(sqlmock.NewResult(-1, *expectedAffectedRows))
+			result, err := db.db.CommonDB().(*sqlDBWrapper).Exec(expectedQuery)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.Query with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			result, err := db.db.CommonDB().(*sqlDBWrapper).Query(expectedQuery)
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.Query with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			rows, err := db.db.CommonDB().(*sqlDBWrapper).Query(expectedQuery)
+			assert.NoError(t, err)
+			assert.NotNil(t, rows)
+			if rows != nil {
+				_ = rows.Close()
+			}
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.QueryRow with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			row := db.db.CommonDB().(*sqlDBWrapper).QueryRow(expectedQuery)
+			assert.Equal(t, expectedError, row.Err())
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.QueryRow with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			row := db.db.CommonDB().(*sqlDBWrapper).QueryRow(expectedQuery)
+			assert.NoError(t, row.Err())
+			_ = row.Scan()
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlDBWrapper.BeginTx with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = beginTransactionLogMessage
+			mock.ExpectBegin().WillReturnError(expectedError)
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).BeginTx(context.Background(), &sql.TxOptions{})
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, tx)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlDBWrapper.BeginTx with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = beginTransactionLogMessage
+			mock.ExpectBegin()
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).BeginTx(context.Background(), &sql.TxOptions{})
+			assert.NoError(t, err)
+			assert.NotNil(t, tx)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlConnWrapper.QueryRowContext with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			conn, err := db.db.CommonDB().(*sqlDBWrapper).conn(context.Background())
+			require.NoError(t, err)
+			defer func() { _ = conn.close(nil) }()
+			row := conn.QueryRowContext(context.Background(), expectedQuery)
+			assert.Equal(t, expectedError, row.Err())
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlConnWrapper.QueryRowContext with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = selectQueryForTesting
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			conn, err := db.db.CommonDB().(*sqlDBWrapper).conn(context.Background())
+			require.NoError(t, err)
+			defer func() { _ = conn.close(nil) }()
+			row := conn.QueryRowContext(context.Background(), expectedQuery)
+			assert.NoError(t, row.Err())
+			_ = row.Scan()
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.ExecContext with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectExec().WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			result, err := stmtWrapper.ExecContext(context.Background())
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.ExecContext with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+			expectedAffectedRows = golang.Ptr(int64(1))
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectExec().WillReturnResult(sqlmock.NewResult(-1, *expectedAffectedRows))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			result, err := stmtWrapper.ExecContext(context.Background())
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.QueryContext with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectQuery().WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			rows, err := stmtWrapper.QueryContext(context.Background())
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, rows)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.QueryContext with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectQuery().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			rows, err := stmtWrapper.QueryContext(context.Background())
+			require.NoError(t, err)
+			if rows != nil {
+				_ = rows.Close()
+			}
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.QueryRowContext with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectQuery().WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			row := stmtWrapper.QueryRowContext(context.Background())
+			assert.Equal(t, expectedError, row.Err())
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "SQLStmtWrapper.QueryRowContext with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			prepareExpectation := mock.ExpectPrepare("^" + regexp.QuoteMeta(expectedQuery) + "$")
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			prepareExpectation.ExpectQuery().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			stmtWrapper, err := txWrapper.prepare(expectedQuery)
+			require.NoError(t, err)
+			defer func() { _ = stmtWrapper.Close() }()
+			row := stmtWrapper.QueryRowContext(context.Background())
+			require.NoError(t, row.Err())
+			_ = row.Scan()
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.Exec with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectExec("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			result, err := txWrapper.Exec(expectedQuery)
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.Exec with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+			expectedAffectedRows = golang.Ptr(int64(1))
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectExec("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnResult(sqlmock.NewResult(-1, *expectedAffectedRows))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			result, err := txWrapper.Exec(expectedQuery)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.Query with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			rows, err := txWrapper.Query(expectedQuery)
+			assert.Equal(t, expectedError, err)
+			assert.Nil(t, rows)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.Query with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			rows, err := txWrapper.Query(expectedQuery)
+			require.NoError(t, err)
+			if rows != nil {
+				_ = rows.Close()
+			}
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.QueryRow with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").WillReturnError(expectedError)
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			row := txWrapper.QueryRow(expectedQuery)
+			assert.Equal(t, expectedError, row.Err())
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.QueryRow with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, withSQLAnalyze bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = updateQueryForTesting
+
+			mock.ExpectBegin()
+			expectAnalyzeForQuery(mock, expectedQuery, expectedError, withSQLAnalyze)
+			mock.ExpectQuery("^" + regexp.QuoteMeta(expectedQuery) + "$").
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1).AddRow(2))
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			defer func() { _ = tx.Commit() }()
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			row := txWrapper.QueryRow(expectedQuery)
+			require.NoError(t, row.Err())
+			_ = row.Scan()
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+	},
+	{
+		name: "sqlTxWrapper.Commit with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = commitTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectCommit().WillReturnError(expectedError)
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			err = txWrapper.Commit()
+			assert.Equal(t, expectedError, err)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlTxWrapper.Commit with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = commitTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectCommit()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			err = txWrapper.Commit()
+			require.NoError(t, err)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlTxWrapper.Rollback with error",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = errors.New("some error")
+			expectedQuery = rollbackTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectRollback().WillReturnError(expectedError)
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			err = txWrapper.Rollback()
+			assert.Equal(t, expectedError, err)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlTxWrapper.Rollback with success",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedQuery = rollbackTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectRollback()
+
+			tx, err := db.db.CommonDB().(*sqlDBWrapper).sqlDB.BeginTx(context.Background(), &sql.TxOptions{})
+			require.NoError(t, err)
+			txWrapper := &sqlTxWrapper{sqlTx: tx, ctx: context.Background(), logConfig: db.logConfig}
+			err = txWrapper.Rollback()
+			require.NoError(t, err)
+			return expectedQuery, expectedAffectedRows, expectedError
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlTxWrapper.Rollback error because of a context cancellation",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = context.Canceled
+			expectedQuery = rollbackTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectRollback()
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			sqlDBWrapper := db.db.CommonDB().(*sqlDBWrapper)
+			oldLogSQLQueriesValue := sqlDBWrapper.logConfig.LogSQLQueries
+			sqlDBWrapper.logConfig.LogSQLQueries = false
+			tx, err := sqlDBWrapper.BeginTx(ctx, &sql.TxOptions{})
+			require.NoError(t, err)
+			sqlDBWrapper.logConfig.LogSQLQueries = oldLogSQLQueriesValue
+			cancelFunc()
+
+			assert.Eventually(t, func() bool {
+				return mock.ExpectationsWereMet() == nil
+			}, 1*time.Second, 10*time.Millisecond)
+			require.Nil(t, mock.ExpectationsWereMet(), "cancelFunc() should have caused the rollback to be called")
+			err = tx.Rollback()
+			require.Equal(t, expectedError, err)
+			return expectedQuery, expectedAffectedRows, errors.New(expectedError.Error() + " (the transaction has been rolled back implicitly)")
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+	{
+		name: "sqlTxWrapper.Commit error because of a context cancellation",
+		funcToRun: func(t *testing.T, db *DB, mock sqlmock.Sqlmock, _ bool) (
+			expectedQuery string, expectedAffectedRows *int64, expectedError error,
+		) {
+			expectedError = context.Canceled
+			expectedQuery = commitTransactionLogMessage
+
+			mock.ExpectBegin()
+			mock.ExpectRollback()
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			sqlDBWrapper := db.db.CommonDB().(*sqlDBWrapper)
+			oldLogSQLQueriesValue := sqlDBWrapper.logConfig.LogSQLQueries
+			sqlDBWrapper.logConfig.LogSQLQueries = false
+			tx, err := sqlDBWrapper.BeginTx(ctx, &sql.TxOptions{})
+			require.NoError(t, err)
+			sqlDBWrapper.logConfig.LogSQLQueries = oldLogSQLQueriesValue
+			cancelFunc()
+
+			assert.Eventually(t, func() bool {
+				return mock.ExpectationsWereMet() == nil
+			}, 1*time.Second, 10*time.Millisecond)
+			require.Nil(t, mock.ExpectationsWereMet(), "cancelFunc() should have caused the rollback to be called")
+			err = tx.Commit()
+			assert.Equal(t, expectedError, err)
+			return expectedQuery, expectedAffectedRows, errors.New(expectedError.Error() + " (the transaction has been rolled back implicitly)")
+		},
+		skipAnalyzeSQLQueriesTesting: true,
+	},
+}
+
+func Test_SQLQueryLogging(t *testing.T) {
+	for _, test := range sqlQueryLoggingTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			for _, logSQLQueries := range []bool{false, true} {
+				for _, analyzeSQLQueries := range []bool{false, true} {
+					if test.skipAnalyzeSQLQueriesTesting && analyzeSQLQueries || analyzeSQLQueries && !logSQLQueries {
+						continue
+					}
+					t.Run(fmt.Sprintf("logSQLQueries=%v,analyzeSQLQueries=%v", logSQLQueries, analyzeSQLQueries), func(t *testing.T) {
+						testoutput.SuppressIfPasses(t)
+
+						verifySQLLogs(t, logSQLQueries, analyzeSQLQueries, test)
+					})
+				}
+			}
+		})
+	}
+}
+
+func verifySQLLogs(t *testing.T, logSQLQueries, analyzeSQLQueries bool, test sqlQueryLoggingTest) {
+	loggerHook, loggerRestoreFunc := logging.MockSharedLoggerHook()
+	defer loggerRestoreFunc()
+
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	db.logConfig.LogSQLQueries = logSQLQueries
+	db.logConfig.AnalyzeSQLQueries = analyzeSQLQueries
+	db.logConfig.Logger = logging.NewStructuredDBLogger()
+
+	expectedQuery, expectedAffectedRows, expectedError := test.funcToRun(t, db, mock, analyzeSQLQueries)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	logEntries := loggerHook.AllEntries()
+	expectedLen := 2
+	if !logSQLQueries {
+		expectedLen--
+	}
+	if expectedError == nil {
+		expectedLen--
+	}
+	if analyzeSQLQueries {
+		expectedLen++
+	}
+	require.Len(t, logEntries, expectedLen)
+	index := 0
+	if logSQLQueries {
+		assert.Equal(t, "info", logEntries[0].Level.String())
+		assert.Equal(t, expectedQuery, logEntries[0].Message)
+		assert.Equal(t, "db", logEntries[0].Data["type"])
+		assert.Greater(t, logEntries[0].Data["duration"], 0.0)
+		if expectedAffectedRows != nil {
+			assert.Equal(t, *expectedAffectedRows, logEntries[0].Data["rows"])
+		} else {
+			assert.Nil(t, logEntries[0].Data["rows"])
+		}
+		index++
+	}
+
+	if expectedError != nil {
+		assert.Equal(t, "error", logEntries[index].Level.String())
+		assert.Equal(t, expectedError.Error(), logEntries[index].Message)
+		assert.Equal(t, "db", logEntries[index].Data["type"])
+		index++
+	}
+
+	if analyzeSQLQueries {
+		if expectedError != nil {
+			assert.Equal(t, "error", logEntries[index].Level.String())
+			assert.Equal(t, "Failed to get an execution plan for a SQL query: "+expectedError.Error(), logEntries[index].Message)
+		} else {
+			assert.Equal(t, "info", logEntries[index].Level.String())
+			assert.Equal(t, "query execution plan: plan", logEntries[index].Message)
+			assert.Greater(t, logEntries[index].Data["duration"], 0.0)
+		}
+		assert.Equal(t, "db", logEntries[index].Data["type"])
+	}
+}

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -117,7 +117,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t
 		UpdateColumn("can_view", "content").Error())
 	assert.NoError(t, permissionGrantedStore.Where("group_id=2 AND item_id=11").
 		UpdateColumn("can_view", "content").Error())
-	assert.NoError(t, permissionGrantedStore.ItemItems().Updates(map[string]interface{}{
+	assert.NoError(t, permissionGrantedStore.ItemItems().UpdateColumn(map[string]interface{}{
 		"content_view_propagation": "as_info",
 	}).Error())
 	assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {

--- a/app/database/permissions.go
+++ b/app/database/permissions.go
@@ -4,7 +4,8 @@ package database
 // depending on the given permission kind.
 func (conn *DB) WherePermissionIsAtLeast(permissionKind, permissionName string) *DB {
 	return newDB(conn.ctx, conn.db.Where("?",
-		NewDataStore(conn).PermissionsGranted().PermissionIsAtLeastSQLExpr(permissionKind, permissionName)), conn.ctes)
+		NewDataStore(conn).PermissionsGranted().PermissionIsAtLeastSQLExpr(permissionKind, permissionName)),
+		conn.ctes, conn.logConfig)
 }
 
 // HavingMaxPermissionAtLeast returns a composable query filtered by `MAX(can_*_generated_value)` >= indexOf(`permissionName`)
@@ -12,7 +13,8 @@ func (conn *DB) WherePermissionIsAtLeast(permissionKind, permissionName string) 
 func (conn *DB) HavingMaxPermissionAtLeast(permissionKind, permissionName string) *DB {
 	return newDB(conn.ctx, conn.db.
 		Having("MAX("+permissionColumnByKind(permissionKind)+") >= ?",
-			NewDataStore(conn).PermissionsGranted().PermissionIndexByKindAndName(permissionKind, permissionName)), conn.ctes)
+			NewDataStore(conn).PermissionsGranted().PermissionIndexByKindAndName(permissionKind, permissionName)),
+		conn.ctes, conn.logConfig)
 }
 
 // JoinsPermissionsForGroupToItems returns a composable query with access rights (as permissions.*_generated_value)

--- a/app/database/query_logger.go
+++ b/app/database/query_logger.go
@@ -73,12 +73,12 @@ func fileWithLineNum() string {
 			return ""
 		}
 		if strings.Contains(file, "jinzhu/gorm") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/db.go") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/data_store.go") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_conn_wrapper.go") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_db_wrapper.go") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_stmt_wrapper.go") ||
-			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_tx_wrapper.go") {
+			strings.HasSuffix(file, "/app/database/db.go") ||
+			strings.HasSuffix(file, "/app/database/data_store.go") ||
+			strings.HasSuffix(file, "/app/database/sql_conn_wrapper.go") ||
+			strings.HasSuffix(file, "/app/database/sql_db_wrapper.go") ||
+			strings.HasSuffix(file, "/app/database/sql_stmt_wrapper.go") ||
+			strings.HasSuffix(file, "/app/database/sql_tx_wrapper.go") {
 			continue
 		}
 		return fmt.Sprintf("%v:%v", file, line)

--- a/app/database/query_logger.go
+++ b/app/database/query_logger.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/jinzhu/gorm"
+
+	log "github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+)
+
+func logSQLQuery(logger log.DBLogger, duration time.Duration, sql string, args []interface{}, rowsAffected *int64) {
+	printArgs := []interface{}{
+		"sql", fileWithLineNum(), duration, sql, args,
+	}
+	if rowsAffected != nil {
+		printArgs = append(printArgs, *rowsAffected)
+	}
+	logger.Print(printArgs...)
+}
+
+var _ queryRowWithoutLogging = &sqlDBWrapper{}
+
+var explainableStatementRegexp = regexp.MustCompile(`(?i)^\s*(SELECT|DELETE|INSERT|REPLACE|UPDATE|TABLE)\s`)
+
+var emptyFunc = func() {}
+
+func getSQLExecutionPlanLoggingFunc(db queryRowWithoutLogging, logConfig *LogConfig, query string, args ...interface{}) func() {
+	if !logConfig.LogSQLQueries || !logConfig.AnalyzeSQLQueries || !explainableStatementRegexp.MatchString(query) {
+		return emptyFunc
+	}
+
+	var plan string
+	planStartTime := gorm.NowFunc()
+	if err := db.queryRowWithoutLogging("EXPLAIN ANALYZE "+query, args...).Scan(&plan); err != nil {
+		return func() {
+			logConfig.Logger.Print("error", fileWithLineNum(), fmt.Sprintf("Failed to get an execution plan for a SQL query: %v", err))
+		}
+	}
+
+	planDuration := gorm.NowFunc().Sub(planStartTime)
+	return func() {
+		logSQLQuery(logConfig.Logger, planDuration, "query execution plan:\n"+plan, nil, nil)
+	}
+}
+
+func getSQLQueryLoggingFunc(
+	rowsAffectedFunc func() *int64, err *error, startTime time.Time, query string, args ...interface{},
+) func(logConfig *LogConfig) {
+	return func(logConfig *LogConfig) {
+		if *err != nil {
+			// Log the error even if we don't log the query, but do it after logging the query
+			defer logConfig.Logger.Print("error", fileWithLineNum(), *err)
+		}
+		if !logConfig.LogSQLQueries {
+			return
+		}
+		var rowsAffected *int64
+		if *err == nil && rowsAffectedFunc != nil {
+			rowsAffected = rowsAffectedFunc()
+		}
+		logSQLQuery(logConfig.Logger, gorm.NowFunc().Sub(startTime), query, args, rowsAffected)
+	}
+}
+
+func fileWithLineNum() string {
+	for i := 4; ; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			return ""
+		}
+		if strings.Contains(file, "jinzhu/gorm") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/db.go") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/data_store.go") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_conn_wrapper.go") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_db_wrapper.go") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_stmt_wrapper.go") ||
+			strings.HasSuffix(file, "/AlgoreaBackend/app/database/sql_tx_wrapper.go") {
+			continue
+		}
+		return fmt.Sprintf("%v:%v", file, line)
+	}
+}

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -1,0 +1,117 @@
+package database
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func Test_fileWithLineNum_ReturnsEmptyStringWhenNoSuitableCallerFound(t *testing.T) {
+	assert.Equal(t, "", fileWithLineNum())
+}
+
+func Test_getSQLExecutionPlanLoggingFunc_DoesNothingDependingOnParameters(t *testing.T) {
+	tests := []struct {
+		name              string
+		query             string
+		logSQLQueries     bool
+		analyzeSQLQueries bool
+	}{
+		{
+			name:  "logSQLQueries is false",
+			query: "SELECT 1", logSQLQueries: false, analyzeSQLQueries: true,
+		},
+		{
+			name:  "analyzeSQLQueries is false",
+			query: "SELECT 1", logSQLQueries: true, analyzeSQLQueries: false,
+		},
+		{
+			name:  "query is not explainable",
+			query: "SET @a=1", logSQLQueries: true, analyzeSQLQueries: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
+			db, mock := NewDBMock()
+			defer func() { _ = db.Close() }()
+
+			var called bool
+			oldEmptyFunc := emptyFunc
+			defer func() { emptyFunc = oldEmptyFunc }()
+			emptyFunc = func() { called = true }
+
+			logConfig := &LogConfig{
+				Logger:            nil,
+				LogSQLQueries:     tt.logSQLQueries,
+				AnalyzeSQLQueries: tt.analyzeSQLQueries,
+			}
+
+			getSQLExecutionPlanLoggingFunc(db.db.CommonDB().(*sqlDBWrapper), logConfig, tt.query)()
+			assert.True(t, called)
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+type getSQLExecutionPlanLoggingFuncTestLogger struct {
+	printsCalled [][]interface{}
+}
+
+func (l *getSQLExecutionPlanLoggingFuncTestLogger) Print(args ...interface{}) {
+	l.printsCalled = append(l.printsCalled, args)
+}
+
+func Test_getSQLExecutionPlanLoggingFunc_RunsExplainAnalyzeForSuitableQueries(t *testing.T) {
+	for _, query := range []string{
+		"SELECT 1",
+		"DELETE mytable",
+		"INSERT INTO mytable (a, b) VALUES (1, 2)",
+		"REPLACE INTO mytable (a, b) VALUES (1, 2)",
+		"UPDATE mytable SET a = 1",
+		"TABLE mytable",
+		"\n\t sElEcT\n\t 1",
+		"\n\t DelEte\n\t mytable",
+		"\n\t iNSerT\n\t InTO mytable (a, b) VALUES (1, 2)",
+		"\n\t RePlacE\n\t InTO mytable (a, b) VALUES (1, 2)",
+		"\n\t uPdAte\n\t mytable sEt a = 1",
+		"\n\t tAblE\n\t mytable",
+	} {
+		t.Run(query, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
+			db, mock := NewDBMock()
+			defer func() { _ = db.Close() }()
+
+			logConfig := &LogConfig{
+				Logger:            &getSQLExecutionPlanLoggingFuncTestLogger{},
+				LogSQLQueries:     true,
+				AnalyzeSQLQueries: true,
+			}
+
+			mock.ExpectQuery("^" + regexp.QuoteMeta("EXPLAIN ANALYZE "+query) + "$").
+				WillReturnRows(mock.NewRows([]string{"plan"}).AddRow("plan"))
+			getSQLExecutionPlanLoggingFunc(db.db.CommonDB().(*sqlDBWrapper), logConfig, query)()
+			require.NoError(t, mock.ExpectationsWereMet())
+
+			printsCalled := logConfig.Logger.(*getSQLExecutionPlanLoggingFuncTestLogger).printsCalled
+			require.Len(t, printsCalled, 1)
+			printCalled := printsCalled[0]
+			require.Len(t, printCalled, 5)
+
+			assert.Equal(t, "sql", printCalled[0])
+			assert.IsType(t, "", printCalled[1])
+			assert.IsType(t, time.Duration(0), printCalled[2])
+			assert.Equal(t, "query execution plan:\nplan", printCalled[3])
+			assert.Nil(t, printCalled[4])
+		})
+	}
+}

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -11,6 +11,23 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
+func Test_fileWithLineNum(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	require.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
+		assert.Contains(t, fileWithLineNum(), "/query_logger_test.go:")
+		return nil
+	}))
+
+	assert.Nil(t, mock.ExpectationsWereMet())
+}
+
 func Test_fileWithLineNum_ReturnsEmptyStringWhenNoSuitableCallerFound(t *testing.T) {
 	assert.Equal(t, "", fileWithLineNum())
 }

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -112,7 +112,11 @@ func markAsPropagatingSomeResultsMarkedAsToBePropagatedAndMarkTheirParentsAsToBe
 				result_exists TINYINT(1) NOT NULL,
 				KEY result_exists (result_exists)
 			)`).Error())
-		defer func() { mustNotBeError(s.Exec("DROP TEMPORARY TABLE results_to_mark").Error()) }()
+		defer func() {
+			// As we start from dropping the temporary table, it's optional to delete it here.
+			// This means we can use a potentially canceled context and ignore the error.
+			s.Exec("DROP TEMPORARY TABLE results_to_mark")
+		}()
 
 		// We mark as 'to_be_recomputed' results of all parents of a chunk of results marked as 'to_be_propagated'.
 		// Also, we insert missing results for chapters having children with results marked as 'to_be_propagated'.

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -40,7 +40,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 			oldDate := currentDate.AddDate(-1, -1, -1)
 
 			assert.NoError(t, resultStore.Where("attempt_id = 1 AND item_id = 1 AND participant_id = 101").
-				Updates(map[string]interface{}{
+				UpdateColumns(map[string]interface{}{
 					"latest_activity_at": oldDate,
 					"tasks_tried":        1,
 					"tasks_with_help":    2,
@@ -49,7 +49,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 				}).Error())
 			assert.NoError(t, resultStore.
 				Where("(item_id = 3 AND participant_id = 101 AND attempt_id = 1) OR (item_id = 3 AND participant_id = 101 AND attempt_id = 2)").
-				Updates(map[string]interface{}{
+				UpdateColumns(map[string]interface{}{
 					"latest_activity_at": currentDate,
 					"tasks_tried":        5,
 					"tasks_with_help":    6,
@@ -57,7 +57,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 				}).Error())
 			assert.NoError(t, resultStore.
 				Where("(item_id = 4 AND participant_id = 101 AND attempt_id = 1) OR (item_id = 4 AND participant_id = 101 AND attempt_id = 2)").
-				Updates(map[string]interface{}{
+				UpdateColumns(map[string]interface{}{
 					"latest_activity_at": oldDate,
 					"tasks_tried":        9,
 					"tasks_with_help":    10,
@@ -65,7 +65,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 					"validated_at":       "2019-05-30 11:00:00",
 				}).Error())
 
-			assert.NoError(t, resultStore.Where("item_id = 2 AND participant_id = 102 AND attempt_id = 1").Updates(map[string]interface{}{
+			assert.NoError(t, resultStore.Where("item_id = 2 AND participant_id = 102 AND attempt_id = 1").UpdateColumn(map[string]interface{}{
 				"latest_activity_at": oldDate,
 			}).Error())
 
@@ -147,7 +147,7 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 	expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
 
 	resultStore := database.NewDataStore(db).Results()
-	assert.NoError(t, resultStore.Where("participant_id = 101 AND attempt_id = 1 AND item_id = 2").Updates(map[string]interface{}{
+	assert.NoError(t, resultStore.Where("participant_id = 101 AND attempt_id = 1 AND item_id = 2").UpdateColumn(map[string]interface{}{
 		"latest_activity_at": time.Time(expectedLatestActivityAt2),
 	}).Error())
 
@@ -188,11 +188,11 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 
 			resultStore := database.NewDataStore(db).Results()
 			assert.NoError(t, resultStore.Where("attempt_id = 1 AND item_id = 1 AND participant_id = 101").
-				Updates(map[string]interface{}{
+				UpdateColumn(map[string]interface{}{
 					"score_computed": 10,
 				}).Error())
 			assert.NoError(t, resultStore.Where("participant_id = 101 AND attempt_id = 1 AND item_id = 2").
-				Updates(map[string]interface{}{
+				UpdateColumns(map[string]interface{}{
 					"score_edit_rule":  test.editRule,
 					"score_edit_value": test.editValue,
 				}).Error())

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -210,10 +210,10 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	assert.NoError(t, database.NewDataStore(db).ItemItems().Where("parent_item_id = 2 AND child_item_id IN (1, 3, 4)").
 		UpdateColumn("category", "Validation").Error())
 
-	assert.NoError(t, itemStore.Where("id=1").Updates(map[string]interface{}{
+	assert.NoError(t, itemStore.Where("id=1").UpdateColumn(map[string]interface{}{
 		"type": "Task",
 	}).Error())
-	assert.NoError(t, itemStore.Where("id=3").Updates(map[string]interface{}{
+	assert.NoError(t, itemStore.Where("id=3").UpdateColumn(map[string]interface{}{
 		"no_score": true,
 	}).Error())
 

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -36,5 +36,5 @@ func (conn *DB) WhereSearchStringMatches(field, fallbackField, searchString stri
 		query = query.Where(condition, searchPattern, searchPattern)
 	}
 
-	return newDB(conn.ctx, query, conn.ctes)
+	return newDB(conn.ctx, query, conn.ctes, conn.logConfig)
 }

--- a/app/database/sql_conn_wrapper.go
+++ b/app/database/sql_conn_wrapper.go
@@ -1,0 +1,145 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	_ "unsafe" // required to use //go:linkname
+
+	"github.com/jinzhu/gorm"
+)
+
+type sqlConnWrapper struct {
+	conn      *sql.Conn
+	logConfig *LogConfig
+}
+
+// Note: all the public methods of sql.Conn are implemented in sqlConnWrapper,
+// but only the ones we use are uncommented.
+
+/*
+// PingContext verifies the connection to the database is still alive.
+func (c *sqlConnWrapper) PingContext(ctx context.Context) error {
+	return c.conn.PingContext(ctx)
+}
+*/
+
+/*
+// ExecContext executes a query without returning any rows.
+// The args are for any placeholder parameters in the query.
+func (c *sqlConnWrapper) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
+	defer getSQLExecutionPlanLoggingFunc(c, c.LogConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(func() *int64 {
+		rowsAffected, _ := result.RowsAffected()
+		return &rowsAffected
+	}, &err, gorm.NowFunc(), query, args...)(c.LogConfig)
+
+	return c.conn.ExecContext(ctx, query, args...)
+}
+*/
+
+/*
+// QueryContext executes a query that returns rows, typically a SELECT.
+// The args are for any placeholder parameters in the query.
+func (c *sqlConnWrapper) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
+	defer getSQLExecutionPlanLoggingFunc(c, c.LogConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(nil, &err, gorm.NowFunc(), query, args...)(c.LogConfig)
+
+	return c.conn.QueryContext(ctx, query, args...)
+}
+*/
+
+// QueryRowContext executes a query that is expected to return at most one row.
+// QueryRowContext always returns a non-nil value. Errors are deferred until
+// Row's Scan method is called.
+// If the query selects no rows, the *Row's Scan will return ErrNoRows.
+// Otherwise, the *Row's Scan scans the first selected row and discards
+// the rest.
+func (c *sqlConnWrapper) QueryRowContext(ctx context.Context, query string, args ...any) (row *sql.Row) {
+	defer getSQLExecutionPlanLoggingFunc(c, c.logConfig, query, args...)()
+	startTime := gorm.NowFunc()
+	defer func() {
+		err := row.Err()
+		getSQLQueryLoggingFunc(nil, &err, startTime, query, args...)(c.logConfig)
+	}()
+
+	return c.conn.QueryRowContext(ctx, query, args...)
+}
+
+/*
+// PrepareContext creates a prepared statement for later queries or executions.
+// Multiple queries or executions may be run concurrently from the
+// returned statement.
+// The caller must call the statement's Close method
+// when the statement is no longer needed.
+//
+// The provided context is used for the preparation of the statement, not for the
+// execution of the statement.
+func (c *sqlConnWrapper) PrepareContext(ctx context.Context, query string) (*SQLStmtWrapper, error) {
+	stmt, err := c.conn.PrepareContext(ctx, query)
+	if err != nil {
+		c.LogConfig.Logger.Print("error", fileWithLineNum(), err)
+		return nil, err
+	}
+	return &SQLStmtWrapper{db: c, sql: query, stmt: stmt, LogConfig: c.LogConfig}, nil
+}
+*/
+
+/*
+// Raw executes f exposing the underlying driver connection for the
+// duration of f. The driverConn must not be used outside of f.
+//
+// Once f returns and err is not driver.ErrBadConn, the Conn will continue to be usable
+// until Conn.Close is called.
+func (c *sqlConnWrapper) Raw(f func(driverConn any) error) (err error) {
+	return c.conn.Raw(f)
+}
+*/
+
+/*
+// BeginTx starts a transaction.
+//
+// The provided context is used until the transaction is committed or rolled back.
+// If the context is canceled, the sql package will roll back
+// the transaction. Tx.Commit will return an error if the context provided to
+// BeginTx is canceled.
+//
+// The provided TxOptions is optional and may be nil if defaults should be used.
+// If a non-default isolation level is used that the driver doesn't support,
+// an error will be returned.
+func (c *sqlConnWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sqlTxWrapper, error) {
+	startTime := gorm.NowFunc()
+	tx, err := c.conn.BeginTx(ctx, opts)
+	if c.LogConfig.LogSQLQueries {
+		logSQLQuery(c.LogConfig.Logger, gorm.NowFunc().Sub(startTime), beginTransactionLogMessage, nil, nil)
+	}
+	if err != nil {
+		c.LogConfig.Logger.Print("error", fileWithLineNum(), err)
+		return nil, err
+	}
+	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, LogConfig: c.LogConfig}, nil
+}
+*/
+
+/*
+// Close returns the connection to the connection pool.
+// All operations after a Close will return with [sql.ErrConnDone].
+// Close is safe to call concurrently with other operations and will
+// block until all other operations finish. It may be useful to first
+// cancel any used context and then call close directly after.
+func (c *sqlConnWrapper) Close() error {
+	return c.conn.Close()
+}
+*/
+
+func (c *sqlConnWrapper) queryRowWithoutLogging(query string, args ...any) *sql.Row {
+	return c.conn.QueryRowContext(context.Background(), query, args...)
+}
+
+var _ queryRowWithoutLogging = &sqlConnWrapper{}
+
+func (c *sqlConnWrapper) close(err error) error {
+	return sqlConnCloseWithError(c.conn, err)
+}
+
+//go:linkname sqlConnCloseWithError database/sql.(*Conn).close
+func sqlConnCloseWithError(_ *sql.Conn, _ error) error

--- a/app/database/sql_db_wrapper.go
+++ b/app/database/sql_db_wrapper.go
@@ -1,0 +1,158 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jinzhu/gorm"
+)
+
+type sqlDBWrapper struct {
+	sqlDB     *sql.DB
+	ctx       context.Context
+	logConfig *LogConfig
+}
+
+// Exec executes a query without returning any rows.
+// The args are for any placeholder parameters in the query.
+//
+// Exec uses the context of [sqlDBWrapper] internally.
+func (sqlDB *sqlDBWrapper) Exec(query string, args ...interface{}) (result sql.Result, err error) {
+	defer getSQLExecutionPlanLoggingFunc(sqlDB, sqlDB.logConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(func() *int64 {
+		rowsAffected, _ := result.RowsAffected()
+		return &rowsAffected
+	}, &err, gorm.NowFunc(), query, args...)(sqlDB.logConfig)
+
+	return sqlDB.sqlDB.ExecContext(sqlDB.ctx, query, args...)
+}
+
+// Prepare is not implemented intentionally and panics if called.
+//
+// Note: Gorm does not use this method, but it is required to implement the [gorm.SQLCommon] interface.
+func (sqlDB *sqlDBWrapper) Prepare(_ string) (*sql.Stmt, error) {
+	panic("sqlDBWrapper.Prepare is not implemented, should not be called")
+}
+
+// Query executes a query that returns rows, typically a SELECT.
+// The args are for any placeholder parameters in the query.
+//
+// Query uses the context of [sqlDBWrapper] internally.
+func (sqlDB *sqlDBWrapper) Query(query string, args ...interface{}) (_ *sql.Rows, err error) {
+	defer getSQLExecutionPlanLoggingFunc(sqlDB, sqlDB.logConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(nil, &err, gorm.NowFunc(), query, args...)(sqlDB.logConfig)
+
+	return sqlDB.sqlDB.QueryContext(sqlDB.ctx, query, args...)
+}
+
+// QueryRow executes a query that is expected to return at most one row.
+// QueryRow always returns a non-nil value. Errors are deferred until
+// [sql.Row]'s Scan method is called.
+// If the query selects no rows, the [*Row.Scan] will return [sql.ErrNoRows].
+// Otherwise, [*sql.Row.Scan] scans the first selected row and discards
+// the rest.
+//
+// QueryRow uses the context of [sqlDBWrapper] internally.
+func (sqlDB *sqlDBWrapper) QueryRow(query string, args ...interface{}) (row *sql.Row) {
+	defer getSQLExecutionPlanLoggingFunc(sqlDB, sqlDB.logConfig, query, args...)()
+	startTime := gorm.NowFunc()
+	defer func() {
+		err := row.Err()
+		getSQLQueryLoggingFunc(nil, &err, startTime, query, args...)(sqlDB.logConfig)
+	}()
+
+	return sqlDB.sqlDB.QueryRowContext(sqlDB.ctx, query, args...)
+}
+
+var _ gorm.SQLCommon = &sqlDBWrapper{}
+
+/*
+type sqlDb interface {
+	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+*/
+// Begin is not implemented intentionally to make sqlDBWrapper incompatible with gorm.sqlDb interface.
+//
+// Note: Gorm calls this method from 'delete' and 'update' callbacks if the db implements 'sqlDb' interface.
+// Otherwise, is silently skips the transaction start.
+// The problem with this method is that it returns a raw sql.Tx which does not have
+// the context of the sqlDBWrapper and logging.
+// Happily, we do not need 'delete' and 'update' callbacks to be transactional as we
+// never use Gorm models and never expose Gorm methods working with models. This means
+// we do not have associations or timestamp fields that Gorm would update automatically.
+// Actually, the only method triggering such callbacks is 'Delete' from the 'gorm.DB' struct
+// and, in our cases, it only executes one DELETE statement, so no transaction is needed.
+/*
+func (sqlDB *sqlDBWrapper) Begin() (*sql.Tx, error) {
+	panic("Begin is not implemented, should not be called")
+}
+*/
+
+const beginTransactionLogMessage = "**BEGIN TRANSACTION**"
+
+// BeginTx starts a transaction.
+//
+// The provided context is used until the transaction is committed or rolled back.
+// If the context is canceled, the sql package will roll back
+// the transaction. [sql.Tx.Commit] will return an error if the context provided to
+// BeginTx is canceled.
+//
+// The provided [sql.TxOptions] is optional and may be nil if defaults should be used.
+// If a non-default isolation level is used that the driver doesn't support,
+// an error will be returned.
+//
+// Note: Gorm uses this method only in [gorm.DB.Transaction] method and only if the db implements
+// the 'sqlDb' interface. We intentionally do not implement this interface to avoid Gorm from
+// calling this method. We never use [gorm.DB.Transaction] method as we do not expose it.
+// So, we intentionally implement this method with a different return value to make sqlDBWrapper
+// incompatible with the 'sqlDb' interface.
+func (sqlDB *sqlDBWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sqlTxWrapper, error) {
+	startTime := gorm.NowFunc()
+	tx, err := sqlDB.sqlDB.BeginTx(ctx, opts)
+	if sqlDB.logConfig.LogSQLQueries {
+		logSQLQuery(sqlDB.logConfig.Logger, gorm.NowFunc().Sub(startTime), beginTransactionLogMessage, nil, nil)
+	}
+	if err != nil {
+		sqlDB.logConfig.Logger.Print("error", fileWithLineNum(), err)
+		return nil, err
+	}
+	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, logConfig: sqlDB.logConfig}, nil
+}
+
+// We intentionally do not implement the 'sqlDb' interface to avoid Gorm from calling 'Begin' method.
+// var _ sqlDb = &sqlDBWrapper{}
+
+type queryRowWithoutLogging interface {
+	queryRowWithoutLogging(query string, args ...interface{}) *sql.Row
+}
+
+func (sqlDB *sqlDBWrapper) queryRowWithoutLogging(query string, args ...interface{}) *sql.Row {
+	return sqlDB.sqlDB.QueryRowContext(context.Background(), query, args...)
+}
+
+var _ queryRowWithoutLogging = &sqlDBWrapper{}
+
+type withContexter interface {
+	withContext(ctx context.Context) gorm.SQLCommon
+}
+
+func (sqlDB *sqlDBWrapper) withContext(ctx context.Context) gorm.SQLCommon {
+	return &sqlDBWrapper{sqlDB: sqlDB.sqlDB, ctx: ctx, logConfig: sqlDB.logConfig}
+}
+
+var _ withContexter = &sqlDBWrapper{}
+
+func (sqlDB *sqlDBWrapper) Close() error {
+	return sqlDB.sqlDB.Close()
+}
+
+var _ interface{ Close() error } = &sqlDBWrapper{}
+
+func (sqlDB *sqlDBWrapper) conn(ctx context.Context) (*sqlConnWrapper, error) {
+	conn, err := sqlDB.sqlDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlConnWrapper{conn: conn, logConfig: sqlDB.logConfig}, nil
+}

--- a/app/database/sql_db_wrapper_test.go
+++ b/app/database/sql_db_wrapper_test.go
@@ -1,0 +1,20 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func TestSQLDBWrapper_Prepare_Panics(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	sqlDBWrapper := db.db.CommonDB().(*sqlDBWrapper)
+	assert.Panics(t, func() { _, _ = sqlDBWrapper.Prepare("SELECT 1") })
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/database/sql_stmt_wrapper.go
+++ b/app/database/sql_stmt_wrapper.go
@@ -1,0 +1,100 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jinzhu/gorm"
+)
+
+// SQLStmtWrapper is a wrapper around a [sql.Stmt] that logs queries and execution plans.
+// An SQLStmtWrapper is safe for concurrent use by multiple goroutines.
+//
+// As the only possible way to get an object of this type is to call [DB.Prepare],
+//
+// If an SQLStmtWrapper is prepared on a Tx or Conn, it will be bound to a single
+// underlying connection forever. If the Tx or Conn closes, the Stmt will
+// become unusable and all operations will return an error.
+// If a Stmt is prepared on a DB, it will remain usable for the lifetime of the
+// DB. When the Stmt needs to execute on a new underlying connection, it will
+// prepare itself on the new connection automatically.
+type SQLStmtWrapper struct {
+	db        queryRowWithoutLogging
+	sql       string
+	stmt      *sql.Stmt
+	logConfig *LogConfig
+}
+
+// Note: We don't implement methods that don't accept a context because
+// they would use a default context (like context.Background() or a maybe a context stored in the struct),
+// which is bad practice. Although sqlDBWrapper and sqlTxWrapper store the context for compatibility reasons,
+// we don't want to encourage this practice.
+
+// ExecContext executes a prepared statement with the given arguments and
+// returns a [sql.Result] summarizing the effect of the statement.
+func (s *SQLStmtWrapper) ExecContext(ctx context.Context, args ...interface{}) (result sql.Result, err error) {
+	defer getSQLExecutionPlanLoggingFunc(s.db, s.logConfig, s.sql, args...)()
+	defer getSQLQueryLoggingFunc(func() *int64 {
+		rowsAffected, _ := result.RowsAffected()
+		return &rowsAffected
+	}, &err, gorm.NowFunc(), s.sql, args...)(s.logConfig)
+
+	return s.stmt.ExecContext(ctx, args...)
+}
+
+/*
+// Exec panics if called.
+func (s *SQLStmtWrapper) Exec(...interface{}) (result sql.Result, err error) {
+	panic("SQLStmtWrapper.Exec should not be called")
+}
+*/
+
+// QueryContext executes a prepared query statement with the given arguments
+// and returns the query results as a [*sql.Rows].
+func (s *SQLStmtWrapper) QueryContext(ctx context.Context, args ...interface{}) (_ *sql.Rows, err error) {
+	defer getSQLExecutionPlanLoggingFunc(s.db, s.logConfig, s.sql, args...)()
+	defer getSQLQueryLoggingFunc(nil, &err, gorm.NowFunc(), s.sql, args...)(s.logConfig)
+
+	return s.stmt.QueryContext(ctx, args...)
+}
+
+/*
+// Query panics if called.
+func (s *SQLStmtWrapper) Query(...interface{}) (_ *sql.Rows, err error) {
+	panic("SQLStmtWrapper.Query should not be called")
+}
+*/
+
+// QueryRowContext executes a prepared query statement with the given arguments.
+// If an error occurs during the execution of the statement, that error will
+// be returned by a call to Scan on the returned [*sql.Row], which is always non-nil.
+// If the query selects no rows, the [*sql.Row.Scan] will return [sql.ErrNoRows].
+// Otherwise, the [*sql.Row.Scan] scans the first selected row and discards
+// the rest.
+//
+// Example usage:
+//
+//	var name string
+//	err := nameByUseridStmt.QueryRow(ctx, id).Scan(&name)
+func (s *SQLStmtWrapper) QueryRowContext(ctx context.Context, args ...interface{}) (row *sql.Row) {
+	defer getSQLExecutionPlanLoggingFunc(s.db, s.logConfig, s.sql, args...)()
+	startTime := gorm.NowFunc()
+	defer func() {
+		err := row.Err()
+		getSQLQueryLoggingFunc(nil, &err, startTime, s.sql, args...)(s.logConfig)
+	}()
+
+	return s.stmt.QueryRowContext(ctx, args...)
+}
+
+/*
+// QueryRow panics if called.
+func (s *SQLStmtWrapper) QueryRow(...interface{}) (row *sql.Row) {
+	panic("SQLStmtWrapper.QueryRow should not be called")
+}
+*/
+
+// Close closes the statement.
+func (s *SQLStmtWrapper) Close() error {
+	return s.stmt.Close()
+}

--- a/app/database/sql_tx_wrapper.go
+++ b/app/database/sql_tx_wrapper.go
@@ -1,0 +1,141 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/jinzhu/gorm"
+)
+
+type sqlTxWrapper struct {
+	sqlTx     *sql.Tx
+	ctx       context.Context
+	logConfig *LogConfig
+}
+
+// Exec executes a query that doesn't return rows.
+// For example: an INSERT and UPDATE.
+//
+// Exec uses the context of [sqlTxWrapper] internally.
+func (sqlTX *sqlTxWrapper) Exec(query string, args ...interface{}) (result sql.Result, err error) {
+	defer getSQLExecutionPlanLoggingFunc(sqlTX, sqlTX.logConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(func() *int64 {
+		affectedRows, _ := result.RowsAffected()
+		return &affectedRows
+	}, &err, gorm.NowFunc(), query, args...)(sqlTX.logConfig)
+
+	return sqlTX.sqlTx.ExecContext(sqlTX.ctx, query, args...)
+}
+
+// Prepare is not implemented intentionally and panics if called. Instead, use [prepare].
+//
+// Note: Gorm does not use this method, but it is required to implement the [gorm.SQLCommon] interface.
+func (sqlTX *sqlTxWrapper) Prepare(_ string) (*sql.Stmt, error) {
+	panic("sqlTxWrapper.Prepare is not implemented, should not be called")
+}
+
+// prepare creates a prepared statement for use within a transaction.
+//
+// The returned statement operates within the transaction and will be closed
+// when the transaction has been committed or rolled back.
+//
+// To use an existing prepared statement on this transaction, see [sql.Tx.Stmt].
+//
+// prepare uses the context of [sqlTxWrapper] internally.
+func (sqlTX *sqlTxWrapper) prepare(query string) (*SQLStmtWrapper, error) {
+	stmt, err := sqlTX.sqlTx.PrepareContext(sqlTX.ctx, query)
+	if err != nil {
+		sqlTX.logConfig.Logger.Print("error", fileWithLineNum(), err)
+		return nil, err
+	}
+	return &SQLStmtWrapper{db: sqlTX, sql: query, stmt: stmt, logConfig: sqlTX.logConfig}, nil
+}
+
+// Query executes a query that returns rows, typically a SELECT.
+//
+// Query uses the context of [sqlTxWrapper] internally.
+func (sqlTX *sqlTxWrapper) Query(query string, args ...interface{}) (_ *sql.Rows, err error) {
+	defer getSQLExecutionPlanLoggingFunc(sqlTX, sqlTX.logConfig, query, args...)()
+	defer getSQLQueryLoggingFunc(nil, &err, gorm.NowFunc(), query, args...)(sqlTX.logConfig)
+
+	return sqlTX.sqlTx.QueryContext(sqlTX.ctx, query, args...)
+}
+
+// QueryRow executes a query that is expected to return at most one row.
+// QueryRow always returns a non-nil value. Errors are deferred until
+// Row's Scan method is called.
+// If the query selects no rows, the *Row's Scan will return ErrNoRows.
+// Otherwise, the *Row's Scan scans the first selected row and discards
+// the rest.
+//
+// QueryRow uses the context of [sqlTxWrapper] internally.
+func (sqlTX *sqlTxWrapper) QueryRow(query string, args ...interface{}) (row *sql.Row) {
+	defer getSQLExecutionPlanLoggingFunc(sqlTX, sqlTX.logConfig, query, args...)()
+	startTime := gorm.NowFunc()
+	defer func() {
+		err := row.Err()
+		getSQLQueryLoggingFunc(nil, &err, startTime, query, args...)(sqlTX.logConfig)
+	}()
+
+	return sqlTX.sqlTx.QueryRowContext(sqlTX.ctx, query, args...)
+}
+
+var _ gorm.SQLCommon = &sqlTxWrapper{}
+
+const commitTransactionLogMessage = "**COMMIT TRANSACTION**"
+
+// Commit commits the transaction.
+func (sqlTX *sqlTxWrapper) Commit() (err error) {
+	startTime := gorm.NowFunc()
+	err = sqlTX.sqlTx.Commit()
+	if sqlTX.logConfig.LogSQLQueries {
+		logSQLQuery(sqlTX.logConfig.Logger, gorm.NowFunc().Sub(startTime), commitTransactionLogMessage, nil, nil)
+	}
+	return sqlTX.handleCommitOrRollbackError(err)
+}
+
+const rollbackTransactionLogMessage = "**ROLLBACK TRANSACTION**"
+
+// Rollback aborts the transaction.
+func (sqlTX *sqlTxWrapper) Rollback() (err error) {
+	startTime := gorm.NowFunc()
+	err = sqlTX.sqlTx.Rollback()
+	if sqlTX.logConfig.LogSQLQueries {
+		logSQLQuery(sqlTX.logConfig.Logger, gorm.NowFunc().Sub(startTime), rollbackTransactionLogMessage, nil, nil)
+	}
+	return sqlTX.handleCommitOrRollbackError(err)
+}
+
+func (sqlTX *sqlTxWrapper) handleCommitOrRollbackError(err error) error {
+	var errorWasPatched bool
+	if err != nil && sqlTX.ctx.Err() != nil { // ignore the returned error if the context has been canceled before
+		err = sqlTX.ctx.Err() // return the context error instead as it is the root cause
+		errorWasPatched = true
+	}
+	if err != nil {
+		errString := err.Error()
+		if errorWasPatched {
+			errString += " (the transaction has been rolled back implicitly)"
+		}
+		sqlTX.logConfig.Logger.Print("error", fileWithLineNum(), errString)
+	}
+	return err
+}
+
+var (
+	_ gorm.SQLCommon = &sqlTxWrapper{}
+	_ driver.Tx      = &sqlTxWrapper{}
+)
+
+func (sqlTX *sqlTxWrapper) queryRowWithoutLogging(query string, args ...interface{}) *sql.Row {
+	return sqlTX.sqlTx.QueryRowContext(context.Background(), query, args...)
+}
+
+var _ queryRowWithoutLogging = &sqlTxWrapper{}
+
+func (sqlTX *sqlTxWrapper) withContext(ctx context.Context) gorm.SQLCommon {
+	return &sqlTxWrapper{sqlTx: sqlTX.sqlTx, ctx: ctx, logConfig: sqlTX.logConfig}
+}
+
+var _ withContexter = &sqlTxWrapper{}

--- a/app/database/sql_tx_wrapper_test.go
+++ b/app/database/sql_tx_wrapper_test.go
@@ -1,0 +1,26 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func TestSQLTxWrapper_Prepare_Panics(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+	db, mock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	assert.NoError(t, db.inTransaction(func(db *DB) error {
+		sqlTxWrapper := db.db.CommonDB().(*sqlTxWrapper)
+		assert.Panics(t, func() { _, _ = sqlTxWrapper.Prepare("SELECT 1") })
+		return nil
+	}))
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/doc/error_responses.go
+++ b/app/doc/error_responses.go
@@ -46,6 +46,14 @@ type notFoundResponse struct {
 	Body struct{ notFound }
 }
 
+// Request Timeout. The request sent from the client takes a longer time to be processed
+// than how long the server was prepared to wait.
+// swagger:response requestTimeoutResponse
+type requestTimeoutResponse struct {
+	// in: body
+	Body struct{ requestTimeout }
+}
+
 // Unprocessable Entity. Returned by services performing groups relations transitions to indicate
 // that the transition is impossible.
 // swagger:response unprocessableEntityResponse

--- a/app/doc/errors.go
+++ b/app/doc/errors.go
@@ -61,6 +61,13 @@ type notFound struct {
 	Message string `json:"message"`
 }
 
+type requestTimeout struct {
+	genericError
+	// required: true
+	// enum: Request Timeout
+	Message string `json:"message"`
+}
+
 type unprocessableEntity struct {
 	genericError
 	// required: true

--- a/app/logging/gorm_log_formatter.go
+++ b/app/logging/gorm_log_formatter.go
@@ -162,11 +162,15 @@ func formatGormDBLog(values ...interface{}) (messages []interface{}) {
 			}
 		}
 
-		messages = append(messages,
-			sql,
-			fmt.Sprintf(" \n\033[36;31m[%v]\033[0m ",
-				strconv.FormatInt(values[5].(int64), 10)+" rows affected or returned "),
-		)
+		messages = append(messages, sql)
+
+		if len(values) >= 6 {
+			messages = append(messages,
+				fmt.Sprintf(" \n\033[36;31m[%v]\033[0m ",
+					strconv.FormatInt(values[5].(int64), 10)+" rows affected "),
+			)
+		}
+
 		return messages
 	}
 

--- a/app/logging/gorm_log_formatter_test.go
+++ b/app/logging/gorm_log_formatter_test.go
@@ -52,7 +52,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				" \033[36;1m[52739.32ms]\033[0m ",
 				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`, `c7`, `c8`, `c9`, `c10`, `c11`, `c12`, `c13`) VALUES " +
 					"(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0.11, 0.12, true)",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`, `c5`, `c6`) VALUES " +
 					"('2022-08-02 15:04:05.123456789', '2022-08-02 15:04:05.123456789', " +
 					"'2022-08-02 15:04:05.123456', '2022-08-02 15:04:05.123456', NULL, '0000-00-00 00:00:00')",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
 				" \033[36;1m[52739.32ms]\033[0m ",
 				"INSERT INTO `t` (`c1`, `c2`, `c3`, `c4`) VALUES (123451234512345, 'testsessiontestsessiontestsessio', 1, 1)",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
 				" \033[36;1m[52739.32ms]\033[0m ",
 				"INSERT INTO `t` (`c1`, `c2`) VALUES ('test', '<binary>')",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
 				" \033[36;1m[52739.32ms]\033[0m ",
 				"INSERT INTO `t` (`c1`, `c2`) VALUES (12345, NULL)",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func Test_GormLogFormatter(t *testing.T) {
 				"\n\033[33m[2021-08-02 15:04:05]\033[0m",
 				" \033[36;1m[52739.32ms]\033[0m ",
 				"INSERT INTO `t` (`c1`) VALUES (NULL)",
-				" \n\x1b[36;31m[1 rows affected or returned ]\x1b[0m ",
+				" \n\x1b[36;31m[1 rows affected ]\x1b[0m ",
 			},
 		},
 		{

--- a/app/logging/raw_db_logger_test.go
+++ b/app/logging/raw_db_logger_test.go
@@ -17,11 +17,10 @@ func TestNewRawDBLogger_TextLog(t *testing.T) {
 	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "text")
-	config.Set("LogRawSQLQueries", true)
 	logger := &Logger{SharedLogger.Logger, config}
-	dbLogger, _, rawLogMode := logger.NewDBLogger()
+	dbLogger := logger.NewDBLogger()
 
-	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
+	rawLogger := NewRawDBLogger(dbLogger, true)
 	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Contains(t, hook.GetAllStructuredLogs(), "some message map[err:<nil>]")
 }
@@ -32,10 +31,9 @@ func TestNewRawDBLogger_HonoursLogMode(t *testing.T) {
 	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "text")
-	config.Set("LogRawSQLQueries", false)
 	logger := &Logger{SharedLogger.Logger, config}
-	dbLogger, _, rawLogMode := logger.NewDBLogger()
-	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
+	dbLogger := logger.NewDBLogger()
+	rawLogger := NewRawDBLogger(dbLogger, false)
 	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Empty(t, hook.GetAllStructuredLogs())
 }
@@ -46,10 +44,9 @@ func TestNewRawDBLogger_JSONLog(t *testing.T) {
 	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "json")
-	config.Set("LogRawSQLQueries", true)
 	logger := &Logger{SharedLogger.Logger, config}
-	dbLogger, _, rawLogMode := logger.NewDBLogger()
-	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
+	dbLogger := logger.NewDBLogger()
+	rawLogger := NewRawDBLogger(dbLogger, true)
 	rawLogger.Log(context.TODO(), "some message", "err", nil)
 	assert.Contains(t, hook.GetAllStructuredLogs(), `msg="some message"`)
 	assert.Contains(t, hook.GetAllStructuredLogs(), `err="<nil>"`)
@@ -61,10 +58,9 @@ func TestRawDBLogger_ShouldSkipSkippedActions(t *testing.T) {
 	defer ResetShared()
 	config := viper.New()
 	config.Set("Format", "json")
-	config.Set("LogRawSQLQueries", true)
 	logger := &Logger{SharedLogger.Logger, config}
-	dbLogger, _, rawLogMode := logger.NewDBLogger()
-	rawLogger := NewRawDBLogger(dbLogger, rawLogMode)
+	dbLogger := logger.NewDBLogger()
+	rawLogger := NewRawDBLogger(dbLogger, true)
 	rawLogger.Log(context.TODO(), "sql-stmt-exec", "err", driver.ErrSkip)
 	assert.Empty(t, hook.GetAllStructuredLogs())
 }

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -22,7 +22,7 @@ var (
 )
 
 // Print defines how StructuredDBLogger print log entries.
-// values: 0: level, 1: source file, 2: duration in ns, 3: query, 4: slice of parameters, 5: rows affected or returned
+// values: 0: level, 1: source file, 2: duration in ns, 3: query, 4: slice of parameters, 5: rows affected
 func (l *StructuredDBLogger) Print(values ...interface{}) {
 	level := values[0]
 	logger := SharedLogger.WithField("type", "db")
@@ -31,11 +31,14 @@ func (l *StructuredDBLogger) Print(values ...interface{}) {
 	case sqlString:
 		duration := float64(values[2].(time.Duration).Nanoseconds()) / float64(time.Second.Nanoseconds()) // to seconds
 		sql := fillSQLPlaceholders(values[3].(string), values[4].([]interface{}))
-		logger.WithFields(map[string]interface{}{
+		fields := map[string]interface{}{
 			"duration": duration,
 			"ts":       time.Now().Format(time.DateTime),
-			"rows":     values[5].(int64),
-		}).Println(strings.TrimSpace(sql))
+		}
+		if len(values) >= 6 {
+			fields["rows"] = values[5].(int64)
+		}
+		logger.WithFields(fields).Println(strings.TrimSpace(sql))
 	case "rawsql":
 		/*
 		   values[0] - level (rawsql)

--- a/app/logging/structuredDBLogger.go
+++ b/app/logging/structuredDBLogger.go
@@ -53,7 +53,7 @@ func (l *StructuredDBLogger) Print(values ...interface{}) {
 		valuesMap["ts"] = time.Now().Format(time.DateTime)
 		logger.WithFields(valuesMap).Println(values[2])
 	default: // level is not "sql"/"rawsql", so typically errors
-		logger.Println(values[2:]...)
+		logger.Errorln(values[2:]...)
 	}
 }
 

--- a/app/logging/structuredDBLogger_test.go
+++ b/app/logging/structuredDBLogger_test.go
@@ -5,19 +5,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/sirupsen/logrus/hooks/test" //nolint:depguard
 	"github.com/spf13/viper"
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
-func TestStructuredDBLogger_Print_SQL(t *testing.T) {
+func TestStructuredDBLogger_Print_SQL_Select(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
-	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
 	defer logging.ResetShared()
@@ -37,19 +37,48 @@ func TestStructuredDBLogger_Print_SQL(t *testing.T) {
 
 	var result []interface{}
 	db.Raw("SELECT $1, $2, $3, $4, $5", 1, timeParam, "foo", []byte("bar"), nil).Scan(&result)
-	assert.Equal(`SELECT 1, '2009-11-10 23:00:00', "foo", "bar", NULL`, hook.LastEntry().Message)
+	assert.Equal(t, `SELECT 1, '2009-11-10 23:00:00', "foo", "bar", NULL`, hook.LastEntry().Message)
 	data := hook.LastEntry().Data
-	assert.Equal("db", data["type"])
-	assert.True(data["duration"].(float64) < 0.1, "unexpected duration: %v", data["duration"])
-	assert.NotNil(data["ts"])
-	assert.Equal(int64(1), data["rows"].(int64))
-	assert.NoError(mock.ExpectationsWereMet())
+	assert.Equal(t, "db", data["type"])
+	assert.True(t, data["duration"].(float64) < 0.1, "unexpected duration: %v", data["duration"])
+	assert.NotNil(t, data["ts"])
+	assert.Equal(t, int64(1), data["rows"].(int64))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStructuredDBLogger_Print_SQL_Update(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	var hook *test.Hook
+	logging.SharedLogger, hook = logging.NewMockLogger()
+	defer logging.ResetShared()
+	conf := viper.New()
+	conf.Set("Format", "json")
+	conf.Set("Output", "stdout")
+	conf.Set("LogSQLQueries", true)
+	logging.SharedLogger.Configure(conf)
+	db, mock := database.NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	timeParam := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(`^UPDATE t1 SET c1=\$1, c2=\$2, c3=\$3, c4=\$4, c5=\$5$`).
+		WithArgs(1, timeParam, "foo", []byte("bar"), nil).
+		WillReturnResult(sqlmock.NewResult(-1, 123))
+
+	db.Exec("UPDATE t1 SET c1=$1, c2=$2, c3=$3, c4=$4, c5=$5", 1, timeParam, "foo", []byte("bar"), nil)
+	assert.Equal(t, `UPDATE t1 SET c1=1, c2='2009-11-10 23:00:00', c3="foo", c4="bar", c5=NULL`, hook.LastEntry().Message)
+	data := hook.LastEntry().Data
+	assert.Equal(t, "db", data["type"])
+	assert.True(t, data["duration"].(float64) < 0.1, "unexpected duration: %v", data["duration"])
+	assert.NotNil(t, data["ts"])
+	assert.Equal(t, int64(123), data["rows"].(int64))
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
-	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
 	defer logging.ResetShared()
@@ -65,14 +94,13 @@ func TestStructuredDBLogger_Print_SQLWithInterrogationMark(t *testing.T) {
 
 	var result []interface{}
 	db.Raw("SELECT ?", 1).Scan(&result)
-	assert.Equal("SELECT 1", hook.LastEntry().Message)
-	assert.NoError(mock.ExpectationsWereMet())
+	assert.Equal(t, "SELECT 1", hook.LastEntry().Message)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
-	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger, hook = logging.NewMockLogger()
 	defer logging.ResetShared()
@@ -90,23 +118,22 @@ func TestStructuredDBLogger_Print_SQLError(t *testing.T) {
 	var result []interface{}
 	db.Raw("SELECT 2").Scan(&result)
 
-	assert.Equal("a query error", hook.Entries[0].Message)
+	assert.Equal(t, "a query error", hook.Entries[0].Message)
 	data := hook.Entries[0].Data
-	assert.Equal("db", data["type"])
+	assert.Equal(t, "db", data["type"])
 
-	assert.Equal("SELECT 2", hook.Entries[1].Message)
+	assert.Equal(t, "SELECT 2", hook.Entries[1].Message)
 	data = hook.Entries[1].Data
-	assert.Equal("db", data["type"])
-	assert.True(data["duration"].(float64) < 1.0, "unexpected duration: %v", data["duration"])
-	assert.NotNil(data["ts"])
-	assert.Equal(int64(0), data["rows"].(int64))
-	assert.NoError(mock.ExpectationsWereMet())
+	assert.Equal(t, "db", data["type"])
+	assert.True(t, data["duration"].(float64) < 1.0, "unexpected duration: %v", data["duration"])
+	assert.NotNil(t, data["ts"])
+	assert.Equal(t, int64(0), data["rows"].(int64))
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestStructuredDBLogger_Print_RawSQLWithDuration(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
-	assert := assertlib.New(t)
 	var hook *test.Hook
 	logging.SharedLogger.Logger, hook = test.NewNullLogger()
 	defer logging.ResetShared()
@@ -117,9 +144,9 @@ func TestStructuredDBLogger_Print_RawSQLWithDuration(t *testing.T) {
 			"duration": 500 * time.Millisecond,
 		})
 
-	assert.Equal("sql-stmt-exec", hook.Entries[0].Message)
+	assert.Equal(t, "sql-stmt-exec", hook.Entries[0].Message)
 	data := hook.Entries[0].Data
-	assert.Equal("db", data["type"])
-	assert.Equal(data["duration"].(float64), 0.5)
-	assert.NotNil(data["ts"])
+	assert.Equal(t, "db", data["type"])
+	assert.Equal(t, data["duration"].(float64), 0.5)
+	assert.NotNil(t, data["ts"])
 }

--- a/app/service/base_test.go
+++ b/app/service/base_test.go
@@ -35,7 +35,9 @@ func TestBase_GetUser(t *testing.T) {
 }
 
 func TestBase_GetStore(t *testing.T) {
-	expectedDB := &database.DB{}
+	db, _ := database.NewDBMock()
+	defer func() { _ = db.Close() }()
+	expectedDB := db
 	expectedContext := context.Background()
 	expectedStore := database.NewDataStoreWithContext(expectedContext, expectedDB)
 	req := (&http.Request{}).WithContext(expectedContext)

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -71,6 +71,12 @@ func ErrNotFound(err error) APIError {
 	return APIError{http.StatusNotFound, err}
 }
 
+// ErrRequestTimeout is for errors caused by out inability to perform the operation in a timely manner.
+// It results in a 408 Request Timeout.
+func ErrRequestTimeout() APIError {
+	return APIError{HTTPStatusCode: http.StatusRequestTimeout}
+}
+
 // ErrConflict is for errors caused by wrong resource state not allowing to perform the operation
 // It results in a 409 Conflict.
 func ErrConflict(err error) APIError {

--- a/app/service/handler.go
+++ b/app/service/handler.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime/debug"
@@ -24,8 +26,12 @@ func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			case APIError:
 				apiErr = err
 			case error:
-				apiErr = ErrUnexpected(err)
-				shouldLogError = true
+				if errors.Is(err, context.DeadlineExceeded) {
+					apiErr = ErrRequestTimeout()
+				} else {
+					apiErr = ErrUnexpected(err)
+					shouldLogError = true
+				}
 			default:
 				apiErr = ErrUnexpected(fmt.Errorf("unknown error: %+v", err))
 				shouldLogError = true

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -30,6 +30,7 @@ logging:
   level: debug # debug, info, warning, error, fatal, panic
   logSQLQueries: true
   logRawSQLQueries: false
+  analyzeSQLQueries: false # run EXPLAIN ANALYZE on all SQL queries (works only if logSQLQueries is true)
 domains:
   -
     domains: [default] # of a list of domains

--- a/conf/config.test.sample.yaml
+++ b/conf/config.test.sample.yaml
@@ -30,6 +30,7 @@ logging:
   level: debug # debug, info, warning, error, fatal, panic
   logSQLQueries: true
   logRawSQLQueries: false
+  analyzeSQLQueries: false # run EXPLAIN ANALYZE on all SQL queries (works only if logSQLQueries is true)
 domains:
   -
     domains: [default] # of a list of domains

--- a/testhelpers/db.go
+++ b/testhelpers/db.go
@@ -86,8 +86,10 @@ func OpenRawDBConnection() (*sql.DB, error) {
 	appenv.ForceTestEnv()
 
 	// needs actual config for connection to DB
-	dbConfig, _ := app.DBConfig(app.LoadConfig())
-	rawDB, err := database.OpenRawDBConnection(dbConfig.FormatDSN())
+	config := app.LoadConfig()
+	dbConfig, _ := app.DBConfig(config)
+	loggingConfig := app.LoggingConfig(config)
+	rawDB, err := database.OpenRawDBConnection(dbConfig.FormatDSN(), loggingConfig.GetBool("LogRawSQLQueries"))
 	if err != nil {
 		panic(err)
 	}

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/rand"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 type dbquery struct {
@@ -181,7 +182,10 @@ func (ctx *TestContext) openDB() *sql.DB {
 	if ctx.db == nil {
 		var err error
 		config, _ := app.DBConfig(ctx.application.Config)
-		ctx.db, err = sql.Open("instrumented-mysql", config.FormatDSN())
+		loggingConfig := app.LoggingConfig(ctx.application.Config)
+		ctx.db, err = sql.Open(
+			golang.IfElse(loggingConfig.GetBool("LogRawSQLQueries"), "instrumented-mysql", "mysql"),
+			config.FormatDSN())
 		if err != nil {
 			fmt.Println("Unable to connect to the database: ", err)
 			os.Exit(1)


### PR DESCRIPTION
DB-related:
Introduce wrappers for sql.Conn, sql.DB, sql.Stmt, sql.Tx allowing us to pass the context (should help handle timeouts) correctly and log SQL queries everywhere (no matter if it is inside a transaction or not, no matter if it is a prepared statement or not).
Rework named locking to ensure it will work and release locks fine even if a request times out, no matter if it is inside a transaction or not (use a separate MySQL connection for each named lock to make things simple and stable).
Introduce SQL queries analyzing when logging.analyzeSQLQueries is enabled and the config setting logging.analyzeSQLQueries enabling it.
Use instrumented-mysql wrapper only if logging.logRawSQLQueries is enabled. (We use instrumented-mysql wrapper (https://github.com/luna-duclos/instrumentedsql) only for raw sql logging which will be very rarely needed after introducing new logging system. Also this wrapper doesn't support the new interface allowing to reuse connections for new MySQL sessions (see https://github.com/luna-duclos/instrumentedsql/issues/53).
Log DB errors after SQL queries (Gorm does the opposite);
Log DB errors even if logging.logSQLQueries is off and use the 'error' level for them;
Turn off Gorm logging as the wrappers do logging now (note: Gorm logs number of selected rows as it performs scans by itself, but our new wrappers do not perform scans and cannot know how many rows will be scanned);
Get rid of Gorm implicit transactions as we do not use Gorm models and don't want to wrap single UPDATE/DELETE statements in transactions.
Fix handling of errors on transaction rollback.
Add temporary table dropping in the beginning of createNewAncestors().

HTTP-related:
Return 408 status code (request timeout) when the context deadline exceeded in all the services.

Other:
DeleteExpiredTokensOfUser() now deletes rows with expires_at=NOW().
Added more tests.
Improved CircleCI config to show tests output and do not rerun tests on failure.

This task can possibly fix #1048. This means that if Amazon's deadline is set on the same context we use in our requests handlers (it should be so, but I wasn't able to check), we will start returning 408 errors right after deployment. So it's worth checking if the timeout is not too small.

I tried really hard to make commits atomic and convenient for reviewing one-by-one.