### PR TITLE
Add support for the NonTempUsers group in the code, add the nonTempUsers group config parameters, move non-temporary users into this group from AllUsers

### DIFF
--- a/.github/conf/config.lambda.yaml
+++ b/.github/conf/config.lambda.yaml
@@ -30,4 +30,5 @@ domains:
   -
     domains: [default]
     allUsersGroup: ALLUSERS # 1 for dev db, 3 for prod
+    nonTempUsersGroup: NONTMPUSERS
     tempUsersGroup: TMPUSERS # 4 for dev, 2 for prod

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,8 @@ jobs:
       env:
         ALL: ${{ secrets.ALL_USERS_GROUP }}
         TMP: ${{ secrets.TMP_USERS_GROUP }}
-      run: sed "s/ALLUSERS/$ALL/" .github/conf/config.lambda.yaml | sed -e "s/TMPUSERS/$TMP/" > lambda-archive/conf/config.yaml
+        NONTMP: ${{ secrets.NONTMP_USERS_GROUP }}
+      run: sed "s/ALLUSERS/$ALL/" .github/conf/config.lambda.yaml | sed -e "s/TMPUSERS/$TMP/" | sed -e "s/NONTMPUSERS/$NONTMP/" > lambda-archive/conf/config.yaml
     - run: cd lambda-archive; zip -r ../lambda.zip .; cd ..
 
     - name: Configure AWS credential

--- a/app/api/auth/create_access_token.feature
+++ b/app/api/auth/create_access_token.feature
@@ -904,6 +904,21 @@ Feature: Create an access token
     And the table "users" at group_id "5577006791947779410" should be:
       | group_id            | login_id | login        | temp_user | default_language            | ABS(TIMESTAMPDIFF(SECOND, registered_at, NOW())) < 3 | last_ip   |
       | 5577006791947779410 | 0        | tmp-49727887 | true      | <expected_default_language> | true                                                 | 127.0.0.1 |
+    And the table "groups_groups" should be:
+      | parent_group_id     | child_group_id      |
+      | 2                   | 3                   |
+      | 2                   | 4                   |
+      | 4                   | 5577006791947779410 |
+    And the table "groups_ancestors" should be:
+      | ancestor_group_id   | child_group_id      | is_self |
+      | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
+      | 2                   | 4                   | false   |
+      | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 4                   | 4                   | true    |
+      | 4                   | 5577006791947779410 | false   |
+      | 5577006791947779410 | 5577006791947779410 | true    |
     Examples:
       | query                                                     | expected_default_language |
       | ?create_temp_user_if_not_authorized=1                     | fr                        |
@@ -921,3 +936,18 @@ Feature: Create an access token
     And the table "users" at group_id "5577006791947779410" should be:
       | group_id            | login_id | login        | temp_user | default_language | ABS(TIMESTAMPDIFF(SECOND, registered_at, NOW())) < 3 | last_ip   |
       | 5577006791947779410 | 0        | tmp-49727887 | true      | fr                | true                                                 | 127.0.0.1 |
+    And the table "groups_groups" should be:
+      | parent_group_id     | child_group_id      |
+      | 2                   | 3                   |
+      | 2                   | 4                   |
+      | 4                   | 5577006791947779410 |
+    And the table "groups_ancestors" should be:
+      | ancestor_group_id   | child_group_id      | is_self |
+      | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
+      | 2                   | 4                   | false   |
+      | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 4                   | 4                   | true    |
+      | 4                   | 5577006791947779410 | false   |
+      | 5577006791947779410 | 5577006791947779410 | true    |

--- a/app/api/auth/create_access_token.feature
+++ b/app/api/auth/create_access_token.feature
@@ -10,14 +10,17 @@ Feature: Create an access token
         -
           domains: [127.0.0.1]
           allUsersGroup: 2
