### PR TITLE
Use different named locks for the propagation command and for the results propagation

### DIFF
--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	resultsPropagationLockName               = "listener_propagate"
+	resultsPropagationLockName               = "results_propagation"
 	resultsPropagationLockWaitTimeout        = 10 * time.Second
 	resultsPropagationPropagationChunkSize   = 200
 	resultsPropagationRecomputationChunkSize = 1000

--- a/cmd/propagation.go
+++ b/cmd/propagation.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	propagationLockName    = "listener_propagate"
-	propagationLockTimeout = 600 * time.Second
+	propagationCommandLockName    = "propagation_command"
+	propagationCommandLockTimeout = 600 * time.Second
 )
 
 func init() { //nolint:gochecknoinits
@@ -42,7 +42,7 @@ func init() { //nolint:gochecknoinits
 			// Propagation.
 			// We use a lock because we don't want this process to be called concurrently.
 			err = database.NewDataStore(application.Database).
-				WithNamedLock(propagationLockName, propagationLockTimeout, func(s *database.DataStore) error {
+				WithNamedLock(propagationCommandLockName, propagationCommandLockTimeout, func(s *database.DataStore) error {
 					return s.InTransaction(func(store *database.DataStore) error {
 						store.SchedulePermissionsPropagation()
 						store.ScheduleResultsPropagation()


### PR DESCRIPTION
In #999, where the async propagation was introduced, it was decided to use a named MySQL lock to prevent the propagation command from running concurrently. For an unknown reason, the name for the new lock was chosen to be exactly the same as the name of the lock used by the results propagation (see https://github.com/France-ioi/AlgoreaBackend/commit/8e0dcb88#diff-d6281de80749bef52a31c0cf821a96c32ed831d606f3d1a5f8e85af6703407bbR19 and https://github.com/France-ioi/AlgoreaBackend/blob/8e0dcb88e43453b6d87bdc0eea0b5636107d29fc/app/database/result_store_propagate.go#L9). Surprisingly, it seemed to work fine: the propagation command acquired the "listener_propagate" lock for the whole command and then it called the results propagation which acquired the "listener_propagate" lock again on the same session (MySQL allows acquiring the same lock many times in the same session).

As of #1215, each named lock is acquired using a separate MySQL session. As the result, the propagation command acquires the "listener_propagate" lock for the whole command and then calls the results propagation which tries to acquire the same named lock again on a separate MySQL session, so it just waits until it gets released. It's a classic deadlock.

Even if it works sometimes for some reason, it's never a great idea to use the same lock name for different purposes.

Here we change the names of both locks (also renaming some constants).