### PR TITLE
Add (can_enter_from, can_enter_until) intervals in itemView, fix calculation of can_request_help for teams there

### DIFF
--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -38,9 +38,9 @@ Feature: Get item view information
       | 28              | 15             |
     And the groups ancestors are computed
     And the database has the following table "items_items":
-      | parent_item_id | child_item_id | child_order | category  | content_view_propagation |
-      | 200            | 210           | 2           | Discovery | as_info                  |
-      | 200            | 220           | 1           | Discovery | as_info                  |
+      | parent_item_id | child_item_id | child_order | category  | content_view_propagation | request_help_propagation |
+      | 200            | 210           | 2           | Discovery | as_info                  | true                     |
+      | 200            | 220           | 1           | Discovery | as_info                  | false                    |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
       | 11       | 200     | solution                 | enter                    | children           | result              | true               |
@@ -60,24 +60,25 @@ Feature: Get item view information
       | 26       | 220     | info                     | none                     | none               | none                | false              |
       | 28       | 220     | content_with_descendants | solution_with_grant      | all                | answer              | true               |
     And the database has the following table "permissions_granted":
-      | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
-      | 11       | 200     | 11              | 2019-05-30 12:01:02 | 3019-06-30 13:03:04 |
-      | 11       | 200     | 13              | 2019-05-30 12:01:02 | 2019-06-30 13:03:04 |
-      | 11       | 200     | 26              | 3019-05-30 12:01:02 | 3019-05-30 12:01:02 |
-      | 11       | 200     | 27              | 3019-05-30 12:01:02 | 3019-05-30 12:01:01 |
-      | 11       | 220     | 11              | 2019-06-30 12:01:02 | 3019-07-30 13:03:04 |
-      | 13       | 200     | 13              | 2020-05-30 12:01:02 | 3020-06-30 13:03:04 |
-      | 15       | 200     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 |
-      | 15       | 220     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 |
-      | 15       | 220     | 13              | 2019-07-30 12:01:02 | 2019-08-30 13:03:04 |
-      | 15       | 220     | 26              | 3019-07-30 12:01:02 | 3019-07-30 12:01:02 |
-      | 15       | 220     | 27              | 3019-07-30 12:01:02 | 3019-07-30 12:01:01 |
-      | 27       | 200     | 26              | 2018-05-30 12:01:02 | 3018-06-30 13:03:04 |
-      | 27       | 200     | 27              | 2018-05-30 12:01:02 | 3019-06-30 13:03:04 |
-      | 27       | 220     | 27              | 2018-06-30 12:01:02 | 3019-07-30 13:03:04 |
-      | 28       | 200     | 26              | 2018-08-30 12:01:02 | 3018-09-30 13:03:04 |
-      | 28       | 220     | 26              | 2018-07-30 12:01:02 | 3018-08-30 13:03:04 |
-      | 28       | 220     | 27              | 2018-07-30 12:01:02 | 3019-08-30 13:03:04 |
+      | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     | is_owner | can_request_help_to |
+      | 11       | 200     | 11              | 2019-05-30 12:01:02 | 3019-06-30 13:03:04 | true     | null                |
+      | 11       | 200     | 13              | 2019-05-30 12:01:02 | 2019-06-30 13:03:04 | false    | null                |
+      | 11       | 200     | 26              | 3019-05-30 12:01:02 | 3019-05-30 12:01:02 | false    | null                |
+      | 11       | 200     | 27              | 3019-05-30 12:01:02 | 3019-05-30 12:01:01 | false    | null                |
+      | 11       | 220     | 11              | 2019-06-30 12:01:02 | 3019-07-30 13:03:04 | false    | null                |
+      | 13       | 200     | 13              | 2020-05-30 12:01:02 | 3020-06-30 13:03:04 | false    | 13                  |
+      | 15       | 200     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 | false    | null                |
+      | 15       | 220     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 | false    | null                |
+      | 15       | 220     | 13              | 2019-07-30 12:01:02 | 2019-08-30 13:03:04 | false    | null                |
+      | 15       | 220     | 26              | 3019-07-30 12:01:02 | 3019-07-30 12:01:02 | false    | null                |
+      | 15       | 220     | 27              | 3019-07-30 12:01:02 | 3019-07-30 12:01:01 | false    | null                |
+      | 17       | 200     | 17              | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 | false    | 17                  |
+      | 27       | 200     | 26              | 2018-05-30 12:01:02 | 3018-06-30 13:03:04 | false    | null                |
+      | 27       | 200     | 27              | 2018-05-30 12:01:02 | 3019-06-30 13:03:04 | false    | null                |
+      | 27       | 220     | 27              | 2018-06-30 12:01:02 | 3019-07-30 13:03:04 | false    | null                |
+      | 28       | 200     | 26              | 2018-08-30 12:01:02 | 3018-09-30 13:03:04 | false    | null                |
+      | 28       | 220     | 26              | 2018-07-30 12:01:02 | 3018-08-30 13:03:04 | false    | null                |
+      | 28       | 220     | 27              | 2018-07-30 12:01:02 | 3019-08-30 13:03:04 | false    | null                |
     And the database has the following table "languages":
       | tag |
       | fr  |