-          TempUsersGroup: 4
+          nonTempUsersGroup: 3
+          tempUsersGroup: 4
       """
     And the database has the following table "groups":
-      | id | name      | type | created_at          |
-      | 2  | AllUsers  | Base | 2020-01-01 00:00:00 |
-      | 4  | TempUsers | Base | 2020-01-01 00:00:00 |
+      | id | name         | type | created_at          |
+      | 2  | AllUsers     | Base | 2020-01-01 00:00:00 |
+      | 3  | NonTempUsers | Base | 2020-01-01 00:00:00 |
+      | 4  | TempUsers    | Base | 2020-01-01 00:00:00 |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
 
   Scenario Outline: Create a new user
@@ -90,6 +93,7 @@ Feature: Create an access token
     And the table "groups" should be:
       | id                  | name                                    | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
       | 2                   | AllUsers                                | Base  | null        | false                                             | false   | false       | null                                    |
+      | 3                   | NonTempUsers                            | Base  | null        | false                                             | false   | false       | null                                    |
       | 4                   | TempUsers                               | Base  | null        | false                                             | false   | false       | null                                    |
       | 4037200794235010051 | Example badges 🐱                       | Other | null        | true                                              | false   | false       | https://badges.example.com/             |
       | 5577006791947779410 | mohammed                                | User  | mohammed    | true                                              | false   | false       | null                                    |
@@ -97,16 +101,20 @@ Feature: Create an access token
       | 8674665223082153551 | Example #1 🐱                           | Other | null        | true                                              | false   | false       | https://badges.example.com/examples/one |
     And the table "groups_groups" should be:
       | parent_group_id     | child_group_id      |
+      | 2                   | 3                   |
       | 2                   | 4                   |
-      | 2                   | 5577006791947779410 |
+      | 3                   | 5577006791947779410 |
       | 4037200794235010051 | 6129484611666145821 |
       | 6129484611666145821 | 8674665223082153551 |
       | 8674665223082153551 | 5577006791947779410 |
     And the table "groups_ancestors" should be:
       | ancestor_group_id   | child_group_id      | is_self |
       | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
       | 2                   | 4                   | false   |
       | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 3                   | 5577006791947779410 | false   |
       | 4                   | 4                   | true    |
       | 4037200794235010051 | 4037200794235010051 | true    |
       | 4037200794235010051 | 5577006791947779410 | false   |
@@ -192,8 +200,8 @@ Feature: Create an access token
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | 2019-05-11 10:42:11    | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 | null          | true        | false          | false             | false            |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
-      | 2               | 11             |
-      | 2               | 13             |
+      | 3               | 11             |
+      | 3               | 13             |
     And the groups ancestors are computed
     And the database has the following table "sessions":
       | session_id | user_id | refresh_token         |
@@ -308,13 +316,17 @@ Feature: Create an access token
     And the table "groups" should stay unchanged
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
-      | 2               | 11             |
+      | 3               | 11             |
     And the table "groups_ancestors" should be:
       | ancestor_group_id | child_group_id | is_self |
       | 2                 | 2              | true    |
+      | 2                 | 3              | false   |
       | 2                 | 4              | false   |
       | 2                 | 11             | false   |
+      | 3                 | 3              | true    |
+      | 3                 | 11             | false   |
       | 4                 | 4              | true    |
       | 11                | 11             | true    |
     And the table "group_membership_changes" should be empty
@@ -399,8 +411,8 @@ Feature: Create an access token
       | 13       | 2018-06-16 21:01:25 | 2018-06-16 22:05:44 | 2018-05-10 10:42:11 | 100000002 | john     | johndoe@gmail.com    | John       | Doe       | 987654321  | gb           | 1999-03-20 | 2021            | 1     | 1, Trafalgar sq.  | WC2N 5DN | City of Westminster | +44 20 7747 2885  | +44 333 300 7774  | en               | I'm John Doe        | http://johndoe.freepages.com  | Male | 1              | 110.55.10.2 |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
-      | 2               | 11             |
-      | 2               | 13             |
+      | 3               | 11             |
+      | 3               | 13             |
     And the groups ancestors are computed
     And the database has the following table "sessions":
       | session_id | user_id | refresh_token         |
@@ -651,23 +663,28 @@ Feature: Create an access token
       | group_id            | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip   | time_zone      | notify_news | photo_autoload | public_first_name | public_last_name |
       | 5577006791947779410 | 2019-07-16 22:02:28 | 2019-07-16 22:02:28 | 0         | 2019-07-16 22:02:28 | 2019-07-16 22:02:28    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | null    | null    | null | null             | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 | Africa/Algiers | true        | true           | true              | true             |
     And the table "groups" should be:
-      | id                  | name       | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
-      | 2                   | AllUsers   | Base  | null        | false                                             | false   | false       | null                                    |
-      | 4                   | TempUsers  | Base  | null        | false                                             | false   | false       | null                                    |
-      | 5577006791947779410 | mohammed   | User  | mohammed    | true                                              | false   | false       | null                                    |
-      | 6129484611666145821 | Example #2 | Other | null        | true                                              | false   | false       | https://badges.example.com/parents      |
-      | 8674665223082153551 | Example #1 | Other | null        | true                                              | false   | false       | https://badges.example.com/examples/one |
+      | id                  | name         | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
+      | 2                   | AllUsers     | Base  | null        | false                                             | false   | false       | null                                    |
+      | 3                   | NonTempUsers | Base  | null        | false                                             | false   | false       | null                                    |
+      | 4                   | TempUsers    | Base  | null        | false                                             | false   | false       | null                                    |
+      | 5577006791947779410 | mohammed     | User  | mohammed    | true                                              | false   | false       | null                                    |
+      | 6129484611666145821 | Example #2   | Other | null        | true                                              | false   | false       | https://badges.example.com/parents      |
+      | 8674665223082153551 | Example #1   | Other | null        | true                                              | false   | false       | https://badges.example.com/examples/one |
     And the table "groups_groups" should be:
       | parent_group_id     | child_group_id      |
+      | 2                   | 3                   |
       | 2                   | 4                   |
-      | 2                   | 5577006791947779410 |
+      | 3                   | 5577006791947779410 |
       | 6129484611666145821 | 8674665223082153551 |
       | 8674665223082153551 | 5577006791947779410 |
     And the table "groups_ancestors" should be:
       | ancestor_group_id   | child_group_id      | is_self |
       | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
       | 2                   | 4                   | false   |
       | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 3                   | 5577006791947779410 | false   |
       | 4                   | 4                   | true    |
       | 5577006791947779410 | 5577006791947779410 | true    |
       | 6129484611666145821 | 5577006791947779410 | false   |
@@ -749,20 +766,25 @@ Feature: Create an access token
       | group_id            | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip   | time_zone      | notify_news | photo_autoload | public_first_name | public_last_name |
       | 5577006791947779410 | 2019-07-16 22:02:28 | 2019-07-16 22:02:28 | 0         | 2019-07-16 22:02:28 | 2019-07-16 22:02:28    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | null    | null    | null | null             | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 | Africa/Algiers | true        | true           | true              | true             |
     And the table "groups" should be:
-      | id                  | name       | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
-      | 2                   | AllUsers   | Base  | null        | false                                             | false   | false       | null                                    |
-      | 4                   | TempUsers  | Base  | null        | false                                             | false   | false       | null                                    |
-      | 5577006791947779410 | mohammed   | User  | mohammed    | true                                              | false   | false       | null                                    |
-      | 8674665223082153551 | Example #1 | Other | null        | true                                              | false   | false       | https://badges.example.com/examples/one |
+      | id                  | name         | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
+      | 2                   | AllUsers     | Base  | null        | false                                             | false   | false       | null                                    |
+      | 3                   | NonTempUsers | Base  | null        | false                                             | false   | false       | null                                    |
+      | 4                   | TempUsers    | Base  | null        | false                                             | false   | false       | null                                    |
+      | 5577006791947779410 | mohammed     | User  | mohammed    | true                                              | false   | false       | null                                    |
+      | 8674665223082153551 | Example #1   | Other | null        | true                                              | false   | false       | https://badges.example.com/examples/one |
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id      |
+      | 2               | 3                   |
       | 2               | 4                   |
-      | 2               | 5577006791947779410 |
+      | 3               | 5577006791947779410 |
     And the table "groups_ancestors" should be:
       | ancestor_group_id   | child_group_id      | is_self |
       | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
       | 2                   | 4                   | false   |
       | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 3                   | 5577006791947779410 | false   |
       | 4                   | 4                   | true    |
       | 5577006791947779410 | 5577006791947779410 | true    |
       | 8674665223082153551 | 8674665223082153551 | true    |
@@ -845,20 +867,25 @@ Feature: Create an access token
       | group_id            | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip   | time_zone      | notify_news | photo_autoload | public_first_name | public_last_name |
       | 5577006791947779410 | 2019-07-16 22:02:28 | 2019-07-16 22:02:28 | 0         | 2019-07-16 22:02:28 | 2019-07-16 22:02:28    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | null    | null    | null | null             | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 | Africa/Algiers | true        | true           | true              | true             |
     And the table "groups" should be:
-      | id                  | name       | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
-      | 2                   | AllUsers   | Base  | null        | false                                             | false   | false       | null                                    |
-      | 4                   | TempUsers  | Base  | null        | false                                             | false   | false       | null                                    |
-      | 5577006791947779410 | mohammed   | User  | mohammed    | true                                              | false   | false       | null                                    |
-      | 8674665223082153551 | Example #1 | Other | null        | false                                             | false   | false       | https://badges.example.com/examples/one |
+      | id                  | name         | type  | description | ABS(TIMESTAMPDIFF(SECOND, NOW(), created_at)) < 3 | is_open | send_emails | text_id                                 |
+      | 2                   | AllUsers     | Base  | null        | false                                             | false   | false       | null                                    |
+      | 3                   | NonTempUsers | Base  | null        | false                                             | false   | false       | null                                    |
+      | 4                   | TempUsers    | Base  | null        | false                                             | false   | false       | null                                    |
+      | 5577006791947779410 | mohammed     | User  | mohammed    | true                                              | false   | false       | null                                    |
+      | 8674665223082153551 | Example #1   | Other | null        | false                                             | false   | false       | https://badges.example.com/examples/one |
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id      |
+      | 2               | 3                   |
       | 2               | 4                   |
-      | 2               | 5577006791947779410 |
+      | 3               | 5577006791947779410 |
     And the table "groups_ancestors" should be:
       | ancestor_group_id   | child_group_id      | is_self |
       | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
       | 2                   | 4                   | false   |
       | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
+      | 3                   | 5577006791947779410 | false   |
       | 4                   | 4                   | true    |
       | 5577006791947779410 | 5577006791947779410 | true    |
       | 8674665223082153551 | 8674665223082153551 | true    |

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -457,16 +457,16 @@ func createOrUpdateUser(s *database.UserStore, userData map[string]interface{}, 
 	}
 	service.MustNotBeError(err)
 
-	found, err := s.GroupGroups().WithExclusiveWriteLock().Where("parent_group_id = ?", domainConfig.AllUsersGroupID).
+	found, err := s.GroupGroups().WithExclusiveWriteLock().Where("parent_group_id = ?", domainConfig.NonTempUsersGroupID).
 		Where("child_group_id = ?", groupID).HasRows()
 	service.MustNotBeError(err)
-	groupsToCreate := make([]map[string]interface{}, 0, 1)
+	groupsGroupsToCreate := make([]map[string]interface{}, 0, 1)
 	if !found {
-		groupsToCreate = append(groupsToCreate,
-			map[string]interface{}{"parent_group_id": domainConfig.AllUsersGroupID, "child_group_id": groupID})
+		groupsGroupsToCreate = append(groupsGroupsToCreate,
+			map[string]interface{}{"parent_group_id": domainConfig.NonTempUsersGroupID, "child_group_id": groupID})
 	}
 
-	service.MustNotBeError(s.GroupGroups().CreateRelationsWithoutChecking(groupsToCreate))
+	service.MustNotBeError(s.GroupGroups().CreateRelationsWithoutChecking(groupsGroupsToCreate))
 	delete(userData, "default_language")
 	service.MustNotBeError(s.ByID(groupID).UpdateColumn(userData).Error())
 	return groupID
@@ -487,7 +487,7 @@ func createGroupFromLogin(store *database.GroupStore, login string, domainConfig
 	}))
 
 	service.MustNotBeError(store.GroupGroups().CreateRelationsWithoutChecking([]map[string]interface{}{
-		{"parent_group_id": domainConfig.AllUsersGroupID, "child_group_id": selfGroupID},
+		{"parent_group_id": domainConfig.NonTempUsersGroupID, "child_group_id": selfGroupID},
 	}))
 
 	return selfGroupID

--- a/app/api/auth/create_access_token_avoid_session_spamming.feature
+++ b/app/api/auth/create_access_token_avoid_session_spamming.feature
@@ -10,7 +10,8 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
         -
           domains: [127.0.0.1]
           allUsersGroup: @AllUsers
-          TempUsersGroup: @TempUsers
+          nonTempUsersGroup: @NonTempUsers
+          tempUsersGroup: @TempUsers
       """
     And the time now is "2020-01-01T01:00:00Z"
     # login_id is used to match with the "id" returned by the login module
