### PR TITLE
Select the newly created/updated result FOR UPDATE in resultStart

### DIFF
--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -129,6 +129,7 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 		service.MustNotBeError(constructQueryForGettingAttemptsList(store, participantID, itemID, srv.GetUser(r)).
 			Where("attempts.id = ?", attemptID).
+			WithExclusiveWriteLock().
 			Scan(&attemptInfo).Error())
 
 		if attemptInfo.UserCreator.GroupID == nil {

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -2,6 +2,7 @@ package items
 
 import (
 	"net/http"
+	"sync/atomic"
 
 	"github.com/go-chi/render"
 
@@ -101,6 +102,8 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 			return apiError.Error // rollback
 		}
 
+		onBeforeInsertingResultInResultStartHook.Load().(func())()
+
 		itemID := ids[len(ids)-1]
 		var found bool
 		found, err = store.Items().ByID(itemID).
@@ -145,4 +148,10 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 	service.MustNotBeError(render.Render(w, r, service.UpdateSuccess(&attemptInfo)))
 	return service.NoError
+}
+
+var onBeforeInsertingResultInResultStartHook atomic.Value
+
+func init() {
+	onBeforeInsertingResultInResultStartHook.Store(func() {})
 }

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 // The request has successfully updated the object
@@ -132,7 +133,7 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 		service.MustNotBeError(constructQueryForGettingAttemptsList(store, participantID, itemID, srv.GetUser(r)).
 			Where("attempts.id = ?", attemptID).
-			WithExclusiveWriteLock().
+			WithCustomWriteLocks(golang.NewSet("attempts"), golang.NewSet("results")).
 			Scan(&attemptInfo).Error())
 
 		if attemptInfo.UserCreator.GroupID == nil {

--- a/app/api/items/start_result_integration_test.go
+++ b/app/api/items/start_result_integration_test.go
@@ -1,0 +1,54 @@
+//go:build !unit
+
+package items_test
+
+import (
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	_ "unsafe"
+
+	"bou.ke/monkey"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+)
+
+func TestService_startResult_concurrency(t *testing.T) {
+	db := testhelpers.SetupDBWithFixtureString(`
+		items: [{id: 1, type: Task, default_language_tag: 'fr', requires_explicit_entry: 0}]
+		groups: [{id: 3, type: User, root_activity_id: 1}]
+		users: [{group_id: 3, login: john}]
+		permissions_generated: [{group_id: 3, item_id: 1, can_view_generated: content}]
+		attempts: [{participant_id: 3, id: 0}]
+		sessions: [{session_id: 3, user_id: 3}]
+		access_tokens: [{token: 'token_john', session_id: 3, expires_at: '9999-12-31 23:59:59'}]`)
+	defer func() { _ = db.Close() }()
+
+	// app server
+	application, err := app.New()
+	if err != nil {
+		t.Fatalf("Unable to load a hooked app: %v", err)
+	}
+	defer func() { _ = application.Database.Close() }()
+	appServer := httptest.NewServer(application.HTTPHandler)
+	defer appServer.Close()
+
+	monkey.Patch(service.SchedulePropagation, func(*database.DataStore, string, []string) {})
+	defer monkey.UnpatchAll()
+
+	onBeforeInsertingResultInResultStartHook.Store(func() {
+		onBeforeInsertingResultInResultStartHook.Store(func() {})
+		testhelpers.VerifyTestHTTPRequestWithToken(t, appServer, "token_john", 200,
+			"POST", "/items/1/start-result?attempt_id=0", nil, nil)
+	})
+	defer onBeforeInsertingResultInResultStartHook.Store(func() {})
+
+	testhelpers.VerifyTestHTTPRequestWithToken(t, appServer, "token_john", 200,
+		"POST", "/items/1/start-result?attempt_id=0", nil, nil)
+}
+
+//go:linkname onBeforeInsertingResultInResultStartHook github.com/France-ioi/AlgoreaBackend/v2/app/api/items.onBeforeInsertingResultInResultStartHook
+var onBeforeInsertingResultInResultStartHook atomic.Value


### PR DESCRIPTION
Try to fix #1201 by selecting the created result FOR UPDATE in resultStart to overcome https://bugs.mysql.com/bug.php?id=116067.

Fixes #1201 