### PR TITLE
Do not analyze tables or recompute db caches in db-migrate command + always close the DB connection in commands

### DIFF
--- a/cmd/db_gen_load.go
+++ b/cmd/db_gen_load.go
@@ -54,6 +54,7 @@ func init() { //nolint:gochecknoinits,gocyclo,gocognit
 			tablesToTruncate := []string{"groups", "groups_groups", "groups_ancestors", "groups_attempts"}
 			for _, tableName := range tablesToTruncate {
 				if _, err := rawdb.Exec(fmt.Sprintf("TRUNCATE %s", tableName)); err != nil {
+					_ = rawdb.Close()
 					panic(err)
 				}
 			}

--- a/cmd/db_gen_migrations.go
+++ b/cmd/db_gen_migrations.go
@@ -61,6 +61,8 @@ in the future.`,
 				os.Exit(1)
 			}
 
+			defer func() { _ = rawdb.Close() }()
+
 			commentRegexp := regexp.MustCompile(" COMMENT '(.+)'$")
 
 			renamedColumns := map[string]string{}

--- a/cmd/db_recompute.go
+++ b/cmd/db_recompute.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 )
 
 func init() { //nolint:gochecknoinits
@@ -34,6 +35,8 @@ func init() { //nolint:gochecknoinits
 				os.Exit(1)
 			}
 
+			defer func() { _ = application.Database.Close() }()
+
 			assertNoError(recomputeDBCaches(application.Database), "Cannot recompute db caches")
 
 			// Success
@@ -42,4 +45,17 @@ func init() { //nolint:gochecknoinits
 	}
 
 	rootCmd.AddCommand(recomputeCmd)
+}
+
+func recomputeDBCaches(gormDB *database.DB) error {
+	return database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
+		fmt.Print("Recalculating groups ancestors\n")
+		assertNoError(store.GroupGroups().CreateNewAncestors(), "Cannot compute groups_groups")
+		fmt.Print("Recalculating items ancestors\n")
+		assertNoError(store.ItemItems().CreateNewAncestors(), "Cannot compute items_items")
+		fmt.Print("Schedule the propagations\n")
+		store.SchedulePermissionsPropagation()
+		store.ScheduleResultsPropagation()
+		return nil
+	})
 }

--- a/cmd/db_restore.go
+++ b/cmd/db_restore.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	_ "github.com/go-sql-driver/mysql" // use to force database/sql to use mysql
+	"github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app"
@@ -20,7 +20,7 @@ func init() { //nolint:gochecknoinits
 		Use:   "db-restore [environment]",
 		Short: "load the last db schema",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
 			// if arg given, replace the env
@@ -41,46 +41,10 @@ func init() { //nolint:gochecknoinits
 				os.Exit(1)
 			}
 
-			// open DB
-			var db *sql.DB
-			db, err = sql.Open("mysql", dbConf.FormatDSN())
-			assertNoError(err, "Unable to connect to the database: ")
-			defer func() { _ = db.Close() }()
-
-			tx, err := db.Begin()
-			assertNoError(err, "Unable to start a transaction: ")
-
-			_, err = tx.Exec("SET FOREIGN_KEY_CHECKS = 0")
-			assertNoError(err, "Unable to query the database: ")
-
-			// remove all tables from DB
-			var rows *sql.Rows
-			rows, err = db.Query(`SELECT CONCAT(table_schema, '.', table_name)
-                            FROM   information_schema.tables
-                            WHERE  table_type   = 'BASE TABLE'
-                              AND  table_schema = '` + dbConf.DBName + "'")
-			assertNoError(err, "Unable to query the database: ")
-
-			defer func() {
-				_ = rows.Close()
-
-				if rows.Err() != nil {
-					panic(rows.Err())
-				}
-			}()
-
-			for rows.Next() {
-				var tableName string
-				assertNoError(rows.Scan(&tableName), "Unable to parse the database result: ")
-				_, err = tx.Exec("DROP TABLE " + tableName)
-				assertNoError(err, "Unable to drop table: ")
+			err = dropAllDBTablesWithForeignKeysChecksDisabled(dbConf)
+			if err != nil {
+				return err
 			}
-
-			_, err = tx.Exec("SET FOREIGN_KEY_CHECKS = 1")
-			assertNoError(err, "Unable to query the database: ")
-
-			err = tx.Commit()
-			assertNoError(err, "Unable to commit the transaction: ")
 
 			// restore the schema
 			// note: current solution is not really great as it makes some assumptions of the config :-/
@@ -103,22 +67,81 @@ func init() { //nolint:gochecknoinits
 			var output []byte
 			output, err = command.CombinedOutput()
 			if err != nil {
-				fmt.Printf("Command finished with error: %v\n", err)
-				fmt.Printf("Output:\n%s", output)
-				os.Exit(1)
+				return fmt.Errorf("command finished with error: %v\nOutput:\n%s", err, output)
 			}
 
 			// Success
 			fmt.Println("DONE")
+
+			return nil
 		},
 	}
 
 	rootCmd.AddCommand(restoreCmd)
 }
 
