### PR TITLE
Fix fulltext search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     docker:
       - image: cimg/go:1.20.2
       - image: mysql:8.0.34
-        command: --default-authentication-plugin=caching_sha2_password --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
+        command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:
           MYSQL_USER: algorea
           MYSQL_PASSWORD: dummy_password
@@ -81,7 +81,7 @@ jobs:
     docker:
       - image: cimg/go:1.20.2
       - image: mysql:8.0.34
-        command: --default-authentication-plugin=caching_sha2_password --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
+        command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:
           MYSQL_USER: algorea
           MYSQL_PASSWORD: dummy_password
@@ -209,7 +209,7 @@ jobs:
     docker:
       - image: cimg/go:1.20.2-browsers
       - image: mysql:8.0.34
-        command: --default-authentication-plugin=caching_sha2_password --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
+        command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:
           MYSQL_USER: algorea
           MYSQL_PASSWORD: dummy_password

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ docker exec -it algoreabackend_db_1 mysql -h localhost -u algorea -pa_db_passwor
 
 The application needs a database (MySQL) to run and requires it for a major part of its tests.
 
-It is recommended to set
-  * `innodb_lock_wait_timeout`=1,
+It is required to set
+  * `innodb_lock_wait_timeout`=5,
+  * `innodb_ft_min_token_size`=1
   * `max-allowed-packet`=10485760
 
 and provide at least 2Gb of memory to the MySQL server.

--- a/app/database/search.go
+++ b/app/database/search.go
@@ -13,15 +13,19 @@ func (conn *DB) WhereSearchStringMatches(field, fallbackField, searchString stri
 
 	// Remove all the special characters from the search string.
 	searchString = strings.Map(func(r rune) rune {
-		// Keep only letters (for all the world languages), digits, and apostrophes.
-		if r == '\'' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+		// Keep only letters (for all the world languages), digits, and underscores.
+		if r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
 			return r
 		}
 
 		return ' '
 	}, searchString)
 
