### PR TITLE
Make the resultStart service less locking

### DIFF
--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -135,7 +135,7 @@ func (srv *Service) startResult(w http.ResponseWriter, r *http.Request) service.
 
 		service.MustNotBeError(constructQueryForGettingAttemptsList(store, participantID, itemID, srv.GetUser(r)).
 			Where("attempts.id = ?", attemptID).
-			WithCustomWriteLocks(golang.NewSet("attempts"), golang.NewSet("results")).
+			WithCustomWriteLocks(golang.NewSet("results"), golang.NewSet[string]()).
 			Scan(&attemptInfo).Error())
 
 		if attemptInfo.UserCreator.GroupID == nil {


### PR DESCRIPTION
We don't need to lock the attempts table when we retrieve the attempts list, also, we can use a shared lock on the results table instead of an exclusive lock.