@@ -152,7 +153,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "can_request_help": false,
+        "can_request_help": true,
         "entering_time_intervals": [
           {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3018-06-30T13:03:04Z"},
           {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"},
@@ -211,7 +212,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false,
+        "can_request_help": true,
         "entering_time_intervals": []
       }
     }
@@ -324,7 +325,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false,
+        "can_request_help": true,
         "entering_time_intervals": []
       }
     }
@@ -383,7 +384,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false,
+        "can_request_help": true,
         "entering_time_intervals": [
           {"can_enter_from": "2020-05-30T12:01:02Z", "can_enter_until": "3020-06-30T13:03:04Z"}
         ]
@@ -498,7 +499,7 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "can_request_help": false,
+        "can_request_help": true,
         "entering_time_intervals": [
           {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3018-06-30T13:03:04Z"},
           {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"},
@@ -510,11 +511,14 @@ Feature: Get item view information
 
   Scenario Outline: With watched_group_id
     Given I am the user with id "11"
-    And the database table "group_managers" also has the following row:
+    And the database table "group_managers" also has the following rows:
       | manager_id | group_id | can_watch_members | can_grant_group_access            |
       | 11         | 15       | false             | <can_grant_group_access>          |
       | 27         | 28       | true              | <can_grant_group_access_ancestor> |
-    And the database table "permissions_generated" also has the following row:
+    And the database table "permissions_granted" also has the following row:
+      | group_id | item_id | source_group_id | can_request_help_to |
+      | 28       | 220     | 11              | true                |
+    And the database table "permissions_generated" also has the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated            | can_edit_generated | can_watch_generated   | is_owner_generated |
       | 11       | 220     | solution           | <can_grant_view_generated>          | none               | <can_watch_generated> | false              |
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
@@ -522,7 +526,7 @@ Feature: Get item view information
     """
       "permissions": {
         "can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants",
-        "can_watch": "answer", "is_owner": true, "can_request_help": false,
+        "can_watch": "answer", "is_owner": true, "can_request_help": true,
         "entering_time_intervals": [
           {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3018-08-30T13:03:04Z"},
           {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3019-08-30T13:03:04Z"},
@@ -615,11 +619,11 @@ Feature: Get item view information
 
   Scenario Outline: With watched_group_id and as_team_id
     Given I am the user with id "11"
-    And the database table "group_managers" also has the following row:
+    And the database table "group_managers" also has the following rows:
       | manager_id | group_id | can_watch_members | can_grant_group_access            |
       | 11         | 15       | false             | <can_grant_group_access>          |
       | 27         | 28       | true              | <can_grant_group_access_ancestor> |
-    And the database table "permissions_generated" also has the following row:
+    And the database table "permissions_generated" also has the following rows:
       | group_id | item_id | can_view_generated | can_grant_view_generated            | can_edit_generated | can_watch_generated   | is_owner_generated |
       | 11       | 220     | solution           | <can_grant_view_generated>          | none               | <can_watch_generated> | false              |
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -59,6 +59,25 @@ Feature: Get item view information
       | 26       | 210     | info                     | none                     | none               | none                | false              |
       | 26       | 220     | info                     | none                     | none               | none                | false              |
       | 28       | 220     | content_with_descendants | solution_with_grant      | all                | answer              | true               |
+    And the database has the following table "permissions_granted":
+      | group_id | item_id | source_group_id | can_enter_from      | can_enter_until     |
+      | 11       | 200     | 11              | 2019-05-30 12:01:02 | 3019-06-30 13:03:04 |
+      | 11       | 200     | 13              | 2019-05-30 12:01:02 | 2019-06-30 13:03:04 |
+      | 11       | 200     | 26              | 3019-05-30 12:01:02 | 3019-05-30 12:01:02 |
+      | 11       | 200     | 27              | 3019-05-30 12:01:02 | 3019-05-30 12:01:01 |
+      | 11       | 220     | 11              | 2019-06-30 12:01:02 | 3019-07-30 13:03:04 |
+      | 13       | 200     | 13              | 2020-05-30 12:01:02 | 3020-06-30 13:03:04 |
+      | 15       | 200     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 |
+      | 15       | 220     | 11              | 2019-07-30 12:01:02 | 3019-08-30 13:03:04 |
+      | 15       | 220     | 13              | 2019-07-30 12:01:02 | 2019-08-30 13:03:04 |
+      | 15       | 220     | 26              | 3019-07-30 12:01:02 | 3019-07-30 12:01:02 |
+      | 15       | 220     | 27              | 3019-07-30 12:01:02 | 3019-07-30 12:01:01 |
+      | 27       | 200     | 26              | 2018-05-30 12:01:02 | 3018-06-30 13:03:04 |
+      | 27       | 200     | 27              | 2018-05-30 12:01:02 | 3019-06-30 13:03:04 |
+      | 27       | 220     | 27              | 2018-06-30 12:01:02 | 3019-07-30 13:03:04 |
+      | 28       | 200     | 26              | 2018-08-30 12:01:02 | 3018-09-30 13:03:04 |
+      | 28       | 220     | 26              | 2018-07-30 12:01:02 | 3018-08-30 13:03:04 |
+      | 28       | 220     | 27              | 2018-07-30 12:01:02 | 3019-08-30 13:03:04 |
     And the database has the following table "languages":
       | tag |
       | fr  |
@@ -133,7 +152,12 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": [
+          {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3018-06-30T13:03:04Z"},
+          {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"},
+          {"can_enter_from": "2019-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"}
+        ]
       }
     }
     """
@@ -187,7 +211,8 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": []
       }
     }
     """
@@ -240,7 +265,8 @@ Feature: Get item view information
         "can_view": "content_with_descendants",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": []
       }
     }
     """
@@ -298,7 +324,8 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": []
       }
     }
     """
@@ -356,7 +383,10 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": [
+          {"can_enter_from": "2020-05-30T12:01:02Z", "can_enter_until": "3020-06-30T13:03:04Z"}
+        ]
       }
     }
     """
