### PR TITLE
Handle DB errors during token unmarshalling correctly in itemGetHintToken & saveGrade

### DIFF
--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -248,7 +248,7 @@ func (requestData *AskHintRequest) unmarshalHintToken(wrapper *askHintRequestWra
 		wrapper.HintRequestedToken.Bytes(),
 		"hint_requested",
 	)
-	if err != nil {
+	if err != nil && !token.IsUnexpectedError(err) {
 		return err
 	}
 	service.MustNotBeError(err)

--- a/app/api/items/ask_hint_test.go
+++ b/app/api/items/ask_hint_test.go
@@ -179,3 +179,27 @@ func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestAskHintRequest_UnmarshalJSON_DBError(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, mock := database.NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	expectedError := errors.New("error")
+	mock.ExpectQuery("^" + regexp.QuoteMeta("SELECT public_key "+
+		"FROM `platforms` JOIN items ON items.platform_id = platforms.id WHERE (items.id = ?) LIMIT 1") + "$").
+		WithArgs(901756573345831409).WillReturnError(expectedError)
+
+	r := &AskHintRequest{
+		store:     database.NewDataStore(db),
+		publicKey: tokentest.AlgoreaPlatformPublicKeyParsed,
+	}
+	assert.PanicsWithError(t, expectedError.Error(), func() {
+		_ = r.UnmarshalJSON([]byte(fmt.Sprintf(`{"task_token": %q, "hint_requested": %q}`,
+			token.Generate(payloadstest.TaskPayloadFromAlgoreaPlatform, tokentest.AlgoreaPlatformPrivateKeyParsed),
+			token.Generate(payloadstest.HintPayloadFromTaskPlatform, tokentest.TaskPlatformPrivateKeyParsed),
+		)))
+	})
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/api/items/ask_hint_test.go
+++ b/app/api/items/ask_hint_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloadstest"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/tokentest"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
@@ -127,12 +128,14 @@ func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, mock := database.NewDBMock()
 			defer func() { _ = db.Close() }()
 
 			if tt.mockDB {
-				mockQuery := mock.ExpectQuery(regexp.QuoteMeta("SELECT public_key " +
-					"FROM `platforms` JOIN items ON items.platform_id = platforms.id WHERE (items.id = ?) LIMIT 1")).
+				mockQuery := mock.ExpectQuery("^" + regexp.QuoteMeta("SELECT public_key "+
+					"FROM `platforms` JOIN items ON items.platform_id = platforms.id WHERE (items.id = ?) LIMIT 1") + "$").
 					WithArgs(tt.itemID)
 
 				if tt.platform != nil {

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -306,9 +306,10 @@ func (requestData *saveGradeRequestParsed) unmarshalScoreToken(wrapper *saveGrad
 			wrapper.ScoreToken.Bytes(),
 			"score_token",
 		)
-		if err != nil {
+		if err != nil && !token.IsUnexpectedError(err) {
 			return err
 		}
+		service.MustNotBeError(err)
 	}
 
 	if !hasScoreToken || !hasPlatformKey {

--- a/app/api/items/save_grade_test.go
+++ b/app/api/items/save_grade_test.go
@@ -1,0 +1,40 @@
+package items
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/payloadstest"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/tokentest"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func Test_saveGradeRequestParsed_UnmarshalJSON(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, mock := database.NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	expectedError := errors.New("error")
+	mock.ExpectQuery("^" + regexp.QuoteMeta("SELECT public_key "+
+		"FROM `platforms` JOIN items ON items.platform_id = platforms.id WHERE (items.id = ?) LIMIT 1") + "$").
+		WithArgs(901756573345831409).WillReturnError(expectedError)
+
+	r := saveGradeRequestParsed{
+		store:     database.NewDataStore(db),
+		publicKey: tokentest.AlgoreaPlatformPublicKeyParsed,
+	}
+	assert.PanicsWithError(t, expectedError.Error(), func() {
+		_ = r.UnmarshalJSON([]byte(fmt.Sprintf(`{"score_token": %q, "answer_token": %q}`,
+			token.Generate(payloadstest.ScorePayloadFromGrader, tokentest.AlgoreaPlatformPrivateKeyParsed),
+			token.Generate(payloadstest.AnswerPayloadFromAlgoreaPlatform, tokentest.AlgoreaPlatformPrivateKeyParsed),
+		)))
+	})
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -396,3 +396,20 @@ func createTmpPrivateKeyFile(key []byte) (*os.File, error) {
 	_, err = tmpFilePrivate.Write(key)
 	return tmpFilePrivate, err
 }
+
+func Test_recoverPanics_and_mustNotBeError(t *testing.T) {
+	expectedError := errors.New("some error")
+	err := func() (err error) {
+		defer recoverPanics(&err)
+		mustNotBeError(expectedError)
+		return nil
+	}()
+	assert.Equal(t, &UnexpectedError{expectedError}, err)
+	assert.Equal(t, expectedError.Error(), err.Error())
+}
+
+func Test_UnexpectedError(t *testing.T) {
+	assert.True(t, IsUnexpectedError(&UnexpectedError{err: errors.New("some error")}))
+	assert.False(t, IsUnexpectedError(errors.New("some error")))
+	assert.False(t, IsUnexpectedError(nil))
+}


### PR DESCRIPTION
Fix a bug caused by https://github.com/France-ioi/AlgoreaBackend/commit/0bfbc7a84cb47286e177b248047ccc67cb7e487f and add a test.
Also, make the DB query expectation regexp in TestAskHintRequest_UnmarshalJSON more strict.