### PR TITLE
Optimize the SQL query generated by ItemStore.GetAncestorsRequestHelpPropagatedQuery()

### DIFF
--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -442,7 +442,7 @@ func getCanRequestHelpToByOrigin(
 	allUsersGroupID int64,
 	user *database.User,
 ) map[string][]canRequestHelpTo {
-	itemAncestorsRequestHelpPropagationQuery := store.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
+	itemAncestorsRequestHelpPropagationQuery := store.Items().GetAncestorsRequestHelpPropagationQuery(itemID)
 
 	var canRequestHelpToPermissions []canRequestHelpToPermissionsRaw
 	err := ancestorPermissions.

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -263,7 +263,7 @@ func (srv *Service) getItem(rw http.ResponseWriter, httpReq *http.Request) servi
 // hasCanRequestHelpTo checks whether there is a can_request_help_to permission on an item-group.
 // The checks are made on item's ancestor while can_request_help_propagation=1, and on group's ancestors.
 func hasCanRequestHelpTo(s *database.DataStore, itemID, groupID int64) bool {
-	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
+	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagationQuery(itemID)
 
 	hasCanRequestHelpTo, err := s.Users().
 		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", groupID).

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -335,15 +335,15 @@ func (s *ItemStore) DeleteItem(itemID int64) (err error) {
 // GetAncestorsRequestHelpPropagatedQuery gets all ancestors of an itemID while request_help_propagation = 1.
 func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
 	return s.Raw(`
-		WITH RECURSIVE items_ancestors_request_help_propagation(item_id) AS
+		WITH RECURSIVE items_ancestors_request_help_propagation(id) AS
 		(
 			SELECT ?
-			UNION ALL
-			SELECT items.id FROM items
-			JOIN items_items ON items_items.parent_item_id = items.id AND	items_items.request_help_propagation = 1
-			JOIN items_ancestors_request_help_propagation ON items_ancestors_request_help_propagation.item_id = items_items.child_item_id
+			UNION
+			SELECT items_items.parent_item_id FROM items_items
+			JOIN items_ancestors_request_help_propagation ON items_ancestors_request_help_propagation.id = items_items.child_item_id
+			WHERE items_items.request_help_propagation = 1
 		)
-		SELECT item_id FROM items_ancestors_request_help_propagation
+		SELECT id FROM items_ancestors_request_help_propagation
 	`, itemID)
 }
 

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -332,8 +332,8 @@ func (s *ItemStore) DeleteItem(itemID int64) (err error) {
 	})
 }
 
-// GetAncestorsRequestHelpPropagatedQuery gets all ancestors of an itemID while request_help_propagation = 1.
-func (s *ItemStore) GetAncestorsRequestHelpPropagatedQuery(itemID int64) *DB {
+// GetAncestorsRequestHelpPropagationQuery gets all ancestors of an itemID while request_help_propagation = 1.
+func (s *ItemStore) GetAncestorsRequestHelpPropagationQuery(itemID int64) *DB {
 	return s.Raw(`
 		WITH RECURSIVE items_ancestors_request_help_propagation(id) AS
 		(

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -88,7 +88,7 @@ func (u *User) CanRequestHelpTo(s *DataStore, itemID, helperGroupID int64) bool 
 		return true
 	}
 
-	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagatedQuery(itemID)
+	itemAncestorsRequestHelpPropagationQuery := s.Items().GetAncestorsRequestHelpPropagationQuery(itemID)
 
 	canRequestHelpTo, err := s.Users().
 		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = ?", u.GroupID).


### PR DESCRIPTION
1. Get rid of `items` table joining in ItemStore.GetAncestorsRequestHelpPropagatedQuery(), use UNION instead of UNION ALL there,
2. Rename ItemStore.GetAncestorsRequestHelpPropagatedQuery() to ItemStore.GetAncestorsRequestHelpPropagationQuery()

Fixes #1140 