### PR TITLE
Print readable values of expected JSON rows in TheResponseAtShouldBe() when lengths do not match

### DIFF
--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -645,26 +645,29 @@ func (ctx *TestContext) formatDBRowAsTableRow(dbRow []*string) string {
 		}
 
 		dbRowValuesStr[i] = *value
-
-		if id, err := strconv.ParseInt(dbRowValuesStr[i], 10, 64); err == nil {
-			if reference, ok := ctx.idToReferenceMap[id]; ok {
-				dbRowValuesStr[i] = reference
-			}
-			continue
-		}
-
-		if dbRowValuesStr[i] == time.Now().Format(time.DateTime) {
-			dbRowValuesStr[i] = "{{currentTimeDB()}}"
-			continue
-		}
-
-		if dbRowValuesStr[i] == time.Now().Format("2006-01-02 15:04:05.000") {
-			dbRowValuesStr[i] = "{{currentTimeDBMs()}}"
-			continue
-		}
+		dbRowValuesStr[i] = ctx.readableValue(dbRowValuesStr[i])
 	}
 
 	return "| " + strings.Join(dbRowValuesStr, " | ") + " |"
+}
+
+func (ctx *TestContext) readableValue(value string) string {
+	if id, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if reference, ok := ctx.idToReferenceMap[id]; ok {
+			return reference
+		}
+		return value
+	}
+
+	if value == time.Now().Format(time.DateTime) {
+		return "{{currentTimeDB()}}"
+	}
+
+	if value == time.Now().Format("2006-01-02 15:04:05.000") {
+		return "{{currentTimeDBMs()}}"
+	}
+
+	return value
 }
 
 // dataRowMatchesSQLRow checks that a data row matches a row from database.

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -121,11 +121,19 @@ func (ctx *TestContext) TheResponseAtShouldBe(jsonPath string, wants *godog.Tabl
 
 		// The result is an array (eg. "element": [...])
 		if len(typedJSONRes) != wantLength {
+			expectedJSONRows := make([]interface{}, len(typedJSONRes))
+			for index, row := range typedJSONRes {
+				if strValue, ok := row.(string); ok {
+					expectedJSONRows[index] = ctx.readableValue(strValue)
+				} else {
+					expectedJSONRows[index] = row
+				}
+			}
 			return fmt.Errorf(
 				"TheResponseAtShouldBe: The JsonPath result length should be %v but is %v for %v",
 				wantLength,
 				len(typedJSONRes),
-				typedJSONRes,
+				expectedJSONRows,
 			)
 		}
 


### PR DESCRIPTION
Print readable values of expected JSON rows (references instead of IDs and currentTimeDB*() instead of timestamps) in TheResponseAtShouldBe() when lengths do not match.