### PR TITLE
Rework app.Server.Start() to return errors instead of exiting the app + change the server's port in tests

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -43,7 +43,6 @@ func (srv *Server) Start() chan error {
 	signal.Notify(quit, os.Interrupt)
 	go func() {
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			fmt.Printf("server returned an error: %v\n", err)
 			serverErrChannel <- err
 		} else {
 			serverErrChannel <- nil

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -3,11 +3,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -27,30 +26,18 @@ func TestServer_Start(t *testing.T) {
 	assert.Equal(t, time.Duration(60000000000), srv.ReadTimeout)
 	assert.Equal(t, time.Duration(60000000000), srv.WriteTimeout)
 
-	lock := sync.Mutex{}
-	exitCalled := false
-	monkey.Patch(os.Exit, func(code int) {
-		lock.Lock()
-		exitCalled = true
-		lock.Unlock()
-		killErr := syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-		assert.NoError(t, killErr)
-	})
-	defer monkey.UnpatchAll()
-
 	doneChannel := srv.Start()
+	defer close(doneChannel)
+
 	err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	assert.NoError(t, err)
 
 	select {
-	case <-doneChannel:
+	case err = <-doneChannel:
+		assert.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		assert.Fail(t, "Timeout on waiting for server to stop")
 	}
-
-	lock.Lock()
-	defer lock.Unlock()
-	assert.False(t, exitCalled)
 }
 
 func TestServer_StartHandlesListenerError(t *testing.T) {
@@ -60,61 +47,64 @@ func TestServer_StartHandlesListenerError(t *testing.T) {
 	srv, err := NewServer(app)
 	assert.NoError(t, err)
 
-	lock := sync.Mutex{}
-	exitCalled := false
-	var exitCode int
-	monkey.Patch(os.Exit, func(code int) {
-		lock.Lock()
-		exitCalled = true
-		exitCode = code
-		lock.Unlock()
-		err := syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-		assert.NoError(t, err)
-	})
-	defer monkey.UnpatchAll()
+	doneChannel := srv.Start()
+	defer close(doneChannel)
+
 	select {
-	case <-srv.Start():
+	case err = <-doneChannel:
+		assert.Error(t, err)
 	case <-time.After(3 * time.Second):
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 		assert.Fail(t, "Timeout on waiting for server to stop")
 	}
-	lock.Lock()
-	defer lock.Unlock()
-	assert.True(t, exitCalled)
-	assert.Equal(t, 1, exitCode)
 }
 
-func TestServer_StartHandlesShutdownError(t *testing.T) {
+func TestServer_StartCanBeStoppedByShutdown(t *testing.T) {
 	app, err := New()
 	assert.NoError(t, err)
 	srv, err := NewServer(app)
 	assert.NoError(t, err)
 
-	lock := sync.Mutex{}
-	exitCalled := false
-	var exitCode int
-	monkey.Patch(os.Exit, func(code int) {
-		lock.Lock()
-		exitCalled = true
-		exitCode = code
-		lock.Unlock()
-	})
-	monkey.PatchInstanceMethod(reflect.TypeOf(&http.Server{ReadTimeout: 1 * time.Second}), "Shutdown",
-		func(*http.Server, context.Context) error { return errors.New("some errror") })
-	defer monkey.UnpatchAll()
-
 	doneChannel := srv.Start()
+	defer close(doneChannel)
+
 	_ = srv.Shutdown(context.Background())
-	err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-	assert.NoError(t, err)
+
 	select {
-	case <-doneChannel:
+	case err := <-doneChannel:
+		assert.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		assert.Fail(t, "Timeout on waiting for server to stop")
 	}
+}
 
-	lock.Lock()
-	defer lock.Unlock()
-	assert.True(t, exitCalled)
-	assert.Equal(t, 1, exitCode)
+func TestServer_StartHandlesShutdownError_OnKilling(t *testing.T) {
+	app, err := New()
+	assert.NoError(t, err)
+	srv, err := NewServer(app)
+	assert.NoError(t, err)
+
+	expectedError := errors.New("some error")
+	var patchGuard *monkey.PatchGuard
+	patchGuard = monkey.PatchInstanceMethod(reflect.TypeOf(&http.Server{}), "Shutdown",
+		func(server *http.Server, ctx context.Context) error {
+			patchGuard.Unpatch()
+			defer patchGuard.Restore()
+			_ = server.Shutdown(ctx)
+			return expectedError
+		})
+	defer monkey.UnpatchAll()
+
+	doneChannel := srv.Start()
+	defer close(doneChannel)
+
+	err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	assert.NoError(t, err)
+
+	select {
+	case err := <-doneChannel:
+		assert.Equal(t, fmt.Errorf("can't shut down the server: %v", expectedError), err)
+	case <-time.After(3 * time.Second):
+		assert.Fail(t, "Timeout on waiting for server to stop")
+	}
 }

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -22,7 +22,7 @@ func TestServer_Start(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check defaults are applied correctly
-	assert.True(t, strings.HasSuffix(srv.Addr, ":8080"))
+	assert.True(t, strings.HasSuffix(srv.Addr, ":8088"))
 	assert.Equal(t, time.Duration(60000000000), srv.ReadTimeout)
 	assert.Equal(t, time.Duration(60000000000), srv.WriteTimeout)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -63,9 +63,9 @@ func init() { //nolint:gochecknoinits
 			if err != nil {
 				return err
 			}
-			<-server.Start()
-
-			return nil
+			doneChannel := server.Start()
+			defer close(doneChannel)
+			return <-doneChannel
 		},
 	}
 

--- a/conf/config.test.sample.yaml
+++ b/conf/config.test.sample.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8088
   rootPath: "/" # the path at which the router is mounted
   compress: false # whether compression is enabled by default
   # domainOverride: dev.algorea.org # use this domain name for cookies and per-domain configuration choosing


### PR DESCRIPTION
This way we can close the DB connection before exiting.
Note: this method is not used in the prod currently.