### PR TITLE
Mark the title as nullable in swagger docs of itemBreadcrumbsGet

### DIFF
--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -68,6 +68,7 @@ import (
 //							enum: [Chapter,Task,Skill]
 //						title:
 //							type: string
+//							x-nullable: true
 //						language_tag:
 //							type: string
 //						attempt_id:


### PR DESCRIPTION
The column item_strings.title is nullable in the DB.