### PR TITLE
Eliminate data races when reading/setting hooks related to forceful retrying of transactions (used only in tests)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - run: go install github.com/France-ioi/go-swagger/cmd/swagger@00200fa
       - run: apk add npm
       - run: npm install -g swagger2openapi
-      - run: npm install -g @redocly/cli@latest
+      - run: npm install -g @redocly/cli@1.25.15
       - checkout
       - run: go build -v # do not use 'make' as the image does not support '-race' arg
       - run: make swagger-generate

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ npm install -g swagger2openapi
 
 Also, you need to install [redocly-cli](https://redocly.com/redocly-cli) to serve the documentation locally:
 ```
-npm install -g @redocly/cli@latest
+npm install -g @redocly/cli@1.25.15
 ```
 
 After everything is installed, you can generate the specification file from code and validate it:

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -26,9 +26,6 @@ func NewDataStore(conn *DB) *DataStore {
 
 // NewDataStoreWithContext returns a new DataStore with the given context.
 func NewDataStoreWithContext(ctx context.Context, db *DB) *DataStore {
-	newSQLDB := db.db.CommonDB().(withContexter).withContext(ctx)
-	newGormDB := cloneGormDB(db.db)
-	replaceDBInGormDB(newGormDB, newSQLDB)
 	return &DataStore{DB: cloneDBWithNewContext(ctx, db)}
 }
 


### PR DESCRIPTION
Otherwise, tests can be unstable on slow computers.