### PR TITLE
Use innodb_ft_user_stopword_table instead of innodb_ft_server_stopword_table in db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql

### DIFF
--- a/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
+++ b/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
@@ -1,21 +1,21 @@
 -- +migrate Up
-SET @old_stopword_table := @@innodb_ft_server_stopword_table;
-SET GLOBAL innodb_ft_server_stopword_table = CONCAT(DATABASE(), '/stopwords');
+SET @old_stopword_table := @@innodb_ft_user_stopword_table;
+SET SESSION innodb_ft_user_stopword_table = CONCAT(DATABASE(), '/stopwords');
 
 ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
 CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
 ALTER TABLE `groups` DROP INDEX `fullTextName`;
 CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
 
-SET GLOBAL innodb_ft_server_stopword_table = @old_stopword_table;
+SET SESSION innodb_ft_user_stopword_table = @old_stopword_table;
 
 -- +migrate Down
-SET @old_stopword_table := @@innodb_ft_server_stopword_table;
-SET GLOBAL innodb_ft_server_stopword_table = NULL;
+SET @old_stopword_table := @@innodb_ft_user_stopword_table;
+SET SESSION innodb_ft_user_stopword_table = NULL;
 
 ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
 CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
 ALTER TABLE `groups` DROP INDEX `fullTextName`;
 CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
 
-SET GLOBAL innodb_ft_server_stopword_table = @old_stopword_table;
+SET SESSION innodb_ft_user_stopword_table = @old_stopword_table;

--- a/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
+++ b/db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql
@@ -1,4 +1,5 @@
 -- +migrate Up
+SET @old_stopword_table := @@innodb_ft_server_stopword_table;
 SET GLOBAL innodb_ft_server_stopword_table = CONCAT(DATABASE(), '/stopwords');
 
 ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
@@ -6,10 +7,15 @@ CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
 ALTER TABLE `groups` DROP INDEX `fullTextName`;
 CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
 
+SET GLOBAL innodb_ft_server_stopword_table = @old_stopword_table;
+
 -- +migrate Down
+SET @old_stopword_table := @@innodb_ft_server_stopword_table;
 SET GLOBAL innodb_ft_server_stopword_table = NULL;
 
 ALTER TABLE `items_strings` DROP INDEX `fullTextTitle`;
 CREATE FULLTEXT INDEX `fullTextTitle` ON `items_strings`(`title`);
 ALTER TABLE `groups` DROP INDEX `fullTextName`;
 CREATE FULLTEXT INDEX `fullTextName` ON `groups`(`name`);
+
+SET GLOBAL innodb_ft_server_stopword_table = @old_stopword_table;


### PR DESCRIPTION
Use innodb_ft_user_stopword_table instead of innodb_ft_server_stopword_table and restore it after applying/undoing db/migrations/2503241300_recreate_fulltext_indexes_with_empty_stopwords_table.sql