### PR TITLE
Set deleteWithTrapsBatchSize to 30 instead of 1000

### DIFF
--- a/app/database/search_test.go
+++ b/app/database/search_test.go
@@ -7,9 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
 func TestDB_WhereSearchStringMatches(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
 	type args struct {
 		field         string
 		fallbackField string
@@ -51,6 +55,8 @@ func TestDB_WhereSearchStringMatches(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
 			db, sqlMock := NewDBMock()
 			defer func() { _ = db.Close() }()
 

--- a/app/database/user_store.go
+++ b/app/database/user_store.go
@@ -15,7 +15,7 @@ func (s *UserStore) ByID(id int64) *DB {
 	return s.Where(s.tableName+".group_id = ?", id)
 }
 
-const deleteWithTrapsBatchSize = 1000
+const deleteWithTrapsBatchSize = 30
 
 // DeleteTemporaryWithTraps deletes temporary users who don't have sessions or whose sessions expired more than `delay` ago.
 // It also removes linked rows in the tables:

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -47,7 +47,7 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 			defer func() { _ = db.Close() }()
 
 			store := database.NewDataStore(db)
-			assert.NoError(t, store.Users().DeleteTemporaryWithTraps(test.delay))
+			require.NoError(t, store.Users().DeleteTemporaryWithTraps(test.delay))
 
 			assertUserRelatedTablesAfterDeletingWithTraps(t, db, test.expectDeletedUsers, test.expectDeletedSessions)
 		})

--- a/app/database/user_store_test.go
+++ b/app/database/user_store_test.go
@@ -16,7 +16,7 @@ func TestUserStore_deleteWithTraps_DoesNothingWhenScopeReturnsNothing(t *testing
 	defer func() { _ = db.Close() }()
 
 	mock.ExpectBegin()
-	mock.ExpectQuery("^" + regexp.QuoteMeta("SELECT group_id FROM `users` LIMIT 1000 FOR UPDATE") + "$").
+	mock.ExpectQuery("^" + regexp.QuoteMeta("SELECT group_id FROM `users` LIMIT 30 FOR UPDATE") + "$").
 		WillReturnRows(mock.NewRows([]string{"group_id"}))
 	mock.ExpectCommit()
 
@@ -40,7 +40,7 @@ func TestUserStore_executeBatchesInTransactions_ProcessesAllTheBatches(t *testin
 	mock.ExpectBegin()
 	mock.ExpectCommit()
 
-	counts := []int{1000, 999}
+	counts := []int{30, 29}
 	step := 0
 	totalCount := 0
 	NewDataStore(db).Users().executeBatchesInTransactions(func(store *DataStore) int {
@@ -50,6 +50,6 @@ func TestUserStore_executeBatchesInTransactions_ProcessesAllTheBatches(t *testin
 		step++
 		return counts[step-1]
 	})
-	assert.Equal(t, 1999, totalCount)
+	assert.Equal(t, 59, totalCount)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
It should make iterations of temporary users deletion shorter.
Partially fixes #1253 