### PR TITLE
Get rid of the N+1 selects problem in permissionsView

### DIFF
--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -113,12 +113,13 @@ type permissionsViewResponse struct {
 }
 
 type canRequestHelpToPermissionsRaw struct {
-	Origin            string
-	SourceGroupID     int64
-	PermissionGroupID int64
-	PermissionItemID  int64
-	GroupID           int64
-	GroupName         string
+	Origin                string
+	SourceGroupID         int64
+	PermissionGroupID     int64
+	PermissionItemID      int64
+	GroupID               int64
+	GroupName             string
+	IsHelpingGroupVisible bool
 }
 
 // swagger:operation GET /groups/{source_group_id}/permissions/{group_id}/{item_id} groups permissionsView
@@ -446,6 +447,7 @@ func getCanRequestHelpToByOrigin(
 
 	var canRequestHelpToPermissions []canRequestHelpToPermissionsRaw
 	err := ancestorPermissions.
+		With("visible_groups", store.Groups().PickVisibleGroups(store.Groups().Select("id"), user)).
 		Joins("JOIN `groups` AS can_request_help_to_group ON can_request_help_to_group.id = permissions_granted.can_request_help_to").
 		Select(`
 			permissions_granted.origin AS origin,
@@ -453,7 +455,8 @@ func getCanRequestHelpToByOrigin(
 			permissions_granted.group_id AS permission_group_id,
 			permissions_granted.item_id AS permission_item_id,
 			can_request_help_to_group.id AS group_id,
-			can_request_help_to_group.name AS group_name
+			can_request_help_to_group.name AS group_name,
+			IFNULL((SELECT 1 FROM visible_groups WHERE visible_groups.id = can_request_help_to_group.id LIMIT 1), 0) AS is_helping_group_visible
 		`).
 		Where("item_id IN (?)", itemAncestorsRequestHelpPropagationQuery.SubQuery()).
 		Scan(&canRequestHelpToPermissions).
@@ -463,13 +466,11 @@ func getCanRequestHelpToByOrigin(
 	canRequestHelpToByOrigin := make(map[string][]canRequestHelpTo)
 	for _, origin := range []string{OriginGroupMembership, OriginItemUnlocking, OriginSelf, OriginOther, OriginComputed, OriginGranted} {
 		canRequestHelpToByOrigin[origin] = filterCanRequestHelpTo(
-			store,
 			canRequestHelpToPermissions,
 			origin,
 			groupID,
 			itemID,
 			sourceGroupID,
-			user.GroupID,
 			allUsersGroupID,
 		)
 	}
@@ -479,20 +480,18 @@ func getCanRequestHelpToByOrigin(
 
 // filterCanRequestHelpTo filters the canRequestHelpTo permissions to only keep the ones matching the wanted origin.
 func filterCanRequestHelpTo(
-	store *database.DataStore,
 	permissions []canRequestHelpToPermissionsRaw,
 	origin string,
 	groupID int64,
 	itemID int64,
 	sourceGroupID int64,
-	visibleGroupID int64,
 	allUsersGroupID int64,
 ) []canRequestHelpTo {
 	results := make([]canRequestHelpTo, 0)
 
 	for _, canRequestHelpToPermission := range permissions {
 		if canRequestHelpToShouldBeAdded(canRequestHelpToPermission, origin, groupID, itemID, sourceGroupID) {
-			results = append(results, canRequestHelpToForUser(canRequestHelpToPermission, store, visibleGroupID, allUsersGroupID))
+			results = append(results, canRequestHelpToForUser(canRequestHelpToPermission, allUsersGroupID))
 		}
 	}
 
@@ -535,8 +534,6 @@ func canRequestHelpToShouldBeAdded(
 // canRequestHelpToForUser converts a canRequestHelpToPermissionsRaw to a canRequestHelpTo returned to the user.
 func canRequestHelpToForUser(
 	permission canRequestHelpToPermissionsRaw,
-	store *database.DataStore,
-	visibleGroupID int64,
 	allUsersGroupID int64,
 ) canRequestHelpTo {
 	curCanRequestHelpTo := canRequestHelpTo{
@@ -546,7 +543,7 @@ func canRequestHelpToForUser(
 	if allUsersGroupID == permission.GroupID {
 		curCanRequestHelpTo.IsAllUsersGroup = true
 		curCanRequestHelpTo.Name = &permission.GroupName
-	} else if store.Groups().IsVisibleForGroup(permission.GroupID, visibleGroupID) {
+	} else if permission.IsHelpingGroupVisible {
 		curCanRequestHelpTo.Name = &permission.GroupName
 	}
 

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -212,8 +212,6 @@ func (s *GroupStore) IsVisibleForGroup(groupID, visibleForGroupID int64) bool {
 
 	isVisible, err := s.PickVisibleGroupsForGroup(s.Groups().DB, visibleForGroupID).
 		Where("groups.id = ?", groupID).
-		Select("1").
-		Limit(1).
 		HasRows()
 	mustNotBeError(err)
 


### PR DESCRIPTION
Instead of querying if a helping group is visible for each row, we can get this information right in the main query of getCanRequestHelpToByOrigin().

Fixes #1141 