@@ -21,9 +22,9 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
       | @UserWith10Sessions_2 | 102      |
       | @UserWith9Sessions    | 9        |
     And there are the following groups:
-      | group      | members                                                                          |
-      | @AllUsers  | @UserWith9Sessions,@UserWith10Sessions,@UserWith10Sessions_2,@UserWith11Sessions |
-      | @TempUsers |                                                                                  |
+      | group         | members                                                                          |
+      | @AllUsers     | @TempUsers,@NonTempUsers                                                         |
+      | @NonTempUsers | @UserWith9Sessions,@UserWith10Sessions,@UserWith10Sessions_2,@UserWith11Sessions |
     And there are the following sessions:
       | session                          | user                  | refresh_token           |
       | @Session_UserWith11Sessions_1    | @UserWith11Sessions   | rt_user_11_session_1    | # shouldn't be deleted because it's the newest one

--- a/app/api/auth/create_access_token_integration_test.go
+++ b/app/api/auth/create_access_token_integration_test.go
@@ -33,7 +33,7 @@ func Test_createGroupFromLogin_Duplicate(t *testing.T) {
 	dataStore := database.NewDataStore(db)
 	var selfGroupID int64
 	require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
-		selfGroupID = createGroupFromLogin(dataStore.Groups(), "test", &domain.CtxConfig{AllUsersGroupID: 100})
+		selfGroupID = createGroupFromLogin(dataStore.Groups(), "test", &domain.CtxConfig{NonTempUsersGroupID: 100})
 		return nil
 	}))
 	assert.Equal(t, int64(2), selfGroupID)

--- a/app/api/auth/create_temp_user.feature
+++ b/app/api/auth/create_temp_user.feature
@@ -6,14 +6,17 @@ Feature: Create a temporary user
         -
           domains: [127.0.0.1]
           allUsersGroup: 2
