### PR TITLE
Fix itemAnswerGetResponse used by swagger docs of currentAnswerGet, answerGet, bestAnswerGet

### DIFF
--- a/app/doc/responses.go
+++ b/app/doc/responses.go
@@ -196,9 +196,10 @@ type itemAnswerGetResponse struct {
 		AuthorID int64 `json:"author_id,string"`
 		// required:true
 		ItemID int64 `json:"item_id,string"`
-		// format:int64
 		// required:true
-		AttemptID *string `json:"attempt_id,string"`
+		AttemptID int64 `json:"attempt_id,string"`
+		// required:true
+		ParticipantID int64 `json:"participant_id,string"`
 		// Can be `null` when there is no applicable existing answer for the user.
 		// e.g., No answer when we try to retrieve the current answer.
 		// Nullable


### PR DESCRIPTION
Add participant_id, make attempt_id not nullable int64

Fixes #1199 