### PR TITLE
Fix dbdoc-gen on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
           aws s3 cp ./index.html s3://franceioi-algorea/spec/index.html --acl public-read
   dbdoc-gen:
     docker:
-      - image: cimg/go:1.20.2-browsers
+      - image: cimg/go:1.20.2
       - image: mysql:8.0.34
         command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
           command: |
             make db-restore
             make db-migrate
+      - run: sudo apt install default-jdk
       - run: sudo apt-get install graphviz # dependency for schemaspy
       - run: make dbdoc
       - store_test_results: &TESTPATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,9 +278,6 @@ workflows:
           requires:
           - deps
       - swagger-gen
-      - dbdoc-gen:
-          requires:
-          - deps
   db-migration-check:
     jobs:
       - deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,9 @@ workflows:
           requires:
           - deps
       - swagger-gen
+      - dbdoc-gen:
+          requires:
+          - deps
   db-migration-check:
     jobs:
       - deps


### PR DESCRIPTION
Do not use the broken image cimg/go:1.20.2-browsers for dbdoc-gen on CircleCI. Instead, use cimg/go:1.20.2 and install default-jdk explicitly.

Fixes #1265 