### PR TITLE
Mark results of a parent item as 'to_be_recomputed' on items_items insertion

### DIFF
--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -23,15 +23,25 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 		"parent_item_id": 1, "child_item_id": 2, "child_order": 1,
 	}))
 
-	assertResultsMarkedAsChanged(t, dataStore, []resultPrimaryKey{
-		{101, 1, 2},
-		{102, 1, 2},
-		{103, 1, 2},
-		{104, 1, 2},
-		{105, 1, 2},
-		{106, 1, 2},
-		{107, 1, 2},
-		{108, 1, 2},
-		{109, 1, 2},
+	assertResultsMarkedAsChanged(t, dataStore, []resultPrimaryKeyAndState{
+		{ResultPrimaryKey: ResultPrimaryKey{101, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{102, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{103, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{104, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{105, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{106, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{107, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{108, 1, 1}, State: "to_be_recomputed"},
+		{ResultPrimaryKey: ResultPrimaryKey{109, 1, 1}, State: "to_be_recomputed"},
+
+		{ResultPrimaryKey: ResultPrimaryKey{101, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{102, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{103, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{104, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{105, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{106, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{107, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{108, 1, 2}},
+		{ResultPrimaryKey: ResultPrimaryKey{109, 1, 2}},
 	})
 }

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -51,15 +51,16 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 		groupID         int64
 		itemID          int64
 		canView         string
-		expectedChanged []resultPrimaryKey
+		expectedChanged []resultPrimaryKeyAndState
 	}{
 		{
 			name:    "make a parent item visible",
 			groupID: 104,
 			itemID:  2,
 			canView: "info",
-			expectedChanged: []resultPrimaryKey{
-				{104, 1, 3}, {105, 1, 3},
+			expectedChanged: []resultPrimaryKeyAndState{
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 3}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 3}},
 			},
 		},
 		{
@@ -67,11 +68,11 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 			groupID: 104,
 			itemID:  1,
 			canView: "info",
-			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2},
-				{104, 1, 3},
-				{105, 1, 2},
-				{105, 1, 3},
+			expectedChanged: []resultPrimaryKeyAndState{
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 3}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 3}},
 			},
 		},
 		{
@@ -79,21 +80,21 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 			groupID:         104,
 			itemID:          2,
 			canView:         "none",
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 		{
 			name:            "make an item visible",
 			groupID:         104,
 			itemID:          3,
 			canView:         "info",
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 		{
 			name:            "make a parent item visible for an expired membership",
 			groupID:         108,
 			itemID:          2,
 			canView:         "none",
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 	} {
 		test := test
@@ -122,7 +123,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 		groupID         int64
 		itemID          int64
 		canView         string
-		expectedChanged []resultPrimaryKey
+		expectedChanged []resultPrimaryKeyAndState
 		noChanges       bool
 		updateExisting  bool
 	}{
@@ -131,8 +132,9 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			groupID: 104,
 			itemID:  2,
 			canView: "info",
-			expectedChanged: []resultPrimaryKey{
-				{104, 1, 3}, {105, 1, 3},
+			expectedChanged: []resultPrimaryKeyAndState{
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 3}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 3}},
 			},
 		},
 		{
@@ -140,11 +142,11 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			groupID: 104,
 			itemID:  1,
 			canView: "info",
-			expectedChanged: []resultPrimaryKey{
-				{104, 1, 2},
-				{104, 1, 3},
-				{105, 1, 2},
-				{105, 1, 3},
+			expectedChanged: []resultPrimaryKeyAndState{
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{104, 1, 3}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 3}},
 			},
 		},
 		{
@@ -152,7 +154,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			groupID:         108,
 			itemID:          1,
 			canView:         "none",
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 			updateExisting:  true,
 		},
 		{
@@ -160,7 +162,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			groupID:         104,
 			itemID:          3,
 			canView:         "info",
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 		{
 			name:           "switch ancestor from invisible to visible",
@@ -168,11 +170,11 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			itemID:         1,
 			canView:        "info",
 			updateExisting: true,
-			expectedChanged: []resultPrimaryKey{
-				{105, 1, 2},
-				{105, 1, 3},
-				{107, 1, 2},
-				{107, 1, 3},
+			expectedChanged: []resultPrimaryKeyAndState{
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{105, 1, 3}},
+				{ResultPrimaryKey: ResultPrimaryKey{107, 1, 2}},
+				{ResultPrimaryKey: ResultPrimaryKey{107, 1, 3}},
 			},
 		},
 		{
@@ -180,7 +182,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			groupID:         108,
 			itemID:          2,
 			canView:         "info",
-			expectedChanged: []resultPrimaryKey{{108, 1, 3}},
+			expectedChanged: []resultPrimaryKeyAndState{{ResultPrimaryKey: ResultPrimaryKey{108, 1, 3}}},
 		},
 		{
 			name:            "no changes",
@@ -188,7 +190,7 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			itemID:          1,
 			canView:         "info",
 			updateExisting:  true,
-			expectedChanged: []resultPrimaryKey{},
+			expectedChanged: []resultPrimaryKeyAndState{},
 			noChanges:       true,
 		},
 	} {

--- a/db/migrations/2411181747_modify_trigger_after_insert_items_items_to_recompute_parent_results.sql
+++ b/db/migrations/2411181747_modify_trigger_after_insert_items_items_to_recompute_parent_results.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    INSERT IGNORE INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`child_item_id`;
+
+    INSERT INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`parent_item_id`
+    ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    INSERT IGNORE INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`child_item_id`;
+END
+-- +migrate StatementEnd


### PR DESCRIPTION
Fixes #1214

Note: We continue marking results of child items as 'to_be_propagated' to create new results for chapters on adding an item with existing results as a new child into some parent item.