-	words := strings.Fields(strings.Trim(searchString, " "))
+	words := strings.Fields(strings.TrimSpace(searchString))
+	if len(words) == 0 {
+		// If the search string has no words, we return an empty result.
+		return conn.Where("FALSE")
+	}
 
 	for i := 0; i < len(words); i++ {
 		word := words[i]

--- a/app/database/search_integration_test.go
+++ b/app/database/search_integration_test.go
@@ -24,13 +24,16 @@ func TestDB_WhereSearchStringMatches_Integration(t *testing.T) {
 			- {id: 444, name: 'éléphant'}
 			- {id: 555, name: 'Task #1'}
 			- {id: 666, name: 'Task #2'}
+			- {id: 777, name: "with'quote"}
 		items_strings:
 			- {item_id: 111, language_tag: fr, title: 'précédente'}
 			- {item_id: 222, language_tag: fr, title: 'jusqu''à'}
 			- {item_id: 333, language_tag: fr, title: "précédente jusqu'à"}
 			- {item_id: 444, language_tag: fr, title: 'éléphant'}
 			- {item_id: 555, language_tag: fr, title: 'Task #1'}
-			- {item_id: 666, language_tag: fr, title: 'Task #2'}`)
+			- {item_id: 666, language_tag: fr, title: 'Task #2'}
+			- {item_id: 777, language_tag: fr, title: "with'quote"}
+`)
 	defer func() { _ = db.Close() }()
 
 	for _, test := range []struct {
@@ -68,6 +71,10 @@ func TestDB_WhereSearchStringMatches_Integration(t *testing.T) {
 		{
 			searchString: "Task #1",
 			expectedIDs:  []int64{555},
+		},
+		{
+			searchString: "with'quote",
+			expectedIDs:  []int64{777},
 		},
 	} {
 		test := test

--- a/app/database/search_integration_test.go
+++ b/app/database/search_integration_test.go
@@ -1,0 +1,104 @@
+//go:build !unit
+
+package database_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func TestDB_WhereSearchStringMatches_Integration(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixtureString(`
+		groups:
+			- {id: 111, name: 'précédente'}
+			- {id: 222, name: 'jusqu''à'}
+			- {id: 333, name: "précédente jusqu'à"}
+			- {id: 444, name: 'éléphant'}
+			- {id: 555, name: 'Task #1'}
+			- {id: 666, name: 'Task #2'}
+		items_strings:
+			- {item_id: 111, language_tag: fr, title: 'précédente'}
+			- {item_id: 222, language_tag: fr, title: 'jusqu''à'}
+			- {item_id: 333, language_tag: fr, title: "précédente jusqu'à"}
+			- {item_id: 444, language_tag: fr, title: 'éléphant'}
+			- {item_id: 555, language_tag: fr, title: 'Task #1'}
+			- {item_id: 666, language_tag: fr, title: 'Task #2'}`)
+	defer func() { _ = db.Close() }()
+
+	for _, test := range []struct {
+		searchString string
+		expectedIDs  []int64
+	}{
+		{
+			searchString: "précédente jusqu'à",
+			expectedIDs:  []int64{333},
+		},
+		{
+			searchString: "éléphant",
+			expectedIDs:  []int64{444},
+		},
+		{
+			searchString: "à",
+			expectedIDs:  []int64{222, 333},
+		},
+		{
+			searchString: "Task-1*",
+			expectedIDs:  []int64{555},
+		},
+		{
+			searchString: "Task",
+			expectedIDs:  []int64{555, 666},
+		},
+		{
+			searchString: "Task ",
+			expectedIDs:  []int64{555, 666},
+		},
+		{
+			searchString: "Task 1",
+			expectedIDs:  []int64{555},
+		},
+		{
+			searchString: "Task #1",
+			expectedIDs:  []int64{555},
+		},
+	} {
+		test := test
+		t.Run(test.searchString, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
+			for _, tableColumns := range []struct {
+				table        string
+				searchColumn string
+				idColumn     string
+			}{
+				{
+					table:        "groups",
+					searchColumn: "name",
+					idColumn:     "id",
+				},
+				{
+					table:        "items_strings",
+					searchColumn: "title",
+					idColumn:     "item_id",
+				},
+			} {
+				t.Run(tableColumns.table, func(t *testing.T) {
+					testoutput.SuppressIfPasses(t)
+					var ids []int64
+					require.NoError(t, database.NewDataStore(db).Table(tableColumns.table).
+						WhereSearchStringMatches(tableColumns.searchColumn, "", test.searchString).
+						Pluck(tableColumns.idColumn, &ids).Error())
+					assert.ElementsMatch(t, test.expectedIDs, ids)
+				})
+			}
+		})
+	}
+}

--- a/db/migrations/2503241255_create_empty_stopwords_table.sql
+++ b/db/migrations/2503241255_create_empty_stopwords_table.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+CREATE TABLE `stopwords`(value VARCHAR(30)) ENGINE = INNODB;
+
+-- +migrate Down
+DROP TABLE `stopwords`;

--- a/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
+++ b/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+SET GLOBAL innodb_ft_server_stopword_table = CONCAT(DATABASE(), '/stopwords');
+
+ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
+CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
+ALTER TABLE `groups` DROP INDEX `fullTextName`;
+CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
+
+-- +migrate Down
+SET GLOBAL innodb_ft_server_stopword_table = NULL;
+
+ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
+CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
+ALTER TABLE `groups` DROP INDEX `fullTextName`;
+CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # connect from host using: "mysql -hlocalhost -Dalgorea_db -ualgorea -pa_db_password --protocol=TCP"
   db:
     image: mysql:8.0.34
-    command: --default-authentication-plugin=caching_sha2_password --max-allowed-packet=10485760 --innodb_lock_wait_timeout=1 --skip-log-bin
+    command: --default-authentication-plugin=caching_sha2_password --max-allowed-packet=10485760 --innodb_lock_wait_timeout=5 --innodb_ft_min_token_size=1 --skip-log-bin
     restart: always
     ports:
       - "3306:3306"
@@ -24,7 +24,7 @@ services:
       retries: 10
   db_test:
     image: mysql:8.0.34
-    command: --default-authentication-plugin=caching_sha2_password --innodb_lock_wait_timeout=1 --skip-log-bin
+    command: --default-authentication-plugin=caching_sha2_password --innodb_lock_wait_timeout=5 --innodb_ft_min_token_size=1 --skip-log-bin
     restart: always
     ports:
       - "3307:3306"


### PR DESCRIPTION
1. When preprocessing the search query in datastore.DB.WhereSearchStringMatches(), keep underscores instead of apostrophes (the way MySQL does it: see https://dev.mysql.com/doc/refman/8.0/en/fulltext-fine-tuning.html#fulltext-modify-character-set and https://github.com/mysql/mysql-server/blob/8.0/storage/innobase/include/fts0tokenize.h#L40), return FALSE condition when there are no words in the search query.
2. Set innodb_lock_wait_timeout=5, innodb_ft_min_token_size=1 for MySQL in Docker, fix the README.md to mention these values. Set innodb_ft_min_token_size=1 for MySQL on CircleCI.
3. Recreate the full-text indexes with empty stopwords list (and innodb_ft_min_token_size=1, note: it should be set before applying the migration).

Before deploying this PR we should set innodb_ft_min_token_size=1 for MySQL on both dev and prod, otherwise the full-text indexes will be created wrongly!

Fixes #1262 