+          nonTempUsersGroup: 3
           tempUsersGroup: 4
       """
     And the database has the following table "groups":
-      | id | name      | type | text_id   |
-      | 2  | AllUsers  | Base | AllUsers  |
-      | 4  | TempUsers | User | TempUsers |
+      | id | name         | type | text_id      |
+      | 2  | AllUsers     | Base | AllUsers     |
+      | 3  | NonTempUsers | Base | NonTempUsers |
+      | 4  | TempUsers    | Base | TempUsers    |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
     And the time now is "2020-07-16T22:02:28Z"
 
@@ -49,8 +52,10 @@ Feature: Create a temporary user
     And the table "groups_ancestors" should be:
       | ancestor_group_id   | child_group_id      | is_self |
       | 2                   | 2                   | true    |
+      | 2                   | 3                   | false   |
       | 2                   | 4                   | false   |
       | 2                   | 5577006791947779410 | false   |
+      | 3                   | 3                   | true    |
       | 4                   | 4                   | true    |
       | 4                   | 5577006791947779410 | false   |
       | 5577006791947779410 | 5577006791947779410 | true    |

--- a/app/api/auth/refresh_access_token_parallel_sessions.feature
+++ b/app/api/auth/refresh_access_token_parallel_sessions.feature
@@ -1,8 +1,8 @@
 Feature: Support for parallel sessions
   Background:
     Given there are the following groups:
-      | group     | parent | members               |
-      | @AllUsers |        | @User1,@UserUntouched |
+      | group         | parent    | members               |
+      | @NonTempUsers | @AllUsers | @User1,@UserUntouched |
     And the time now is "2020-01-01T01:00:00Z"
     And there are the following sessions:
       | session                | user           | refresh_token       |

--- a/app/api/auth/refresh_access_token_remove_expired_of_user_on_refresh.feature
+++ b/app/api/auth/refresh_access_token_remove_expired_of_user_on_refresh.feature
@@ -1,8 +1,9 @@
 Feature: Support for parallel sessions
   Background:
     Given there are the following groups:
-      | group     | parent | members                                        |
-      | @AllUsers |        | @User1,@UserUntouched,@UserWithoutExpiredToken |
+      | group         | parent    | members                                        |
+      | @TempUsers    | @AllUsers |                                                |
+      | @NonTempUsers | @AllUsers | @User1,@UserUntouched,@UserWithoutExpiredToken |
     And the time now is "2020-01-01T01:00:00Z"
     And there are the following sessions:
       | session                          | user                     | refresh_token                 |
@@ -53,10 +54,10 @@ Feature: Support for parallel sessions
 
   Scenario: Should remove the expired access tokens of the user when refreshing a token, when the user is a temp user
     Given there are the following users:
-      | user                     | groups    | temp_user |
-      | @User1                   | @AllUsers | true      |
-      | @UserUntouched           | @AllUsers | true      |
-      | @UserWithoutExpiredToken | @AllUsers | true      |
+      | user                     | groups     | temp_user |
+      | @User1                   | @TempUsers | true      |
+      | @UserUntouched           | @TempUsers | true      |
+      | @UserWithoutExpiredToken | @TempUsers | true      |
     And the "Authorization" request header is "Bearer t_user_1_session_1_most_recent"
     When I send a POST request to "/auth/token"
     Then the response code should be 201
@@ -83,10 +84,10 @@ Feature: Support for parallel sessions
 
   Scenario: Should not remove any access token if there's no expired one for the user, when the user is a temp user
     Given there are the following users:
-      | user                     | groups    | temp_user |
-      | @User1                   | @AllUsers | true      |
-      | @UserUntouched           | @AllUsers | true      |
-      | @UserWithoutExpiredToken | @AllUsers | true      |
+      | user                     | groups     | temp_user |
+      | @User1                   | @TempUsers | true      |
+      | @UserUntouched           | @TempUsers | true      |
+      | @UserWithoutExpiredToken | @TempUsers | true      |
     And the "Authorization" request header is "Bearer t_user_without_expired_token"
     When I send a POST request to "/auth/token"
     Then the response code should be 201

--- a/app/api/currentuser/delete.feature
+++ b/app/api/currentuser/delete.feature
@@ -1,16 +1,18 @@
 Feature: Delete the current user
   Background:
     Given the database has the following table "groups":
-      | id  | type  | name       | require_lock_membership_approval_until |
-      | 2   | Base  | AllUsers   | 9999-12-31 23:59:59                    |
-      | 4   | Base  | TempUsers  | null                                   |
-      | 21  | User  | user       | null                                   |
-      | 31  | User  | tmp-1234   | null                                   |
-      | 100 | Class | Some class | null                                   |
+      | id  | type  | name         | require_lock_membership_approval_until |
+      | 2   | Base  | AllUsers     | 9999-12-31 23:59:59                    |
+      | 3   | Base  | NonTempUsers | null                                   |
+      | 4   | Base  | TempUsers    | null                                   |
+      | 21  | User  | user         | null                                   |
+      | 31  | User  | tmp-1234     | null                                   |
+      | 100 | Class | Some class   | null                                   |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
-      | 2               | 21             |
+      | 3               | 21             |
       | 4               | 31             |
     And the groups ancestors are computed
     And the database has the following table "group_pending_requests":
@@ -52,13 +54,15 @@ Feature: Delete the current user
       | temp_user | login    | group_id |
       | 1         | tmp-1234 | 31       |
     And the table "groups" should be:
-      | id  | type  | name       |
-      | 2   | Base  | AllUsers   |
-      | 4   | Base  | TempUsers  |
-      | 31  | User  | tmp-1234   |
-      | 100 | Class | Some class |
+      | id  | type  | name         |
+      | 2   | Base  | AllUsers     |
+      | 3   | Base  | NonTempUsers |
+      | 4   | Base  | TempUsers    |
+      | 31  | User  | tmp-1234     |
+      | 100 | Class | Some class   |
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
       | 4               | 31             |
     And the table "group_pending_requests" should be:
@@ -70,8 +74,10 @@ Feature: Delete the current user
     And the table "groups_ancestors" should be:
       | ancestor_group_id | child_group_id | is_self |
       | 2                 | 2              | true    |
+      | 2                 | 3              | false   |
       | 2                 | 4              | false   |
       | 2                 | 31             | false   |
+      | 3                 | 3              | true    |
       | 4                 | 4              | true    |
       | 4                 | 31             | false   |
       | 31                | 31             | true    |
@@ -92,15 +98,17 @@ Feature: Delete the current user
       | temp_user | login | group_id |
       | 0         | user  | 21       |
     And the table "groups" should be:
-      | id  | type  | name       |
-      | 2   | Base  | AllUsers   |
-      | 4   | Base  | TempUsers  |
-      | 21  | User  | user       |
-      | 100 | Class | Some class |
+      | id  | type  | name         |
+      | 2   | Base  | AllUsers     |
+      | 3   | Base  | NonTempUsers |
+      | 4   | Base  | TempUsers    |
+      | 21  | User  | user         |
+      | 100 | Class | Some class   |
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
-      | 2               | 21             |
+      | 3               | 21             |
     And the table "group_pending_requests" should be:
       | group_id | member_id |
       | 100      | 21        |
@@ -110,8 +118,11 @@ Feature: Delete the current user
     And the table "groups_ancestors" should be:
       | ancestor_group_id | child_group_id | is_self |
       | 2                 | 2              | true    |
+      | 2                 | 3              | false   |
       | 2                 | 4              | false   |
       | 2                 | 21             | false   |
+      | 3                 | 3              | true    |
+      | 3                 | 21             | false   |
       | 4                 | 4              | true    |
       | 21                | 21             | true    |
       | 100               | 100            | true    |

--- a/app/api/currentuser/delete.robustness.feature
+++ b/app/api/currentuser/delete.robustness.feature
@@ -2,15 +2,17 @@ Feature: Delete the current user - robustness
   Background:
     Given the DB time now is "2019-08-09 23:59:59"
     And the database has the following table "groups":
-      | id | type  | name      | require_lock_membership_approval_until |
-      | 2  | Base  | AllUsers  | null                                   |
-      | 4  | Base  | TempUsers | null                                   |
-      | 21 | User  | user      | null                                   |
-      | 50 | Class | Our class | 2019-08-10 00:00:00                    |
+      | id | type  | name         | require_lock_membership_approval_until |
+      | 2  | Base  | AllUsers     | null                                   |
+      | 3  | Base  | NonTempUsers | null                                   |
+      | 4  | Base  | TempUsers    | null                                   |
+      | 21 | User  | user         | null                                   |
+      | 50 | Class | Our class    | 2019-08-10 00:00:00                    |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id | lock_membership_approved_at |
+      | 2               | 3              | null                        |
       | 2               | 4              | null                        |
-      | 2               | 21             | null                        |
+      | 3               | 21             | null                        |
       | 50              | 21             | 2019-05-30 11:00:00         |
     And the groups ancestors are computed
     And the database has the following user:
@@ -50,17 +52,21 @@ Feature: Delete the current user - robustness
     And the response error message should contain "Login module failed"
     And the table "users" should be empty
     And the table "groups" should be:
-      | id | type  | name      | require_lock_membership_approval_until |
-      | 2  | Base  | AllUsers  | null                                   |
-      | 4  | Base  | TempUsers | null                                   |
-      | 50 | Class | Our class | 2019-08-10 00:00:00                    |
+      | id | type  | name         | require_lock_membership_approval_until |
+      | 2  | Base  | AllUsers     | null                                   |
+      | 3  | Base  | NonTempUsers | null                                   |
+      | 4  | Base  | TempUsers    | null                                   |
+      | 50 | Class | Our class    | 2019-08-10 00:00:00                    |
     And the table "groups_groups" should be:
       | parent_group_id | child_group_id |
+      | 2               | 3              |
       | 2               | 4              |
     And the table "groups_ancestors" should be:
       | ancestor_group_id | child_group_id | is_self |
       | 2                 | 2              | true    |
+      | 2                 | 3              | false   |
       | 2                 | 4              | false   |
+      | 3                 | 3              | true    |
       | 4                 | 4              | true    |
       | 50                | 50             | true    |
     And logs should contain:

--- a/app/api/groups/add_child.robustness.feature
+++ b/app/api/groups/add_child.robustness.feature
@@ -89,7 +89,7 @@ Feature: Add a parent-child relation between two groups - robustness
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
 
-  Scenario: Child group is AllUsers groups
+  Scenario: Child group is of type Base
     Given I am the user with id "27"
     When I send a POST request to "/groups/13/relations/16"
     Then the response code should be 403

--- a/app/api/groups/check_code.feature
+++ b/app/api/groups/check_code.feature
@@ -74,7 +74,7 @@ Feature: Check if the group code is valid
       domains:
         -
           domains: [127.0.0.1]
-          allUsersGroup: 3
+          nonTempUsersGroup: 3
       """
     When I send a GET request to "/groups/is-code-valid?code=3456789abc"
     Then the response code should be 200
@@ -111,7 +111,7 @@ Feature: Check if the group code is valid
       domains:
         -
           domains: [127.0.0.1]
-          allUsersGroup: 3
+          nonTempUsersGroup: 3
       """
     When I send a GET request to "/groups/is-code-valid?code=3456789abc"
     Then the response code should be 200

--- a/app/api/groups/check_code.go
+++ b/app/api/groups/check_code.go
@@ -102,7 +102,7 @@ func (srv *Service) checkCode(w http.ResponseWriter, r *http.Request) service.AP
 	store := srv.GetStore(r)
 	userIDToCheck := user.GroupID
 	if user.IsTempUser {
-		userIDToCheck = domain.ConfigFromContext(r.Context()).AllUsersGroupID
+		userIDToCheck = domain.ConfigFromContext(r.Context()).NonTempUsersGroupID
 	}
 
 	valid, reason, groupID := checkGroupCodeForUser(store, userIDToCheck, code)

--- a/app/api/groups/create_user_batch.feature
+++ b/app/api/groups/create_user_batch.feature
@@ -1,11 +1,11 @@
 Feature: Create a user batch
   Background:
     Given the database has the following table "groups":
-      | id | type    | name     | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
-      | 2  | Base    | AllUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
-      | 3  | Club    | Club     | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
-      | 4  | Friends | Friends  | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
-      | 21 | User    | owner    | 2016-08-10 12:34:55 | none                                  | null                                   | 0                      |
+      | id | type    | name         | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
+      | 2  | Base    | NonTempUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
+      | 3  | Club    | Club         | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
+      | 4  | Friends | Friends      | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
+      | 21 | User    | owner        | 2016-08-10 12:34:55 | none                                  | null                                   | 0                      |
     And the database has the following user:
       | group_id | login | first_name  | last_name | default_language |
       | 21       | owner | Jean-Michel | Blanquer  | en               |
@@ -30,7 +30,7 @@ Feature: Create a user batch
       domains:
         -
           domains: [127.0.0.1]
-          allUsersGroup: 2
+          nonTempUsersGroup: 2
       """
 
   Scenario: Create a new user batch
