### PR TITLE
Try closing the DB connection after AWS Lambda gets SIGTERM

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,31 +1,39 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/akrylysov/algnhsa"
 	_ "github.com/aws/aws-lambda-go/events" // force algnhsa dependency
-	_ "github.com/aws/aws-lambda-go/lambda" // force algnhsa dependency
+	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/spf13/cobra"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	log "github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 )
 
 var rootCmd = &cobra.Command{
 	Use: "AlgoreaBackend",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		application, err := app.New()
-		defer func() {
+		closeDB := func() {
 			if application != nil && application.Database != nil {
 				_ = application.Database.Close()
 			}
-		}()
+		}
+		defer closeDB()
 		if err != nil {
 			return err
 		}
 
-		algnhsa.ListenAndServe(application.HTTPHandler, nil)
+		lambdaHandler := algnhsa.New(application.HTTPHandler, nil)
+		lambda.StartWithOptions(lambdaHandler, lambda.WithEnableSIGTERM(func() {
+			log.SharedLogger.WithContext(context.Background()).Info("Got SIGTERM, closing the DB connection")
+			closeDB()
+			log.SharedLogger.WithContext(context.Background()).Info("Closed the DB connection after receiving SIGTERM")
+		}))
 
 		return nil
 	},


### PR DESCRIPTION
Here we will try closing the DB connection when AWS Lambda gets a SIGTERM signal. A lambda has about 500ms between getting SIGTERM and SIGKILL (see https://pkg.go.dev/github.com/aws/aws-lambda-go/lambda#WithEnableSIGTERM). Anyway, if there is an active SQL query in progress, the Close() method will wait, so it's still not guaranteed the connection will be always closed before termination, but, at least, we well see more logs in such situation.