### PR TITLE
Acquire shared row locks instead of exclusive row locks in DB queries causing request timeouts in production

### DIFF
--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -108,7 +108,7 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 		itemID := ids[len(ids)-1]
 		var found bool
 		found, err = store.Items().ByID(itemID).
-			Where("NOT items.requires_explicit_entry").WithExclusiveWriteLock().HasRows()
+			Where("NOT items.requires_explicit_entry").WithSharedWriteLock().HasRows()
 		service.MustNotBeError(err)
 		if !found {
 			apiError = service.InsufficientAccessRightsError

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -291,7 +291,7 @@ func (s *ItemStore) CheckSubmissionRights(participantID, itemID int64) (hasAcces
 	var readOnly bool
 	err = s.WhereGroupHasPermissionOnItems(participantID, "view", "content").
 		Where("id = ?", itemID).
-		WithExclusiveWriteLock().
+		WithSharedWriteLock().
 		PluckFirst("read_only", &readOnly).Error()
 	if gorm.IsRecordNotFoundError(err) {
 		return false, errors.New("no access to the task item"), nil

--- a/app/database/result_store.go
+++ b/app/database/result_store.go
@@ -29,6 +29,7 @@ func (s *ResultStore) GetHintsInfoForActiveAttempt(participantID, attemptID, ite
 	mustNotBeError(s.Results().
 		ByID(participantID, attemptID, itemID).
 		WithCustomWriteLocks(golang.NewSet("attempts"), golang.NewSet("results")).
+		Select("hints_requested, hints_cached").
 		Joins("JOIN attempts ON attempts.participant_id = results.participant_id AND attempts.id = results.attempt_id").
 		Where("NOW() < attempts.allows_submissions_until").
 		Scan(&hintsInfo).Error())

--- a/app/database/result_store.go
+++ b/app/database/result_store.go
@@ -28,7 +28,7 @@ func (s *ResultStore) GetHintsInfoForActiveAttempt(participantID, attemptID, ite
 	var hintsInfo HintsInfo
 	mustNotBeError(s.Results().
 		ByID(participantID, attemptID, itemID).
-		WithExclusiveWriteLock().Select("hints_requested, hints_cached").
+		WithCustomWriteLocks(golang.NewSet("attempts"), golang.NewSet("results")).
 		Joins("JOIN attempts ON attempts.participant_id = results.participant_id AND attempts.id = results.attempt_id").
 		Where("NOW() < attempts.allows_submissions_until").
 		Scan(&hintsInfo).Error())


### PR DESCRIPTION
Acquire shared row locks instead of exclusive row locks in startResult(), ItemStore.CheckSubmissionRights(), ResultStore.GetHintsInfoForActiveAttempt()