@@ -409,7 +439,8 @@ Feature: Get item view information
         "can_view": "info",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": []
       }
     }
     """
@@ -467,7 +498,12 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "result",
         "is_owner": true,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": [
+          {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3018-06-30T13:03:04Z"},
+          {"can_enter_from": "2018-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"},
+          {"can_enter_from": "2019-05-30T12:01:02Z", "can_enter_until": "3019-06-30T13:03:04Z"}
+        ]
       }
     }
     """
@@ -484,7 +520,15 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "can_request_help": false}
+      "permissions": {
+        "can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants",
+        "can_watch": "answer", "is_owner": true, "can_request_help": false,
+        "entering_time_intervals": [
+          {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3018-08-30T13:03:04Z"},
+          {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3019-08-30T13:03:04Z"},
+          {"can_enter_from": "2019-07-30T12:01:02Z", "can_enter_until": "3019-08-30T13:03:04Z"}
+        ]
+      }
     """
     And the template constant "average_score" is:
     """
@@ -545,7 +589,17 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "<can_watch_generated>",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": [
+          {
+            "can_enter_from": "2018-06-30T12:01:02Z",
+            "can_enter_until": "3019-07-30T13:03:04Z"
+          },
+          {
+            "can_enter_from": "2019-06-30T12:01:02Z",
+            "can_enter_until": "3019-07-30T13:03:04Z"
+          }
+        ]
       }
       <expected_watched_group_part>
     }
