### PR TITLE
Speed up groupRootsView even more

### DIFF
--- a/app/api/groups/get_group.go
+++ b/app/api/groups/get_group.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -259,4 +260,73 @@ func (srv *Service) getGroup(w http.ResponseWriter, r *http.Request) service.API
 	render.Respond(w, r, result)
 
 	return service.NoError
+}
+
+// currentUserMembershipSQLColumn returns an SQL column expression to get the current user membership
+// (direct/descendant/none) in the group. The column name is `current_user_membership`.
+func currentUserMembershipSQLColumn(currentUser *database.User) string {
+	return fmt.Sprintf(`
+		IF(
+			EXISTS(
+				SELECT 1 FROM groups_groups_active
+				WHERE groups_groups_active.parent_group_id = groups.id AND
+				      groups_groups_active.child_group_id = %d
+			),
+			'direct',
+			IF(
+				EXISTS(
+					SELECT 1 FROM groups_groups_active
+					JOIN groups_ancestors_active AS group_descendants
+						ON group_descendants.ancestor_group_id = groups.id AND
+						   group_descendants.child_group_id = groups_groups_active.parent_group_id
+					WHERE groups_groups_active.child_group_id = %d
+				),
+				'descendant',
+				'none'
+			)
+		) AS 'current_user_membership'`, currentUser.GroupID, currentUser.GroupID)
+}
+
+// currentUserManagershipSQLColumn is an SQL column expression to get the current user managership
+// (direct/ancestor/descendant/none) of the group. The column name is `current_user_managership`.
+const currentUserManagershipSQLColumn = `
+		IF(
+			EXISTS(
+				SELECT 1 FROM user_ancestors
+				JOIN group_managers
+					ON group_managers.group_id = groups.id AND
+					   group_managers.manager_id = user_ancestors.ancestor_group_id
+			),
+			'direct',
+			IF(
+				EXISTS(
+					SELECT 1 FROM user_ancestors
+					JOIN groups_ancestors_active AS group_ancestors ON group_ancestors.child_group_id = groups.id
+					JOIN group_managers
+						ON group_managers.group_id = group_ancestors.ancestor_group_id AND
+						   group_managers.manager_id = user_ancestors.ancestor_group_id
+				),
+				'ancestor',
+				IF(
+					EXISTS(
+						SELECT 1 FROM user_ancestors
+						JOIN group_managers ON group_managers.manager_id = user_ancestors.ancestor_group_id
+						JOIN groups_ancestors_active AS managed_groups
+							ON managed_groups.ancestor_group_id = group_managers.group_id
+						JOIN ` + "`groups`" + ` AS managed_descendant
+							ON managed_descendant.id = managed_groups.child_group_id AND
+							   managed_descendant.type != 'User'
+						JOIN groups_ancestors_active AS group_descendants
+							ON group_descendants.ancestor_group_id = groups.id AND
+							   group_descendants.child_group_id = managed_descendant.id
+					),
+					'descendant',
+					'none'
+				)
+			)
+		) AS 'current_user_managership'`
+
+// ancestorsOfUserQuery returns a query to get the ancestors of the given user (as ancestor_group_id).
+func ancestorsOfUserQuery(store *database.DataStore, user *database.User) *database.DB {
+	return store.ActiveGroupAncestors().Where("child_group_id = ?", user.GroupID).Select("ancestor_group_id")
 }

--- a/app/api/groups/get_roots.go
+++ b/app/api/groups/get_roots.go
@@ -55,27 +55,50 @@ func (srv *Service) getRoots(w http.ResponseWriter, r *http.Request) service.API
 	store := srv.GetStore(r)
 
 	const columns = "ancestor_group.id, ancestor_group.type, ancestor_group.name"
-	matchingGroupsQuery := store.Groups().AncestorsOfJoinedGroups(store, user).Select(columns).
-		Union(ancestorsOfManagedGroupsQuery(store, user).Select(columns))
+	matchingGroupsQuery := store.Raw(`
+		SELECT id, MAX(type) AS type, MAX(name) AS name,
+		       MAX(is_ancestor_of_joined) AS is_ancestor_of_joined,
+		       MAX(is_direct_parent) AS is_direct_parent,
+		       MAX(is_ancestor_of_managed) AS is_ancestor_of_managed,
+		       MAX(is_managed_directly) AS is_managed_directly,
+		       MAX(is_managed_via_ancestor) AS is_managed_via_ancestor
+		FROM ? AS matching_groups
+		GROUP BY id`,
+		ancestorsOfJoinedGroupsQuery(store, user).
+			Select(columns+
+				", 1 AS is_ancestor_of_joined, is_direct_parent, 0 AS is_ancestor_of_managed, 0 AS is_managed_directly, 0 AS is_managed_via_ancestor").
+			UnionAll(ancestorsOfManagedGroupsQuery(store, user).
+				Select(columns+
+					", 0 AS is_ancestor_of_joined, 0 AS is_direct_parent, 1 AS is_ancestor_of_managed, is_managed_directly, is_managed_via_ancestor")).
+			SubQuery())
 