-func assertNoError(err error, message string) {
+func dropAllDBTablesWithForeignKeysChecksDisabled(dbConf *mysql.Config) error {
+	// open DB
+	var db *sql.DB
+	var err error
+	db, err = sql.Open("mysql", dbConf.FormatDSN())
 	if err != nil {
-		fmt.Println(message, err)
-		os.Exit(1)
+		return fmt.Errorf("unable to connect to the database: %v", err)
 	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("unable to start a transaction: %v", err)
+	}
+
+	_, err = tx.Exec("SET FOREIGN_KEY_CHECKS = 0")
+	if err != nil {
+		return fmt.Errorf("unable to query the database: %v", err)
+	}
+
+	err = dropAllDBTables(dbConf, db, tx)
+	if err != nil {
+		return err
+	}
+
+	// No need to restore FOREIGN_KEY_CHECKS as we close the connection.
+	// Also, no need to commit the transaction as DROP TABLE is auto-committed.
+
+	return nil
+}
+
+func dropAllDBTables(dbConf *mysql.Config, db *sql.DB, tx *sql.Tx) error {
+	// remove all tables from DB
+	var rows *sql.Rows
+	var err error
+	// nolint:gosec
+	rows, err = db.Query(`SELECT CONCAT(table_schema, '.', table_name)
+	                      FROM   information_schema.tables
+	                      WHERE  table_type   = 'BASE TABLE'
+	                      AND  table_schema = '` + dbConf.DBName + "'")
+	if err != nil {
+		return fmt.Errorf("unable to query the database: %v", err)
+	}
+
+	defer func() {
+		_ = rows.Close()
+
+		if rows.Err() != nil {
+			panic(rows.Err())
+		}
+	}()
+
+	for rows.Next() {
+		var tableName string
+		err = rows.Scan(&tableName)
+		if err != nil {
+			return fmt.Errorf("unable to parse the database result: %v", err)
+		}
+		_, err = tx.Exec("DROP TABLE " + tableName)
+		if err != nil {
+			return fmt.Errorf("unable to drop table: %v", err)
+		}
+	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/akrylysov/algnhsa"
@@ -15,13 +14,20 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use: "AlgoreaBackend",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		application, err := app.New()
+		defer func() {
+			if application != nil && application.Database != nil {
+				_ = application.Database.Close()
+			}
+		}()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		algnhsa.ListenAndServe(application.HTTPHandler, nil)
+
+		return nil
 	},
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -20,7 +21,7 @@ func init() { //nolint:gochecknoinits
 		Use:   "serve [environment]",
 		Short: "start http server",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
 			// if arg given, replace the env
@@ -36,28 +37,35 @@ func init() { //nolint:gochecknoinits
 
 			var application *app.Application
 			application, err = app.New()
+			defer func() {
+				if application != nil && application.Database != nil {
+					_ = application.Database.Close()
+				}
+			}()
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			if !skipChecks {
 				var domainConfig []domain.ConfigItem
 				domainConfig, err = app.DomainsConfig(application.Config)
 				if err != nil {
-					log.Fatalf("Cannot load domain config: %s\n", err)
+					return fmt.Errorf("cannot load domain config: %s", err)
 				}
 				err = configdb.CheckConfig(database.NewDataStore(application.Database), domainConfig)
 				if err != nil {
-					log.Fatalf("Integrity check failed: %s\nUse --skip-checks to bypass the integrity check\n", err)
+					return fmt.Errorf("integrity check failed: %s\nUse --skip-checks to bypass the integrity check", err)
 				}
 			}
 
 			var server *app.Server
 			server, err = app.NewServer(application)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			<-server.Start()
+
+			return nil
 		},
 	}
 


### PR DESCRIPTION
1. Do not analyze tables or recompute db caches in db-migrate command
2. Close the db connection in commands even when errors occur

Fixes #1184 

Note: We need to guarantee somehow that there are no concurrent requests/propagations running while the db-migrate command is being executed. Otherwise, any unpredictable data corruptions are possible as old code (code from a previous release) is not compatible with the DB after migrations are applied and the new code (code from a release to be deployed) is not compatible with the DB before migrations are applied. So, neither the old code, nor the new code can be running concurrently while we are executing DB migrations.