@@ -571,7 +625,15 @@ Feature: Get item view information
       | 27       | 220     | none               | <can_grant_view_generated_ancestor> | none               | none                  | false              |
     And the template constant "permissions" is:
     """
-      "permissions": {"can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants", "can_watch": "answer", "is_owner": true, "can_request_help": false}
+      "permissions": {
+        "can_edit": "all", "can_grant_view": "solution_with_grant", "can_view": "content_with_descendants",
+        "can_watch": "answer", "is_owner": true, "can_request_help": false,
+        "entering_time_intervals": [
+          {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3018-08-30T13:03:04Z"},
+          {"can_enter_from": "2018-07-30T12:01:02Z", "can_enter_until": "3019-08-30T13:03:04Z"},
+          {"can_enter_from": "2019-07-30T12:01:02Z", "can_enter_until": "3019-08-30T13:03:04Z"}
+        ]
+      }
     """
     And the template constant "average_score" is:
     """
@@ -632,7 +694,8 @@ Feature: Get item view information
         "can_view": "solution",
         "can_watch": "none",
         "is_owner": false,
-        "can_request_help": false
+        "can_request_help": false,
+        "entering_time_intervals": []
       }
       <expected_watched_group_part>
     }

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -98,7 +98,7 @@ type itemRootNodeNotChapterFields struct {
 
 // only if watched_group_id is given.
 type itemResponseWatchedGroupItemInfo struct {
-	// only if the current can watch the item or grant permissions to both the watched group and the item
+	// only if the current user can watch the item or grant permissions to both the watched group and the item
 	Permissions *getItemItemPermissions `json:"permissions,omitempty"`
 
 	// Average score of all "end-members" within the watched group

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -347,25 +347,6 @@ func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
 	`, itemID)
 }
 
-// HasCanRequestHelpTo checks whether there is a can_request_help_to permission on an item-group.
-// The checks are made on item's ancestor while can_request_help_propagation=1, and on group's ancestors.
-func (s *ItemStore) HasCanRequestHelpTo(itemID, groupID int64) bool {
-	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
-
-	hasCanRequestHelpTo, err := s.Users().
-		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", groupID).
-		Joins(`JOIN permissions_granted ON
-			permissions_granted.group_id = groups_ancestors_active.ancestor_group_id AND
-			(permissions_granted.item_id = ? OR permissions_granted.item_id IN (?))`, itemID, itemAncestorsRequestHelpPropagationQuery.SubQuery()).
-		Where("permissions_granted.can_request_help_to IS NOT NULL OR permissions_granted.is_owner = 1").
-		Select("1").
-		Limit(1).
-		HasRows()
-	mustNotBeError(err)
-
-	return hasCanRequestHelpTo
-}
-
 // GetItemIDFromTextID gets the item_id from the text_id of an item.
 func (s *ItemStore) GetItemIDFromTextID(textID string) (itemID int64, err error) {
 	err = s.Select("items.id AS id").


### PR DESCRIPTION
1. Output entering_time_intervals as an array of (can_enter_from, can_enter_until) pairs as part of permissions of the participant and (optionally, when watched_group_id is given and the current user can watch the item or grant permissions to both the watched group and the item) the watched group in itemView. We output only intervals having can_enter_until > now() and can_enter_until > can_enter_from.
2. Rework the code setting can_request_help in itemView, modify its cucumber tests to check can_request_help is always set correctly, calculate can_request_help for the team (not for the user) when as_team_id is given.

Fixes #1172 