### PR TITLE
Lock the groups_groups row FOR UPDATE when checking if a user is already a member of a badge group in GroupStore.storeBadge()

### DIFF
--- a/app/database/badges.go
+++ b/app/database/badges.go
@@ -93,7 +93,9 @@ func (s *GroupStore) storeBadge(
 		if !groupCreated && !newUser {
 			var err error
 			alreadyMember, err = s.ActiveGroupGroups().
-				Where("parent_group_id = ? AND child_group_id = ?", badgeGroupID, userID).HasRows()
+				Where("parent_group_id = ? AND child_group_id = ?", badgeGroupID, userID).
+				WithExclusiveWriteLock().
+				HasRows()
 			mustNotBeError(err)
 		}
 		if !alreadyMember {


### PR DESCRIPTION
Otherwise, the following transition may fail because of concurrent transactions.
