### PR TITLE
Return unlocked items in saveGrade + other fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - run: go install github.com/France-ioi/go-swagger/cmd/swagger@00200fa
       - run: apk add npm
       - run: npm install -g swagger2openapi
-      - run: npm install -g @redocly/cli@latest
+      - run: npm install -g @redocly/cli@1.25.15
       - checkout
       - run: go build -v # do not use 'make' as the image does not support '-race' arg
       - run: make swagger-generate

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ npm install -g swagger2openapi
 
 Also, you need to install [redocly-cli](https://redocly.com/redocly-cli) to serve the documentation locally:
 ```
-npm install -g @redocly/cli@latest
+npm install -g @redocly/cli@1.25.15
 ```
 
 After everything is installed, you can generate the specification file from code and validate it:

--- a/app/api/groups/get_user_progress_csv.go
+++ b/app/api/groups/get_user_progress_csv.go
@@ -220,15 +220,12 @@ func processCSVResultRow(
 	currentRowNumber := 0
 	return func(m map[string]interface{}) error {
 		var score string
-		switch v := m["score"].(type) {
-		case string:
-			score = v
-		case nil:
-			score = ""
+		if m["score"] != nil {
+			score = fmt.Sprintf("%v", m["score"])
 		}
 
-		itemID := convertToInt64(m["item_id"])
-		groupID := convertToInt64(m["group_id"])
+		itemID := m["item_id"].(int64)
+		groupID := m["group_id"].(int64)
 
 		if currentRowNumber%uniqueItemsCount == 0 {
 			groupNames := generateGroupNamesFunc(groupID)
@@ -249,19 +246,6 @@ func processCSVResultRow(
 		currentRowNumber++
 		return nil
 	}
-}
-
-func convertToInt64(value interface{}) int64 {
-	var err error
-	var result int64
-	switch v := value.(type) {
-	case string:
-		result, err = strconv.ParseInt(v, 10, 64)
-		service.MustNotBeError(err)
-	case int64:
-		result = v
-	}
-	return result
 }
 
 func joinUserProgressResultsForCSV(db *database.DB, userID interface{}) *database.DB {

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -640,10 +640,10 @@ Feature: Save grading result
       | 0  | 101            |
       | 1  | 101            |
     And the database table "items" also has the following row:
-      | id  | platform_id | url                                                                     | validation_type | default_language_tag |
-      | 80  | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721840  | All             | fr                   |
-      | 90  | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721841  | All             | fr                   |
-      | 100 | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721842  | All             | fr                   |
+      | id  | type    | validation_type | default_language_tag |
+      | 80  | Chapter | All             | fr                   |
+      | 90  | Chapter | All             | fr                   |
+      | 100 | Chapter | All             | de                   |
     And the database table "item_dependencies" also has the following row:
       | item_id | dependent_item_id | score |
       | 60      | 80                | 0     |
@@ -706,8 +706,8 @@ Feature: Save grading result
             },
             {
               "item_id": 100,
-              "language_tag": null,
-              "title": null,
+              "language_tag": "de",
+              "title": "Kapitel C",
               "type": "Chapter"
             }
           ]

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -1,8 +1,8 @@
 Feature: Save grading result
   Background:
     Given the database has the following user:
-      | login | group_id |
-      | john  | 101      |
+      | login | group_id | default_language |
+      | john  | 101      | en               |
     And the database has the following table "groups":
       | id  | name | type |
       | 201 | team | Team |
@@ -20,6 +20,10 @@ Feature: Save grading result
       | 60 | 10          | http://taskplatform.mblockelet.info/task.html?taskId=403449543672183937 | All             | fr                   |
       | 10 | null        | null                                                                    | AllButOne       | fr                   |
       | 70 | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721839  | All             | fr                   |
+    And the database has the following table "items_strings":
+      | item_id | language_tag | title        |
+      | 50      | fr           | Chapitre A   |
+      | 50      | en           | Chapter A    |
     And the database has the following table "item_dependencies":
       | item_id | dependent_item_id | score |
       | 60      | 50                | 98    |
@@ -78,7 +82,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -95,6 +100,7 @@ Feature: Save grading result
       | 0          | 101            | 50      | 100            | 1           | 1         | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 |
       | 1          | 101            | 60      | 0              | 0           | 0         | 2019-05-29 11:00:00 | null                 | null                | null                |
     And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario: User is able to save the grading result for a team (participant_id is the first integer in idAttempt in the score token)
     Given I am the user with id "101"
@@ -133,7 +139,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -150,6 +157,7 @@ Feature: Save grading result
       | 0          | 201            | 50      | 100            | 1           | 1         | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | 2017-05-29 06:38:38 |
       | 1          | 201            | 60      | 0              | 0           | 0         | 2019-05-29 11:00:00 | null                 | null                | null                |
     And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario Outline: User is able to save the grading result with a low score and idAttempt
     Given I am the user with id "101"
@@ -188,7 +196,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": false
+          "validated": false,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -205,6 +214,7 @@ Feature: Save grading result
       | 0          | 101            | 50      | <score_computed> | 1           | 0         | 2019-05-30 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
       | 1          | 101            | 60      | 0                | 0           | 0         | 2019-05-29 11:00:00 | null                 | null                | null         |
     And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
   Examples:
     | score | score_edit_rule | score_edit_value | score_computed | parent_score |
     | 99    | null            | null             | 99             | 49.5         |
@@ -250,7 +260,15 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": false
+          "validated": false,
+          "unlocked_items": [
+            {
+              "item_id": 50,
+              "language_tag": "en",
+              "title": "Chapter A",
+              "type": "Chapter"
+            }
+          ]
         },
         "message": "created",
         "success": true
@@ -266,6 +284,7 @@ Feature: Save grading result
       | 101            | 0          | 50      | 0              | 0           | 0         | 2019-05-30 11:00:00 | null                 | 2017-04-29 06:38:38 | null         |
       | 101            | 1          | 60      | 99             | 1           | 0         | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
     And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario Outline: Should keep previous score if it is greater
     Given I am the user with id "101"
@@ -308,7 +327,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": false
+          "validated": false,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -366,7 +386,15 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": [
+            {
+              "item_id": 50,
+              "language_tag": "en",
+              "title": "Chapter A",
+              "type": "Chapter"
+            }
+          ]
         },
         "message": "created",
         "success": true
@@ -412,7 +440,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -452,7 +481,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": false
+          "validated": false,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -493,7 +523,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -537,7 +568,8 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
@@ -593,9 +625,107 @@ Feature: Save grading result
       """
       {
         "data": {
-          "validated": true
+          "validated": true,
+          "unlocked_items": []
         },
         "message": "created",
         "success": true
       }
       """
