### PR TITLE
Fix the message about propagation in db-recompute command

### DIFF
--- a/cmd/db_recompute.go
+++ b/cmd/db_recompute.go
@@ -62,7 +62,7 @@ func recomputeDBCaches(gormDB *database.DB) error {
 		if err := store.ItemItems().CreateNewAncestors(); err != nil {
 			return fmt.Errorf("cannot compute items_items: %v", err)
 		}
-		fmt.Print("Schedule the propagations\n")
+		fmt.Print("Running propagation of permissions and results\n")
 		store.SchedulePermissionsPropagation()
 		store.ScheduleResultsPropagation()
 		return nil


### PR DESCRIPTION
Print "Running propagation of permissions and results" instead of "Schedule the propagations" in "db-recompute".

Fixes #1117 