### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@ FROM golang:1.20
 
 WORKDIR /go/src/AlgoreaBackend
 
-# first copy the dependencies file so that even if we change a detail, the "go get" can stay in cache
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN go get -d -v ./...
-
 # Install tools to allow some administration on the container
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		default-mysql-client \
 		vim \
 	&& rm -rf /var/lib/apt/lists/*
+
+# first copy the dependencies file so that even if we change a detail, the "go get" can stay in cache
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go get -d -v ./...
 
 # copy all files except those in .dockerignore
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       ALGOREA_LOGGING__LEVEL: debug
     volumes:
       - ./db/migrations/:/go/src/AlgoreaBackend/db/migrations/:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: >
       /bin/sh -c "
         echo \"Wait 1sec for MySQL to be ready...\";


### PR DESCRIPTION
1. Dockerfile: copy project-related files after installing dependencies to get more from caching
2. docker-compose.yml: add an extra host host.docker.internal as a synonym for the host machine which can be used in config files (e.g. in loginModuleURL).