### PR TITLE
Prevent mutual blocking of concurrent sync propagations by adding connection_id column to results_propagate_sync & permissions_propagate_sync

### DIFF
--- a/app/api/items/start_result_integration_test.go
+++ b/app/api/items/start_result_integration_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestService_startResult_concurrency(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	db := testhelpers.SetupDBWithFixtureString(`
 		items: [{id: 1, type: Task, default_language_tag: 'fr', requires_explicit_entry: 0}]
 		groups: [{id: 3, type: User, root_activity_id: 1}]

--- a/app/database/permission_granted_store.go
+++ b/app/database/permission_granted_store.go
@@ -71,5 +71,5 @@ func (s *PermissionGrantedStore) EditNameByIndex(index int) string {
 }
 
 func (s *PermissionGrantedStore) permissionsPropagateTableName() string {
-	return golang.IfElse(s.arePropagationsSync(), "permissions_propagate_sync", "permissions_propagate")
+	return golang.IfElse(s.arePropagationsSync(), "permissions_propagate_sync_conn", "permissions_propagate")
 }

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 // computeAllAccess recomputes fields of permissions_generated.
@@ -27,8 +28,10 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 
 	// marking group-item pairs whose parents are marked with propagate_to = 'children' as 'self'
 	queryMarkChildrenOfChildrenAsSelf := `
-		INSERT INTO ` + permissionsPropagateTableName + ` (group_id, item_id, propagate_to)
+		INSERT INTO ` + permissionsPropagateTableName +
+		` (` + golang.If(s.arePropagationsSync(), "connection_id, ") + `group_id, item_id, propagate_to)
 		SELECT
+			` + golang.If(s.arePropagationsSync(), "CONNECTION_ID(), ") + `
 			parents.group_id,
 			items_items.child_item_id,
 			'self' as propagate_to

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -223,8 +223,10 @@ func markAsPropagatingSomeResultsMarkedAsToBePropagatedAndMarkTheirParentsAsToBe
 				WHERE NOT result_exists`).Error())
 
 			mustNotBeError(s.Exec(`
-				INSERT INTO ` + resultsPropagateTableName + ` (participant_id, attempt_id, item_id, state)
+				INSERT INTO ` + resultsPropagateTableName +
+				` (` + golang.If(s.arePropagationsSync(), "connection_id, ") + `participant_id, attempt_id, item_id, state)
 				SELECT
+					` + golang.If(s.arePropagationsSync(), "CONNECTION_ID(), ") + `
 					results_to_mark.participant_id, results_to_mark.attempt_id, results_to_mark.item_id, 'to_be_recomputed'
 				FROM results_to_mark
 				ON DUPLICATE KEY UPDATE state = 'to_be_recomputed'`).Error())

--- a/db/migrations/2501231952_add_column_connection_id_to_permissions_propagate_sync.sql
+++ b/db/migrations/2501231952_add_column_connection_id_to_permissions_propagate_sync.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+ALTER TABLE `permissions_propagate_sync`
+  ADD COLUMN `connection_id` BIGINT UNSIGNED NOT NULL FIRST,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`connection_id`, `group_id`, `item_id`),
+  DROP INDEX `propagate_to_group_id_item_id`,
+  ADD INDEX `connection_id_propagate_to_group_id_item_id` (`connection_id`, `propagate_to`, `group_id`, `item_id`);
+
+-- +migrate Down
+ALTER TABLE `permissions_propagate_sync`
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`group_id`, `item_id`),
+  DROP INDEX `connection_id_propagate_to_group_id_item_id`,
+  ADD INDEX `propagate_to_group_id_item_id` (`propagate_to`, `group_id`, `item_id`),
+  DROP COLUMN `connection_id`;

--- a/db/migrations/2501232000_add_column_connection_id_to_results_propagate_sync.sql
+++ b/db/migrations/2501232000_add_column_connection_id_to_results_propagate_sync.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+ALTER TABLE `results_propagate_sync`
+  ADD COLUMN `connection_id` BIGINT UNSIGNED NOT NULL FIRST,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`connection_id`,`participant_id`,`attempt_id`,`item_id`),
+  DROP INDEX `state`,
+  ADD INDEX `connection_id_state` (`connection_id`, `state`);
+
+-- +migrate Down
+ALTER TABLE `results_propagate_sync`
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`participant_id`,`attempt_id`,`item_id`),
+  DROP INDEX `connection_id_state`,
+  ADD INDEX `state` (`state`),
+  DROP COLUMN `connection_id`;

--- a/db/migrations/2501232006_rework_triggers_to_store_connection_id_for_sync_permissions_and_results_propagations.sql
+++ b/db/migrations/2501232006_rework_triggers_to_store_connection_id_for_sync_permissions_and_results_propagations.sql
@@ -1,0 +1,187 @@
+-- +migrate Up
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+    IF NEW.`can_view_generated` != 'none' THEN
+      IF @synchronous_propagations THEN
+        INSERT IGNORE INTO `results_propagate_sync`
+        SELECT CONNECTION_ID() AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      ELSE
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+    IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+      IF @synchronous_propagations THEN
+        INSERT IGNORE INTO `results_propagate_sync`
+        SELECT CONNECTION_ID() AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      ELSE
+        INSERT IGNORE INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        FROM `results`
+            JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                      `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+            JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                              `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_granted` AFTER INSERT ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    INSERT INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`)
+      VALUE (CONNECTION_ID(), NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_granted` AFTER UPDATE ON `permissions_granted` FOR EACH ROW BEGIN
+    IF NOT (NEW.`can_view` <=> OLD.`can_view` AND NEW.`can_grant_view` <=> OLD.`can_grant_view` AND
+            NEW.`can_watch` <=> OLD.`can_watch` AND NEW.`can_edit` <=> OLD.`can_edit` AND
+            NEW.`is_owner` <=> OLD.`is_owner`) THEN
+      IF @synchronous_propagations THEN
+        REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`) VALUE (CONNECTION_ID(), NEW.`group_id`, NEW.`item_id`, 'self');
+      ELSE
+        INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+        ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+      END IF;
+    END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_delete_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_delete_permissions_granted` AFTER DELETE ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`) VALUE (CONNECTION_ID(), OLD.`group_id`, OLD.`item_id`, 'self');
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_insert_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
+  IF NEW.`can_view_generated` != 'none' THEN
+    IF @synchronous_propagations THEN
+      INSERT IGNORE INTO `results_propagate_sync`
+      SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+      FROM `results`
+             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+             JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    ELSE
+      INSERT IGNORE INTO `results_propagate`
+      SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+      FROM `results`
+             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+             JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_generated`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
+  IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
+    IF @synchronous_propagations THEN
+      INSERT IGNORE INTO `results_propagate_sync`
+      SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+      FROM `results`
+             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+             JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    ELSE
+      INSERT IGNORE INTO `results_propagate`
+      SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+      FROM `results`
+             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
+                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
+             JOIN `groups_ancestors_active` ON `groups_ancestors_active`.`child_group_id` = `results`.`participant_id` AND
+                                               `groups_ancestors_active`.`ancestor_group_id` = NEW.`group_id`;
+    END IF;
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_insert_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_permissions_granted` AFTER INSERT ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    INSERT INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`)
+      VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+      VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_update_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_permissions_granted` AFTER UPDATE ON `permissions_granted` FOR EACH ROW BEGIN
+  IF NOT (NEW.`can_view` <=> OLD.`can_view` AND NEW.`can_grant_view` <=> OLD.`can_grant_view` AND
+          NEW.`can_watch` <=> OLD.`can_watch` AND NEW.`can_edit` <=> OLD.`can_edit` AND
+          NEW.`is_owner` <=> OLD.`is_owner`) THEN
+    IF @synchronous_propagations THEN
+      REPLACE INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self');
+    ELSE
+      INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
+      ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+    END IF;
+  END IF;
+END
+-- +migrate StatementEnd
+
+DROP TRIGGER `after_delete_permissions_granted`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_delete_permissions_granted` AFTER DELETE ON `permissions_granted` FOR EACH ROW BEGIN
+  IF @synchronous_propagations THEN
+    REPLACE INTO `permissions_propagate_sync` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self');
+  ELSE
+    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self')
+    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2501232236_create_view_results_propagate_sync_conn.sql
+++ b/db/migrations/2501232236_create_view_results_propagate_sync_conn.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+CREATE VIEW `results_propagate_sync_conn` AS
+  SELECT * FROM `results_propagate_sync` WHERE `connection_id` = CONNECTION_ID();
+
+-- +migrate Down
+DROP VIEW `results_propagate_sync_conn`;

--- a/db/migrations/2501232239_create_view_permissions_propagate_sync_conn.sql
+++ b/db/migrations/2501232239_create_view_permissions_propagate_sync_conn.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+CREATE VIEW `permissions_propagate_sync_conn` AS
+  SELECT * FROM `permissions_propagate_sync` WHERE `connection_id` = CONNECTION_ID();
+
+-- +migrate Down
+DROP VIEW `permissions_propagate_sync_conn`;


### PR DESCRIPTION
1. Add columns with CONNECTION_ID() to results_propagate_sync and permissions_propagate_sync in order to prevent concurrent sync results/permissions propagations from blocking each other.
2. Suppress output of TestService_startResult_concurrency() when it passes.

Fixes #1239 