### PR TITLE
Fix the result type of itemGetAdditionalTime in swagger docs

### DIFF
--- a/app/api/items/get_group_additional_times.go
+++ b/app/api/items/get_group_additional_times.go
@@ -49,11 +49,9 @@ type additionalTimes struct {
 //			required: true
 //	responses:
 //		"200":
-//			description: OK. Success response with item's info
+//			description: OK. Success response with additional times
 //			schema:
-//				type: array
-//				items:
-//					"$ref": "#/definitions/additionalTimes"
+//				"$ref": "#/definitions/additionalTimes"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"
 //		"403":


### PR DESCRIPTION
It should not be an array anymore.

Fixes #1266 