+
+  Scenario: Unlocks multiple items recursively
+    Given I am the user with id "101"
+    And the database has the following table "attempts":
+      | id | participant_id |
+      | 0  | 101            |
+      | 1  | 101            |
+    And the database table "items" also has the following row:
+      | id  | platform_id | url                                                                     | validation_type | default_language_tag |
+      | 80  | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721840  | All             | fr                   |
+      | 90  | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721841  | All             | fr                   |
+      | 100 | 20          | http://taskplatform1.mblockelet.info/task.html?taskId=4034495436721842  | All             | fr                   |
+    And the database table "item_dependencies" also has the following row:
+      | item_id | dependent_item_id | score |
+      | 60      | 80                | 0     |
+      | 80      | 100               | 0     |
+    And the database table "items_items" also has the following row:
+      | parent_item_id | child_item_id | child_order |
+      | 80             | 90            | 0           |
+    And the database table "items_ancestors" also has the following row:
+      | ancestor_item_id | child_item_id |
+      | 80               | 90            |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title      |
+      | 80      | fr           | Chapitre B |
+      | 100     | de           | Kapitel C  |
+    And the database has the following table "results":
+      | attempt_id | participant_id | item_id | score_obtained_at   | latest_activity_at  | score_computed |
+      | 0          | 101            | 50      | 2017-04-29 06:38:38 | 2019-05-30 11:00:00 | 0              |
+      | 1          | 101            | 60      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 | 0              |
+      | 1          | 101            | 80      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 | 0              |
+      | 1          | 101            | 90      | 2017-05-29 06:38:38 | 2019-05-29 11:00:00 | 20             |
+    And the database has the following table "answers":
+      | id  | author_id | participant_id | attempt_id | item_id | created_at          |
+      | 123 | 101       | 101            | 0          | 50      | 2017-05-29 06:38:38 |
+      | 124 | 101       | 101            | 0          | 60      | 2017-05-29 06:38:38 |
+    And "scoreToken" is a token signed by the task platform with the following payload:
+      """
+      {
+        "idUser": "101",
+        "idItemLocal": "60",
+        "idAttempt": "101/1",
+        "itemUrl": "http://taskplatform.mblockelet.info/task.html?taskId=403449543672183937",
+        "score": "99",
+        "idUserAnswer": "124"
+      }
+      """
+    When I send a POST request to "/items/save-grade" with the following body:
+      """
+      {
+        "score_token": "{{scoreToken}}"
+      }
+      """
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "data": {
+          "validated": false,
+          "unlocked_items": [
+            {
+              "item_id": 50,
+              "language_tag": "en",
+              "title": "Chapter A",
+              "type": "Chapter"
+            },
+            {
+              "item_id": 80,
+              "language_tag": "fr",
+              "title": "Chapitre B",
+              "type": "Chapter"
+            },
+            {
+              "item_id": 100,
+              "language_tag": null,
+              "title": null,
+              "type": "Chapter"
+            }
+          ]
+        },
+        "message": "created",
+        "success": true
+      }
+      """
+    And the table "answers" should stay unchanged
+    And the table "gradings" should be:
+      | answer_id | score | ABS(TIMESTAMPDIFF(SECOND, graded_at, NOW())) < 3 |
+      | 124       | 99    | 1                                                |
+    And the table "attempts" should stay unchanged
+    And the table "results" should be:
+      | participant_id | attempt_id | item_id | score_computed | tasks_tried | validated | latest_activity_at  | latest_submission_at | score_obtained_at   | validated_at |
+      | 101            | 0          | 50      | 0              | 0           | 0         | 2019-05-30 11:00:00 | null                 | 2017-04-29 06:38:38 | null         |
+      | 101            | 1          | 60      | 99             | 1           | 0         | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+      | 101            | 1          | 80      | 20             | 0           | 0         | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+      | 101            | 1          | 90      | 20             | 0           | 0         | 2019-05-29 11:00:00 | null                 | 2017-05-29 06:38:38 | null         |
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -429,3 +429,8 @@ func (s *DataStore) InsertOrUpdateMaps(dataMap []map[string]interface{}, updateC
 func ContextWithTransactionRetrying(ctx context.Context) context.Context {
 	return context.WithValue(ctx, retryEachTransactionContextKey, true)
 }
+
+func (s *DataStore) arePropagationsSync() bool {
+	propagationsAreSync, _ := s.ctx.Value(propagationsAreSyncContextKey).(bool)
+	return propagationsAreSync
+}

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -272,7 +272,7 @@ func (s *DataStore) InTransaction(txFunc func(*DataStore) error, txOptions ...*s
 	}
 	if propagationsToRun.Results && !prohibitedPropagations.Results {
 		propagationsToRun.Results = false
-		err = s.Results().propagate()
+		err = s.Results().processResultsRecomputeForItemsAndPropagate()
 	}
 
 	return err
@@ -315,7 +315,7 @@ func (s *DataStore) SetPropagationsModeToSync() (err error) {
 	return nil
 }
 
-// ScheduleResultsPropagation schedules a run of ResultStore::propagate() after the transaction commit.
+// ScheduleResultsPropagation schedules a run of ResultStore::processResultsRecomputeForItemsAndPropagate() after the transaction commit.
 func (s *DataStore) ScheduleResultsPropagation() {
 	s.mustBeInTransaction()
 

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -98,7 +98,7 @@ func OpenWithLogConfig(source interface{}, lc LogConfig, rawSQLQueriesLoggingEna
 	dbConn, _ = gorm.Open(driverName, rawConnection)
 
 	// gorm.Open only pings the connection when it's sql.DB. So we need to ping it ourselves.
-	if err = dbConn.CommonDB().(*sqlDBWrapper).sqlDB.Ping(); err != nil && ownSQLDBConnection {
+	if err = dbConn.CommonDB().(*sqlDBWrapper).sqlDB.PingContext(ctx); err != nil && ownSQLDBConnection {
 		_ = dbConn.CommonDB().(*sqlDBWrapper).sqlDB.Close()
 	}
 

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -110,22 +110,33 @@ func OpenWithLogConfig(source interface{}, lc LogConfig, rawSQLQueriesLoggingEna
 
 // OpenRawDBConnection creates a new DB connection.
 func OpenRawDBConnection(sourceDSN string, enableRawLevelLogging bool) (*sql.DB, error) {
+	registerWrappedDriver := true
+	for _, driverName := range sql.Drivers() {
+		if driverName == "wrapped-mysql" {
+			registerWrappedDriver = false
+			break
+		}
+	}
+	if registerWrappedDriver {
+		sql.Register("wrapped-mysql", newMySQLDriverWrapper(&mysql.MySQLDriver{}))
+	}
+
 	if enableRawLevelLogging {
-		registerDriver := true
+		registerInstrumentedDriver := true
 		for _, driverName := range sql.Drivers() {
 			if driverName == "instrumented-mysql" {
-				registerDriver = false
+				registerInstrumentedDriver = false
 				break
 			}
 		}
 
-		if registerDriver {
+		if registerInstrumentedDriver {
 			rawDBLogger := NewRawDBLogger()
 			sql.Register("instrumented-mysql",
-				instrumentedsql.WrapDriver(&mysql.MySQLDriver{}, instrumentedsql.WithLogger(rawDBLogger)))
+				instrumentedsql.WrapDriver(newMySQLDriverWrapper(&mysql.MySQLDriver{}), instrumentedsql.WithLogger(rawDBLogger)))
 		}
 	}
-	return sql.Open(golang.IfElse(enableRawLevelLogging, "instrumented-mysql", "mysql"), sourceDSN)
+	return sql.Open(golang.IfElse(enableRawLevelLogging, "instrumented-mysql", "wrapped-mysql"), sourceDSN)
 }
 
 // New clones a new db connection without search conditions.

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -1583,7 +1583,7 @@ func TestOpen_OpenRawDBConnectionError(t *testing.T) {
 
 func assertRawDBIsOK(t *testing.T, rawDB *sql.DB) {
 	assert.Equal(t, "*instrumentedsql.WrappedDriver", fmt.Sprintf("%T", rawDB.Driver()))
-	assert.Contains(t, fmt.Sprintf("%#v", rawDB), "parent:(*mysql.connector)")
+	assert.Contains(t, fmt.Sprintf("%#v", rawDB), "parent:(*database.mysqlConnectorWrapper)")
 }
 
 func TestDB_mustBeInTransaction_DoesNothingInTransaction(t *testing.T) {

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -32,16 +32,16 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			shouldDeleteOrphans: false,
 			remainingGroupIDs:   []int64{1, 2, 3, 4, 5},
 			remainingGroupsGroups: []map[string]interface{}{
-				{"parent_group_id": "2", "child_group_id": "5"},
+				{"parent_group_id": int64(2), "child_group_id": int64(5)},
 			},
 			remainingGroupsAncestors: []map[string]interface{}{
-				{"ancestor_group_id": "1", "child_group_id": "1"},
-				{"ancestor_group_id": "2", "child_group_id": "2"},
-				{"ancestor_group_id": "2", "child_group_id": "5"},
-				{"ancestor_group_id": "3", "child_group_id": "3"},
-				{"ancestor_group_id": "4", "child_group_id": "4"},
-				{"ancestor_group_id": "5", "child_group_id": "5"},
-				{"ancestor_group_id": "111", "child_group_id": "111"},
+				{"ancestor_group_id": int64(1), "child_group_id": int64(1)},
+				{"ancestor_group_id": int64(2), "child_group_id": int64(2)},
+				{"ancestor_group_id": int64(2), "child_group_id": int64(5)},
+				{"ancestor_group_id": int64(3), "child_group_id": int64(3)},
+				{"ancestor_group_id": int64(4), "child_group_id": int64(4)},
+				{"ancestor_group_id": int64(5), "child_group_id": int64(5)},
+				{"ancestor_group_id": int64(111), "child_group_id": int64(111)},
 			},
 			expectedGrantedPermissions: []grantedPermission{
 				{GroupID: 1, ItemID: 1, SourceGroupID: 1, Origin: "group_membership", CanView: "none"},
@@ -64,14 +64,14 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			shouldDeleteOrphans: false,
 			remainingGroupIDs:   []int64{1, 2, 3},
 			remainingGroupsGroups: []map[string]interface{}{
-				{"parent_group_id": "3", "child_group_id": "2"},
+				{"parent_group_id": int64(3), "child_group_id": int64(2)},
 			},
 			remainingGroupsAncestors: []map[string]interface{}{
-				{"ancestor_group_id": "1", "child_group_id": "1"},
-				{"ancestor_group_id": "2", "child_group_id": "2"},
-				{"ancestor_group_id": "3", "child_group_id": "2"},
-				{"ancestor_group_id": "3", "child_group_id": "3"},
-				{"ancestor_group_id": "111", "child_group_id": "111"},
+				{"ancestor_group_id": int64(1), "child_group_id": int64(1)},
+				{"ancestor_group_id": int64(2), "child_group_id": int64(2)},
+				{"ancestor_group_id": int64(3), "child_group_id": int64(2)},
+				{"ancestor_group_id": int64(3), "child_group_id": int64(3)},
+				{"ancestor_group_id": int64(111), "child_group_id": int64(111)},
 			},
 			expectedGrantedPermissions: []grantedPermission{
 				{GroupID: 1, ItemID: 1, SourceGroupID: 1, Origin: "group_membership", CanView: "none"},
@@ -93,10 +93,10 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			remainingGroupIDs:     []int64{1, 3, 4},
 			remainingGroupsGroups: nil,
 			remainingGroupsAncestors: []map[string]interface{}{
-				{"ancestor_group_id": "1", "child_group_id": "1"},
-				{"ancestor_group_id": "3", "child_group_id": "3"},
-				{"ancestor_group_id": "4", "child_group_id": "4"},
-				{"ancestor_group_id": "111", "child_group_id": "111"},
+				{"ancestor_group_id": int64(1), "child_group_id": int64(1)},
+				{"ancestor_group_id": int64(3), "child_group_id": int64(3)},
+				{"ancestor_group_id": int64(4), "child_group_id": int64(4)},
+				{"ancestor_group_id": int64(111), "child_group_id": int64(111)},
 			},
 			expectedGrantedPermissions: []grantedPermission{
 				{GroupID: 1, ItemID: 1, SourceGroupID: 1, Origin: "group_membership", CanView: "none"},
@@ -115,17 +115,17 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			shouldDeleteOrphans: true,
 			remainingGroupIDs:   []int64{1, 3, 5, 10},
 			remainingGroupsGroups: []map[string]interface{}{
-				{"parent_group_id": "10", "child_group_id": "3"},
-				{"parent_group_id": "10", "child_group_id": "5"},
+				{"parent_group_id": int64(10), "child_group_id": int64(3)},
+				{"parent_group_id": int64(10), "child_group_id": int64(5)},
 			},
 			remainingGroupsAncestors: []map[string]interface{}{
-				{"ancestor_group_id": "1", "child_group_id": "1"},
-				{"ancestor_group_id": "3", "child_group_id": "3"},
-				{"ancestor_group_id": "5", "child_group_id": "5"},
-				{"ancestor_group_id": "10", "child_group_id": "3"},
-				{"ancestor_group_id": "10", "child_group_id": "5"},
-				{"ancestor_group_id": "10", "child_group_id": "10"},
-				{"ancestor_group_id": "111", "child_group_id": "111"},
+				{"ancestor_group_id": int64(1), "child_group_id": int64(1)},
+				{"ancestor_group_id": int64(3), "child_group_id": int64(3)},
+				{"ancestor_group_id": int64(5), "child_group_id": int64(5)},
+				{"ancestor_group_id": int64(10), "child_group_id": int64(3)},
+				{"ancestor_group_id": int64(10), "child_group_id": int64(5)},
+				{"ancestor_group_id": int64(10), "child_group_id": int64(10)},
+				{"ancestor_group_id": int64(111), "child_group_id": int64(111)},
 			},
 			expectedGrantedPermissions: []grantedPermission{
 				{GroupID: 1, ItemID: 1, SourceGroupID: 1, Origin: "group_membership", CanView: "none"},
@@ -147,11 +147,11 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			remainingGroupIDs:     []int64{1, 8, 9, 11},
 			remainingGroupsGroups: nil,
 			remainingGroupsAncestors: []map[string]interface{}{
-				{"ancestor_group_id": "1", "child_group_id": "1"},
-				{"ancestor_group_id": "8", "child_group_id": "8"},
-				{"ancestor_group_id": "9", "child_group_id": "9"},
-				{"ancestor_group_id": "11", "child_group_id": "11"},
-				{"ancestor_group_id": "111", "child_group_id": "111"},
+				{"ancestor_group_id": int64(1), "child_group_id": int64(1)},
+				{"ancestor_group_id": int64(8), "child_group_id": int64(8)},
+				{"ancestor_group_id": int64(9), "child_group_id": int64(9)},
+				{"ancestor_group_id": int64(11), "child_group_id": int64(11)},
+				{"ancestor_group_id": int64(111), "child_group_id": int64(111)},
 			},
 			expectedGrantedPermissions: []grantedPermission{
 				{GroupID: 1, ItemID: 1, SourceGroupID: 1, Origin: "group_membership", CanView: "none"},
@@ -517,7 +517,7 @@ func TestGroupGroupStore_TriggerBeforeUpdate_RefusesToModifyParentGroupIDOrChild
 	`)
 	defer func() { _ = db.Close() }()
 
-	const expectedErrorMessage = "Error 1644: Unable to change immutable columns of groups_groups " +
+	const expectedErrorMessage = "Error 1644 (45000): Unable to change immutable columns of groups_groups " +
 		"(parent_group_id/child_group_id/is_team_membership)"
 
 	groupGroupStore := database.NewDataStore(db).GroupGroups()

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -4,7 +4,6 @@ package database_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,8 +68,8 @@ func TestGroupStore_CreateNew(t *testing.T) {
 			if test.shouldCreateAttempts {
 				expectedAttempts = []map[string]interface{}{
 					{
-						"participant_id": strconv.FormatInt(newID, 10), "id": "0", "creator_id": nil, "parent_attempt_id": nil,
-						"root_item_id": nil, "created_at_set": "1",
+						"participant_id": newID, "id": int64(0), "creator_id": nil, "parent_attempt_id": nil,
+						"root_item_id": nil, "created_at_set": int64(1),
 					},
 				}
 			}
@@ -421,7 +420,7 @@ func TestGroupStore_DeleteGroup_RecomputesAccessForOrphanedSourceGroups(t *testi
 }
 
 func TestGroupStore_TriggerBeforeUpdate_RefusesToModifyType(t *testing.T) {
-	const expectedErrorMessage = "Error 1644: Unable to change groups.type from/to User/Team"
+	const expectedErrorMessage = "Error 1644 (45000): Unable to change groups.type from/to User/Team"
 
 	for _, test := range []struct {
 		oldType     string

--- a/app/database/mysql_conn_reset.go
+++ b/app/database/mysql_conn_reset.go
@@ -1,0 +1,145 @@
+package database
+
+import (
+	"context"
+	"database/sql/driver"
+	"net"
+	"sync/atomic"
+	"time"
+	_ "unsafe" // for go:linkname
+
+	"github.com/go-sql-driver/mysql"
+
+	log "github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+)
+
+// A buffer which is used for both reading and writing.
+// This is possible since communication on each connection is synchronous.
+// In other words, we can't write and read simultaneously on the same connection.
+// The buffer is similar to bufio.Reader / Writer but zero-copy-ish
+// Also highly optimized for this particular use case.
+// This buffer is backed by two byte slices in a double-buffering scheme.
+type buffer struct {
+	_ []byte // buf is a byte buffer who's length and capacity are equal.
+	_ net.Conn
+	_ int
+	_ int
+	_ time.Duration
+	_ [2][]byte // dbuf is an array with the two byte slices that back this buffer
+	_ uint      // flipccnt is the current buffer counter for double-buffering
+}
+
+type mysqlResult struct {
+	// One entry in both slices is created for every executed statement result.
+	_ []int64
+	_ []int64
+}
+
+type connector struct {
+	_ *mysql.Config // immutable private copy.
+	_ string        // Encoded connection attributes.
+}
+
+// https://dev.mysql.com/doc/internals/en/capability-flags.html#packet-Protocol::CapabilityFlags
+type clientFlag uint32
+
+// http://dev.mysql.com/doc/internals/en/status-flags.html
+type statusFlag uint16
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://github.com/golang/go/issues/8005#issuecomment-190753527
+// for details.
+type (
+	noCopy     struct{}
+	atomicBool = atomic.Bool
+)
+
+// atomicError is a wrapper for atomically accessed error values.
+type atomicError struct {
+	_ noCopy
+	_ atomic.Value
+}
+
+type mysqlConn struct {
+	_ buffer
+	_ net.Conn
+	_ net.Conn    // underlying connection when netConn is TLS connection.
+	_ mysqlResult // managed by clearResult() and handleOkPacket().
+	_ *mysql.Config
+	_ *connector
+	_ int
+	_ int
+	_ time.Duration
+	_ clientFlag
+	_ statusFlag
+	_ uint8
+	_ bool
+
+	// for context support (Go 1.8+)
+	_      bool
+	_      chan<- context.Context
+	_      chan struct{}
+	_      chan<- struct{}
+	_      atomicError // set non-nil if conn is canceled
+	closed atomicBool  // set when conn is closed, before closech is closed
+}
+
+const comResetConnection byte = 31
+
+// Reset resets the MySQL connection.
+// The implementation is based on the original Ping method from the go-sql-driver/mysql package,
+// but it sends a comResetConnection command instead of a comPing command.
+// Also, it logs the command if raw SQL queries logging is enabled.
+func (mc *mysqlConn) Reset(ctx context.Context) (err error) {
+	if log.SharedLogger.IsRawSQLQueriesLoggingEnabled() {
+		startTime := time.Now()
+		defer func() {
+			log.SharedLogger.WithContext(ctx).WithFields(map[string]interface{}{
+				"type": "db", "err": err, "duration": time.Since(startTime).String(),
+			}).Info("sql-conn-reset")
+		}()
+	}
+
+	if mc.closed.Load() {
+		mysqlConnLog(mc, mysql.ErrInvalidConn)
+		return driver.ErrBadConn
+	}
+
+	if err = mysqlConnWatchCancel(mc, ctx); err != nil {
+		return
+	}
+	defer mysqlConnFinish(mc)
+
+	handleOk := mysqlConnClearResult(mc)
+
+	if err = mysqlConnWriteCommandPacket(mc, comResetConnection); err != nil {
+		return mysqlConnMarkBadConn(mc, err)
+	}
+
+	return mysqlOKHandlerReadResultOK(handleOk)
+}
+
+//go:linkname mysqlConnLog github.com/go-sql-driver/mysql.(*mysqlConn).log
+func mysqlConnLog(*mysqlConn, ...any)
+
+//go:linkname mysqlConnWatchCancel github.com/go-sql-driver/mysql.(*mysqlConn).watchCancel
+func mysqlConnWatchCancel(*mysqlConn, context.Context) error //nolint: revive
+
+//go:linkname mysqlConnFinish github.com/go-sql-driver/mysql.(*mysqlConn).finish
+func mysqlConnFinish(*mysqlConn)
+
+type okHandler mysqlConn
+
+//go:linkname mysqlConnClearResult github.com/go-sql-driver/mysql.(*mysqlConn).clearResult
+func mysqlConnClearResult(*mysqlConn) *okHandler
+
+//go:linkname mysqlConnWriteCommandPacket github.com/go-sql-driver/mysql.(*mysqlConn).writeCommandPacket
+func mysqlConnWriteCommandPacket(*mysqlConn, byte) error
+
+//go:linkname mysqlConnMarkBadConn github.com/go-sql-driver/mysql.(*mysqlConn).markBadConn
+func mysqlConnMarkBadConn(*mysqlConn, error) error
+
+//go:linkname mysqlOKHandlerReadResultOK github.com/go-sql-driver/mysql.(*okHandler).readResultOK
+func mysqlOKHandlerReadResultOK(*okHandler) error

--- a/app/database/mysql_connection_wrapper.go
+++ b/app/database/mysql_connection_wrapper.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"context"
+	"database/sql/driver"
+	"unsafe"
+)
+
+type mysqlConnWrapper struct {
+	conn driver.Conn
+}
+
+func (conn *mysqlConnWrapper) Begin() (driver.Tx, error) {
+	panic("should not be called")
+}
+
+func (conn *mysqlConnWrapper) Prepare(query string) (driver.Stmt, error) {
+	return conn.conn.Prepare(query)
+}
+
+func (conn *mysqlConnWrapper) Close() error {
+	return conn.conn.Close()
+}
+
+var _ driver.Conn = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return conn.conn.(driver.ConnBeginTx).BeginTx(ctx, opts)
+}
+
+var _ driver.ConnBeginTx = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return conn.conn.(driver.ConnPrepareContext).PrepareContext(ctx, query)
+}
+
+var _ driver.ConnPrepareContext = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return conn.conn.(driver.ExecerContext).ExecContext(ctx, query, args)
+}
+
+var _ driver.ExecerContext = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) Ping(ctx context.Context) error {
+	return conn.conn.(driver.Pinger).Ping(ctx)
+}
+
+var _ driver.Pinger = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return conn.conn.(driver.QueryerContext).QueryContext(ctx, query, args)
+}
+
+var _ driver.QueryerContext = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) CheckNamedValue(nv *driver.NamedValue) error {
+	return conn.conn.(driver.NamedValueChecker).CheckNamedValue(nv)
+}
+
+var _ driver.NamedValueChecker = &mysqlConnWrapper{}
+
+type ifaceAccessor struct {
+	_    unsafe.Pointer
+	conn *mysqlConn
+}
+
+func (conn *mysqlConnWrapper) ResetSession(ctx context.Context) error {
+	err := conn.conn.(driver.SessionResetter).ResetSession(ctx)
+	if err != nil {
+		return err
+	}
+
+	// really reset the session
+	return conn.Reset(ctx)
+}
+
+func (conn *mysqlConnWrapper) Reset(ctx context.Context) error {
+	//nolint:gosec // G103: Here we convert driver.Conn to go-sql-driver/mysql.Conn which we make accessible via mysqlConn struct.
+	return ((*ifaceAccessor)(unsafe.Pointer(&conn.conn)).conn).Reset(ctx)
+}
+
+var _ driver.SessionResetter = &mysqlConnWrapper{}
+
+func (conn *mysqlConnWrapper) IsValid() bool {
+	return conn.conn.(driver.Validator).IsValid()
+}
+
+var _ driver.Validator = &mysqlConnWrapper{}

--- a/app/database/mysql_connection_wrapper_integration_test.go
+++ b/app/database/mysql_connection_wrapper_integration_test.go
@@ -1,0 +1,138 @@
+//go:build !unit
+
+package database_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"bou.ke/monkey"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+)
+
+func TestMysqlConnectionWrapper_ResetSession(t *testing.T) {
+	db, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	var result *int64
+	_, err = conn.ExecContext(ctx, "SET @a := 1")
+	require.NoError(t, err)
+	err = conn.QueryRowContext(ctx, "SELECT @a").Scan(&result)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, int64(1), *result)
+
+	err = conn.Raw(func(driverConn any) error {
+		return driverConn.(driver.SessionResetter).ResetSession(context.Background())
+	})
+	require.NoError(t, err)
+
+	err = conn.QueryRowContext(ctx, "SELECT @a").Scan(&result)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestMysqlConnectionWrapper_ResetSession_FailsOnClosedConnection(t *testing.T) {
+	db, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	err = conn.Raw(func(driverConn any) error {
+		require.NoError(t, driverConn.(driver.Conn).Close())
+		return driverConn.(driver.SessionResetter).ResetSession(context.Background())
+	})
+	require.Equal(t, driver.ErrBadConn, err)
+}
+
+type resetter = interface {
+	Reset(context.Context) error
+}
+
+func TestMysqlConnectionWrapper_Reset_FailsOnClosedConnection(t *testing.T) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
+		func(_ *viper.Viper, key string) bool { return false })
+	defer monkey.UnpatchAll()
+
+	db, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	err = conn.Raw(func(driverConn any) error {
+		require.NoError(t, driverConn.(driver.Conn).Close())
+		return driverConn.(resetter).Reset(context.Background())
+	})
+	require.Equal(t, driver.ErrBadConn, err)
+}
+
+func TestMysqlConnectionWrapper_Reset_FailsWhenContextIsCancelled(t *testing.T) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
+		func(_ *viper.Viper, key string) bool { return false })
+	defer monkey.UnpatchAll()
+
+	db, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	err = conn.Raw(func(driverConn any) error {
+		cancelFunc()
+		return driverConn.(resetter).Reset(ctx)
+	})
+	require.Equal(t, context.Canceled, err)
+}
+
+func TestMysqlConnectionWrapper_Reset_FailsWhenWriteCommandPacketFails(t *testing.T) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
+		func(_ *viper.Viper, key string) bool { return false })
+	defer monkey.UnpatchAll()
+
+	db, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	expectedError := errors.New("some error")
+	err = conn.Raw(func(driverConn any) error {
+		monkey.Patch(mysqlConnWriteCommandPacket, func(unsafe.Pointer, byte) error {
+			return expectedError
+		})
+		defer monkey.UnpatchAll()
+		return driverConn.(resetter).Reset(ctx)
+	})
+	require.Equal(t, expectedError, err)
+}
+
+//go:linkname mysqlConnWriteCommandPacket github.com/go-sql-driver/mysql.(*mysqlConn).writeCommandPacket
+func mysqlConnWriteCommandPacket(unsafe.Pointer, byte) error

--- a/app/database/mysql_connection_wrapper_test.go
+++ b/app/database/mysql_connection_wrapper_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"unsafe"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_mysqlConnWrapper_Begin_Panics(t *testing.T) {
+	conn := &mysqlConnWrapper{}
+	assert.Panics(t, func() { _, _ = conn.Begin() }, "Begin() should panic")
+}
+
+type stmtMock struct{}
+
+func (stmt *stmtMock) Close() error                               { return nil }
+func (stmt *stmtMock) NumInput() int                              { return 0 }
+func (stmt *stmtMock) Exec([]driver.Value) (driver.Result, error) { return nil, nil }
+func (stmt *stmtMock) Query([]driver.Value) (driver.Rows, error)  { return nil, nil }
+
+var _ driver.Stmt = &stmtMock{}
+
+type connMock struct{}
+
+func (conn *connMock) Prepare(string) (driver.Stmt, error) {
+	return &stmtMock{}, errors.New("error")
+}
+func (conn *connMock) Begin() (driver.Tx, error) { return nil, nil }
+func (conn *connMock) Close() error              { return nil }
+
+var _ driver.Conn = &connMock{}
+
+func Test_mysqlConnWrapper_Prepare(t *testing.T) {
+	conn := &mysqlConnWrapper{conn: &connMock{}}
+	expectedQuery := "SELECT * FROM table"
+	expectedStmt := &stmtMock{}
+	expectedErr := errors.New("error")
+	monkey.Patch(mysqlConnPrepare, func(c unsafe.Pointer, query string) (driver.Stmt, error) {
+		assert.Equal(t, conn, (*mysqlConnWrapper)(c))
+		assert.Equal(t, expectedQuery, query)
+		return expectedStmt, expectedErr
+	})
+	defer monkey.UnpatchAll()
+	stmt, err := conn.Prepare(expectedQuery)
+	assert.Equal(t, expectedStmt, stmt)
+	assert.Equal(t, expectedErr, err)
+}
+
+//go:linkname mysqlConnPrepare github.com/go-sql-driver/mysql.(*mysqlConn).Prepare
+func mysqlConnPrepare(unsafe.Pointer, string) (driver.Stmt, error)

--- a/app/database/mysql_connector_wrapper.go
+++ b/app/database/mysql_connector_wrapper.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+type mysqlConnectorWrapper struct {
+	connector driver.Connector
+	driver    *mysqlDriverWrapper
+}
+
+func (c *mysqlConnectorWrapper) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &mysqlConnWrapper{conn: conn}, nil
+}
+
+func (c *mysqlConnectorWrapper) Driver() driver.Driver {
+	return c.driver
+}
+
+var _ driver.Connector = &mysqlConnectorWrapper{}

--- a/app/database/mysql_connector_wrapper_test.go
+++ b/app/database/mysql_connector_wrapper_test.go
@@ -1,0 +1,16 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_mysqlConnectorWrapper_Driver(t *testing.T) {
+	expectedDriver := &mysqlDriverWrapper{}
+	c := &mysqlConnectorWrapper{
+		connector: nil,
+		driver:    expectedDriver,
+	}
+	assert.Equal(t, expectedDriver, c.Driver())
+}

--- a/app/database/mysql_driver_wrapper.go
+++ b/app/database/mysql_driver_wrapper.go
@@ -1,0 +1,31 @@
+package database
+
+import "database/sql/driver"
+
+type mysqlDriverWrapper struct {
+	driver driver.Driver
+}
+
+func newMySQLDriverWrapper(driverToWrap driver.Driver) driver.Driver {
+	return &mysqlDriverWrapper{driver: driverToWrap}
+}
+
+func (d *mysqlDriverWrapper) Open(name string) (driver.Conn, error) {
+	conn, err := d.driver.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &mysqlConnWrapper{conn: conn}, nil
+}
+
+var _ driver.Driver = &mysqlDriverWrapper{}
+
+func (d *mysqlDriverWrapper) OpenConnector(name string) (driver.Connector, error) {
+	connector, err := d.driver.(driver.DriverContext).OpenConnector(name)
+	if err != nil {
+		return nil, err
+	}
+	return &mysqlConnectorWrapper{connector: connector}, nil
+}
+
+var _ driver.DriverContext = &mysqlDriverWrapper{}

--- a/app/database/mysql_driver_wrapper_test.go
+++ b/app/database/mysql_driver_wrapper_test.go
@@ -1,0 +1,72 @@
+package database
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type connMockWithName struct {
+	*connMock
+	name string
+}
+
+type driverMock struct{}
+
+func (d *driverMock) Open(name string) (driver.Conn, error) {
+	return &connMockWithName{&connMock{}, name}, nil
+}
+
+var _ driver.Driver = &driverMock{}
+
+const expectedDriverName = "name"
+
+func Test_mysqlDriverWrapper_Open(t *testing.T) {
+	d := &mysqlDriverWrapper{
+		driver: &driverMock{},
+	}
+	got, err := d.Open(expectedDriverName)
+	require.NoError(t, err)
+	assert.Equal(t, &mysqlConnWrapper{&connMockWithName{&connMock{}, expectedDriverName}}, got)
+}
+
+type driverMockWithError struct{}
+
+func (d *driverMockWithError) Open(name string) (driver.Conn, error) {
+	return &connMockWithName{&connMock{}, name}, fmt.Errorf("error for %s", name)
+}
+
+var _ driver.Driver = &driverMockWithError{}
+
+func Test_mysqlDriverWrapper_Open_Error(t *testing.T) {
+	d := &mysqlDriverWrapper{
+		driver: &driverMockWithError{},
+	}
+	got, err := d.Open(expectedDriverName)
+	assert.Equal(t, fmt.Errorf("error for %s", expectedDriverName), err)
+	assert.Nil(t, got)
+}
+
+type driverConnectorMockWithError struct{}
+
+func (d *driverConnectorMockWithError) Open(string) (driver.Conn, error) { return nil, nil }
+
+var _ driver.Driver = &driverConnectorMockWithError{}
+
+func (d *driverConnectorMockWithError) OpenConnector(name string) (driver.Connector, error) {
+	return &mysqlConnectorWrapper{}, fmt.Errorf("error for %s", name)
+}
+
+var _ driver.DriverContext = &driverConnectorMockWithError{}
+
+func Test_mysqlDriverWrapper_OpenConnector_Error(t *testing.T) {
+	d := &mysqlDriverWrapper{
+		driver: &driverConnectorMockWithError{},
+	}
+	got, err := d.OpenConnector(expectedDriverName)
+	assert.Equal(t, fmt.Errorf("error for %s", expectedDriverName), err)
+	assert.Nil(t, got)
+}

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -237,7 +237,7 @@ func TestPermissionGeneratedStore_TriggerBeforeUpdate_RefusesToModifyGroupIDOrIt
 	`)
 	defer func() { _ = db.Close() }()
 
-	const expectedErrorMessage = "Error 1644: Unable to change immutable " +
+	const expectedErrorMessage = "Error 1644 (45000): Unable to change immutable " +
 		"permissions_generated.group_id and/or permissions_generated.child_item_id"
 
 	dataStore := database.NewDataStoreWithTable(db, "permissions_generated")

--- a/app/database/permission_granted_store.go
+++ b/app/database/permission_granted_store.go
@@ -1,6 +1,10 @@
 package database
 
-import "github.com/jinzhu/gorm"
+import (
+	"github.com/jinzhu/gorm"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
+)
 
 // PermissionGrantedStore implements database operations on `permissions_granted`.
 type PermissionGrantedStore struct {
@@ -64,4 +68,8 @@ func (s *PermissionGrantedStore) EditIndexByName(name string) int {
 // EditNameByIndex returns the 'edit' permission name with the given index from 'can_edit' enum.
 func (s *PermissionGrantedStore) EditNameByIndex(index int) string {
 	return s.PermissionNameByKindAndIndex("edit", index)
+}
+
+func (s *PermissionGrantedStore) permissionsPropagateTableName() string {
+	return golang.IfElse(s.arePropagationsSync(), "permissions_propagate_sync", "permissions_propagate")
 }

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -36,18 +36,43 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 		JOIN permissions_propagate AS parents_propagate
 			ON parents_propagate.group_id = parents.group_id AND parents_propagate.item_id = parents.item_id
 		WHERE parents_propagate.propagate_to = 'children'
+		GROUP BY parents.group_id, items_items.child_item_id
 		ON DUPLICATE KEY UPDATE propagate_to='self'`
 
 	// deleting 'children' permissions_propagate
 	const queryDeleteProcessedChildren = `DELETE FROM permissions_propagate WHERE propagate_to = 'children'`
 
+	const queryDropTemporaryTable = `DROP TEMPORARY TABLE IF EXISTS permissions_propagate_processing`
+	// creating permissions_propagate_processing
+	const queryCreateTemporaryTable = `CREATE TEMPORARY TABLE permissions_propagate_processing ` +
+		`(group_id BIGINT(20) NOT NULL, item_id BIGINT(20) NOT NULL, PRIMARY KEY (group_id, item_id))`
+
+	// marking 'self' permissions_propagate that are not descendants of other 'self' permissions_propagate for processing
+	// in permissions_propagate_processing
+	const queryInsertIntoPermissionsPropagateProcessing = `
+		INSERT INTO permissions_propagate_processing (group_id, item_id)
+		SELECT group_id, item_id
+		FROM permissions_propagate
+		WHERE propagate_to = 'self' AND (
+			SELECT 1
+			FROM permissions_propagate AS ancestor_propagate
+			JOIN items_ancestors
+				ON items_ancestors.child_item_id = permissions_propagate.item_id AND
+				   items_ancestors.ancestor_item_id = ancestor_propagate.item_id
+			WHERE ancestor_propagate.group_id = permissions_propagate.group_id AND
+			      ancestor_propagate.propagate_to = 'self'
+			LIMIT 1
+			FOR SHARE
+		) IS NULL
+		FOR SHARE`
+
 	// computation for group-item pairs marked as 'self' in permissions_propagate (so all of them)
 	const queryUpdatePermissionsGenerated = `
 		INSERT INTO permissions_generated
 			(group_id, item_id, can_view_generated, can_grant_view_generated, can_watch_generated, can_edit_generated, is_owner_generated)
-		SELECT
-			permissions_propagate.group_id,
-			permissions_propagate.item_id,
+		SELECT STRAIGHT_JOIN
+			permissions_propagate_processing.group_id,
+			permissions_propagate_processing.item_id,
 			IF(MAX(permissions_granted.is_owner), 'solution', GREATEST(
 				IFNULL(MAX(permissions_granted.can_view_value), 1),
 				IFNULL(MAX(
@@ -76,12 +101,12 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 				IFNULL(MAX(IF(items_items.edit_propagation, LEAST(parent.can_edit_generated_value, 3 /* all */), 1)), 1)
 			)) AS can_edit_generated,
 			IFNULL(MAX(permissions_granted.is_owner), 0) AS is_owner_generated
-		FROM permissions_propagate
+		FROM permissions_propagate_processing
 		LEFT JOIN permissions_granted USING (group_id, item_id)
-		LEFT JOIN items_items ON items_items.child_item_id = permissions_propagate.item_id
+		LEFT JOIN items_items ON items_items.child_item_id = permissions_propagate_processing.item_id
 		LEFT JOIN permissions_generated AS parent
-		  ON parent.item_id = items_items.parent_item_id AND parent.group_id = permissions_propagate.group_id
-		GROUP BY permissions_propagate.group_id, permissions_propagate.item_id
+		  ON parent.item_id = items_items.parent_item_id AND parent.group_id = permissions_propagate_processing.group_id
+		GROUP BY permissions_propagate_processing.group_id, permissions_propagate_processing.item_id
 		ON DUPLICATE KEY UPDATE
 			can_view_generated = VALUES(can_view_generated),
 			can_grant_view_generated = VALUES(can_grant_view_generated),
@@ -90,12 +115,12 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 			is_owner_generated = VALUES(is_owner_generated)`
 
 	// marking 'self' permissions_propagate (so all of them) as 'children'
-	// (although all existing rows in permissions_propagate have propagate_to='self' at this moment,
-	//  we still need to use WHERE clause in order for MySQL to use indexes,
-	//  otherwise the query can take minutes to execute)
 	const queryMarkSelfAsChildren = `
 		UPDATE permissions_propagate
-		SET propagate_to = 'children' WHERE propagate_to='self'`
+		JOIN permissions_propagate_processing
+			ON permissions_propagate_processing.group_id = permissions_propagate.group_id AND
+			   permissions_propagate_processing.item_id = permissions_propagate.item_id
+		SET permissions_propagate.propagate_to = 'children'`
 
 	// ------------------------------------------------------------------------------------
 	// Here we execute the statements
@@ -107,12 +132,17 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 		mustNotBeError(s.InTransaction(func(store *DataStore) error {
 			initTransactionTime := time.Now()
 
+			mustNotBeError(store.Exec(queryCreateTemporaryTable).Error())
+			defer store.Exec(queryDropTemporaryTable)
+
 			mustNotBeError(store.Exec(queryMarkChildrenOfChildrenAsSelf).Error())
 			mustNotBeError(store.Exec(queryDeleteProcessedChildren).Error())
+			mustNotBeError(store.Exec(queryInsertIntoPermissionsPropagateProcessing).Error())
 			mustNotBeError(store.Exec(queryUpdatePermissionsGenerated).Error())
 
-			rowsAffected := store.Exec(queryMarkSelfAsChildren).RowsAffected()
-			mustNotBeError(store.Error())
+			result := store.Exec(queryMarkSelfAsChildren)
+			mustNotBeError(result.Error())
+			rowsAffected := result.RowsAffected()
 
 			logging.SharedLogger.WithContext(store.ctx).
 				Debugf("Duration of permissions propagation step: %d rows affected, took %v", rowsAffected, time.Since(initTransactionTime))

--- a/app/database/raw_db_logger_integration_test.go
+++ b/app/database/raw_db_logger_integration_test.go
@@ -59,3 +59,48 @@ func Test_RawSQLQueryLogging_Duration(t *testing.T) {
 		}
 	}
 }
+
+func Test_RawSQLQueryLogging_ResetSession(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(&logging.Logger{}), "IsRawSQLQueriesLoggingEnabled",
+		func(_ *logging.Logger) bool { return true })
+	defer monkey.UnpatchAll()
+
+	sqlDB, err := testhelpers.OpenRawDBConnection()
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+
+	loggerHook, loggerRestoreFunc := logging.MockSharedLoggerHook()
+	defer loggerRestoreFunc()
+
+	db, err := database.OpenWithLogConfig(sqlDB, database.LogConfig{LogSQLQueries: true}, true)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var result []interface{}
+	require.NoError(t, db.Raw("SELECT 1").Scan(&result).Error())
+	require.NoError(t, db.Raw("SELECT 1").Scan(&result).Error())
+
+	entries := loggerHook.AllEntries()
+	expectedMessages := []string{
+		"sql-conn-reset", "SELECT 1", "sql-conn-reset", "SELECT 1",
+	}
+	require.Len(t, entries, len(expectedMessages))
+
+	for i, entry := range entries {
+		assert.Equal(t, expectedMessages[i], entry.Message)
+		assert.Equal(t, "db", entry.Data["type"])
+		assert.Contains(t, entry.Data, "duration")
+		if duration, ok := entry.Data["duration"]; ok {
+			assert.IsType(t, "", duration)
+			if durationStr, ok := duration.(string); ok {
+				parsedDuration, err := time.ParseDuration(durationStr)
+				assert.NoError(t, err)
+				if err == nil {
+					assert.Greater(t, parsedDuration, 0*time.Second)
+				}
+			}
+		}
+	}
+}

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -54,12 +54,12 @@ func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
 
 	oldTS := time.Now().UTC().Add(-time.Minute).Format(time.DateTime)
 	grantedPermissions := []map[string]interface{}{
-		generateGrantedPermissionsRow("1001", "content", oldTS, "9999-12-31 23:59:58", oldTS),
-		generateGrantedPermissionsRow("1002", "content_with_descendants", oldTS, "9999-12-31 23:59:58", oldTS),
-		generateGrantedPermissionsRow("2001", "content", oldTS, "9999-12-31 23:59:58", oldTS),
-		generateGrantedPermissionsRow("2002", "info", oldTS, "9999-12-31 23:59:58", oldTS),
-		generateGrantedPermissionsRow("4001", "none", oldTS, "9999-12-31 23:59:58", oldTS),
-		generateGrantedPermissionsRow("4002", "content", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(1001, "content", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(1002, "content_with_descendants", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(2001, "content", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(2002, "info", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(4001, "none", oldTS, "9999-12-31 23:59:58", oldTS),
+		generateGrantedPermissionsRow(4002, "content", oldTS, "9999-12-31 23:59:58", oldTS),
 	}
 	assert.NoError(t, database.NewDataStore(db).PermissionsGranted().InsertMaps(grantedPermissions))
 
@@ -72,14 +72,14 @@ func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := range grantedPermissions {
-		grantedPermissions[i]["updated"] = "0"
+		grantedPermissions[i]["updated"] = int64(0)
 		delete(grantedPermissions[i], "latest_update_at")
 	}
 	const content = "content"
 	grantedPermissions[3]["can_view"] = content
 	grantedPermissions[4]["can_view"] = content
-	grantedPermissions[3]["updated"] = "1"
-	grantedPermissions[4]["updated"] = "1"
+	grantedPermissions[3]["updated"] = int64(1)
+	grantedPermissions[4]["updated"] = int64(1)
 
 	var result []map[string]interface{}
 	assert.NoError(t, dataStore.PermissionsGranted().
@@ -91,10 +91,10 @@ func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
 	assert.Equal(t, grantedPermissions, result)
 }
 
-func generateGrantedPermissionsRow(itemID, canView, canEnterFrom, canEnterUntil, latestUpdateAt string) map[string]interface{} {
+func generateGrantedPermissionsRow(itemID int64, canView, canEnterFrom, canEnterUntil, latestUpdateAt string) map[string]interface{} {
 	return map[string]interface{}{
-		"group_id": "101", "item_id": itemID, "can_view": canView, "can_enter_from": canEnterFrom,
-		"can_enter_until": canEnterUntil, "source_group_id": "101", "origin": "item_unlocking", "latest_update_at": latestUpdateAt,
+		"group_id": int64(101), "item_id": itemID, "can_view": canView, "can_enter_from": canEnterFrom,
+		"can_enter_until": canEnterUntil, "source_group_id": int64(101), "origin": "item_unlocking", "latest_update_at": latestUpdateAt,
 	}
 }
 
@@ -116,12 +116,12 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHas
 	assert.NoError(t, db.Exec("UPDATE items SET requires_explicit_entry=1").Error())
 	oldTS := time.Now().UTC().Add(-time.Minute).Format(time.DateTime)
 	grantedPermissions := []map[string]interface{}{
-		generateGrantedPermissionsRow("1001", "content", oldTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("1002", "content", oldTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("2001", "content", oldTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("2002", "content", oldTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("4001", "content", oldTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("4002", "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(1001, "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(1002, "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(2001, "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(2002, "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(4001, "content", oldTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(4002, "content", oldTS, "9999-12-31 23:59:59", oldTS),
 	}
 	assert.NoError(t, database.NewDataStore(db).PermissionsGranted().InsertMaps(grantedPermissions))
 
@@ -149,12 +149,12 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_CanEnterFromI
 	oldTS := time.Now().UTC().Add(-time.Minute).Format(time.DateTime)
 	futureTS := time.Now().UTC().Add(time.Minute).Format(time.DateTime)
 	grantedPermissions := []map[string]interface{}{
-		generateGrantedPermissionsRow("1001", "none", futureTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("1002", "none", futureTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("2001", "none", futureTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("2002", "none", futureTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("4001", "none", futureTS, "9999-12-31 23:59:59", oldTS),
-		generateGrantedPermissionsRow("4002", "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(1001, "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(1002, "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(2001, "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(2002, "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(4001, "none", futureTS, "9999-12-31 23:59:59", oldTS),
+		generateGrantedPermissionsRow(4002, "none", futureTS, "9999-12-31 23:59:59", oldTS),
 	}
 	assert.NoError(t, database.NewDataStore(db).PermissionsGranted().InsertMaps(grantedPermissions))
 

--- a/db/migrations/2412070000_rework_triggers_to_allow_sync_permissions_and_results_propagations_when_needed.sql
+++ b/db/migrations/2412070000_rework_triggers_to_allow_sync_permissions_and_results_propagations_when_needed.sql
@@ -1,0 +1,159 @@
+-- +migrate Up
+CREATE TABLE `permissions_propagate_sync` LIKE `permissions_propagate`;
+CREATE TABLE `results_propagate_sync` LIKE `results_propagate`;
+
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+    IF NEW.`can_view_generated` != 'none' THEN
+      IF @synchronous_propagations THEN
+        INSERT IGNORE INTO `results_propagate_sync`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      ELSE
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+    IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+      IF @synchronous_propagations THEN
+        INSERT IGNORE INTO `results_propagate_sync`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      ELSE
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_granted` AFTER INSERT ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    INSERT INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`)
+      VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_granted` AFTER UPDATE ON `permissions_granted` FOR EACH ROW BEGIN
+    IF NOT (NEW.`can_view` <=> OLD.`can_view` AND NEW.`can_grant_view` <=> OLD.`can_grant_view` AND
+            NEW.`can_watch` <=> OLD.`can_watch` AND NEW.`can_edit` <=> OLD.`can_edit` AND
+            NEW.`is_owner` <=> OLD.`is_owner`) THEN
+      IF @synchronous_propagations THEN
+        REPLACE INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self');
+      ELSE
+        INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+        ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_delete_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_delete_permissions_granted` AFTER DELETE ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    REPLACE INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self');
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+    IF NEW.`can_view_generated` != 'none' THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+    IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_granted` AFTER INSERT ON `permissions_granted` FOR EACH ROW BEGIN
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+END
+-- +migrate StatementEnd
+
+  DROP TRIGGER `after_update_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_granted` AFTER UPDATE ON `permissions_granted` FOR EACH ROW BEGIN
+    IF NOT (NEW.`can_view` <=> OLD.`can_view` AND NEW.`can_grant_view` <=> OLD.`can_grant_view` AND
+            NEW.`can_watch` <=> OLD.`can_watch` AND NEW.`can_edit` <=> OLD.`can_edit` AND
+            NEW.`is_owner` <=> OLD.`is_owner`) THEN
+        INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+        ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_delete_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_delete_permissions_granted` AFTER DELETE ON `permissions_granted` FOR EACH ROW BEGIN
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+END
+-- +migrate StatementEnd
+
+DROP TABLE `permissions_propagate_sync`;
+DROP TABLE `results_propagate_sync`;

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-playground/locales v0.12.1
 	github.com/go-playground/universal-translator v0.16.0
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/go-cmp v0.5.9
 	github.com/jinzhu/gorm v1.9.17-0.20211120011537-5c235b72a414
 	github.com/lithammer/dedent v1.1.0
@@ -43,6 +43,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
 bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a h1:3SgJcK9l5uPdBC/X17wanyJAMxM33+4ZhEIV96MIH8U=
@@ -66,8 +68,8 @@ github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3yg
 github.com/go-playground/universal-translator v0.16.0 h1:X++omBR/4cE2MNg91AoC3rmGrCjJ8eAeUP/K/EKx4DM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/gobuffalo/envy v1.6.9 h1:ShEJ/fUg/wr5qIYmTTOnUQ0sy1yGo+4uYQJNgg753S8=
 github.com/gobuffalo/envy v1.6.9/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/packd v0.0.0-20181114190715-f25c5d2471d7 h1:7AZMyDyRxIm2cbSXRvUEUJrankvMV1xcAOrrWUWp7yE=

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -297,7 +297,7 @@ func (ctx *TestContext) loadColumnsFromDBTable(gormDB *database.DB, dbTableName 
 		rowCells := make([]*messages.PickleTableCell, len(dbColumnNames))
 		for j, columnName := range dbColumnNames {
 			rowCells[j] = &messages.PickleTableCell{
-				Value: row[columnName].(string),
+				Value: fmt.Sprintf("%v", row[columnName]),
 			}
 		}
 


### PR DESCRIPTION
1. Return unlocked items in saveGrade
2. Upgrade go-sql-driver/sql to v1.8.1
3. Fix redocly/cli at v1.25.15 (v1.26 doesn't work with our generated schema)
4. Call PingContext() instead of Ping() to handle timeouts on pinging the DB
5. Fix setting can_enter_until on items unlocking: set can_enter_until to +inf when the unlocked item requires explicit entry and the current value of can_enter_until is not +inf.

Fixes #1224