-	query := store.
-		With("matching_groups", matchingGroupsQuery).
-		With("user_ancestors", ancestorsOfUserQuery(store, user)).
-		Table("matching_groups AS `groups`").
-		Select(`
-				groups.id, groups.type, groups.name,
-				` + currentUserMembershipSQLColumn(user) + `,
-				` + currentUserManagershipSQLColumn).
-		Where("groups.type != 'Base'").
-		Where(`
+	query := store.Raw(`
+		SELECT groups.id, groups.type, groups.name,
+		       IF(
+			       is_ancestor_of_joined,
+			       IF(is_direct_parent, 'direct', 'descendant'),
+			       'none'
+		       ) AS 'current_user_membership',
+		       IF(
+		         NOT is_ancestor_of_managed,
+		         'none',
+		         IF(
+		           is_managed_directly,
+		           'direct',
+		           IF(is_managed_via_ancestor, 'ancestor', 'descendant')
+		         )
+		       ) AS 'current_user_managership'
+		FROM ? AS `+"`groups`"+`
+		WHERE
+			type != 'Base' AND
 			NOT EXISTS(
-				SELECT 1 FROM ` + "`groups`" + ` AS parent_group
+				SELECT 1 FROM `+"`groups`"+` AS parent_group
 				JOIN groups_groups_active
 					ON groups_groups_active.parent_group_id = parent_group.id AND
 					   groups_groups_active.child_group_id = groups.id
 				WHERE parent_group.type != 'Base'
-			)`).
-		Order("groups.name")
+			)
+		ORDER BY groups.name`, matchingGroupsQuery.SubQuery())
 
 	var result []groupRootsViewResponseRow
 	service.MustNotBeError(query.Scan(&result).Error())
@@ -84,19 +107,45 @@ func (srv *Service) getRoots(w http.ResponseWriter, r *http.Request) service.API
 	return service.NoError
 }
 
