### PR TITLE
Remove special characters from search strings in database.DB.WhereSearchStringMatches()

### DIFF
--- a/app/database/search_test.go
+++ b/app/database/search_test.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"database/sql/driver"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_WhereSearchStringMatches(t *testing.T) {
+	type args struct {
+		field         string
+		fallbackField string
+		searchString  string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantCondition string
+		wantArgs      []driver.Value
+	}{
+		{
+			name: "words with accents",
+			args: args{field: "title2", fallbackField: "title3", searchString: "précédente jusqu'à"},
+			wantCondition: "((title2 IS NOT NULL AND MATCH(title2) AGAINST(? IN BOOLEAN MODE)) OR " +
+				"(title2 IS NULL AND MATCH(title3) AGAINST(? IN BOOLEAN MODE)))",
+			wantArgs: []driver.Value{"+précédente* +jusqu'à*", "+précédente* +jusqu'à*"},
+		},
+		{
+			name: "no letters",
+			args: args{field: "title", fallbackField: "title2", searchString: "```"},
+			wantCondition: "((title IS NOT NULL AND MATCH(title) AGAINST(? IN BOOLEAN MODE)) OR " +
+				"(title IS NULL AND MATCH(title2) AGAINST(? IN BOOLEAN MODE)))",
+			wantArgs: []driver.Value{"", ""},
+		},
+		{
+			name:          "no fallback field",
+			args:          args{field: "title", searchString: "abc def"},
+			wantCondition: "((title IS NOT NULL AND MATCH(title) AGAINST(? IN BOOLEAN MODE)))",
+			wantArgs:      []driver.Value{"+abc* +def*"},
+		},
+		{
+			name:          "filters out special characters",
+			args:          args{field: "title", searchString: "~!@#$%^&*()_+`-=[]\\{}|;':\",./<>?"},
+			wantCondition: "((title IS NOT NULL AND MATCH(title) AGAINST(? IN BOOLEAN MODE)))",
+			wantArgs:      []driver.Value{"+'*"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			db, sqlMock := NewDBMock()
+			defer func() { _ = db.Close() }()
+
+			sqlMock.ExpectQuery("^" + regexp.QuoteMeta("SELECT * FROM `items` WHERE "+tt.wantCondition) + "$").
+				WithArgs(tt.wantArgs...).
+				WillReturnRows(sqlMock.NewRows([]string{"id"}))
+
+			var result []map[string]interface{}
+			require.NoError(t, db.Table("items").
+				WhereSearchStringMatches(tt.args.field, tt.args.fallbackField, tt.args.searchString).
+				ScanIntoSliceOfMaps(&result).Error())
+
+			assert.NoError(t, sqlMock.ExpectationsWereMet())
+		})
+	}
+}


### PR DESCRIPTION
Preprocess search strings in database.DB.WhereSearchStringMatches() keeping only letters/digits/apostrophes.

Fixes #1209

Note: Unfortunately, there is no way to escape special characters acting like operators of boolean full-text search in MySQL inside search words and use such words outside of the exact phrase operator (double quotes) at the same time. So, we should filter out all the operator characters [+-()~<>*"@]. At the same time, for security reason, here we remove all the characters except for alpha-numeric characters (for all languages of the world) and apostrophes.