### PR TITLE
Rework itemPathFromRootFind & itemBreadcrumbsFromRootsGet: Prefer paths having attempts for final items + require items visibility correctly

### DIFF
--- a/app/api/items/create_attempt.go
+++ b/app/api/items/create_attempt.go
@@ -32,7 +32,7 @@ import (
 //		* the participant should have a started, allowing submission, not ended result for each item but the last,
 //			with `{parent_attempt_id}` (or its parent attempt each time we reach a root of an attempt) as the attempt,
 //		* if `{ids}` consists of only one item, the `{parent_attempt_id}` should be zero,
-//		* the last item in `{ids}` should be either 'Task', or 'Chapter',
+//		* the final item in `{ids}` should be either 'Task', or 'Chapter',
 //
 //		otherwise the 'forbidden' error is returned.
 //

--- a/app/api/items/create_attempt.robustness.feature
+++ b/app/api/items/create_attempt.robustness.feature
@@ -109,7 +109,7 @@ Feature: Create an attempt for an item - robustness
     And the response error message should contain "The item doesn't allow multiple attempts"
     And the table "attempts" should stay unchanged
 
-  Scenario: Not enough permissions for the last item in the path
+  Scenario: Not enough permissions for the final item in the path
     Given I am the user with id "101"
     And the database table "permissions_generated" also has the following row:
       | group_id | item_id | can_view_generated |

--- a/app/api/items/enter.go
+++ b/app/api/items/enter.go
@@ -21,17 +21,17 @@ import (
 //
 //
 //							 Restrictions:
-//								 * the last item in `{ids}` should require explicit entry;
+//								 * the final item in `{ids}` should require explicit entry;
 //								 * `as_team_id` (if given) should be the current user's team;
 //								 * the first item in `{ids}` should be a root activity/skill (groups.root_activity_id/root_skill_id)
 //									 of a group the participant is a descendant of or manages;
 //								 * `{ids}` should be an ordered list of parent-child items;
 //								 * the group (the user or his team) should have at least 'content' access
-//									 on each of the items in `{ids}` except the last one and at least 'info' access for the last one;
+//									 on each of the items in `{ids}` except the final one and at least 'info' access for the final one;
 //								 * the group should have a started, allowing submission, not ended result for each item but the last,
 //									 with `{parent_attempt_id}` (or its parent attempt each time we reach a root of an attempt) as the attempt;
 //								 * if `{ids}` consists of only one item, the `{parent_attempt_id}` should be zero;
-//								 * the group (the user or his team) must be qualified for the last item in `{ids}` (itemGetEntryState returns "ready").
+//								 * the group (the user or his team) must be qualified for the final item in `{ids}` (itemGetEntryState returns "ready").
 //
 //							 Otherwise, the "Forbidden" response is returned.
 //	parameters:

--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -26,10 +26,10 @@ import (
 //		* the list of item IDs should be a valid path from a root item
 //		 (`items.id`=`groups.root_activity_id|root_skill_id` for one of the participant's ancestor groups or managed groups),
 //		* `as_team_id` (if given) should be the current user's team,
-//		* the participant should have at least 'content' access on each listed item except the last one through that path,
-//			and at least 'info' access on the last item,
+//		* the participant should have at least 'content' access on each listed item except the final one through that path,
+//			and at least 'info' access on the final item,
 //		* all the results within the ancestry of `attempt_id`/`parent_attempt_id` on the items' path
-//			(except for the last item if `parent_attempt_id` is given) should be started (`started_at` is not null),
+//			(except for the final item if `parent_attempt_id` is given) should be started (`started_at` is not null),
 //
 //		otherwise the 'forbidden' error is returned.
 //	parameters:
@@ -39,13 +39,13 @@ import (
 //			description: slash-separated list of IDs
 //			required: true
 //		- name: parent_attempt_id
-//			description: "`id` of an attempt for the second to the last item in the path.
+//			description: "`id` of an attempt for the second to the final item in the path.
 //								This parameter is incompatible with `attempt_id`."
 //			in: query
 //			type: integer
 //			format: int64
 //		- name: attempt_id
-//			description: "`id` of an attempt for the last item in the path.
+//			description: "`id` of an attempt for the final item in the path.
 //								This parameter is incompatible with `parent_attempt_id`."
 //			in: query
 //			type: integer
@@ -75,14 +75,14 @@ import (
 //							type: string
 //						attempt_id:
 //							description: the attempt for this item (result) within ancestry of `attempt_id` or `parent_attempt_id`
-//				 	                 (skipped for the last item if `parent_attempt_id` is used)
+//				 	                 (skipped for the final item if `parent_attempt_id` is used)
 //							type: string
 //							format: int64
 //						attempt_number:
 //							description: the order of this attempt result among the other results (within the parent attempt)
 //													 sorted by `started_at`
 //													 (only for items allowing multiple submissions;
-//													 skipped for the last item if `parent_attempt_id` is used)
+//													 skipped for the final item if `parent_attempt_id` is used)
 //							type: string
 //							format: int64
 //					required: [item_id, type, title, language_tag]

--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -61,15 +61,16 @@ Feature: Find all breadcrumbs to an item
       | 100              | 101           |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
+      | 90       | 60      | content                  |
+      | 102      | 10      | content_with_descendants |
       | 102      | 60      | none                     |
+      | 102      | 70      | info                     |
+      | 102      | 100     | content                  |
+      | 102      | 101     | content                  |
       | 111      | 10      | content_with_descendants |
-      | 111      | 60      | content                  |
-      | 111      | 70      | info                     |
       | 111      | 50      | content_with_descendants |
       | 111      | 80      | content                  |
       | 111      | 90      | info                     |
-      | 111      | 100     | content                  |
-      | 111      | 101     | content                  |
     And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |

--- a/app/api/items/get_breadcrumbs_from_roots.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.feature
@@ -101,13 +101,13 @@ Feature: Find all breadcrumbs to an item
       <expected_output>
       """
   Examples:
-    | service_url                                                                                                   | expected_output                                                                                                                                                                                                                                                                                                       |
-    | /items/50/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                                      |
-    | /items/by-text-id/-_%20%27%23%26%3F%3A%3D%2F%5C.%2C%2B%25%C2%A4%E2%82%ACa%C3%A9%C3%A0d/breadcrumbs-from-roots | [{"started_by_participant": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                                      |
-    | /items/10/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                                      |
-    | /items/by-text-id/id10/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                                      |
-    | /items/90/breadcrumbs-from-roots                                                                              | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
-    | /items/by-text-id/id90/breadcrumbs-from-roots                                                                 | [{"started_by_participant": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"started_by_participant": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
+    | service_url                                                                                                   | expected_output                                                                                                                                                                                                                                                                               |
+    | /items/50/breadcrumbs-from-roots                                                                              | [{"is_started": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                          |
+    | /items/by-text-id/-_%20%27%23%26%3F%3A%3D%2F%5C.%2C%2B%25%C2%A4%E2%82%ACa%C3%A9%C3%A0d/breadcrumbs-from-roots | [{"is_started": true, "path": [{"id": "50", "title": "DFS", "language_tag": "en", "type": "Task"}]}]                                                                                                                                                                                          |
+    | /items/10/breadcrumbs-from-roots                                                                              | [{"is_started": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                          |
+    | /items/by-text-id/id10/breadcrumbs-from-roots                                                                 | [{"is_started": true, "path": [{"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"}]}]                                                                                                                                                                          |
+    | /items/90/breadcrumbs-from-roots                                                                              | [{"is_started": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"is_started": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
+    | /items/by-text-id/id90/breadcrumbs-from-roots                                                                 | [{"is_started": true, "path": [{"id": "80", "title": "Trees", "language_tag": "en", "type": "Chapter"}, {"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}, {"is_started": true, "path": [{"id": "90", "title": "Queues", "language_tag": "en", "type": "Chapter"}]}] |
 
   Scenario: Should return a breadcrumb when there are missing results, like path-from-root
     Given the database has the following user:
@@ -164,7 +164,7 @@ Feature: Find all breadcrumbs to an item
       """
       [
         {
-          "started_by_participant": false,
+          "is_started": false,
           "path": [
             {"id": "1010", "title": "Chapter 1", "language_tag": "en", "type": "Chapter"},
             {"id": "1011", "title": "Chapter 2", "language_tag": "en", "type": "Chapter"},
@@ -183,14 +183,14 @@ Feature: Find all breadcrumbs to an item
       """
       [
         {
-          "started_by_participant": true,
+          "is_started": true,
           "path": [
             {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
             {"id": "70","title": null, "language_tag": "fr", "type": "Task"}
           ]
         },
         {
-          "started_by_participant": true,
+          "is_started": true,
           "path": [
             {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
             {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"},
@@ -212,13 +212,13 @@ Feature: Find all breadcrumbs to an item
       """
       [
         {
-          "started_by_participant": true,
+          "is_started": true,
           "path": [
             {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}
           ]
         },
         {
-          "started_by_participant": true,
+          "is_started": true,
           "path": [
             {"id": "10", "title": "Graphe: Methodes", "language_tag": "fr", "type": "Chapter"},
             {"id": "60", "title": "Reduce Graph", "language_tag": "en", "type": "Task"}
@@ -239,7 +239,7 @@ Feature: Find all breadcrumbs to an item
       """
       [
         {
-          "started_by_participant": false,
+          "is_started": false,
           "path": [
             {"id": "100", "title": "Chapter Containing Explicit Entry Not Started", "language_tag": "en", "type": "Chapter"},
             {"id": "101", "title": "Explicit Entry Not Started", "language_tag": "en", "type": "Task"}

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -177,7 +177,7 @@ func (srv *Service) getBreadcrumbsFromRoots(w http.ResponseWriter, r *http.Reque
 }
 
 func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *database.User, itemID int64) []breadcrumbPath {
-	itemPaths := FindItemPaths(store, participantID, itemID, 0)
+	itemPaths := findItemPaths(store, participantID, itemID, 0)
 	if len(itemPaths) == 0 {
 		return nil
 	}

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -50,7 +50,7 @@ type breadcrumbElement struct {
 //
 //
 //		Paths can contain only items visible to the participant
-//		(`can_view`>='content' on every item on the path but the last one and `can_view`>='info' for the last one).
+//		(`can_view`>='content' on every item on the path but the final one and `can_view`>='info' for the final one).
 //		The item info (`title` and `language_tag`) in the paths is in the current user's language,
 //		or the item's default language (if not available).
 //

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -48,7 +48,7 @@ type breadcrumbElement struct {
 //		The participant is `participant_id` (if given) or the current user (otherwise).
 //
 //
-//		Paths can contain only items visible to the current user
+//		Paths can contain only items visible to the participant
 //		(`can_view`>='content' on every item on the path but the last one and `can_view`>='info' for the last one).
 //		The item info (`title` and `language_tag`) in the paths is in the current user's language,
 //		or the item's default language (if not available).

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -43,15 +43,29 @@ type breadcrumbElement struct {
 //	summary: List all possible breadcrumbs for an item using `item_id`
 //	description: >
 //		Lists all paths from a root (`root_activity_id`|`root_skill_id` of groups the participant is descendant of or manages)
-//		to the given item that the participant may have used to access this item,
-//		so path for which the participant has a started attempt (possibly ended/not-allowing-submissions) on every item.
+//		to the given item that the participant may have used to access this item.
 //
+//
+//		Each path consists only of the items visible to both the participant and the current user
+//		(`can_view`>='content' for all the items except for the final one and `can_view`>='info' for the final one).
+//		The chain of attempts in the path cannot have missing results for non-final items that require explicit entry.
+//		It also cannot have not-started results within or below ended or non-submission-allowing attempts for non-final items.
+//
+//
+//		Note that paths may contain items without results for final items or non-final items not requiring explicit entry.
+//		Also, paths may contain not-started results for final items even within or below ended or non-submission-allowing attempts.
+//		It is even possible that the final item has no linked attempt at all while the final item requires explicit entry.
+//
+//
+//		The service sorts the paths in the following order:
+//			* Paths with an attempt linked to the final item come first.
+//			* Paths where missing or not-started results are closer to the end of the path are prioritized.
+//			* Paths with fewer missing or not-started results are preferred.
+//			* Paths with higher `attempt_id` values are ranked higher.
 //
 //		The participant is `participant_id` (if given) or the current user (otherwise).
 //
 //
-//		Paths can contain only items visible to both the participant and the current user
-//		(`can_view`>='content' on every item on the path but the final one and `can_view`>='info' for the final one).
 //		The item info (`title` and `language_tag`) in the paths is in the current user's language,
 //		or the item's default language (if not available).
 //

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -17,9 +17,10 @@ import (
 type breadcrumbPath struct {
 	// required: true
 	Path []breadcrumbElement `json:"path"`
-	// Whether the path is already started by the participant.
+	// Whether the path is already started by the participant
+	// (true when the participant has at least one result with `started_at` set for each item in the path).
 	// required: true
-	StartedByParticipant bool `json:"started_by_participant"`
+	IsStarted bool `json:"is_started"`
 }
 
 // swagger:model breadcrumbElement
@@ -192,8 +193,8 @@ func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *d
 			breadcrumb = append(breadcrumb, breadcrumbElement{ID: idInt64})
 		}
 		breadcrumbs = append(breadcrumbs, breadcrumbPath{
-			StartedByParticipant: itemPath.IsStarted,
-			Path:                 breadcrumb,
+			IsStarted: itemPath.IsStarted,
+			Path:      breadcrumb,
 		})
 	}
 

--- a/app/api/items/get_breadcrumbs_from_roots.go
+++ b/app/api/items/get_breadcrumbs_from_roots.go
@@ -177,7 +177,7 @@ func (srv *Service) getBreadcrumbsFromRoots(w http.ResponseWriter, r *http.Reque
 }
 
 func findItemBreadcrumbs(store *database.DataStore, participantID int64, user *database.User, itemID int64) []breadcrumbPath {
-	itemPaths := FindItemPaths(store, user, participantID, itemID, PathRootUser, 0)
+	itemPaths := FindItemPaths(store, participantID, itemID, 0)
 	if len(itemPaths) == 0 {
 		return nil
 	}

--- a/app/api/items/get_breadcrumbs_from_roots.robustness.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.robustness.feature
@@ -41,9 +41,9 @@ Feature: Find all breadcrumbs to an item - robustness
       | 60               | 70            |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
-      | 102      | 60      | info               |
+      | 102      | 60      | none               |
       | 111      | 10      | info               |
-      | 111      | 60      | none               |
+      | 111      | 60      | info               |
       | 111      | 70      | none               |
     And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |

--- a/app/api/items/get_breadcrumbs_from_roots.robustness.feature
+++ b/app/api/items/get_breadcrumbs_from_roots.robustness.feature
@@ -41,10 +41,7 @@ Feature: Find all breadcrumbs to an item - robustness
       | 60               | 70            |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
-      | 102      | 60      | none               |
       | 111      | 10      | info               |
-      | 111      | 60      | info               |
-      | 111      | 70      | none               |
     And the database has the following table "attempts":
       | id | participant_id | root_item_id | parent_attempt_id |
       | 0  | 101            | null         | null              |
@@ -88,6 +85,9 @@ Feature: Find all breadcrumbs to an item - robustness
 
   Scenario Outline: No access to participant_id
     Given I am the user with id "111"
+    And the database table "permissions_generated" also has the following row:
+      | group_id | item_id | can_view_generated |
+      | 111      | 60      | info               |
     When I send a GET request to "<service_url>?participant_id=<participant_id>"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
@@ -100,6 +100,9 @@ Feature: Find all breadcrumbs to an item - robustness
 
   Scenario Outline: No paths
     Given I am the user with id "111"
+    And the database table "permissions_generated" also has the following row:
+      | group_id | item_id | can_view_generated |
+      | 111      | 60      | info               |
     When I send a GET request to "<service_url>?participant_id=102"
     Then the response code should be 403
     And the response error message should contain "Insufficient access rights"
@@ -109,3 +112,18 @@ Feature: Find all breadcrumbs to an item - robustness
     | /items/by-text-id/id70/breadcrumbs-from-roots |
     | /items/60/breadcrumbs-from-roots              |
     | /items/by-text-id/id60/breadcrumbs-from-roots |
+
+  Scenario Outline: Paths are not visible to the current user (info of the final item is not visible)
+    Given I am the user with id "111"
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated |
+      | 102      | 10      | content            |
+      | 102      | 60      | content            |
+      | 111      | 60      | none               |
+    When I send a GET request to "<service_url>?participant_id=102"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+    Examples:
+      | service_url                                   |
+      | /items/60/breadcrumbs-from-roots              |
+      | /items/by-text-id/id60/breadcrumbs-from-roots |

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -108,10 +108,6 @@ func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) serv
 	return service.NoError
 }
 
-// PathRootType is used for FindItemPaths.
-// It allows finding the roots either by participant, or by user.
-type PathRootType int
-
 // FindItemPaths gets the paths from root items to the given item for the given participant.
 //
 // When {limit}=0, return all the paths.

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -35,6 +35,8 @@ type rawItemPath struct {
 //
 //		The path consists only of the items visible to the participant
 //		(`can_view`>='content' for all the items except for the last one and `can_view`>='info' for the last one).
+//		The chain of attempts in the path cannot have missing results for non-final items that require explicit entry.
+//		It also cannot have not-started results within or below ended or non-submission-allowing attempts for non-final items.
 //
 //		Of all possible paths, the service chooses the one having:
 //			* an attempt linked to the last item if such a path exists,
@@ -42,24 +44,15 @@ type rawItemPath struct {
 //			* preferring paths having less missing/not-started results,
 //			* and having higher values of `attempt_id`.
 //
-//		For a path to be returned, each of its items must:
-//			* Either have `requires_explicit_entry`=0 ,
-//			* Or if it has `requires_explicit_entry=1`,
-//				then the following condition must be fulfilled, except if it is the last item of the path:
-//				the item must have at least one result with `started`=1 AND its attempt must have
-//					(`attempt.ended_at` IS NULL) AND (`NOW()` < `attempt.allows_submissions_until`).
-//				In other words, we only return a path to an item requiring explicit entry if the participant
-//				has started solving it, and it is still open.
-//
 //		If `as_team_id` is given, the attempts/results of the path are linked to the `as_team_id` group instead of
-//		the current user group.
+//		the current user's self group, the participant becomes the given team group.
 //
 //		Restrictions:
 //
 //			* if `as_team_id` is given, it should be a user's parent team group,
 //			* at least one path should exist,
 //
-//			Otherwise the 'forbidden' error is returned.
+//			otherwise, the 'forbidden' error is returned.
 //	parameters:
 //		- name: item_id
 //			in: path

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -38,6 +38,12 @@ type rawItemPath struct {
 //		The chain of attempts in the path cannot have missing results for non-final items that require explicit entry.
 //		It also cannot have not-started results within or below ended or non-submission-allowing attempts for non-final items.
 //
+//
+//		Note that the path may contain items without results for its final item or non-final items not requiring explicit entry.
+//		Also, the path may contain not-started results for its final item even within or below ended or non-submission-allowing attempts.
+//		It is even possible that the final item has no linked attempt at all while the final item requires explicit entry.
+//
+//
 //		Of all possible paths, the service chooses the one having:
 //			* an attempt linked to the final item if such a path exists,
 //			* missing/not-started results located closer to the end of the path,

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -102,7 +102,7 @@ func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) serv
 
 	participantID := service.ParticipantIDFromContext(r.Context())
 
-	itemPaths := FindItemPaths(srv.GetStore(r), participantID, itemID, 1)
+	itemPaths := findItemPaths(srv.GetStore(r), participantID, itemID, 1)
 	if itemPaths == nil {
 		return service.InsufficientAccessRightsError
 	}
@@ -110,10 +110,10 @@ func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) serv
 	return service.NoError
 }
 
-// FindItemPaths gets the paths from root items to the given item for the given participant.
+// findItemPaths gets the paths from root items to the given item for the given participant.
 //
 // When {limit}=0, return all the paths.
-func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit int) []ItemPath {
+func findItemPaths(store *database.DataStore, participantID, itemID int64, limit int) []ItemPath {
 	var limitStatement string
 	if limit > 0 {
 		limitStatement = " LIMIT " + strconv.Itoa(limit)

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -36,6 +36,7 @@ type rawItemPath struct {
 //		(`can_view`>='content' for all the items except for the last one and `can_view`>='info' for the last one).
 //
 //		Of all possible paths, the service chooses the one having:
+//			* an attempt linked to the last item if such a path exists,
 //			* missing/not-started results located closer to the end of the path,
 //			* preferring paths having less missing/not-started results,
 //			* and having higher values of `attempt_id`.
@@ -197,7 +198,7 @@ func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit
 		SELECT path, is_started
 		FROM paths
 		WHERE paths.last_item_id = ?
-		ORDER BY score, attempts DESC
+		ORDER BY last_attempt_id IS NULL, score, attempts DESC
 		`+limitStatement,
 		groupsWithRootItems.SubQuery(), visibleItems.SubQuery(), itemID, itemID, participantID, itemID, canViewContentIndex,
 		participantID, itemID, itemID, canViewContentIndex, itemID).

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -34,12 +34,12 @@ type rawItemPath struct {
 //		Finds a path from any of root items to a given item.
 //
 //		The path consists only of the items visible to the participant
-//		(`can_view`>='content' for all the items except for the last one and `can_view`>='info' for the last one).
+//		(`can_view`>='content' for all the items except for the final one and `can_view`>='info' for the final one).
 //		The chain of attempts in the path cannot have missing results for non-final items that require explicit entry.
 //		It also cannot have not-started results within or below ended or non-submission-allowing attempts for non-final items.
 //
 //		Of all possible paths, the service chooses the one having:
-//			* an attempt linked to the last item if such a path exists,
+//			* an attempt linked to the final item if such a path exists,
 //			* missing/not-started results located closer to the end of the path,
 //			* preferring paths having less missing/not-started results,
 //			* and having higher values of `attempt_id`.

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -140,106 +140,72 @@ func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit
 	canViewContentIndex := store.PermissionsGranted().ViewIndexByName("content")
 
 	var rawItemPaths []rawItemPath
-	service.MustNotBeError(store.Raw(
-		`
-			WITH RECURSIVE
+	service.MustNotBeError(store.Raw(`
+		WITH RECURSIVE paths (path, last_item_id, last_attempt_id, score, attempts, is_started, is_active) AS (
+			WITH
 				groups_with_root_items AS ?,
 				visible_items AS ?,
 				root_items AS (
-					(SELECT visible_items.id AS id
-						 FROM groups_with_root_items
-									JOIN visible_items
-									ON (visible_items.id = root_activity_id OR visible_items.id = root_skill_id))
+					SELECT visible_items.id AS id FROM groups_with_root_items JOIN visible_items ON visible_items.id = root_activity_id
+					UNION
+					SELECT visible_items.id FROM groups_with_root_items JOIN visible_items ON visible_items.id = root_skill_id
 				),
 				item_ancestors AS (
-					(SELECT visible_items.id, requires_explicit_entry, can_view_generated_value
-						 FROM items_ancestors
-									JOIN visible_items ON visible_items.id = items_ancestors.ancestor_item_id
-						WHERE child_item_id = ?)
+					SELECT visible_items.id, requires_explicit_entry, can_view_generated_value
+					FROM items_ancestors
+					JOIN visible_items ON visible_items.id = items_ancestors.ancestor_item_id
+					WHERE child_item_id = ?
 					UNION
-					(SELECT id,	requires_explicit_entry, can_view_generated_value
-						 FROM visible_items
-						WHERE id = ?)
+					SELECT id, requires_explicit_entry, can_view_generated_value FROM visible_items WHERE id = ?
 				),
 				root_ancestors AS (
-					(SELECT item_ancestors.id, requires_explicit_entry, can_view_generated_value
-						 FROM item_ancestors
-									JOIN root_items ON root_items.id = item_ancestors.id)
-				),
-				paths (path, last_item_id, last_attempt_id, score, attempts, is_started, is_active) AS (
-					(SELECT CAST(root_ancestors.id AS CHAR(1024)),
-								  root_ancestors.id,
-							 	  attempts.id,
-								  results.started_at IS NULL,
-								  CAST(LPAD(attempts.id, 20, 0) AS CHAR(1024)),
-								  results.started_at IS NOT NULL,
-								  attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
-						 FROM root_ancestors
-								  LEFT JOIN attempts
-									ON attempts.participant_id = ?
-									   AND (NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
-								  LEFT JOIN results
-									ON results.participant_id = attempts.participant_id
-									   AND attempts.id = results.attempt_id
-										 AND results.item_id = root_ancestors.id
-						WHERE root_ancestors.id = ?
-					     OR (
-										attempts.id IS NOT NULL
-								AND	root_ancestors.can_view_generated_value >= ?
-						  	AND (NOT root_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
-						  	AND (results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until)
-						  	AND (results.attempt_id IS NOT NULL OR attempts.id = 0)
-							 )
-					)
-				 	UNION
-				 	(SELECT CONCAT(paths.path, '/', item_ancestors.id),
-								  item_ancestors.id,
-								  attempts.id,
-								  (paths.score << 1) + (results.started_at IS NULL),
-								  CONCAT(paths.attempts, '/', LPAD(attempts.id, 20, 0)),
-								  paths.is_started AND results.started_at IS NOT NULL,
-								  paths.is_active AND attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
-						 FROM paths
-								  JOIN items_items ON items_items.parent_item_id = paths.last_item_id
-								  JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
-								  LEFT JOIN attempts
-									ON attempts.participant_id = ?
-									   AND (NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id)
-									   AND IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.last_attempt_id
-								  LEFT JOIN results
-									ON results.participant_id = attempts.participant_id
-									   AND attempts.id = results.attempt_id
-										 AND results.item_id = item_ancestors.id
-					 	WHERE paths.last_item_id <> ?
-						 AND (
-									item_ancestors.id = ?
-									OR (
-											 item_ancestors.can_view_generated_value >= ?
-									 AND (NOT item_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL)
-									 AND (   results.started_at IS NOT NULL
-												OR (attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until AND paths.is_active)
-									 )
-									)
-						 )
-				  )
+					SELECT item_ancestors.id, requires_explicit_entry, can_view_generated_value
+					FROM item_ancestors
+					JOIN root_items ON root_items.id = item_ancestors.id
 				)
-			SELECT path, is_started FROM paths
-			 WHERE paths.last_item_id = ?
-			 ORDER BY score, attempts DESC
-			 `+limitStatement,
-		groupsWithRootItems.SubQuery(),
-		visibleItems.SubQuery(),
-		itemID,
-		itemID,
-		participantID,
-		itemID,
-		canViewContentIndex,
-		participantID,
-		itemID,
-		itemID,
-		canViewContentIndex,
-		itemID,
-	).
+			(SELECT CAST(root_ancestors.id AS CHAR(1024)), root_ancestors.id, attempts.id, results.started_at IS NULL,
+			        CAST(LPAD(attempts.id, 20, 0) AS CHAR(1024)), results.started_at IS NOT NULL,
+			        attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
+			FROM root_ancestors
+			LEFT JOIN attempts ON attempts.participant_id = ? AND
+				(NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
+			LEFT JOIN results ON results.participant_id = attempts.participant_id AND
+				attempts.id = results.attempt_id AND results.item_id = root_ancestors.id
+			WHERE root_ancestors.id = ? OR (
+				attempts.id IS NOT NULL AND
+				root_ancestors.can_view_generated_value >= ? AND
+				(NOT root_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL) AND
+				(results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until) AND
+				(results.attempt_id IS NOT NULL OR attempts.id = 0)
+			))
+			UNION
+			(SELECT CONCAT(paths.path, '/', item_ancestors.id), item_ancestors.id, attempts.id, (paths.score << 1) + (results.started_at IS NULL),
+			        CONCAT(paths.attempts, '/', LPAD(attempts.id, 20, 0)),
+			        paths.is_started AND results.started_at IS NOT NULL,
+			        paths.is_active AND attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
+			FROM paths
+			JOIN items_items ON items_items.parent_item_id = paths.last_item_id
+			JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
+			LEFT JOIN attempts ON attempts.participant_id = ? AND
+				(NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id) AND
+				IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.last_attempt_id
+			LEFT JOIN results ON results.participant_id = attempts.participant_id AND
+				attempts.id = results.attempt_id AND results.item_id = item_ancestors.id
+			WHERE paths.last_item_id <> ? AND (
+				item_ancestors.id = ? OR (
+					item_ancestors.can_view_generated_value >= ? AND
+					(NOT item_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL) AND
+					(results.started_at IS NOT NULL OR (attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until AND paths.is_active))
+				)
+			)
+		))
+		SELECT path, is_started
+		FROM paths
+		WHERE paths.last_item_id = ?
+		ORDER BY score, attempts DESC
+		`+limitStatement,
+		groupsWithRootItems.SubQuery(), visibleItems.SubQuery(), itemID, itemID, participantID, itemID, canViewContentIndex,
+		participantID, itemID, itemID, canViewContentIndex, itemID).
 		Scan(&rawItemPaths).Error())
 
 	if len(rawItemPaths) == 0 {

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -112,7 +112,7 @@ func (srv *Service) getPathFromRoot(w http.ResponseWriter, r *http.Request) serv
 //
 // When {limit}=0, return all the paths.
 func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit int) []ItemPath {
-	limitStatement := ""
+	var limitStatement string
 	if limit > 0 {
 		limitStatement = " LIMIT " + strconv.Itoa(limit)
 	}

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -168,7 +168,6 @@ func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit
 			LEFT JOIN results ON results.participant_id = attempts.participant_id AND
 				attempts.id = results.attempt_id AND results.item_id = root_ancestors.id
 			WHERE root_ancestors.id = ? OR (
-				attempts.id IS NOT NULL AND
 				root_ancestors.can_view_generated_value >= ? AND
 				(NOT root_ancestors.requires_explicit_entry OR results.attempt_id IS NOT NULL) AND
 				(results.started_at IS NOT NULL OR attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until) AND

--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -160,7 +160,7 @@ func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit
 					JOIN root_items ON root_items.id = item_ancestors.id
 				)
 			(SELECT CAST(root_ancestors.id AS CHAR(1024)), root_ancestors.id, attempts.id, results.started_at IS NULL,
-			        CAST(LPAD(attempts.id, 20, 0) AS CHAR(1024)), results.started_at IS NOT NULL,
+			        CAST(LPAD(IFNULL(attempts.id, '!'), 20, 0) AS CHAR(1024)), results.started_at IS NOT NULL,
 			        attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
 			FROM root_ancestors
 			LEFT JOIN attempts ON attempts.participant_id = ? AND
@@ -176,7 +176,7 @@ func FindItemPaths(store *database.DataStore, participantID, itemID int64, limit
 			))
 			UNION
 			(SELECT CONCAT(paths.path, '/', item_ancestors.id), item_ancestors.id, attempts.id, (paths.score << 1) + (results.started_at IS NULL),
-			        CONCAT(paths.attempts, '/', LPAD(attempts.id, 20, 0)),
+			        CONCAT(paths.attempts, '/', LPAD(IFNULL(attempts.id, '!'), 20, 0)),
 			        paths.is_started AND results.started_at IS NOT NULL,
 			        paths.is_active AND attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
 			FROM paths

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -328,6 +328,32 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "21", "22"}, IsStarted: false}},
 		},
 		{
+			name: "prefers the path having an attempt for the last item",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 1}
+					- {parent_item_id: 21, child_item_id: 22, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 2, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 101, id: 1}
+					- {participant_id: 101, id: 3, parent_attempt_id: 1, root_item_id: 22}
+					- {participant_id: 101, id: 4, parent_attempt_id: 1, root_item_id: 21}
+				results:
+					- {participant_id: 101, attempt_id: 1, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 3, item_id: 22}
+					- {participant_id: 101, attempt_id: 4, item_id: 21, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
+		},
+		{
 			name: "get paths whose attempt chains have missing results for last item requiring explicit entry",
 			fixture: `
 				permissions_generated:

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -171,7 +171,6 @@ func Test_FindItemPaths(t *testing.T) {
 					- {group_id: 100, item_id: 1, can_view_generated: content}
 					- {group_id: 100, item_id: 2, can_view_generated: content}
 					- {group_id: 100, item_id: 22, can_view_generated: content}
-					- {group_id: 100, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 100, id: 1, parent_attempt_id: 0, root_item_id: 22}
 					- {participant_id: 100, id: 2, parent_attempt_id: 1, root_item_id: 22}
@@ -185,8 +184,8 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 100, attempt_id: 3, item_id: 22}
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 			`,
-			args: args{participantID: 100, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
+			args: args{participantID: 100, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
 			name: "supports paths starting with an item requiring explicit entry",
@@ -194,15 +193,14 @@ func Test_FindItemPaths(t *testing.T) {
 				groups: [{id: 103, root_activity_id: 22}]
 				permissions_generated:
 					- {group_id: 103, item_id: 22, can_view_generated: content}
-					- {group_id: 103, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 103, id: 0}
 					- {participant_id: 103, id: 1, parent_attempt_id: 0, root_item_id: 22}
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 22}
 			`,
-			args: args{participantID: 103, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"22", "23"}, IsStarted: false}},
+			args: args{participantID: 103, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"22"}, IsStarted: false}},
 		},
 		{
 			name: "can find a path without a result for the first item",
@@ -231,7 +229,6 @@ func Test_FindItemPaths(t *testing.T) {
 					- {group_id: 101, item_id: 2, can_view_generated: content}
 					- {group_id: 101, item_id: 21, can_view_generated: content}
 					- {group_id: 101, item_id: 22, can_view_generated: content}
-					- {group_id: 101, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1}
 					- {participant_id: 101, id: 2}
@@ -251,8 +248,8 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22"}, IsStarted: true}},
 		},
 		{
 			name: "prefers the path for the attempt chain with the highest score",
@@ -267,7 +264,6 @@ func Test_FindItemPaths(t *testing.T) {
 					- {group_id: 101, item_id: 2, can_view_generated: content}
 					- {group_id: 101, item_id: 21, can_view_generated: content}
 					- {group_id: 101, item_id: 22, can_view_generated: content}
-					- {group_id: 101, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1}
 					- {participant_id: 101, id: 2}
@@ -286,8 +282,8 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: true}},
 		},
 		{
 			name: "prefers the path for the last (by id) attempt chain among all chains with started results for the same items",
@@ -350,6 +346,10 @@ func Test_FindItemPaths(t *testing.T) {
 		{
 			name: "ignores paths whose attempt chains have missing results for items requiring explicit entry for a non-last item",
 			fixture: `
+				items:
+					- {id: 23, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 23, child_order: 1}
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: content}
@@ -385,10 +385,15 @@ func Test_FindItemPaths(t *testing.T) {
 		{
 			name: "ignores paths whose attempt chains have not started results below an attempt not allowing submissions for non-last item",
 			fixture: `
+				items:
+					- {id: 23, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 23, child_order: 1}
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: content}
 					- {group_id: 200, item_id: 22, can_view_generated: content}
+					- {group_id: 200, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1, allows_submissions_until: 2019-05-30 11:00:00}
 					- {participant_id: 101, id: 2, root_item_id: 22, parent_attempt_id: 1}
@@ -420,10 +425,15 @@ func Test_FindItemPaths(t *testing.T) {
 		{
 			name: "ignores paths whose attempt chains have not started results below an ended attempt for non-last item",
 			fixture: `
+				items:
+					- {id: 23, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 23, child_order: 1}
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: content}
 					- {group_id: 200, item_id: 22, can_view_generated: content}
+					- {group_id: 200, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1, ended_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, id: 2, root_item_id: 22, parent_attempt_id: 1}
@@ -441,7 +451,6 @@ func Test_FindItemPaths(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: content}
 					- {group_id: 200, item_id: 22, can_view_generated: content}
-					- {group_id: 200, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1, ended_at: 2019-05-30 11:00:00, allows_submissions_until: 2019-05-30 11:00:00}
 					- {participant_id: 101, id: 2, root_item_id: 22, parent_attempt_id: 1}
@@ -450,8 +459,8 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: true}},
 		},
 		{
 			name: "get paths whose attempt chains have not started results for an attempt not allowing submissions for the last item",
@@ -572,13 +581,11 @@ func Test_FindItemPaths(t *testing.T) {
 			- {id: 3, default_language_tag: fr}
 			- {id: 4, default_language_tag: fr}
 			- {id: 22, default_language_tag: fr, requires_explicit_entry: true}
-			- {id: 23, default_language_tag: fr}
 		items_items:
 			- {parent_item_id: 1, child_item_id: 2, child_order: 1}
 			- {parent_item_id: 2, child_item_id: 3, child_order: 1}
 			- {parent_item_id: 2, child_item_id: 22, child_order: 2}
 			- {parent_item_id: 3, child_item_id: 4, child_order: 1}
-			- {parent_item_id: 22, child_item_id: 23, child_order: 1}
 		attempts:
 			- {participant_id: 100, id: 0}
 			- {participant_id: 101, id: 0}

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -327,7 +327,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "21", "22"}, IsStarted: false}},
 		},
 		{
-			name: "prefers the path having an attempt for the last item",
+			name: "prefers the path having an attempt for the final item",
 			fixture: `
 				items:
 					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
@@ -353,7 +353,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "supports paths whose attempt chains do not have results for the last item requiring explicit entry",
+			name: "supports paths whose attempt chains do not have results for the final item requiring explicit entry",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -369,7 +369,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains do not have results for a non-last item requiring explicit entry",
+			name: "ignores paths whose attempt chains do not have results for a non-final item requiring explicit entry",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -390,7 +390,7 @@ func Test_findItemPaths(t *testing.T) {
 			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for the last item requiring explicit entry",
+			name: "supports paths whose attempt chains do not have started results for the final item requiring explicit entry",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -407,7 +407,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for a non-last item requiring explicit entry",
+			name: "supports paths whose attempt chains do not have started results for a non-final item requiring explicit entry",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -430,7 +430,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for the last item while its attempts do not allow submissions",
+			name: "supports paths whose attempt chains do not have started results for the final item while its attempts do not allow submissions",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -448,7 +448,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts do not allow submissions",
+			name: "ignores paths whose attempt chains do not have started results for a non-final item while its attempts do not allow submissions",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -470,7 +470,7 @@ func Test_findItemPaths(t *testing.T) {
 			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for the last item while its attempts are ended",
+			name: "supports paths whose attempt chains do not have started results for the final item while its attempts are ended",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -488,7 +488,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts are ended",
+			name: "ignores paths whose attempt chains do not have started results for a non-final item while its attempts are ended",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -542,7 +542,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for the last item while its attempts do not allow submissions",
+			name: "supports paths whose attempt chains do not have started results for the final item while its attempts do not allow submissions",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 2}]
 				permissions_generated:
@@ -558,7 +558,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts do not allow submissions",
+			name: "ignores paths whose attempt chains do not have started results for a non-final item while its attempts do not allow submissions",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:
@@ -587,7 +587,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
-			name: "supports paths whose attempt chains do not have started results for an ended attempt of the last item",
+			name: "supports paths whose attempt chains do not have started results for an ended attempt of the final item",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 2}]
 				permissions_generated:
@@ -603,7 +603,7 @@ func Test_findItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains do not have started results for an ended attempt of non-last item",
+			name: "ignores paths whose attempt chains do not have started results for an ended attempt of non-final item",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -136,7 +136,19 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
-			name: "should return the element if it's the only one with explicit entry and without started result",
+			name: "supports paths where content of the only item is not visible",
+			fixture: `
+				groups: [{id: 103, root_activity_id: 1}]
+				permissions_generated:
+					- {group_id: 103, item_id: 1, can_view_generated: info}
+				attempts:
+					- {participant_id: 103, id: 0}
+			`,
+			args: args{participantID: 103, itemID: 1, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
+		},
+		{
+			name: "supports paths where the only element requiring explicit entry doesn't have a result",
 			fixture: `
 				groups:
 					- {id: 110, root_activity_id: 10}
@@ -149,20 +161,6 @@ func Test_FindItemPaths(t *testing.T) {
 			`,
 			args: args{participantID: 100, itemID: 10, limit: 1},
 			want: []items.ItemPath{{Path: []string{"10"}, IsStarted: false}},
-		},
-		{
-			name: "should return the path if the last element has explicit entry and no started result",
-			fixture: `
-				items_items:
-					- {parent_item_id: 1, child_item_id: 10, child_order: 2}
-				items:
-					- {id: 10, default_language_tag: fr, requires_explicit_entry: true}
-				permissions_generated:
-					- {group_id: 100, item_id: 1, can_view_generated: content}
-					- {group_id: 100, item_id: 10, can_view_generated: content}
-			`,
-			args: args{participantID: 100, itemID: 10, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "10"}, IsStarted: false}},
 		},
 		{
 			name: "steps into child attempts for items requiring explicit entry",
@@ -354,7 +352,7 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "get paths whose attempt chains have missing results for last item requiring explicit entry",
+			name: "supports paths whose attempt chains do not have results for the last item requiring explicit entry",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -370,7 +368,7 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains have missing results for items requiring explicit entry for a non-last item",
+			name: "ignores paths whose attempt chains do not have results for a non-last item requiring explicit entry",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -391,7 +389,47 @@ func Test_FindItemPaths(t *testing.T) {
 			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
-			name: "get paths whose attempt chains have not started results below an attempt not allowing submissions for the last item",
+			name: "supports paths whose attempt chains do not have started results for the last item requiring explicit entry",
+			fixture: `
+				permissions_generated:
+					- {group_id: 200, item_id: 1, can_view_generated: content}
+					- {group_id: 200, item_id: 2, can_view_generated: content}
+					- {group_id: 200, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 101, id: 1, root_item_id: 22, parent_attempt_id: 0}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 1, item_id: 22}
+			`,
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
+		},
+		{
+			name: "supports paths whose attempt chains do not have started results for a non-last item requiring explicit entry",
+			fixture: `
+				items:
+					- {id: 23, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 23, child_order: 1}
+				permissions_generated:
+					- {group_id: 200, item_id: 1, can_view_generated: content}
+					- {group_id: 200, item_id: 2, can_view_generated: content}
+					- {group_id: 200, item_id: 22, can_view_generated: content}
+					- {group_id: 200, item_id: 23, can_view_generated: content}
+				attempts:
+					- {participant_id: 101, id: 1, root_item_id: 22, parent_attempt_id: 0}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 1, item_id: 22}
+					- {participant_id: 101, attempt_id: 1, item_id: 23, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, itemID: 23, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
+		},
+		{
+			name: "supports paths whose attempt chains do not have started results for the last item while its attempts do not allow submissions",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -409,7 +447,7 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains have not started results below an attempt not allowing submissions for non-last item",
+			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts do not allow submissions",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -431,7 +469,7 @@ func Test_FindItemPaths(t *testing.T) {
 			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
-			name: "get paths whose attempt chains have not started results below an ended attempt for the last item",
+			name: "supports paths whose attempt chains do not have started results for the last item while its attempts are ended",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -449,7 +487,7 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains have not started results below an ended attempt for non-last item",
+			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts are ended",
 			fixture: `
 				items:
 					- {id: 23, default_language_tag: fr}
@@ -471,7 +509,7 @@ func Test_FindItemPaths(t *testing.T) {
 			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
-			name: "supports path with attempt chains having ended or not allowing submissions attempts",
+			name: "supports path with attempt chains having ended or not allowing submissions attempts with started results",
 			fixture: `
 				permissions_generated:
 					- {group_id: 200, item_id: 1, can_view_generated: content}
@@ -489,7 +527,7 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: true}},
 		},
 		{
-			name: "get paths whose attempt chains have not started results for an attempt not allowing submissions for the last item",
+			name: "supports paths whose attempt chains do not have started results for the only item while its attempts do not allow submissions",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:
@@ -503,11 +541,28 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains have not started results for an attempt not allowing submissions for non-last item",
+			name: "supports paths whose attempt chains do not have started results for the last item while its attempts do not allow submissions",
+			fixture: `
+				groups: [{id: 103, root_activity_id: 2}]
+				permissions_generated:
+					- {group_id: 103, item_id: 2, can_view_generated: content}
+					- {group_id: 103, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 103, id: 0}
+					- {participant_id: 103, id: 1, parent_attempt_id: 0, root_item_id: 22, allows_submissions_until: 2019-05-30 11:00:00}
+				results:
+					- {participant_id: 103, attempt_id: 1, item_id: 22}
+			`,
+			args: args{participantID: 103, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"2", "22"}, IsStarted: false}},
+		},
+		{
+			name: "ignores paths whose attempt chains do not have started results for a non-last item while its attempts do not allow submissions",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:
 					- {group_id: 103, item_id: 1, can_view_generated: content}
+					- {group_id: 103, item_id: 2, can_view_generated: content}
 				attempts:
 					- {participant_id: 103, id: 1, allows_submissions_until: 2019-05-30 11:00:00}
 				results:
@@ -517,7 +572,7 @@ func Test_FindItemPaths(t *testing.T) {
 			args: args{participantID: 103, itemID: 2, limit: 1},
 		},
 		{
-			name: "get paths whose attempt chains have not started results for an ended attempt for the last item",
+			name: "supports paths whose attempt chains do not have started results for an ended attempt of the only item",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:
@@ -531,11 +586,28 @@ func Test_FindItemPaths(t *testing.T) {
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
-			name: "ignores paths whose attempt chains have not started results for an ended attempt for non-last item",
+			name: "supports paths whose attempt chains do not have started results for an ended attempt of the last item",
+			fixture: `
+				groups: [{id: 103, root_activity_id: 2}]
+				permissions_generated:
+					- {group_id: 103, item_id: 2, can_view_generated: content}
+					- {group_id: 103, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 103, id: 0}
+					- {participant_id: 103, id: 1, parent_attempt_id: 0, root_item_id: 22, ended_at: 2019-05-30 11:00:00}
+				results:
+					- {participant_id: 103, attempt_id: 1, item_id: 22}
+			`,
+			args: args{participantID: 103, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"2", "22"}, IsStarted: false}},
+		},
+		{
+			name: "ignores paths whose attempt chains do not have started results for an ended attempt of non-last item",
 			fixture: `
 				groups: [{id: 103, root_activity_id: 1}]
 				permissions_generated:
 					- {group_id: 103, item_id: 1, can_view_generated: content}
+					- {group_id: 103, item_id: 2, can_view_generated: content}
 				attempts:
 					- {participant_id: 103, id: 1, ended_at: 2019-05-30 11:00:00}
 				results:

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -4,6 +4,7 @@ package items_test
 
 import (
 	"testing"
+	_ "unsafe"
 
 	"github.com/stretchr/testify/assert"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
-func Test_FindItemPaths(t *testing.T) {
+func Test_findItemPaths(t *testing.T) {
 	type args struct {
 		participantID int64
 		itemID        int64
@@ -703,8 +704,11 @@ func Test_FindItemPaths(t *testing.T) {
 				s.ScheduleResultsPropagation()
 				return nil
 			}))
-			got := items.FindItemPaths(store, tt.args.participantID, tt.args.itemID, tt.args.limit)
+			got := findItemPaths(store, tt.args.participantID, tt.args.itemID, tt.args.limit)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
+
+//go:linkname findItemPaths github.com/France-ioi/AlgoreaBackend/v2/app/api/items.findItemPaths
+func findItemPaths(store *database.DataStore, participantID, itemID int64, limit int) []items.ItemPath

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -293,7 +293,7 @@ func Test_FindItemPaths(t *testing.T) {
 			name: "prefers the path for the last (by id) attempt chain among all chains with started results for the same items",
 			fixture: `
 				items:
-					- {id: 21, default_language_tag: fr}
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
 				items_items:
 					- {parent_item_id: 1, child_item_id: 21, child_order: 1}
 					- {parent_item_id: 21, child_item_id: 22, child_order: 1}
@@ -302,7 +302,6 @@ func Test_FindItemPaths(t *testing.T) {
 					- {group_id: 101, item_id: 2, can_view_generated: content}
 					- {group_id: 101, item_id: 21, can_view_generated: content}
 					- {group_id: 101, item_id: 22, can_view_generated: content}
-					- {group_id: 101, item_id: 23, can_view_generated: content}
 				attempts:
 					- {participant_id: 101, id: 1}
 					- {participant_id: 101, id: 2}
@@ -310,7 +309,9 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 101, id: 4, parent_attempt_id: 0, root_item_id: 22}
 					- {participant_id: 101, id: 5, parent_attempt_id: 0, root_item_id: 22}
 					- {participant_id: 101, id: 6}
-					- {participant_id: 101, id: 7, parent_attempt_id: 6, root_item_id: 22}
+					- {participant_id: 101, id: 7, parent_attempt_id: 6, root_item_id: 21}
+					- {participant_id: 101, id: 8, parent_attempt_id: 7, root_item_id: 22}
+					- {participant_id: 101, id: 9, parent_attempt_id: 6, root_item_id: 22}
 				results:
 					- {participant_id: 101, attempt_id: 0, item_id: 1}
 					- {participant_id: 101, attempt_id: 1, item_id: 1}
@@ -318,14 +319,17 @@ func Test_FindItemPaths(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 1, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 2, started_at: 2019-05-30 11:00:00}
-					- {participant_id: 101, attempt_id: 6, item_id: 21, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 6, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 7, item_id: 21, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 					- {participant_id: 101, attempt_id: 3, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 8, item_id: 22, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 9, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{participantID: 101, itemID: 23, limit: 1},
-			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
+			args: args{participantID: 101, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "21", "22"}, IsStarted: false}},
 		},
 		{
 			name: "get paths whose attempt chains have missing results for last item requiring explicit entry",

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
-func Test_FindItemPath(t *testing.T) {
+func Test_FindItemPaths(t *testing.T) {
 	type args struct {
 		participantID int64
 		itemID        int64
-		user          *database.User
-		pathRootBy    items.PathRootType // items.PathRootUser is tested in get_breadcrumb_from_roots.feature.
 		limit         int
 	}
 	tests := []struct {
@@ -34,13 +32,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: info}
 					- {group_id: 200, item_id: 2, can_view_generated: info}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 2, limit: 1},
 		},
 		{
 			name: "fails if not enough permissions for the second item",
@@ -49,13 +41,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: none}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 2, limit: 1},
 		},
 		{
 			name: "supports a root activity as a first item",
@@ -64,13 +50,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 1, can_view_generated: content}
 					- {group_id: 200, item_id: 2, can_view_generated: info}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 2, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
@@ -80,13 +60,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 200, item_id: 3, can_view_generated: content}
 					- {group_id: 200, item_id: 4, can_view_generated: info}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        4,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 4, limit: 1},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
@@ -101,13 +75,7 @@ func Test_FindItemPath(t *testing.T) {
 				attempts:
 					- {participant_id: 102, id: 0}
 			`,
-			args: args{
-				participantID: 102,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 102, itemID: 2, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
@@ -122,13 +90,7 @@ func Test_FindItemPath(t *testing.T) {
 				attempts:
 					- {participant_id: 102, id: 0}
 			`,
-			args: args{
-				participantID: 102,
-				itemID:        4,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 102, itemID: 4, limit: 1},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
@@ -144,13 +106,7 @@ func Test_FindItemPath(t *testing.T) {
 				attempts:
 					- {participant_id: 103, id: 0}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 2, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
@@ -166,13 +122,7 @@ func Test_FindItemPath(t *testing.T) {
 				attempts:
 					- {participant_id: 103, id: 0}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        4,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 4, limit: 1},
 			want: []items.ItemPath{{Path: []string{"3", "4"}, IsStarted: false}},
 		},
 		{
@@ -182,13 +132,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 100, item_id: 1, can_view_generated: content}
 					- {group_id: 100, item_id: 2, can_view_generated: content}
 			`,
-			args: args{
-				participantID: 100,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 100, itemID: 2, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
@@ -203,13 +147,7 @@ func Test_FindItemPath(t *testing.T) {
 				permissions_generated:
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
-			args: args{
-				participantID: 100,
-				itemID:        10,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 100, itemID: 10, limit: 1},
 			want: []items.ItemPath{{Path: []string{"10"}, IsStarted: false}},
 		},
 		{
@@ -223,13 +161,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {group_id: 100, item_id: 1, can_view_generated: content}
 					- {group_id: 100, item_id: 10, can_view_generated: content}
 			`,
-			args: args{
-				participantID: 100,
-				itemID:        10,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 100, itemID: 10, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "10"}, IsStarted: false}},
 		},
 		{
@@ -253,13 +185,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 100, attempt_id: 3, item_id: 22}
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 			`,
-			args: args{
-				participantID: 100,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 100, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
@@ -275,13 +201,7 @@ func Test_FindItemPath(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 22}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"22", "23"}, IsStarted: false}},
 		},
 		{
@@ -295,13 +215,7 @@ func Test_FindItemPath(t *testing.T) {
 				results:
 					- {participant_id: 101, attempt_id: 1, item_id: 2}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 2, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2"}, IsStarted: false}},
 		},
 		{
@@ -337,13 +251,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
 		},
 		{
@@ -378,13 +286,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
@@ -421,15 +323,8 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 3, item_id: 22, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 4, item_id: 22}
 					- {participant_id: 101, attempt_id: 5, item_id: 22, started_at: 2019-05-30 11:00:00}
-					- {participant_id: 101, attempt_id: 7, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "21", "22", "23"}, IsStarted: false}},
 		},
 		{
@@ -445,13 +340,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        22,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 22, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
@@ -469,13 +358,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 0, item_id: 23, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
 			name: "get paths whose attempt chains have not started results below an attempt not allowing submissions for the last item",
@@ -492,13 +375,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        22,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 22, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
@@ -516,13 +393,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
 			name: "get paths whose attempt chains have not started results below an ended attempt for the last item",
@@ -539,13 +410,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        22,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 22, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22"}, IsStarted: false}},
 		},
 		{
@@ -563,13 +428,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 		},
 		{
 			name: "supports path with attempt chains having ended or not allowing submissions attempts",
@@ -587,13 +446,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 101, attempt_id: 1, item_id: 2, started_at: 2019-05-30 11:00:00}
 					- {participant_id: 101, attempt_id: 2, item_id: 22, started_at: 2019-05-30 11:00:00}
 			`,
-			args: args{
-				participantID: 101,
-				itemID:        23,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 101, itemID: 23, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1", "2", "22", "23"}, IsStarted: false}},
 		},
 		{
@@ -607,13 +460,7 @@ func Test_FindItemPath(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        1,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 1, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
@@ -628,13 +475,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 					- {participant_id: 103, attempt_id: 1, item_id: 2}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 2, limit: 1},
 		},
 		{
 			name: "get paths whose attempt chains have not started results for an ended attempt for the last item",
@@ -647,13 +488,7 @@ func Test_FindItemPath(t *testing.T) {
 				results:
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        1,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 1, limit: 1},
 			want: []items.ItemPath{{Path: []string{"1"}, IsStarted: false}},
 		},
 		{
@@ -668,13 +503,7 @@ func Test_FindItemPath(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 					- {participant_id: 103, attempt_id: 1, item_id: 2}
 			`,
-			args: args{
-				participantID: 103,
-				itemID:        2,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
+			args: args{participantID: 103, itemID: 2, limit: 1},
 		},
 		{
 			name: "returns all the paths when there is more than one",
@@ -698,13 +527,7 @@ func Test_FindItemPath(t *testing.T) {
 						- {participant_id: 103, attempt_id: 0, item_id: 100, started_at: 2020-01-01 01:01:01}
 						- {participant_id: 103, attempt_id: 0, item_id: 101, started_at: 2020-01-01 01:01:01}
 				`,
-			args: args{
-				participantID: 103,
-				itemID:        101,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         0,
-			},
+			args: args{participantID: 103, itemID: 101},
 			want: []items.ItemPath{
 				{Path: []string{"100", "101"}, IsStarted: true},
 				{Path: []string{"101"}, IsStarted: true},
@@ -732,61 +555,8 @@ func Test_FindItemPath(t *testing.T) {
 						- {participant_id: 103, attempt_id: 0, item_id: 100, started_at: 2020-01-01 01:01:01}
 						- {participant_id: 103, attempt_id: 0, item_id: 101, started_at: 2020-01-01 01:01:01}
 				`,
-			args: args{
-				participantID: 103,
-				itemID:        101,
-				user:          &database.User{},
-				pathRootBy:    items.PathRootParticipant,
-				limit:         1,
-			},
-			want: []items.ItemPath{
-				{Path: []string{"100", "101"}, IsStarted: true},
-			},
-		},
-		{
-			name: "is_started should be true when the path is started by the participant, not if only by the user",
-			fixture: `
-					groups:
-						- {id: 998, root_activity_id: 1000}
-						- {id: 999, root_activity_id: 1001}
-						- {id: 1000}
-						- {id: 1001}
-					groups_groups:
-						- {parent_group_id: 998, child_group_id: 1000}
-						- {parent_group_id: 998, child_group_id: 1001}
-						- {parent_group_id: 999, child_group_id: 1000}
-						- {parent_group_id: 999, child_group_id: 1001}
-					items:
-						- {id: 1000, default_language_tag: fr}
-						- {id: 1001, default_language_tag: fr}
-					items_items:
-						- {parent_item_id: 1000, child_item_id: 1001, child_order: 1}
-					permissions_generated:
-						- {group_id: 1000, item_id: 1000, can_view_generated: content}
-						- {group_id: 1000, item_id: 1001, can_view_generated: content}
-						- {group_id: 1001, item_id: 1000, can_view_generated: content}
-						- {group_id: 1001, item_id: 1001, can_view_generated: content}
-					attempts:
-						- {participant_id: 1000, id: 0}
-						- {participant_id: 1001, id: 0}
-					results:
-						- {participant_id: 1000, attempt_id: 0, item_id: 1001, started_at: 2020-01-01 01:01:01}
-						- {participant_id: 1001, attempt_id: 0, item_id: 1000, started_at: 2020-01-01 01:01:01}
-						- {participant_id: 1001, attempt_id: 0, item_id: 1001, started_at: 2020-01-01 01:01:01}
-				`,
-			args: args{
-				participantID: 1000,
-				itemID:        1001,
-				user: &database.User{
-					GroupID: 1001,
-				},
-				pathRootBy: items.PathRootUser,
-				limit:      0,
-			},
-			want: []items.ItemPath{
-				{Path: []string{"1001"}, IsStarted: true},
-				{Path: []string{"1000", "1001"}, IsStarted: false},
-			},
+			args: args{participantID: 103, itemID: 101, limit: 1},
+			want: []items.ItemPath{{Path: []string{"100", "101"}, IsStarted: true}},
 		},
 	}
 	const globalFixture = `
@@ -817,7 +587,6 @@ func Test_FindItemPath(t *testing.T) {
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)
-			var got []items.ItemPath
 			assert.NoError(t, store.InTransaction(func(s *database.DataStore) error {
 				assert.NoError(t, s.GroupGroups().CreateNewAncestors())
 				assert.NoError(t, s.ItemItems().CreateNewAncestors())
@@ -825,14 +594,7 @@ func Test_FindItemPath(t *testing.T) {
 				s.ScheduleResultsPropagation()
 				return nil
 			}))
-			got = items.FindItemPaths(
-				store,
-				tt.args.user,
-				tt.args.participantID,
-				tt.args.itemID,
-				tt.args.pathRootBy,
-				tt.args.limit,
-			)
+			got := items.FindItemPaths(store, tt.args.participantID, tt.args.itemID, tt.args.limit)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -43,7 +43,7 @@ type updatedStartResultResponse struct { // nolint:unused
 //			* if `as_team_id` is given, it should be a user's parent team group,
 //			* the first item in `{ids}` should be a root activity/skill (groups.root_activity_id/root_skill_id) of a group
 //				the participant is a descendant of or manages,
-//			* the last item in `{ids}` should not require explicit entry (`items.requires_explicit_entry` should be false),
+//			* the final item in `{ids}` should not require explicit entry (`items.requires_explicit_entry` should be false),
 //			* `{ids}` should be an ordered list of parent-child items,
 //			* the group starting the result should have at least 'content' access on each of the items in `{ids}`,
 //			* the participant should have a started, allowing submission, not ended result for each item but the last,

--- a/app/api/items/start_result.robustness.feature
+++ b/app/api/items/start_result.robustness.feature
@@ -92,7 +92,7 @@ Feature: Start a result for an item - robustness
     And the response error message should contain "Can't use given as_team_id as a user's team"
     And the table "attempts" should stay unchanged
 
-  Scenario: Not enough permissions for the last item in the path
+  Scenario: Not enough permissions for the final item in the path
     Given I am the user with id "101"
     And the database table "permissions_generated" also has the following row:
       | group_id | item_id | can_view_generated |

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -48,7 +48,7 @@ import (
 //			format: int64
 //	responses:
 //		"201":
-//			description: "Created. Success response with the attempt id for the last item in the path"
+//			description: "Created. Success response with the attempt id for the final item in the path"
 //			schema:
 //					type: object
 //					required: [success, message, data]
@@ -66,7 +66,7 @@ import (
 //							required: [attempt_id]
 //							properties:
 //								attempt_id:
-//									description: The attempt linked to the last item in the path
+//									description: The attempt linked to the final item in the path
 //									type: integer
 //									format: string
 //		"400":

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -145,13 +145,13 @@ func (s *ItemStore) itemAttemptChainWithoutAttemptForTail(ids []int64, groupID i
 }
 
 // BreadcrumbsHierarchyForParentAttempt returns attempts ids and 'order' (for items allowing multiple attempts)
-// for the given list of item ids (but the last item) if it is a valid participation hierarchy
+// for the given list of item ids (but the final item) if it is a valid participation hierarchy
 // for the given `parentAttemptID` which means all the following statements are true:
 //   - the first item in `ids` is a root activity/skill (groups.root_activity_id/root_skill_id)
 //     of a group the `groupID` is a descendant of or manages,
 //   - `ids` is an ordered list of parent-child items,
-//   - the `groupID` group has at least 'content' access on each of the items in `ids` except for the last one and
-//     at least 'info' access on the last one,
+//   - the `groupID` group has at least 'content' access on each of the items in `ids` except for the final one and
+//     at least 'info' access on the final one,
 //   - the `groupID` group has a started result for each item but the last,
 //     with `parentAttemptID` (or its parent attempt each time we reach a root of an attempt) as the attempt,
 //   - if `ids` consists of only one item, the `parentAttemptID` is zero.
@@ -183,8 +183,8 @@ func (s *ItemStore) BreadcrumbsHierarchyForParentAttempt(ids []int64, groupID, p
 //   - the first item in `ids` is an activity/skill item (groups.root_activity_id/root_skill_id) of a group
 //     the `groupID` is a descendant of or manages,
 //   - `ids` is an ordered list of parent-child items,
-//   - the `groupID` group has at least 'content' access on each of the items in `ids` except for the last one and
-//     at least 'info' access on the last one,
+//   - the `groupID` group has at least 'content' access on each of the items in `ids` except for the final one and
+//     at least 'info' access on the final one,
 //   - the `groupID` group has a started result for each item,
 //     with `attemptID` (or its parent attempt each time we reach a root of an attempt) as the attempt.
 func (s *ItemStore) BreadcrumbsHierarchyForAttempt(ids []int64, groupID, attemptID int64, withWriteLock bool) (

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -48,14 +48,14 @@ func (s *ItemStore) GetSearchQuery(user *User, searchString string, typesList []
 //     with `parentAttemptID` (or its parent attempt each time we reach a root of an attempt) as the attempt,
 //   - if `ids` consists of only one item, the `parentAttemptID` is zero.
 func (s *ItemStore) IsValidParticipationHierarchyForParentAttempt(
-	ids []int64, groupID, parentAttemptID int64, requireContentAccessToTheLastItem, withWriteLock bool,
+	ids []int64, groupID, parentAttemptID int64, requireContentAccessToTheFinalItem, withWriteLock bool,
 ) (bool, error) {
 	if len(ids) == 0 || len(ids) == 1 && parentAttemptID != 0 {
 		return false, nil
 	}
 
 	return s.participationHierarchyForParentAttempt(
-		ids, groupID, parentAttemptID, true, requireContentAccessToTheLastItem, "1", withWriteLock).HasRows()
+		ids, groupID, parentAttemptID, true, requireContentAccessToTheFinalItem, "1", withWriteLock).HasRows()
 }
 
 // visibleItemsFromListForGroupQuery returns a query for selecting visible items from a list of item ids for a group.
@@ -73,11 +73,11 @@ func (s *ItemStore) visibleItemsFromListForGroupQuery(itemIDs []int64, groupID i
 }
 
 func (s *ItemStore) participationHierarchyForParentAttempt(
-	ids []int64, groupID, parentAttemptID int64, requireAttemptsToBeActive, requireContentAccessToTheLastItem bool,
+	ids []int64, groupID, parentAttemptID int64, requireAttemptsToBeActive, requireContentAccessToTheFinalItem bool,
 	columnsList string, withWriteLock bool,
 ) *DB {
 	subQuery := s.itemAttemptChainWithoutAttemptForTail(
-		ids, groupID, requireAttemptsToBeActive, requireContentAccessToTheLastItem, withWriteLock)
+		ids, groupID, requireAttemptsToBeActive, requireContentAccessToTheFinalItem, withWriteLock)
 
 	if len(ids) > 1 {
 		subQuery = subQuery.
@@ -89,7 +89,7 @@ func (s *ItemStore) participationHierarchyForParentAttempt(
 }
 
 func (s *ItemStore) itemAttemptChainWithoutAttemptForTail(ids []int64, groupID int64,
-	requireAttemptsToBeActive, requireContentAccessToTheLastItem, withWriteLock bool,
+	requireAttemptsToBeActive, requireContentAccessToTheFinalItem, withWriteLock bool,
 ) *DB {
 	participantAncestors := s.ActiveGroupAncestors().Where("child_group_id = ?", groupID).
 		Joins("JOIN `groups` ON groups.id = groups_ancestors_active.ancestor_group_id")
@@ -136,7 +136,7 @@ func (s *ItemStore) itemAttemptChainWithoutAttemptForTail(ids []int64, groupID i
 		}
 	}
 
-	if requireContentAccessToTheLastItem {
+	if requireContentAccessToTheFinalItem {
 		subQuery = subQuery.Where(fmt.Sprintf("items%d.can_view_generated_value >= ?", len(ids)-1),
 			s.PermissionsGranted().ViewIndexByName("content"))
 	}
@@ -251,25 +251,25 @@ func resultsForBreadcrumbsHierarchy(ids []int64, data map[string]interface{}) (
 }
 
 func (s *ItemStore) breadcrumbsHierarchyForAttempt(
-	ids []int64, groupID, attemptID int64, requireContentAccessToTheLastItem bool,
+	ids []int64, groupID, attemptID int64, requireContentAccessToTheFinalItem bool,
 	columnsList string, withWriteLock bool,
 ) *DB {
-	lastItemIndex := len(ids) - 1
+	finalItemIndex := len(ids) - 1
 	subQuery := s.
-		itemAttemptChainWithoutAttemptForTail(ids, groupID, false, requireContentAccessToTheLastItem, withWriteLock).
-		Where(fmt.Sprintf("attempts%d.id = ?", lastItemIndex), attemptID)
+		itemAttemptChainWithoutAttemptForTail(ids, groupID, false, requireContentAccessToTheFinalItem, withWriteLock).
+		Where(fmt.Sprintf("attempts%d.id = ?", finalItemIndex), attemptID)
 	subQuery = subQuery.
 		Joins(fmt.Sprintf(`
 				JOIN results AS results%d ON results%d.participant_id = ? AND
 					results%d.item_id = items%d.id AND results%d.started_at IS NOT NULL`,
-			lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex), groupID).
+			finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex), groupID).
 		Joins(fmt.Sprintf(`
 				JOIN attempts AS attempts%d ON attempts%d.participant_id = results%d.participant_id AND
-					attempts%d.id = results%d.attempt_id`, lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex))
+					attempts%d.id = results%d.attempt_id`, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex))
 	if len(ids) > 1 {
 		subQuery = subQuery.Where(fmt.Sprintf(
 			"IF(attempts%d.root_item_id = items%d.id, attempts%d.parent_attempt_id, attempts%d.id) = attempts%d.id",
-			lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex, lastItemIndex-1))
+			finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex-1))
 	}
 
 	subQuery = subQuery.Select(columnsList)

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -467,37 +467,37 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 			args: args{ids: []int64{6, 8}, groupID: 101, parentAttemptID: 201},
 		},
 		{
-			name:                 "no content access to the last item when requireContentAccessToTheLastItem = true",
+			name:                 "no content access to the final item when requireContentAccessToTheLastItem = true",
 			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
 			wantAttemptIDMap:     map[int64]int64{2: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name: "no access to the last item when requireContentAccessToTheLastItem = false",
+			name: "no access to the final item when requireContentAccessToTheLastItem = false",
 			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheLastItem: false},
 		},
 		{
-			name:                 "content access to the last item when requireContentAccessToTheLastItem = true",
+			name:                 "content access to the final item when requireContentAccessToTheLastItem = true",
 			args:                 args{ids: []int64{4, 6}, groupID: 101, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
 			want:                 true,
 			wantAttemptIDMap:     map[int64]int64{4: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "info access to the last item when requireContentAccessToTheLastItem = false",
+			name:                 "info access to the final item when requireContentAccessToTheLastItem = false",
 			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheLastItem: false},
 			want:                 true,
 			wantAttemptIDMap:     map[int64]int64{2: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name: "no access to the last item when requireContentAccessToTheLastItem = true",
+			name: "no access to the final item when requireContentAccessToTheLastItem = true",
 			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
 		},
-		{name: "no content access to the second to the last item", args: args{ids: []int64{2, 4, 6}, groupID: 105, parentAttemptID: 201}},
+		{name: "no content access to the second to the final item", args: args{ids: []int64{2, 4, 6}, groupID: 105, parentAttemptID: 201}},
 		{name: "no content access to the first item", args: args{ids: []int64{2, 4, 6}, groupID: 106, parentAttemptID: 201}},
 		{name: "result of the first item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 107, parentAttemptID: 201}},
-		{name: "result of the second to the last item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 108, parentAttemptID: 201}},
+		{name: "result of the second to the final item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 108, parentAttemptID: 201}},
 		{
 			name:                 "attempt of the first item is expired",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 109, parentAttemptID: 201},
@@ -505,7 +505,7 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the second to the last item is expired",
+			name:                 "attempt of the second to the final item is expired",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 110, parentAttemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201},
 			wantAttemptNumberMap: map[int64]int{},
@@ -517,14 +517,14 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the second to the last item is ended",
+			name:                 "attempt of the second to the final item is ended",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 112, parentAttemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{name: "the first item is not a parent of the second item", args: args{ids: []int64{4, 4, 6}, groupID: 113, parentAttemptID: 200}},
 		{
-			name: "the second to the last item is not a parent of the last item",
+			name: "the second to the final item is not a parent of the final item",
 			args: args{ids: []int64{2, 4, 4}, groupID: 113, parentAttemptID: 200},
 		},
 		{
@@ -537,13 +537,13 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 115, parentAttemptID: 200},
 		},
 		{
-			name: "the third from the end item's attempt is not a parent for the second to the last items's attempt " +
-				"while the second to the last item's attempt root_item_id is set",
+			name: "the third from the end item's attempt is not a parent for the second to the final items's attempt " +
+				"while the second to the final item's attempt root_item_id is set",
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 116, parentAttemptID: 201},
 		},
 		{
-			name: "the third from the end item's attempt is not the same as the second to the last items's attempt " +
-				"while the second to the last item's attempt root_item_id is not set",
+			name: "the third from the end item's attempt is not the same as the second to the final items's attempt " +
+				"while the second to the final item's attempt root_item_id is not set",
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 117, parentAttemptID: 200},
 		},
 		{
@@ -910,26 +910,26 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 			args: args{ids: []int64{6, 8}, groupID: 101, attemptID: 202},
 		},
 		{
-			name: "no access to the last item",
+			name: "no access to the final item",
 			args: args{ids: []int64{2, 4}, groupID: 104, attemptID: 201},
 		},
 		{
-			name:                 "content access to the last item",
+			name:                 "content access to the final item",
 			args:                 args{ids: []int64{4, 6}, groupID: 101, attemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{4: 200, 6: 201},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "info access to the last item",
+			name:                 "info access to the final item",
 			args:                 args{ids: []int64{2, 4}, groupID: 103, attemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201},
 			wantAttemptNumberMap: map[int64]int{},
 		},
-		{name: "no content access to the second to the last item", args: args{ids: []int64{2, 4, 6}, groupID: 105, attemptID: 202}},
+		{name: "no content access to the second to the final item", args: args{ids: []int64{2, 4, 6}, groupID: 105, attemptID: 202}},
 		{name: "no content access to the first item", args: args{ids: []int64{2, 4, 6}, groupID: 106, attemptID: 202}},
 		{name: "result of the first item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 107, attemptID: 202}},
-		{name: "result of the second to the last item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 108, attemptID: 202}},
-		{name: "result of the last item is not started", args: args{ids: []int64{2, 4}, groupID: 108, attemptID: 201}},
+		{name: "result of the second to the final item is not started", args: args{ids: []int64{2, 4, 6}, groupID: 108, attemptID: 202}},
+		{name: "result of the final item is not started", args: args{ids: []int64{2, 4}, groupID: 108, attemptID: 201}},
 		{
 			name:                 "attempt of the first item is expired",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 109, attemptID: 202},
@@ -937,13 +937,13 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the second to the last item is expired",
+			name:                 "attempt of the second to the final item is expired",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 110, attemptID: 202},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201, 6: 202},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the last item is expired",
+			name:                 "attempt of the final item is expired",
 			args:                 args{ids: []int64{2, 4}, groupID: 110, attemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201},
 			wantAttemptNumberMap: map[int64]int{},
@@ -955,19 +955,19 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the second to the last item is ended",
+			name:                 "attempt of the second to the final item is ended",
 			args:                 args{ids: []int64{2, 4, 6}, groupID: 112, attemptID: 202},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201, 6: 202},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "attempt of the last item is ended",
+			name:                 "attempt of the final item is ended",
 			args:                 args{ids: []int64{2, 4}, groupID: 112, attemptID: 201},
 			wantAttemptIDMap:     map[int64]int64{2: 200, 4: 201},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{name: "the first item is not a parent of the second item", args: args{ids: []int64{4, 4, 6}, groupID: 113, attemptID: 200}},
-		{name: "the second to the last item is not a parent of the last item", args: args{ids: []int64{2, 4, 4}, groupID: 113, attemptID: 200}},
+		{name: "the second to the final item is not a parent of the final item", args: args{ids: []int64{2, 4, 4}, groupID: 113, attemptID: 200}},
 		{
 			name: "the first item's attempt is not a parent for the second items's attempt while the second item's attempt root_item_id is set",
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 114, attemptID: 202},
@@ -978,23 +978,23 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 115, attemptID: 200},
 		},
 		{
-			name: "the third to the end item's attempt is not a parent for the second to the last items's attempt " +
-				"while the second to the last item's attempt root_item_id is set",
+			name: "the third to the end item's attempt is not a parent for the second to the final items's attempt " +
+				"while the second to the final item's attempt root_item_id is set",
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 116, attemptID: 201},
 		},
 		{
-			name: "the second to the last item's attempt is not a parent for the last items's attempt " +
-				"while the last item's attempt root_item_id is set",
+			name: "the second to the final item's attempt is not a parent for the final items's attempt " +
+				"while the final item's attempt root_item_id is set",
 			args: args{ids: []int64{2, 4, 6}, groupID: 116, attemptID: 201},
 		},
 		{
-			name: "the third from the end item's attempt is not the same as the second to the last items's attempt " +
-				"while the second to the last item's attempt root_item_id is not set",
+			name: "the third from the end item's attempt is not the same as the second to the final items's attempt " +
+				"while the second to the final item's attempt root_item_id is not set",
 			args: args{ids: []int64{2, 4, 6, 8}, groupID: 117, attemptID: 200},
 		},
 		{
-			name: "the second the last item's attempt is not the same as the last items's attempt " +
-				"while the last item's attempt root_item_id is not set",
+			name: "the second the final item's attempt is not the same as the final items's attempt " +
+				"while the final item's attempt root_item_id is not set",
 			args: args{ids: []int64{2, 4, 6}, groupID: 117, attemptID: 200},
 		},
 		{

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -391,10 +391,10 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 	}))
 
 	type args struct {
-		ids                               []int64
-		groupID                           int64
-		parentAttemptID                   int64
-		requireContentAccessToTheLastItem bool
+		ids                                []int64
+		groupID                            int64
+		parentAttemptID                    int64
+		requireContentAccessToTheFinalItem bool
 	}
 	tests := []struct {
 		name                 string
@@ -467,32 +467,32 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 			args: args{ids: []int64{6, 8}, groupID: 101, parentAttemptID: 201},
 		},
 		{
-			name:                 "no content access to the final item when requireContentAccessToTheLastItem = true",
-			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
+			name:                 "no content access to the final item when requireContentAccessToTheFinalItem = true",
+			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheFinalItem: true},
 			wantAttemptIDMap:     map[int64]int64{2: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name: "no access to the final item when requireContentAccessToTheLastItem = false",
-			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheLastItem: false},
+			name: "no access to the final item when requireContentAccessToTheFinalItem = false",
+			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheFinalItem: false},
 		},
 		{
-			name:                 "content access to the final item when requireContentAccessToTheLastItem = true",
-			args:                 args{ids: []int64{4, 6}, groupID: 101, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
+			name:                 "content access to the final item when requireContentAccessToTheFinalItem = true",
+			args:                 args{ids: []int64{4, 6}, groupID: 101, parentAttemptID: 200, requireContentAccessToTheFinalItem: true},
 			want:                 true,
 			wantAttemptIDMap:     map[int64]int64{4: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name:                 "info access to the final item when requireContentAccessToTheLastItem = false",
-			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheLastItem: false},
+			name:                 "info access to the final item when requireContentAccessToTheFinalItem = false",
+			args:                 args{ids: []int64{2, 4}, groupID: 103, parentAttemptID: 200, requireContentAccessToTheFinalItem: false},
 			want:                 true,
 			wantAttemptIDMap:     map[int64]int64{2: 200},
 			wantAttemptNumberMap: map[int64]int{},
 		},
 		{
-			name: "no access to the final item when requireContentAccessToTheLastItem = true",
-			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheLastItem: true},
+			name: "no access to the final item when requireContentAccessToTheFinalItem = true",
+			args: args{ids: []int64{2, 4}, groupID: 104, parentAttemptID: 200, requireContentAccessToTheFinalItem: true},
 		},
 		{name: "no content access to the second to the final item", args: args{ids: []int64{2, 4, 6}, groupID: 105, parentAttemptID: 201}},
 		{name: "no content access to the first item", args: args{ids: []int64{2, 4, 6}, groupID: 106, parentAttemptID: 201}},
@@ -576,7 +576,7 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 
 				assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 					got, err := store.Items().IsValidParticipationHierarchyForParentAttempt(
-						tt.args.ids, tt.args.groupID, tt.args.parentAttemptID, tt.args.requireContentAccessToTheLastItem, writeLock)
+						tt.args.ids, tt.args.groupID, tt.args.parentAttemptID, tt.args.requireContentAccessToTheFinalItem, writeLock)
 					assert.Equal(t, tt.want, got)
 					assert.NoError(t, err)
 					return nil


### PR DESCRIPTION
1. Require items in the paths returned by itemBreadcrumbsFromRootsGet to be visible by both the participant and the current user ("content" for non-final items, "info" for final items). Previously, we required them to be visible by the current user only. (Fixes #1284)
2. Prefer paths having attempts linked to their final items in itemPathFromRootFind (return such a path if it exists) & itemBreadcrumbsFromRootsGet (place such paths before others).
3. itemBreadcrumbsFromRootsGet: Rename breadcrumbPath.StartedByParticipant to breadcrumbPath.IsStarted [the JSON field "started_by_participant" becomes "is_started".
4. Make the docs of itemPathFromRootFind & itemBreadcrumbsFromRootsGet reflect their real behaviour.4. Improve tests of items.findItemPaths() (previously known as items.FindItemPaths()).
5. Sort by attempt ids correctly even when there is no attempt for an item in items.FindItemPaths().
6. Do not deduplicate results in items.findItemPaths(), use MySQL's GROUP BY instead.
7. Other code-related improvements.