-// ancestorsOfManagedGroupsQuery returns a query to get the ancestors of the groups (excluding users) managed by
-// the given user (as ancestor_group_id).
-func ancestorsOfManagedGroupsQuery(store *database.DataStore, user *database.User) *database.DB {
-	managedNonUserGroupsQuery := store.ActiveGroupAncestors().ManagedByUser(user).
-		Joins("JOIN `groups` ON groups.id = groups_ancestors_active.child_group_id AND groups.type != 'User'").
-		Select("DISTINCT groups.id")
+// ancestorsOfJoinedGroupsQuery returns a query selecting all ancestors of groups joined by the given user
+// (excluding ContestParticipants). Additionally, it returns whether the ancestor is a direct parent
+// of the given user (`is_direct_parent` column).
+func ancestorsOfJoinedGroupsQuery(store *database.DataStore, user *database.User) *database.DB {
+	distinctAncestorsOfJoinedGroupsQuery := store.ActiveGroupGroups().
+		Where("groups_groups_active.child_group_id = ?", user.GroupID).
+		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id").
+		Select("groups_ancestors_active.ancestor_group_id AS id, MAX(groups_ancestors_active.is_self) AS is_direct_parent").
+		Group("groups_ancestors_active.ancestor_group_id")
 
-	return store.With("managed_non_user_groups", managedNonUserGroupsQuery).
-		Table("managed_non_user_groups").
-		Joins(`
-			JOIN groups_ancestors_active AS ancestors_of_managed
-				ON ancestors_of_managed.child_group_id = managed_non_user_groups.id`).
-		Joins("JOIN `groups` AS ancestor_group ON ancestor_group.id = ancestors_of_managed.ancestor_group_id").
-		Where("ancestor_group.type != 'ContestParticipants'").
-		Select("DISTINCT ancestors_of_managed.ancestor_group_id")
+	return store.Table("`groups` AS ancestor_group").
+		Joins("JOIN ? AS distinct_ancestors ON ancestor_group.id = distinct_ancestors.id",
+			distinctAncestorsOfJoinedGroupsQuery.SubQuery()).
+		Where("type != 'ContestParticipants'")
+}
+
+// ancestorsOfManagedGroupsQuery returns a query to get the ancestors (excluding ContestParticipants)
+// of the groups (excluding users) managed by the given user (as ancestor_group.*).
+func ancestorsOfManagedGroupsQuery(store *database.DataStore, user *database.User) *database.DB {
+	distinctGroupsManagedByUserQuery := store.ActiveGroupAncestors().ManagedByUser(user).
+		Select("groups_ancestors_active.child_group_id AS id, MAX(groups_ancestors_active.is_self) AS is_managed_directly").
+		Group("groups_ancestors_active.child_group_id")
+
+	distinctManagedNonUserGroupsQuery := store.Groups().
+		Joins("JOIN ? AS distinct_managed ON distinct_managed.id = groups.id", distinctGroupsManagedByUserQuery.SubQuery()).
+		Where("groups.type != 'User'").
+		Select("groups.id, is_managed_directly")
+
+	distinctAncestorsOfManagedNonUserGroupsQuery := store.ActiveGroupAncestors().
+		Joins("JOIN ? AS distinct_managed_non_user_groups ON distinct_managed_non_user_groups.id = child_group_id",
+			distinctManagedNonUserGroupsQuery.SubQuery()).
+		Select(`
+			ancestor_group_id AS id,
+			MAX(is_managed_directly AND is_self) AS is_managed_directly,
+			MAX(NOT is_managed_directly AND is_self) AS is_managed_via_ancestor`).
+		Group("ancestor_group_id")
+
+	return store.Table("`groups` AS ancestor_group").
+		Joins("JOIN ? AS distinct_ancestors_of_managed ON distinct_ancestors_of_managed.id = ancestor_group.id",
+			distinctAncestorsOfManagedNonUserGroupsQuery.SubQuery()).
+		Where("type != 'ContestParticipants'")
 }

--- a/app/api/groups/get_roots.go
+++ b/app/api/groups/get_roots.go
@@ -36,7 +36,12 @@ type groupRootsViewResponseRow struct {
 //	summary: List root groups
 //	description: >
 //		Returns groups which are ancestors of joined groups or managed non-user groups
-//		and do not have parents. Groups of type "Base" or "User" are ignored.
+//		and do not have parents (except for parents of type "Base").
+//		Groups of type "Base", "ContestParticipants" are ignored.
+//
+//
+//		(Note that it's impossible for the service to return groups of type "User" because a user group cannot be joined,
+//		and managed user groups are skipped as well.)
 //	responses:
 //		"200":
 //			description: OK. Success response with an array of root groups

--- a/app/database/group_store.go
+++ b/app/database/group_store.go
@@ -168,7 +168,7 @@ func (s *GroupStore) AncestorsOfJoinedGroupsForGroup(store *DataStore, groupID i
 		Select("groups_ancestors_active.ancestor_group_id")
 }
 
-// AncestorsOfJoinedGroups returns a query selecting all group ancestors ids of of groups joined by the given user.
+// AncestorsOfJoinedGroups returns a query selecting all group ancestors ids of groups joined by the given user.
 func (s *GroupStore) AncestorsOfJoinedGroups(store *DataStore, user *User) *DB {
 	return s.AncestorsOfJoinedGroupsForGroup(store, user.GroupID)
 }


### PR DESCRIPTION
1) Optimize the query generated by ancestorsOfManagedGroupsQuery():
    * deduplicate ids of managed groups before joining the groups table to them,
    * deduplicate ids of ancestors of managed groups before joining the groups table to them,
    * collect 'is_managed_directly' and 'is_managed_via_ancestor' fields.
2) Instead of GroupStore.AncestorsOfJoinedGroupsForGroup(), use its rewritten copy (ancestorsOfJoinedGroupsQuery()) which:
    * deduplicates ids of ancestors of joined groups before joining the groups table to them,
    * collects 'is_direct_parent' field.
3) Replace the UNION with UNION ALL in the main query in order to combine fields collected by both subqueries (using MAX() with GROUP BY).
4) Completely get rid of all the per-row sub-selects calculating current_user_membership and current_user_managership (calculate the values basing on the collected fields 'is_managed_directly', 'is_managed_via_ancestor, 'is_direct_parent' instead).

On my computer, the optimized query runs 2.88 times faster than the query deployed with #1290 (0.5 seconds vs 1.44 seconds). I hope we will see the same amount of acceleration in production.

Related to #1248 