### PR TITLE
create the NonTempUsers base group and make it a child of the AllUser…

### DIFF
--- a/db/migrations/2506041904_create_non_temp_users_base_group.sql
+++ b/db/migrations/2506041904_create_non_temp_users_base_group.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+INSERT INTO `groups` (`id`, `name`, `type`, `text_id`, `description`) VALUE
+  (4, 'NonTempUsers', 'Base', 'NonTempUsers', 'non-temporary users');
+
+-- +migrate Down
+DELETE FROM `groups` WHERE `id`=4 AND `type`='Base' AND `text_id`='NonTempUsers';

--- a/db/migrations/2506041905_add_non_temp_users_group_into_all_users_group.sql
+++ b/db/migrations/2506041905_add_non_temp_users_group_into_all_users_group.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+INSERT INTO `groups_groups` (parent_group_id, child_group_id)
+  SELECT id, 4 FROM `groups` WHERE `type`='Base' AND `text_id`='AllUsers';
+
+-- +migrate Down
+DELETE FROM `groups_groups`
+WHERE child_group_id=4 AND parent_group_id =
+    (SELECT id FROM `groups` WHERE `type`='Base' AND `text_id`='AllUsers' LIMIT 1);


### PR DESCRIPTION
This PR is the first part of #1288, it is meant to be deployed first, before the second part.

Note that we use the ID=4 for the new group assuming it is free everywhere.

As the migrations make the groups ancestors inconsistent, the deployment should be done while the prod is turned off. The `db-recompute` command should be executed after this PR is deployed and before the prod back on.

These migrations are very quick, just a couple of seconds including the `db-recompute` command.