### PR TITLE
Fix and rework marking permissions for recomputing in triggers of items_items

### DIFF
--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -3,9 +3,11 @@
 package database_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -19,6 +21,8 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	dataStore := database.NewDataStore(db)
+	assertResultsMarkedAsChanged(t, dataStore, []resultPrimaryKeyAndState{})
+
 	assert.NoError(t, dataStore.ItemItems().InsertMap(map[string]interface{}{
 		"parent_item_id": 1, "child_item_id": 2, "child_order": 1,
 	}))
@@ -44,4 +48,108 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 		{ResultPrimaryKey: ResultPrimaryKey{108, 1, 2}},
 		{ResultPrimaryKey: ResultPrimaryKey{109, 1, 2}},
 	})
+}
+
+func TestItemItemStore_TriggerAfterInsert_MarksPermissionsForRecomputing(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
+	defer func() { _ = db.Close() }()
+
+	dataStore := database.NewDataStore(db)
+	require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
+		dataStore.SchedulePermissionsPropagation()
+		return nil
+	}))
+
+	var markedPermissions []groupItemsResultRow
+	require.NoError(t, dataStore.Table("permissions_propagate").
+		Select("group_id, item_id, propagate_to").
+		Order("group_id, item_id").Scan(&markedPermissions).Error())
+	require.Empty(t, markedPermissions)
+
+	assert.NoError(t, dataStore.ItemItems().InsertMap(map[string]interface{}{
+		"parent_item_id": 1, "child_item_id": 2, "child_order": 1,
+	}))
+
+	require.NoError(t, dataStore.Table("permissions_propagate").
+		Select("group_id, item_id, propagate_to").
+		Order("group_id, item_id").Scan(&markedPermissions).Error())
+	assert.Equal(t, []groupItemsResultRow{
+		{GroupID: 1, ItemID: 2, PropagateTo: "self"},
+		{GroupID: 2, ItemID: 2, PropagateTo: "self"},
+	}, markedPermissions)
+}
+
+func TestItemItemStore_TriggerAfterUpdate_MarksPermissionsForRecomputing(t *testing.T) {
+	for _, test := range []struct {
+		column   string
+		newValue interface{}
+	}{
+		{column: "content_view_propagation", newValue: "as_info"},
+		{column: "upper_view_levels_propagation", newValue: "as_is"},
+		{column: "grant_view_propagation", newValue: 1},
+		{column: "watch_propagation", newValue: 1},
+		{column: "edit_propagation", newValue: 1},
+	} {
+		test := test
+		t.Run(fmt.Sprintf("%s=%v", test.column, test.newValue), func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+
+			db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
+			defer func() { _ = db.Close() }()
+
+			dataStore := database.NewDataStore(db)
+			require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
+				dataStore.SchedulePermissionsPropagation()
+				return nil
+			}))
+
+			var markedPermissions []groupItemsResultRow
+			require.NoError(t, dataStore.Table("permissions_propagate").
+				Select("group_id, item_id, propagate_to").
+				Order("group_id, item_id").Scan(&markedPermissions).Error())
+			require.Empty(t, markedPermissions)
+
+			assert.NoError(t, dataStore.ItemItems().Where("parent_item_id=4 AND child_item_id=1").
+				UpdateColumn(test.column, test.newValue).Error())
+
+			require.NoError(t, dataStore.Table("permissions_propagate").
+				Select("group_id, item_id, propagate_to").
+				Order("group_id, item_id").Scan(&markedPermissions).Error())
+			assert.Equal(t, []groupItemsResultRow{
+				{GroupID: 1, ItemID: 1, PropagateTo: "self"},
+				{GroupID: 2, ItemID: 1, PropagateTo: "self"},
+			}, markedPermissions)
+		})
+	}
+}
+
+func TestItemItemStore_TriggerBeforeDelete_MarksPermissionsForRecomputing(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixture("permission_granted_store/compute_all_access/_common")
+	defer func() { _ = db.Close() }()
+
+	dataStore := database.NewDataStore(db)
+	require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
+		dataStore.SchedulePermissionsPropagation()
+		return nil
+	}))
+
+	var markedPermissions []groupItemsResultRow
+	require.NoError(t, dataStore.Table("permissions_propagate").
+		Select("group_id, item_id, propagate_to").
+		Order("group_id, item_id").Scan(&markedPermissions).Error())
+	require.Empty(t, markedPermissions)
+
+	assert.NoError(t, dataStore.ItemItems().Delete("parent_item_id=4 AND child_item_id=1").Error())
+
+	require.NoError(t, dataStore.Table("permissions_propagate").
+		Select("group_id, item_id, propagate_to").
+		Order("group_id, item_id").Scan(&markedPermissions).Error())
+	assert.Equal(t, []groupItemsResultRow{
+		{GroupID: 1, ItemID: 1, PropagateTo: "self"},
+		{GroupID: 2, ItemID: 1, PropagateTo: "self"},
+	}, markedPermissions)
 }

