### PR TITLE
Fix MySQL triggers related to sync propagations 

### DIFF
--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -313,7 +313,7 @@ func (s *DataStore) SetPropagationsModeToSync() (err error) {
 
 	defer recoverPanics(&err)
 
-	mustNotBeError(s.Exec("SET @synchronous_propagations = 1").Error())
+	mustNotBeError(s.Exec("SET @synchronous_propagations_connection_id = CONNECTION_ID()").Error())
 
 	s.DB = cloneDBWithNewContext(context.WithValue(s.DB.ctx, propagationsAreSyncContextKey, true), s.DB)
 	return nil

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -801,7 +801,8 @@ func TestDataStore_SetPropagationsModeToSync(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	mock.ExpectBegin()
-	mock.ExpectExec("SET @synchronous_propagations = 1").WillReturnResult(sqlmock.NewResult(-1, 0))
+	mock.ExpectExec("^" + regexp.QuoteMeta("SET @synchronous_propagations_connection_id = CONNECTION_ID()") + "$").
+		WillReturnResult(sqlmock.NewResult(-1, 0))
 	mock.ExpectCommit()
 
 	require.Nil(t, db.ctx.Value(propagationsAreSyncContextKey))

--- a/db/migrations/2501232006_rework_triggers_to_store_connection_id_for_sync_permissions_and_results_propagations.sql
+++ b/db/migrations/2501232006_rework_triggers_to_store_connection_id_for_sync_permissions_and_results_propagations.sql
@@ -3,9 +3,9 @@ DROP TRIGGER `after_insert_permissions_generated`;
 -- +migrate StatementBegin
 CREATE TRIGGER `after_insert_permissions_generated` AFTER INSERT ON `permissions_generated` FOR EACH ROW BEGIN
     IF NEW.`can_view_generated` != 'none' THEN
-      IF @synchronous_propagations THEN
+      IF @synchronous_propagations_connection_id > 0 THEN
         INSERT IGNORE INTO `results_propagate_sync`
-        SELECT CONNECTION_ID() AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        SELECT @synchronous_propagations_connection_id AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
         FROM `results`
             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
@@ -28,9 +28,9 @@ DROP TRIGGER `after_update_permissions_generated`;
 -- +migrate StatementBegin
 CREATE TRIGGER `after_update_permissions_generated` AFTER UPDATE ON `permissions_generated` FOR EACH ROW BEGIN
     IF OLD.`can_view_generated` = 'none' AND NEW.can_view_generated != 'none' THEN
-      IF @synchronous_propagations THEN
+      IF @synchronous_propagations_connection_id > 0 THEN
         INSERT IGNORE INTO `results_propagate_sync`
-        SELECT CONNECTION_ID() AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+        SELECT @synchronous_propagations_connection_id AS `connection_id`, `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
         FROM `results`
             JOIN `items_ancestors` ON `items_ancestors`.`child_item_id` = `results`.`item_id` AND
                                       `items_ancestors`.`ancestor_item_id` = NEW.`item_id`
@@ -52,14 +52,12 @@ END
 DROP TRIGGER `after_insert_permissions_granted`;
 -- +migrate StatementBegin
 CREATE TRIGGER `after_insert_permissions_granted` AFTER INSERT ON `permissions_granted` FOR EACH ROW BEGIN
-  IF @synchronous_propagations THEN
-    INSERT INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`)
-      VALUE (CONNECTION_ID(), NEW.`group_id`, NEW.`item_id`, 'self')
-    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+  IF @synchronous_propagations_connection_id > 0 THEN
+    REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`)
+      VALUE (@synchronous_propagations_connection_id, NEW.`group_id`, NEW.`item_id`, 'self');
   ELSE
-    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
-    VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
-    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+    REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+      VALUE (NEW.`group_id`, NEW.`item_id`, 'self');
   END IF;
 END
 -- +migrate StatementEnd
@@ -70,11 +68,12 @@ CREATE TRIGGER `after_update_permissions_granted` AFTER UPDATE ON `permissions_g
     IF NOT (NEW.`can_view` <=> OLD.`can_view` AND NEW.`can_grant_view` <=> OLD.`can_grant_view` AND
             NEW.`can_watch` <=> OLD.`can_watch` AND NEW.`can_edit` <=> OLD.`can_edit` AND
             NEW.`is_owner` <=> OLD.`is_owner`) THEN
-      IF @synchronous_propagations THEN
-        REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`) VALUE (CONNECTION_ID(), NEW.`group_id`, NEW.`item_id`, 'self');
+      IF @synchronous_propagations_connection_id > 0 THEN
+        REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`)
+          VALUE (@synchronous_propagations_connection_id, NEW.`group_id`, NEW.`item_id`, 'self');
       ELSE
-        INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (NEW.`group_id`, NEW.`item_id`, 'self')
-        ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+        REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+          VALUE (NEW.`group_id`, NEW.`item_id`, 'self');
       END IF;
     END IF;
 END
@@ -83,11 +82,12 @@ END
 DROP TRIGGER `after_delete_permissions_granted`;
 -- +migrate StatementBegin
 CREATE TRIGGER `after_delete_permissions_granted` AFTER DELETE ON `permissions_granted` FOR EACH ROW BEGIN
-  IF @synchronous_propagations THEN
-    REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`) VALUE (CONNECTION_ID(), OLD.`group_id`, OLD.`item_id`, 'self');
+  IF @synchronous_propagations_connection_id > 0 THEN
+    REPLACE INTO `permissions_propagate_sync` (`connection_id`, `group_id`, `item_id`, `propagate_to`)
+      VALUE (@synchronous_propagations_connection_id, OLD.`group_id`, OLD.`item_id`, 'self');
   ELSE
-    INSERT INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`) VALUE (OLD.`group_id`, OLD.`item_id`, 'self')
-    ON DUPLICATE KEY UPDATE `propagate_to` = 'self';
+    REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+      VALUE (OLD.`group_id`, OLD.`item_id`, 'self');
   END IF;
 END
 -- +migrate StatementEnd


### PR DESCRIPTION
#1240 revealed a MySQL bug: after app/api/items/save_grade.feature test (which uses sync permissions & results propagations) was run, insertion into permissions_granted (even in MySQL console without \@synchronous_propagations variable set) caused marking the permission to be propagated in the permissions_propagate_sync table instead of the permissions_propagate table, the connection_id column was set to a wrong value there as well.

I wasn't able to reproduce the bug without running our tests so I consider the bug as hard-to-reproduce. I haven't reported it for that reason.

On the other hand, I found out that if we don't use CONNECTION_ID() inside triggers (by setting @synchronous_propagations_connection_id to CONNECTION_ID() in order to mark future propagations as sync) and compare @synchronous_propagations_connection_id > 0 instead of just considering boolean @synchronous_propagations inside the triggers to determine if the propagations are sync, everything works fine.

So, here is the patch.

Fixes #1239 