@@ -100,7 +100,7 @@ Feature: Create a user batch
       | 8674665223082153551 | null            | null               | 0         | 2019-07-16 22:02:28 | 100000030 | test_custom_ctc | en               | null  | null        | null      |
     And the table "groups" should be:
       | id                  | name            | type    | description     | created_at          | is_open | send_emails |
-      | 2                   | AllUsers        | Base    | null            | 2015-08-10 12:34:55 | false   | false       |
+      | 2                   | NonTempUsers    | Base    | null            | 2015-08-10 12:34:55 | false   | false       |
       | 3                   | Club            | Club    | null            | 2017-08-10 12:34:55 | false   | false       |
       | 4                   | Friends         | Friends | null            | 2018-08-10 12:34:55 | false   | false       |
       | 21                  | owner           | User    | null            | 2016-08-10 12:34:55 | false   | false       |

--- a/app/api/groups/create_user_batch.go
+++ b/app/api/groups/create_user_batch.go
@@ -296,7 +296,7 @@ func createBatchUsersInDB(store *database.DataStore, input createUserBatchReques
 			}
 			relationsToCreate = append(relationsToCreate,
 				map[string]interface{}{
-					"parent_group_id":                domainConfig.AllUsersGroupID,
+					"parent_group_id":                domainConfig.NonTempUsersGroupID,
 					"child_group_id":                 userGroupID,
 					"personal_info_view_approved_at": nil, "lock_membership_approved_at": nil, "watch_approved_at": nil,
 				},

--- a/app/api/groups/create_user_batch.robustness.feature
+++ b/app/api/groups/create_user_batch.robustness.feature
@@ -1,10 +1,10 @@
 Feature: Create a user batch - robustness
   Background:
     Given the database has the following table "groups":
-      | id | type    | name     | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
-      | 2  | Base    | AllUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
-      | 3  | Club    | Club     | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
-      | 4  | Friends | Friends  | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
+      | id | type    | name         | created_at          | require_personal_info_access_approval | require_lock_membership_approval_until | require_watch_approval |
+      | 2  | Base    | NonTempUsers | 2015-08-10 12:34:55 | none                                  | null                                   | 0                      |
+      | 3  | Club    | Club         | 2017-08-10 12:34:55 | view                                  | 3030-01-01 00:00:00                    | 1                      |
+      | 4  | Friends | Friends      | 2018-08-10 12:34:55 | edit                                  | 2019-01-01 00:00:00                    | 0                      |
     And the database has the following user:
       | group_id | login | first_name  | last_name |
       | 21       | owner | Jean-Michel | Blanquer  |
@@ -35,7 +35,7 @@ Feature: Create a user batch - robustness
       domains:
         -
           domains: [127.0.0.1]
-          allUsersGroup: 2
+          nonTempUsersGroup: 2
       """
 
   Scenario: Missing required fields

--- a/app/api/groups/get_permissions_can_request_help_to.feature
+++ b/app/api/groups/get_permissions_can_request_help_to.feature
@@ -9,18 +9,25 @@
 #          If those permissions definitions get fixed, then this file can be merged with them.
 Feature: Get permissions can_request_help_to for a group
   Background:
-    Given allUsersGroup is defined as the group @AllUsers
+    Given the application config is:
+      """
+      domains:
+        -
+          domains: [127.0.0.1]
+          allUsersGroup: @AllUsers
+      """
     And there are the following groups:
-      | group                    | parent                   | members  |
-      | @AllUsers                |                          |          |
-      | @School                  |                          | @Teacher |
-      | @ClassParentParentParent |                          |          |
-      | @ClassParentParent       | @ClassParentParentParent |          |
-      | @ClassParent             | @ClassParentParent       |          |
-      | @Class                   | @ClassParent             |          |
-      | @OtherSourceGroup        |                          |          |
+      | group                    | parent                   | members                 |
+      | @AllUsers                |                          | @NonTempUser,@TempUsers |
+      | @School                  |                          | @Teacher                |
+      | @ClassParentParentParent |                          |                         |
+      | @ClassParentParent       | @ClassParentParentParent |                         |
+      | @ClassParent             | @ClassParentParent       |                         |
+      | @Class                   | @ClassParent             |                         |
+      | @OtherSourceGroup        |                          |                         |
     And the group @Teacher is a manager of the group @ClassAnotherParent and can grant group access
     And the group @Class is a child of the group @ClassAnotherParent
+    And the group @Teacher is a child of the group @NonTempUsers
     And there are the following items:
       | item                        | type    |
       | @ChapterParent              | Chapter |
@@ -82,7 +89,7 @@ Feature: Get permissions can_request_help_to for a group
       """
         {
           "id": "@AllUsers",
-          "name": "AllUsers",
+          "name": "Group AllUsers",
           "is_all_users_group": true
         }
       """
@@ -124,7 +131,7 @@ Feature: Get permissions can_request_help_to for a group
   Then the response code should be 200
   And the response at $.granted_via_self.can_request_help_to[*] should be:
     | id                       | name                          | is_all_users_group |
-    | @AllUsers                | AllUsers                      | true               |
+    | @AllUsers                | Group AllUsers                | true               |
     | @HelperGroupSelf1        | Group HelperGroupSelf1        | false              |
     | @HelperOtherSourceGroup1 | Group HelperOtherSourceGroup1 | false              |
   And the response at $.granted.can_request_help_to in JSON should be:
@@ -138,24 +145,24 @@ Feature: Get permissions can_request_help_to for a group
   And the response at $.granted_via_group_membership.can_request_help_to[*] should be:
     | id                           | name                              | is_all_users_group |
     | @HelperGroupGroupMembership2 | Group HelperGroupGroupMembership2 | false              |
-    | @AllUsers                    | AllUsers                          | true               |
+    | @AllUsers                    | Group AllUsers                    | true               |
     | @HelperOtherSourceGroup2     | Group HelperOtherSourceGroup2     | false              |
   And the response at $.granted_via_item_unlocking.can_request_help_to[*] should be:
     | id                        | name                           | is_all_users_group |
     | @HelperGroupItemUnlocking | Group HelperGroupItemUnlocking | false              |
-    | @AllUsers                 | AllUsers                       | true               |
+    | @AllUsers                 | Group AllUsers                 | true               |
     | @HelperGroupNotVisible    | <undefined>                    | false              |
     | @HelperOtherSourceGroup3  | Group HelperOtherSourceGroup3  | false              |
   And the response at $.granted_via_other.can_request_help_to[*] should be:
     | id                                | name                          | is_all_users_group |
-    | @AllUsers                         | AllUsers                      | true               |
+    | @AllUsers                         | Group AllUsers                | true               |
     | @HelperGroupOther1                | Group HelperGroupOther1       | false              |
     | @HelperGroupOther2                | Group HelperGroupOther2       | false              |
     | @HelperOtherSourceGroup4          | Group HelperOtherSourceGroup4 | false              |
     | @HelperOtherSourceGroupNotVisible | <undefined>                   | false              |
   And the response at $.computed.can_request_help_to[*] should be:
     | id                                | name                              | is_all_users_group |
-    | @AllUsers                         | AllUsers                          | true               |
+    | @AllUsers                         | Group AllUsers                    | true               |
     | @HelperGroupSelf1                 | Group HelperGroupSelf1            | false              |
     | @HelperGroupGroupMembership1      | Group HelperGroupGroupMembership1 | false              |
     | @HelperGroupGroupMembership2      | Group HelperGroupGroupMembership2 | false              |
@@ -205,7 +212,7 @@ Feature: Get permissions can_request_help_to for a group
       | @HelperGroupSelf1            | Group HelperGroupSelf1            | false              |
       | @HelperGroupSelfNotVisible   | <undefined>                       | false              |
       | @HelperGroupGroupMembership1 | Group HelperGroupGroupMembership1 | false              |
-      | @AllUsers                    | AllUsers                          | true               |
+      | @AllUsers                    | Group AllUsers                    | true               |
       | @HelperGroupItemUnlocking1   | Group HelperGroupItemUnlocking1   | false              |
       | @HelperGroupItemUnlocking2   | Group HelperGroupItemUnlocking2   | false              |
       | @HelperGroupOther1           | Group HelperGroupOther1           | false              |

--- a/app/api/groups/remove_child.robustness.feature
+++ b/app/api/groups/remove_child.robustness.feature
@@ -84,7 +84,7 @@ Feature: Remove a direct parent-child relation between two groups - robustness
     And the table "groups_groups" should stay unchanged
     And the table "groups_ancestors" should stay unchanged
 
-  Scenario: Child group is AllUsers group
+  Scenario: Child group is of type Base
     Given I am the user with id "21"
     When I send a DELETE request to "/groups/13/relations/53"
     Then the response code should be 403

--- a/app/api/groups/update_permissions_can_request_help_to.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.feature
@@ -9,15 +9,22 @@
 #          If those permissions definitions get fixed, then this file can be merged with them.
 Feature: Change item access rights for a group - can_request_help_to
   Background:
-    Given allUsersGroup is defined as the group @AllUsers
+    Given the application config is:
+      """
+      domains:
+        -
+          domains: [127.0.0.1]
+          allUsersGroup: @AllUsers
+      """
     And there are the following groups:
-      | group           | parent       | members  |
-      | @AllUsers       |              |          |
-      | @School         |              | @Teacher |
-      | @Class          | @ClassParent |          |
-      | @OldHelperGroup |              |          |
-      | @NewHelperGroup |              |          |
+      | group           | parent       | members                  |
+      | @AllUsers       |              | @NonTempUsers,@TempUsers |
+      | @School         |              | @Teacher                 |
+      | @Class          | @ClassParent |                          |
+      | @OldHelperGroup |              |                          |
+      | @NewHelperGroup |              |                          |
     And the group @Teacher is a manager of the group @ClassParent and can grant group access
+    And the group @Teacher is a child of the group @NonTempUsers
     And there are the following tasks:
       | item  |
       | @Item |

--- a/app/api/groups/update_permissions_can_request_help_to.robustness.feature
+++ b/app/api/groups/update_permissions_can_request_help_to.robustness.feature
@@ -9,14 +9,21 @@
 #          If those permissions definitions get fixed, then this file can be merged with them.
 Feature: Change item access rights for a group - can_request_help_to
   Background:
-    Given allUsersGroup is defined as the group @AllUsers
+    Given the application config is:
+      """
+      domains:
+        -
+          domains: [127.0.0.1]
+          allUsersGroup: @AllUsers
+      """
     And there are the following groups:
-      | group        | parent       | members  |
-      | @AllUsers    |              |          |
-      | @School      |              | @Teacher |
-      | @Class       | @ClassParent |          |
-      | @HelperGroup |              |          |
+      | group        | parent       | members                  |
+      | @AllUsers    |              | @NonTempUsers,@TempUsers |
+      | @School      |              | @Teacher                 |
+      | @Class       | @ClassParent |                          |
+      | @HelperGroup |              |                          |
     And the group @Teacher is a manager of the group @ClassParent and can grant group access
+    And the group @Teacher is a child of the group @NonTempUsers
     And there are the following tasks:
       | item  |
       | @Item |

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -285,9 +285,10 @@ func TestDomainsConfig_Success(t *testing.T) {
 	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	sampleDomain := domain.ConfigItem{
-		Domains:        []string{"localhost", "other"},
-		AllUsersGroup:  2,
-		TempUsersGroup: 3,
+		Domains:           []string{"localhost", "other"},
+		AllUsersGroup:     2,
+		TempUsersGroup:    3,
+		NonTempUsersGroup: 4,
 	}
 	globalConfig.Set("domains", []domain.ConfigItem{sampleDomain})
 	config, err := DomainsConfig(globalConfig)
@@ -331,9 +332,10 @@ func TestReplaceDomainsConfig(t *testing.T) {
 	application, _ := New()
 	application.ReplaceDomainsConfig(globalConfig)
 	expected := []domain.ConfigItem{{
-		Domains:        []string{"localhost", "other"},
-		AllUsersGroup:  0,
-		TempUsersGroup: 0,
+		Domains:           []string{"localhost", "other"},
+		AllUsersGroup:     0,
+		TempUsersGroup:    0,
+		NonTempUsersGroup: 0,
 	}}
 	config, _ := DomainsConfig(application.Config)
 	assert.Equal(expected, config)

--- a/app/database/configdb/config.go
+++ b/app/database/configdb/config.go
@@ -19,6 +19,7 @@ func CheckConfig(datastore *database.DataStore, domainsConfig []domain.ConfigIte
 			id   int64
 		}{
 			{name: "AllUsers", id: domainConfig.AllUsersGroup},
+			{name: "NonTempUsers", id: domainConfig.NonTempUsersGroup},
 			{name: "TempUsers", id: domainConfig.TempUsersGroup},
 		} {
 			hasRows, err := groupStore.ByID(spec.id).HasRows()
@@ -35,6 +36,7 @@ func CheckConfig(datastore *database.DataStore, domainsConfig []domain.ConfigIte
 			parentID   int64
 			childID    int64
 		}{
+			{parentName: "AllUsers", childName: "NonTempUsers", parentID: domainConfig.AllUsersGroup, childID: domainConfig.NonTempUsersGroup},
 			{parentName: "AllUsers", childName: "TempUsers", parentID: domainConfig.AllUsersGroup, childID: domainConfig.TempUsersGroup},
 		} {
 			hasRows, err := groupGroupStore.
@@ -68,6 +70,7 @@ func insertRootGroupsAndRelations(store *database.DataStore, domainsConfig []dom
 		domainConfig := domainConfig
 		insertRootGroups(groupStore, &domainConfig)
 		for _, spec := range []map[string]interface{}{
+			{"parent_group_id": domainConfig.AllUsersGroup, "child_group_id": domainConfig.NonTempUsersGroup},
 			{"parent_group_id": domainConfig.AllUsersGroup, "child_group_id": domainConfig.TempUsersGroup},
 		} {
 			found, err := groupGroupStore.
@@ -97,6 +100,7 @@ func insertRootGroups(groupStore *database.GroupStore, domainConfig *domain.Conf
 		id   int64
 	}{
 		{name: "AllUsers", id: domainConfig.AllUsersGroup},
+		{name: "NonTempUsers", id: domainConfig.NonTempUsersGroup},
 		{name: "TempUsers", id: domainConfig.TempUsersGroup},
 	} {
 		found, err := groupStore.

--- a/app/database/configdb/config_integration_test.go
+++ b/app/database/configdb/config_integration_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -25,21 +26,25 @@ func TestCheckConfig_Integration(t *testing.T) {
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"127.0.0.1", "192.168.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 				{
 					Domains:       []string{"www.france-ioi.org"},
-					AllUsersGroup: 6, TempUsersGroup: 8,
+					AllUsersGroup: 6, NonTempUsersGroup: 7, TempUsersGroup: 8,
 				},
 			},
 			fixtures: `
 groups:
 	- {id: 2}
+	- {id: 3}
 	- {id: 4}
 	- {id: 6}
+	- {id: 7}
 	- {id: 8}
 groups_groups:
+	- {parent_group_id: 2, child_group_id: 3}
 	- {parent_group_id: 2, child_group_id: 4}
+	- {parent_group_id: 6, child_group_id: 7}
 	- {parent_group_id: 6, child_group_id: 8}
 			`,
 		},
@@ -48,41 +53,79 @@ groups_groups:
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"192.168.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			fixtures: `
 groups:
+	- {id: 3}
 	- {id: 4}
 			`,
 			expectedError: errors.New("no AllUsers group for domain \"192.168.0.1\""),
+		},
+		{
+			name: "NonTempUsers is missing",
+			config: []domain.ConfigItem{
+				{
+					Domains:       []string{"127.0.0.1"},
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
+				},
+			},
+			fixtures: `
+groups:
+	- {id: 2}
+	- {id: 4}
+			`,
+			expectedError: errors.New("no NonTempUsers group for domain \"127.0.0.1\""),
 		},
 		{
 			name: "TempUsers is missing",
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"127.0.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			fixtures: `
 groups:
 	- {id: 2}
+	- {id: 3}
 			`,
 			expectedError: errors.New("no TempUsers group for domain \"127.0.0.1\""),
+		},
+		{
+			name: "AllUsers -> NonTempUsers relation is missing",
+			config: []domain.ConfigItem{
+				{
+					Domains:       []string{"127.0.0.1"},
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
+				},
+			},
+			fixtures: `
+groups:
+	- {id: 2}
+	- {id: 3}
+	- {id: 4}
+groups_groups:
+	- {parent_group_id: 2, child_group_id: 4}
+			`,
+			expectedError: errors.New("no AllUsers -> NonTempUsers link in groups_groups for domain \"127.0.0.1\""),
 		},
 		{
 			name: "AllUsers -> TempUsers relation is missing",
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"127.0.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			fixtures: `
 groups:
 	- {id: 2}
+	- {id: 3}
 	- {id: 4}
+groups_groups:
+	- {parent_group_id: 2, child_group_id: 3}
 			`,
 			expectedError: errors.New("no AllUsers -> TempUsers link in groups_groups for domain \"127.0.0.1\""),
 		},
@@ -98,11 +141,11 @@ groups:
 			conf.Set("domains", tt.config)
 
 			domainConfig, err := app.DomainsConfig(conf)
-			assertlib.NoError(t, err)
+			require.NoError(t, err)
 
 			err = CheckConfig(database.NewDataStore(db), domainConfig)
 
-			assertlib.Equal(t, tt.expectedError, err)
+			assert.Equal(t, tt.expectedError, err)
 		})
 	}
 }
@@ -119,14 +162,16 @@ func TestCreateMissingData_Integration(t *testing.T) {
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"127.0.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			fixtures: `
 groups:
 	- {id: 2, type: "Base", name: "AllUsers", text_id: "AllUsers"}
+	- {id: 3, type: "Base", name: "NonTempUsers", text_id: "NonTempUsers"}
 	- {id: 4, type: "Base", name: "TempUsers", text_id: "TempUsers"}
 groups_groups:
+	- {parent_group_id: 2, child_group_id: 3}
 	- {parent_group_id: 2, child_group_id: 4}
 			`,
 			checkConfigPassBefore: true,
@@ -136,7 +181,7 @@ groups_groups:
 			config: []domain.ConfigItem{
 				{
 					Domains:       []string{"127.0.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			checkConfigPassBefore: false,
@@ -153,22 +198,22 @@ groups_groups:
 			conf.Set("domains", tt.config)
 
 			domainConfig, err := app.DomainsConfig(conf)
-			assertlib.NoError(t, err)
+			require.NoError(t, err)
 
 			// Verify that CheckConfig() passes or fails as expected before we call CreateMissingData().
 			errCheckConfigBefore := CheckConfig(database.NewDataStore(db), domainConfig)
 			if tt.checkConfigPassBefore {
-				assertlib.NoError(t, errCheckConfigBefore)
+				require.NoError(t, errCheckConfigBefore)
 			} else {
-				assertlib.Error(t, errCheckConfigBefore)
+				require.Error(t, errCheckConfigBefore)
 			}
 
 			err = CreateMissingData(database.NewDataStore(db), domainConfig)
-			assertlib.NoError(t, err)
+			assert.NoError(t, err)
 
 			// Once CreateMissingData() have been called, CheckConfig() should pass.
 			err = CheckConfig(database.NewDataStore(db), domainConfig)
-			assertlib.NoError(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/app/domain/domain.go
+++ b/app/domain/domain.go
@@ -14,15 +14,17 @@ const (
 
 // CtxConfig contains domain-specific settings related to a request context.
 type CtxConfig struct {
-	AllUsersGroupID  int64
-	TempUsersGroupID int64
+	AllUsersGroupID     int64
+	NonTempUsersGroupID int64
+	TempUsersGroupID    int64
 }
 
 // ConfigItem is one item of the configuration list.
 type ConfigItem struct {
-	Domains        []string
-	AllUsersGroup  int64
-	TempUsersGroup int64
+	Domains           []string
+	AllUsersGroup     int64
+	NonTempUsersGroup int64
+	TempUsersGroup    int64
 }
 
 // ConfigFromContext retrieves the current domain configuration from a context set by the middleware.

--- a/app/domain/domain_test.go
+++ b/app/domain/domain_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConfigFromContext(t *testing.T) {
-	expectedConfig := &CtxConfig{AllUsersGroupID: 101, TempUsersGroupID: 103}
+	expectedConfig := &CtxConfig{AllUsersGroupID: 101, NonTempUsersGroupID: 102, TempUsersGroupID: 103}
 	ctx := context.WithValue(context.Background(), ctxDomainConfig, expectedConfig)
 	conf := ConfigFromContext(ctx)
 

--- a/app/domain/middleware.go
+++ b/app/domain/middleware.go
@@ -16,8 +16,9 @@ func Middleware(domains []ConfigItem, domainOverride string) func(next http.Hand
 	for _, domain := range domains {
 		for _, host := range domain.Domains {
 			domainsMap[host] = &CtxConfig{
-				AllUsersGroupID:  domain.AllUsersGroup,
-				TempUsersGroupID: domain.TempUsersGroup,
+				AllUsersGroupID:     domain.AllUsersGroup,
+				NonTempUsersGroupID: domain.NonTempUsersGroup,
+				TempUsersGroupID:    domain.TempUsersGroup,
 			}
 			if host == "default" {
 				defaultConfig = domainsMap[host]

--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -25,14 +25,14 @@ func TestMiddleware(t *testing.T) {
 			domains: []ConfigItem{
 				{
 					Domains:       []string{"france-ioi.org", "www.france-ioi.org"},
-					AllUsersGroup: 6, TempUsersGroup: 7,
+					AllUsersGroup: 6, NonTempUsersGroup: 8, TempUsersGroup: 7,
 				},
 				{
 					Domains:       []string{"192.168.0.1", "127.0.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
-			expectedConfig:     &CtxConfig{AllUsersGroupID: 2, TempUsersGroupID: 4},
+			expectedConfig:     &CtxConfig{AllUsersGroupID: 2, NonTempUsersGroupID: 3, TempUsersGroupID: 4},
 			expectedDomain:     "127.0.0.1",
 			expectedStatusCode: http.StatusOK,
 			shouldEnterService: true,
@@ -42,15 +42,15 @@ func TestMiddleware(t *testing.T) {
 			domains: []ConfigItem{
 				{
 					Domains:       []string{"france-ioi.org", "www.france-ioi.org"},
-					AllUsersGroup: 6, TempUsersGroup: 7,
+					AllUsersGroup: 6, NonTempUsersGroup: 8, TempUsersGroup: 7,
 				},
 				{
 					Domains:       []string{"default"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			expectedDomain:     "127.0.0.1",
-			expectedConfig:     &CtxConfig{AllUsersGroupID: 2, TempUsersGroupID: 4},
+			expectedConfig:     &CtxConfig{AllUsersGroupID: 2, NonTempUsersGroupID: 3, TempUsersGroupID: 4},
 			expectedStatusCode: http.StatusOK,
 			shouldEnterService: true,
 		},
@@ -59,16 +59,16 @@ func TestMiddleware(t *testing.T) {
 			domains: []ConfigItem{
 				{
 					Domains:       []string{"france-ioi.org", "www.france-ioi.org"},
-					AllUsersGroup: 6, TempUsersGroup: 7,
+					AllUsersGroup: 6, NonTempUsersGroup: 8, TempUsersGroup: 7,
 				},
 				{
 					Domains:       []string{"default"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			domainOverride:     "www.france-ioi.org",
 			expectedDomain:     "www.france-ioi.org",
-			expectedConfig:     &CtxConfig{AllUsersGroupID: 6, TempUsersGroupID: 7},
+			expectedConfig:     &CtxConfig{AllUsersGroupID: 6, NonTempUsersGroupID: 8, TempUsersGroupID: 7},
 			expectedStatusCode: http.StatusOK,
 			shouldEnterService: true,
 		},
@@ -77,11 +77,11 @@ func TestMiddleware(t *testing.T) {
 			domains: []ConfigItem{
 				{
 					Domains:       []string{"france-ioi.org", "www.france-ioi.org"},
-					AllUsersGroup: 5, TempUsersGroup: 7,
+					AllUsersGroup: 5, NonTempUsersGroup: 6, TempUsersGroup: 7,
 				},
 				{
 					Domains:       []string{"192.168.0.1"},
-					AllUsersGroup: 2, TempUsersGroup: 4,
+					AllUsersGroup: 2, NonTempUsersGroup: 3, TempUsersGroup: 4,
 				},
 			},
 			expectedStatusCode: http.StatusNotImplemented,

--- a/conf/config.sample.yaml
+++ b/conf/config.sample.yaml
@@ -35,4 +35,5 @@ domains:
   -
     domains: [default] # of a list of domains
     allUsersGroup: 3
+    nonTempUsersGroup: 4
     tempUsersGroup: 2

--- a/conf/config.test.sample.yaml
+++ b/conf/config.test.sample.yaml
@@ -35,4 +35,5 @@ domains:
   -
     domains: [default] # of a list of domains
     allUsersGroup: 3
+    nonTempUsersGroup: 4
     tempUsersGroup: 2

--- a/db/migrations/2506042226_move_non_temp_users_from_all_users_group_into_non_temp_users_group.sql
+++ b/db/migrations/2506042226_move_non_temp_users_from_all_users_group_into_non_temp_users_group.sql
@@ -1,0 +1,25 @@
+-- +migrate Up
+SELECT `id` INTO @all_users_group FROM `groups` WHERE `type`='Base' AND `text_id`='AllUsers';
+SELECT `id` INTO @non_temp_users_group FROM `groups` WHERE `type`='Base' AND `text_id`='NonTempUsers';
+
+INSERT IGNORE INTO `groups_groups` (parent_group_id, child_group_id)
+  SELECT @non_temp_users_group, users.group_id
+  FROM `users` WHERE NOT temp_user;
+
+DELETE `groups_groups`
+FROM `groups_groups`
+JOIN `users` ON `users`.`group_id`=`groups_groups`.`child_group_id` AND NOT `users`.`temp_user`
+WHERE `groups_groups`.`parent_group_id`=@all_users_group;
+
+-- +migrate Down
+SELECT `id` INTO @all_users_group FROM `groups` WHERE `type`='Base' AND `text_id`='AllUsers';
+SELECT `id` INTO @non_temp_users_group FROM `groups` WHERE `type`='Base' AND `text_id`='NonTempUsers';
+
+INSERT IGNORE INTO `groups_groups` (parent_group_id, child_group_id)
+SELECT @all_users_group, users.group_id
+FROM `users` WHERE NOT temp_user;
+
+DELETE `groups_groups`
+FROM `groups_groups`
+JOIN `users` ON `users`.`group_id`=`groups_groups`.`child_group_id` AND NOT `users`.`temp_user`
+WHERE `groups_groups`.`parent_group_id`=@non_temp_users_group;

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -24,7 +24,6 @@ func (ctx *TestContext) registerFeaturesForGroups(s *godog.ScenarioContext) {
 		`^(@\w+) is a member of the group (@\w+) who has approved access to his personal info$`,
 		ctx.UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonalInfo,
 	)
-	s.Step(`allUsersGroup is defined as the group (@\w+)$`, ctx.AllUsersGroupIsDefinedAsTheGroup)
 
 	s.Step(`^the field "([^"]*)" of the group (@\w+) should be "([^"]*)"$`, ctx.TheFieldOfTheGroupShouldBe)
 	s.Step(`^(@\w+) should not be a member of the group (@\w+)$`, ctx.UserShouldNotBeAMemberOfTheGroup)
@@ -197,32 +196,6 @@ func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonal
 	}
 
 	ctx.addPersonalInfoViewApprovedFor(user, group)
-
-	return nil
-}
-
-// AllUsersGroupIsDefinedAsTheGroup creates and sets the allUsersGroup.
-func (ctx *TestContext) AllUsersGroupIsDefinedAsTheGroup(group string) (err error) {
-	defer recoverPanics(&err)
-
-	ctx.addGroup(group, "Base")
-
-	groupPrimaryKey := ctx.getGroupPrimaryKey(ctx.getIDOfReference(group))
-	ctx.setGroupFieldInDatabase(groupPrimaryKey, "name", "AllUsers")
-
-	err = ctx.TheApplicationConfigIs(&godog.DocString{
-		Content: `
-domains:
-  -
-    domains: [127.0.0.1]
-    allUsersGroup: ` + group + `
-`,
-	})
-	if err != nil {
-		return err
-	}
-
-	ctx.allUsersGroup = group
 
 	return nil
 }

--- a/testhelpers/app_language_users.go
+++ b/testhelpers/app_language_users.go
@@ -15,28 +15,6 @@ func (ctx *TestContext) registerFeaturesForUsers(s *godog.ScenarioContext) {
 	s.Step(`^there are the following users:$`, ctx.ThereAreTheFollowingUsers)
 }
 
-// addUsersIntoAllUsersGroup adds all users in the AllUsers group if it is defined.
-func (ctx *TestContext) addUsersIntoAllUsersGroup() error {
-	if ctx.allUsersGroup == "" {
-		return nil
-	}
-
-	idColumnIndex := getDBTableColumnIndex(ctx.dbTableData["users"], "group_id")
-	if idColumnIndex == -1 {
-		panic("The users table does not have group_id column")
-	}
-
-	for rowIndex := 1; rowIndex < len(ctx.dbTableData["users"].Rows); rowIndex++ {
-		userID := ctx.dbTableData["users"].Rows[rowIndex].Cells[idColumnIndex].Value
-		err := ctx.UserIsAMemberOfTheGroup(userID, ctx.allUsersGroup)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // getUserPrimaryKey returns the primary key of a group.
 func (ctx *TestContext) getUserPrimaryKey(groupID int64) map[string]string {
 	return map[string]string{"group_id": strconv.FormatInt(groupID, 10)}

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cucumber/godog"
 	messages "github.com/cucumber/messages/go/v21"
 
-	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/rand"
 )
 
@@ -96,28 +95,7 @@ func (ctx *TestContext) populateDatabase() error {
 		return nil
 	}
 
-	db, err := database.Open(ctx.db)
-	if err != nil {
-		return err
-	}
-
-	// add all the defined table rows in the database.
-	err = database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
-		store.Exec("SET FOREIGN_KEY_CHECKS=0")
-		defer store.Exec("SET FOREIGN_KEY_CHECKS=1")
-
-		err = ctx.addUsersIntoAllUsersGroup()
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	err = ctx.DBItemsAncestorsAndPermissionsAreComputed()
+	err := ctx.DBItemsAncestorsAndPermissionsAreComputed()
 	if err != nil {
 		return err
 	}

--- a/testhelpers/test_context.go
+++ b/testhelpers/test_context.go
@@ -47,7 +47,6 @@ type TestContext struct {
 	referenceToIDMap                map[string]int64
 	idToReferenceMap                map[int64]string
 	currentThreadKey                map[string]string
-	allUsersGroup                   string
 	needPopulateDatabase            bool
 	previousRandSource              interface{}
 	previousGeneratedGroupCodeIndex int


### PR DESCRIPTION
1. Add a new config setting nonTempUsersGroup, make it used by the config checker (on startup) and by the `install` command.
2. Modify the code to make it add new/updated users into the NonTempUsers group instead of the AllUsers group.
3. Move non-temporary users from the AllUsers group into the NonTempUsers group.

This PR is the second part of https://github.com/France-ioi/AlgoreaBackend/issues/1288, it is meant to be deployed after #1291.

As the migration makes the groups ancestors inconsistent, the deployment should be done while the prod is turned off. The db-recompute command should be executed after this PR is deployed and before the prod back on.

Note the `NONTMPUSERS` env variable for AWS Lambda.

The migration can take several (up to three) minutes, and the db-recompute command can take about one minute. So, up to four minutes of outage in total.

Fixes #1288 