--- a/db/migrations/2507011113_fix_and_rework_marking_permissions_for_recomputing_in_before_delete_items_items_trigger.sql
+++ b/db/migrations/2507011113_fix_and_rework_marking_permissions_for_recomputing_in_before_delete_items_items_trigger.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'self' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`child_item_id`;
+
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT IGNORE INTO `results_recompute_for_items` (`item_id`) VALUES (OLD.`parent_item_id`);
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `before_delete_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EACH ROW BEGIN
+  INSERT IGNORE INTO `items_propagate` (`id`, `ancestors_computation_state`)
+  VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
+
+  INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+  FROM `permissions_generated`
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+
+  -- Some results' ancestors should probably be removed
+  -- DELETE FROM `results` WHERE ...
+
+  INSERT IGNORE INTO `results_recompute_for_items` (`item_id`) VALUES (OLD.`parent_item_id`);
+END
+-- +migrate StatementEnd

--- a/db/migrations/2507011120_rework_marking_permissions_for_recomputing_in_after_update_items_items_trigger.sql
+++ b/db/migrations/2507011120_rework_marking_permissions_for_recomputing_in_after_update_items_items_trigger.sql
@@ -1,0 +1,47 @@
+-- +migrate Up
+DROP TRIGGER IF EXISTS `after_update_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_items_items` AFTER UPDATE ON `items_items` FOR EACH ROW BEGIN
+    IF (OLD.`content_view_propagation` != NEW.`content_view_propagation` OR
+        OLD.`upper_view_levels_propagation` != NEW.`upper_view_levels_propagation` OR
+        OLD.`grant_view_propagation` != NEW.`grant_view_propagation` OR
+        OLD.`watch_propagation` != NEW.`watch_propagation` OR
+        OLD.`edit_propagation` != NEW.`edit_propagation`) THEN
+        REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+        SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'self' as `propagate_to`
+        FROM `permissions_generated`
+        WHERE `permissions_generated`.`item_id` = NEW.`child_item_id`;
+    END IF;
+    IF (OLD.`category` != NEW.`category` OR OLD.`score_weight` != NEW.`score_weight`) THEN
+        INSERT INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+        FROM `results`
+        WHERE `item_id` = NEW.`parent_item_id`
+        ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+    END IF;
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS `after_update_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_update_items_items` AFTER UPDATE ON `items_items` FOR EACH ROW BEGIN
+    IF (OLD.`content_view_propagation` != NEW.`content_view_propagation` OR
+        OLD.`upper_view_levels_propagation` != NEW.`upper_view_levels_propagation` OR
+        OLD.`grant_view_propagation` != NEW.`grant_view_propagation` OR
+        OLD.`watch_propagation` != NEW.`watch_propagation` OR
+        OLD.`edit_propagation` != NEW.`edit_propagation`) THEN
+        INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+        SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+        FROM `permissions_generated`
+        WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id` OR `permissions_generated`.`item_id` = OLD.`parent_item_id`;
+    END IF;
+    IF (OLD.`category` != NEW.`category` OR OLD.`score_weight` != NEW.`score_weight`) THEN
+        INSERT INTO `results_propagate`
+        SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+        FROM `results`
+        WHERE `item_id` = NEW.`parent_item_id`
+        ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+    END IF;
+END
+-- +migrate StatementEnd

--- a/db/migrations/2507011128_rework_marking_permissions_for_recomputing_in_after_insert_items_items_trigger.sql
+++ b/db/migrations/2507011128_rework_marking_permissions_for_recomputing_in_after_insert_items_items_trigger.sql
@@ -1,0 +1,43 @@
+-- +migrate Up
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, NEW.`child_item_id`, 'self' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    INSERT IGNORE INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`child_item_id`;
+
+    INSERT INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`parent_item_id`
+    ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+END
+-- +migrate StatementEnd
+
+-- +migrate Down
+DROP TRIGGER `after_insert_items_items`;
+-- +migrate StatementBegin
+CREATE TRIGGER `after_insert_items_items` AFTER INSERT ON `items_items` FOR EACH ROW BEGIN
+    INSERT IGNORE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
+    SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'children' as `propagate_to`
+    FROM `permissions_generated`
+    WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
+
+    INSERT IGNORE INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_propagated' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`child_item_id`;
+
+    INSERT INTO `results_propagate`
+    SELECT `participant_id`, `attempt_id`, `item_id`, 'to_be_recomputed' AS `state`
+    FROM `results`
+    WHERE `item_id` = NEW.`parent_item_id`
+    ON DUPLICATE KEY UPDATE `state` = 'to_be_recomputed';
+END
+-- +migrate StatementEnd


### PR DESCRIPTION
1. Fix permissions marking in the before_delete_items_items trigger: instead of marking generated permissions related to the parent item with 'propagate_to=children' (which doesn't affect permissions of the removed child item!), mark generated permissions related to the removed child item as 'propagate_to=self'. This bug is almost 10 years old. We inherited it from the original PHP implementation of AlgoreaPlatform (see https://github.com/France-ioi/AlgoreaPlatform/commit/41fcc3ac3bf27d58afffc9e1c854e9e8021fffe4).
2. Rework permissions marking in the after_update_items_items trigger: instead of marking generated permissions related to the parent item with 'propagate_to=children', mark generated permissions related to the child item as 'propagate_to=self' which is more effective as we do not need to recompute permissions related to other children of the parent item.
3. Rework permissions marking in after_insert_items_items trigger: instead of marking generated permissions related to the parent item with 'propagate_to=children', for each generated permissions related to the parent item, mark the (group_id, child item's id) pair as 'propagate_to=self' which is more effective as we do not need to recompute permissions related to other children of the parent item.
4. Add tests.