### PR TITLE
Validate tokens returned by the login module + enable more linters + upgrade golangci-lint to v1.64.7

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,7 +92,7 @@ linters:
     - ireturn          # For update to go1.20
     - maintidx         # For update to go1.20
     - nlreturn         # For update to go1.20
-    - nonamedreturns   # For update to go1.20
+    - nonamedreturns   # Doesn't allow named returns in functions. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
     - sqlclosecheck    # For update to go1.20
     - tagliatelle      # For update to go1.20
     - tenv             # For update to go1.20

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,7 +93,6 @@ linters:
     - maintidx         # For update to go1.20
     - nlreturn         # For update to go1.20
     - nonamedreturns   # Doesn't allow named returns in functions. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - sqlclosecheck    # For update to go1.20
     - tagliatelle      # For update to go1.20
     - tenv             # For update to go1.20
     - thelper          # For update to go1.20

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   govet:
-    check-shadowing: true
+    shadow: true
     settings:
       printf:
         funcs:
@@ -69,31 +69,36 @@ linters-settings:
     detect-opposite: true
   paralleltest:
     ignore-missing: true
+  tagliatelle:
+    case:
+      rules:
+        json: snake
+        yaml: camel
+        xml: camel
+        toml: camel
+        bson: camel
+        avro: snake
+        mapstructure: kebab
+        env: upperSnake
+        envconfig: upperSnake
+        whatever: snake
+      overrides:
+        - pkg: app/payloads
+          ignore: true
 
 linters:
   enable-all: true
   disable:
-    - deadcode         # Deprecated.
-    - exhaustivestruct # Deprecated.
-    - golint           # Deprecated.
-    - ifshort          # Deprecated.
-    - interfacer       # Deprecated.
-    - maligned         # Deprecated.
-    - nosnakecase      # Deprecated.
-    - scopelint        # Deprecated.
-    - structcheck      # Deprecated.
-    - varcheck         # Deprecated.
     - gochecknoglobals
     - testpackage      # Requires that go tests files are in a different package, but current tests are on private functions
     - wsl              # Requires white lines between blocks. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - goerr113         # Doesn't allow dynamic errors, requires wrapped static errors. (Disabled by default in golangci-lint)
+    - err113           # Doesn't allow dynamic errors, requires wrapped static errors. (Disabled by default in golangci-lint)
     - contextcheck     # Checks whether a function uses a non-inherited context. (Many false positives. Disabled by default in golangci-lint)
     - forcetypeassert  # For update to go1.20
     - ireturn          # For update to go1.20
     - maintidx         # For update to go1.20
     - nlreturn         # For update to go1.20
     - nonamedreturns   # Doesn't allow named returns in functions. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - tagliatelle      # For update to go1.20
     - tenv             # For update to go1.20
     - thelper          # For update to go1.20
     - usestdlibvars    # For update to go1.20
@@ -102,17 +107,19 @@ linters:
     - exhaustruct      # For update to go1.20
     - gomoddirectives  # For update to go1.20
     - dupl             # For update to go1.20
+    - testifylint
+    - usetesting
+    - perfsprint
+    - recvcheck
 
-run:
-  skip-dirs:
+issues:
+  exclude-use-default: false
+  exclude-dirs:
     - ^db$
     - ^app/database/testdata$
     - ^test-results$
     - ^pkg/golinters/goanalysis/(checker|passes)$
     - ^app/doc$
-
-issues:
-  exclude-use-default: false
   exclude-rules:
     - path: _test\.go$
       linters:
@@ -129,16 +136,9 @@ issues:
     - text: unknown JSON option "squash" # an option provided by the mapstructure library and the formdata package
       linters:
         - staticcheck
-    - text: "timeCmpSimplify:" # this one suggests replacing !After() with Before() which is not correct
-      linters:
-        - gocritic
     - text: "Duplicate words \\(.*[:,].*\\) found"
       linters:
         - dupword
-
-  exclude:
-    - "not declared by package utf8"
-    - "unicode/utf8/utf8.go"
   max-issues-per-linter: 0
   max-same-issues: 0
   #fix: true # Enable to try auto fix.
@@ -146,4 +146,4 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.53.3 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.64.7 # use the fixed version to not introduce new linters unexpectedly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,8 @@ linters-settings:
   nilnil:
     only-two: false
     detect-opposite: true
+  paralleltest:
+    ignore-missing: true
 
 linters:
   enable-all: true
@@ -91,7 +93,6 @@ linters:
     - maintidx         # For update to go1.20
     - nlreturn         # For update to go1.20
     - nonamedreturns   # For update to go1.20
-    - paralleltest     # For update to go1.20
     - sqlclosecheck    # For update to go1.20
     - tagliatelle      # For update to go1.20
     - tenv             # For update to go1.20

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_BIN_DIR=./bin
 
 BIN_PATH=$(LOCAL_BIN_DIR)/$(BIN_NAME)
 GOLANGCILINT=$(LOCAL_BIN_DIR)/golangci-lint
-GOLANGCILINT_VERSION=1.53.3
+GOLANGCILINT_VERSION=1.64.7
 MYSQL_CONNECTOR_JAVA=$(LOCAL_BIN_DIR)/mysql-connector-java-8.jar
 SCHEMASPY=$(LOCAL_BIN_DIR)/schemaspy-6.0.0.jar
 PWD=$(shell pwd)
@@ -102,7 +102,7 @@ lint:
 	@[ -e $(GOLANGCILINT) ] && \
 		($(GOLANGCILINT) --version | grep -F "version $(GOLANGCILINT_VERSION) built" > /dev/null || rm $(GOLANGCILINT)) || true
 	$(MAKE) $(GOLANGCILINT)
-	$(GOLANGCILINT) run -v --deadline 10m0s
+	$(GOLANGCILINT) run -v --timeout 10m0s
 
 swagger-generate:
 	swagger generate spec --nullable-pointers --scan-models -o ./swagger.yaml && \

--- a/app/api/auth/auth.go
+++ b/app/api/auth/auth.go
@@ -40,5 +40,7 @@ func validateAndGetExpiresInFromOAuth2Token(token *oauth2.Token) (expiresIn int3
 	}
 
 	expiresIn64 := int64(time.Until(token.Expiry).Round(time.Second) / time.Second)
+	//nolint:gosec // G115: The oauth2 package guarantees that the "expires_in" value is always <= 2^31-1.
+	// Also, the "expires_in" value is always greater than 0 in valid tokens.
 	return int32(expiresIn64), nil
 }

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -271,7 +271,7 @@ func (srv *Service) createAccessToken(w http.ResponseWriter, r *http.Request) er
 
 	userProfile, err := loginmodule.NewClient(srv.AuthConfig.GetString("loginModuleURL")).GetUserProfile(r.Context(), token.AccessToken)
 	service.MustNotBeError(err)
-	userProfile["last_ip"] = strings.SplitN(r.RemoteAddr, ":", 2)[0] //nolint:gomnd // cut off the port
+	userProfile["last_ip"] = strings.SplitN(r.RemoteAddr, ":", 2)[0] //nolint:mnd // cut off the port
 
 	domainConfig := domain.ConfigFromContext(r.Context())
 
@@ -352,7 +352,7 @@ func parseRequestParametersForCreateAccessToken(r *http.Request) (map[string]int
 	}
 
 	contentType := strings.ToLower(strings.TrimSpace(
-		strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0])) //nolint:gomnd // cut off the parameters, keep only the media type
+		strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0])) //nolint:mnd // cut off the parameters, keep only the media type
 	switch contentType {
 	case "application/json":
 		if err := parseJSONParams(r, requestData); err != nil {

--- a/app/api/auth/create_access_token.robustness.feature
+++ b/app/api/auth/create_access_token.robustness.feature
@@ -211,3 +211,31 @@ Feature: Login callback - robustness
     | ?use_cookie=abc                                  | Wrong value for use_cookie (should have a boolean value (0 or 1))              |
     | ?cookie_same_site=abc                            | Wrong value for cookie_same_site (should have a boolean value (0 or 1))        |
     | ?cookie_secure=abc                               | Wrong value for cookie_secure (should have a boolean value (0 or 1))           |
+
+  Scenario: Should be an error when the login module returns an expired access token
+    Given the time now is "2019-07-16T22:02:28Z"
+    And the template constant "code_from_oauth" is "somecode"
+    And the template constant "access_token_from_oauth" is "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6Ijc3M2IyMjY0ZDU0MDUzNWQ5OTFlMjNlODY0MzljNzJmYjI0MWI5ZWY1ZTI5NjMyYjc3OWQwNjdlNmJmZWRiYmUyZDM4NmQ4YmQ2OTBlNGI3In0.eyJhdWQiOiIxIiwianRpIjoiNzczYjIyNjRkNTQwNTM1ZDk5MWUyM2U4NjQzOWM3MmZiMjQxYjllZjVlMjk2MzJiNzc5ZDA2N2U2YmZlZGJiZTJkMzg2ZDhiZDY5MGU0YjciLCJpYXQiOjE1NjM1Mjk4MjUsIm5iZiI6MTU2MzUyOTgyNSwiZXhwIjoxNTk1MTUyMjI0LCJzdWIiOiIxMDAwMDAwMDEiLCJzY29wZXMiOlsiYWNjb3VudCJdfQ.hcMLfoK8ocb0dpJg-R6EViMePCE4uw_Zzid_CIzFMFT6khY7m1kLorzKgYLWbDBxyxG-RBWTjJIbE-0J96VvLegYoZo5JObHzZP_FQyOUQ-qVe98mjI3Mc0a-dmr5bQyPTS2OC2COlFnletMHhBe4D_DSh2Zi8TfN79kTjsYErN59Vc4Bz0sPPmnLRqdKbg8r6jVX-s6cidN8mgDjujAljiaPkjCCiumdMj9kSfTKLNxMu1e9-4GfN41xc72ikstcBXjvakTyeq2-M9Wcby4XA5fys313kKlKQy3WJAVW3D6qMEwRH566vesEIx-RWUIlkPyV4QvIaE3k4mKdiO6c21LSFFSlIfr6jkVaGDvi8Rc9g77CWgUXaZOsETliW0Yea0tL9fG1negRr9uQGKyOZCM1dxSlBJAKlD3kyLi4ykEw6uTp0tM-AdwRB7mUpu9bw3evpr7f0mN65Nhd-byAuys0PXyegZeSKxZB3i1mAzE6s7vUbADJcBOx0kRmfkpT3kfUkJ4c9QohVCpkIMl80sbxcv9RTck0P9W1J-LGUULTtcPeaLNz85q7DKKbdiTAcbqzQkxZn0hO2wrF-3L0p_ms-yQg8ebu-ZJIzUG5LQq6Szu-QpXyQPP3NdKqHEvMhKoFY-9BZwA9SCEfiB8kMwCm9TAfztZBiCRcS2I4LE"
+    And the template constant "refresh_token_from_oauth" is "def502008be6565fe7888139650994031dcf475fd4ec863d9d088562aeff095c4fb5026d189b05385b5d6e834bb26ed98d67b19f21c8e4f70e035083b8aba36027c748eb0a8fc987b900a96734eb3952733d8d87368cbf5194195dfee364ebe774117dc8e51075ea7afe356d985021a38be505ea7328137d0f3552dcf4ed1b7187affee3399964b81d396a597fb9ef78c1651c5203529cd016a9c9584fc024e597e47327c36431981000741c8e6e24066718b3b46d6278a0f13b0d1bd87e2811269a2464b832b765f45d40a878ce4d3bc9da03aad32dc6f17caa52f67befffd89bae734ac0b424d9a32bd2e47c47dfee43e534d36d6cc180759b3d220ddea18ba70d8490501934e960a9ad99012184fcd67f471a16c65db5185f24ace83857efefdd935280cc0a9653150d89f9ca531283ec9e566592de626d0c350ddd682f59ede69f29acfb0bc3104d826afabd0f1e1a246375154c78a9ad27a2c47bde5159686a4264bd91f16ffa185554d09858402a68"
+    And the login module "token" endpoint for code "{{code_from_oauth}}" and code_verifier "123456" and redirect_uri "http://my.url" returns 200 with body:
+      """
+      {
+        "token_type":"Bearer",
+        "expires_in":9,
+        "access_token":"{{access_token_from_oauth}}",
+        "refresh_token":"{{refresh_token_from_oauth}}"
+      }
+      """
+    When I send a POST request to "/auth/token?code={{code_from_oauth}}&code_verifier=123456&redirect_uri=http%3A%2F%2Fmy.url"
+    Then the response code should be 401
+    And the response error message should contain "Got an invalid OAuth2 token"
+    And the response header "Set-Cookie" should not be set
+    And the table "users" should remain unchanged
+    And the table "groups" should remain unchanged
+    And the table "groups_groups" should remain unchanged
+    And the table "groups_ancestors" should remain unchanged
+    And the table "attempts" should remain unchanged
+    And the table "group_membership_changes" should remain unchanged
+    And the table "sessions" should remain unchanged
+    And the table "access_tokens" should remain unchanged
+    And the table "group_managers" should remain unchanged

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/auth"
@@ -108,8 +107,7 @@ func (srv *Service) createTempUser(w http.ResponseWriter, r *http.Request) error
 		return err
 	}))
 
-	srv.respondWithNewAccessToken(r, w, service.CreationSuccess[map[string]interface{}],
-		token, time.Now().Add(time.Duration(expiresIn)*time.Second), cookieAttributes)
+	srv.respondWithNewAccessToken(r, w, service.CreationSuccess[map[string]interface{}], token, expiresIn, cookieAttributes)
 	return nil
 }
 

--- a/app/api/auth/create_temp_user.go
+++ b/app/api/auth/create_temp_user.go
@@ -84,7 +84,7 @@ func (srv *Service) createTempUser(w http.ResponseWriter, r *http.Request) error
 	service.MustNotBeError(srv.GetStore(r).InTransaction(func(store *database.DataStore) error {
 		userID := createTempUserGroup(store)
 		login := createTempUser(store, userID, defaultLanguage,
-			strings.SplitN(r.RemoteAddr, ":", 2)[0]) //nolint:gomnd // cut off the port
+			strings.SplitN(r.RemoteAddr, ":", 2)[0]) //nolint:mnd // cut off the port
 
 		service.MustNotBeError(store.Groups().ByID(userID).UpdateColumn(map[string]interface{}{
 			"name":        login,

--- a/app/api/currentuser/get_full_dump.go
+++ b/app/api/currentuser/get_full_dump.go
@@ -72,7 +72,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 	_, err := w.Write([]byte("{"))
 	service.MustNotBeError(err)
 
-	writeJSONObjectElement("current_user", w, func(writer io.Writer) {
+	writeJSONObjectElement("current_user", w, func(_ io.Writer) {
 		columns := getColumnsList(store, "users", nil)
 		var userData []map[string]interface{}
 		service.MustNotBeError(store.Users().ByID(user.GroupID).Select(columns).
@@ -82,7 +82,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 
 	if full {
 		writeComma(w)
-		writeJSONObjectArrayElement("sessions", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("sessions", w, func(_ io.Writer) {
 			columns := getColumnsList(store, "sessions", []string{"refresh_token"})
 			service.MustNotBeError(store.Sessions().
 				Where("user_id = ?", user.GroupID).
@@ -92,7 +92,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 		})
 
 		writeComma(w)
-		writeJSONObjectArrayElement("access_tokens", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("access_tokens", w, func(_ io.Writer) {
 			columns := getColumnsList(store, "access_tokens", []string{"token"})
 			service.MustNotBeError(store.AccessTokens().
 				Joins("JOIN sessions ON sessions.session_id = access_tokens.session_id").
@@ -104,7 +104,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 	}
 
 	writeComma(w)
-	writeJSONObjectArrayElement("managed_groups", w, func(writer io.Writer) {
+	writeJSONObjectArrayElement("managed_groups", w, func(_ io.Writer) {
 		service.MustNotBeError(store.Groups().ManagedBy(user).
 			Order("`groups`.`id`").
 			Group("`groups`.`id`").
@@ -112,7 +112,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 	})
 
 	writeComma(w)
-	writeJSONObjectArrayElement("joined_groups", w, func(writer io.Writer) {
+	writeJSONObjectArrayElement("joined_groups", w, func(_ io.Writer) {
 		service.MustNotBeError(store.ActiveGroupGroups().
 			Where("groups_groups_active.child_group_id = ?", user.GroupID).
 			Joins("JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id").
@@ -123,27 +123,27 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 
 	if full {
 		writeComma(w)
-		writeJSONObjectArrayElement("answers", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("answers", w, func(_ io.Writer) {
 			service.MustNotBeError(store.Answers().Where("author_id = ?", user.GroupID).
 				Order("id").
 				ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 
 		writeComma(w)
-		writeJSONObjectArrayElement("attempts", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("attempts", w, func(_ io.Writer) {
 			service.MustNotBeError(buildQueryForGettingAttemptsOrResults(store.Attempts().DataStore, user, "attempts").
 				Order("participant_id, id").ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 
 		writeComma(w)
-		writeJSONObjectArrayElement("results", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("results", w, func(_ io.Writer) {
 			service.MustNotBeError(buildQueryForGettingAttemptsOrResults(store.Results().DataStore, user, "results").
 				Order("participant_id, attempt_id, item_id").ScanAndHandleMaps(streamerFunc(w)).Error())
 		})
 	}
 
 	writeComma(w)
-	writeJSONObjectArrayElement("groups_groups", w, func(writer io.Writer) {
+	writeJSONObjectArrayElement("groups_groups", w, func(_ io.Writer) {
 		columns := getColumnsList(store, "groups_groups", nil)
 		service.MustNotBeError(store.GroupGroups().
 			Where("child_group_id = ?", user.GroupID).
@@ -154,7 +154,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 	})
 
 	writeComma(w)
-	writeJSONObjectArrayElement("group_managers", w, func(writer io.Writer) {
+	writeJSONObjectArrayElement("group_managers", w, func(_ io.Writer) {
 		columns := getColumnsList(store, "group_managers", nil)
 		service.MustNotBeError(store.GroupManagers().
 			Where("manager_id = ?", user.GroupID).
@@ -166,7 +166,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 
 	if full {
 		writeComma(w)
-		writeJSONObjectArrayElement("group_membership_changes", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("group_membership_changes", w, func(_ io.Writer) {
 			columns := getColumnsList(store, "group_membership_changes", nil)
 			service.MustNotBeError(store.GroupMembershipChanges().
 				Where("member_id = ?", user.GroupID).
@@ -177,7 +177,7 @@ func (srv *Service) getDumpCommon(r *http.Request, w http.ResponseWriter, full b
 		})
 
 		writeComma(w)
-		writeJSONObjectArrayElement("group_pending_requests", w, func(writer io.Writer) {
+		writeJSONObjectArrayElement("group_pending_requests", w, func(_ io.Writer) {
 			columns := getColumnsList(store, "group_pending_requests", nil)
 			service.MustNotBeError(store.GroupPendingRequests().
 				Where("member_id = ?", user.GroupID).

--- a/app/api/groups/create_code_test.go
+++ b/app/api/groups/create_code_test.go
@@ -29,7 +29,7 @@ func TestGenerateGroupCode(t *testing.T) {
 
 func TestGenerateGroupCode_HandlesError(t *testing.T) {
 	expectedError := errors.New("some error")
-	monkey.Patch(rand.Int, func(rand io.Reader, max *big.Int) (n *big.Int, err error) {
+	monkey.Patch(rand.Int, func(_ io.Reader, _ *big.Int) (n *big.Int, err error) {
 		return nil, expectedError
 	})
 	defer monkey.UnpatchAll()

--- a/app/api/groups/create_user_batch.go
+++ b/app/api/groups/create_user_batch.go
@@ -207,7 +207,7 @@ func checkCreateUserBatchRequestParameters(store *database.DataStore, user *data
 		numberOfUsersToBeCreated += subgroup.Count
 	}
 
-	//nolint:gomnd // 32^postfix_length should be greater than 2*numberOfUsersToBeCreated
+	//nolint:mnd // 32^postfix_length should be greater than 2*numberOfUsersToBeCreated
 	if float64(input.PostfixLength) <= math.Log(float64(2*numberOfUsersToBeCreated))/math.Log(32) {
 		return 0, nil, service.ErrInvalidRequest(errors.New("'postfix_length' is too small"))
 	}
@@ -262,7 +262,7 @@ func createBatchUsersInDB(store *database.DataStore, input createUserBatchReques
 		domainConfig := domain.ConfigFromContext(r.Context())
 
 		result := make([]*resultRow, 0, len(subgroupsApprovals))
-		relationsToCreate := make([]map[string]interface{}, 0, 2*numberOfUsersToBeCreated) //nolint:gomnd // 2 relations per user
+		relationsToCreate := make([]map[string]interface{}, 0, 2*numberOfUsersToBeCreated) //nolint:mnd // 2 relations per user
 		usersToCreate := make([]map[string]interface{}, 0, numberOfUsersToBeCreated)
 		attemptsToCreate := make([]map[string]interface{}, 0, numberOfUsersToBeCreated)
 		usersInSubgroup := 0

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -164,7 +164,7 @@ func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request
 	// Used to be a subquery, but it failed with MySQL-8.0.26 due to obscure bugs introduced in this version.
 	// It works when doing the query first and using the result in the second query.
 	// See commit 5a25fbded8134c93c72dc853f72071943a1bd24c
-	managedGroupsWithCanGrantGroupAccessIds := user.GetManagedGroupsWithCanGrantGroupAccessIds(store)
+	managedGroupsWithCanGrantGroupAccessIDs := user.GetManagedGroupsWithCanGrantGroupAccessIDs(store)
 
 	var sourceGroupsQuery, groupsQuery *database.DB
 	if forDescendants {
@@ -178,7 +178,7 @@ func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request
 
 		sourceGroupsQuery = store.Groups().
 			Where("groups.type != 'User'").
-			Where("id IN (?)", managedGroupsWithCanGrantGroupAccessIds).
+			Where("id IN (?)", managedGroupsWithCanGrantGroupAccessIDs).
 			Where("id IN ?", ancestorsAndDescendantsQuery.SubQuery()).
 			Select("groups.id, groups.name")
 
@@ -190,7 +190,7 @@ func (srv *Service) getGrantedPermissions(w http.ResponseWriter, r *http.Request
 	} else {
 		sourceGroupsQuery = store.ActiveGroupAncestors().
 			Where("child_group_id = ?", groupID).
-			Where("ancestor_group_id IN (?)", managedGroupsWithCanGrantGroupAccessIds).
+			Where("ancestor_group_id IN (?)", managedGroupsWithCanGrantGroupAccessIDs).
 			Joins("JOIN `groups` ON groups.id = ancestor_group_id").
 			Where("groups.type != 'User'").
 			Select("groups.id, groups.name")

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -350,7 +350,8 @@ func scanAndBuildProgressResults(
 				// Convert it by parsing
 				result := &database.Time{}
 				err := result.ScanString(data.(string))
-				return *result, err
+				service.MustNotBeError(err)
+				return *result, nil
 			},
 		),
 		Result:           reflDecodedTableCell.Addr().Interface(),

--- a/app/api/groups/update_group.go
+++ b/app/api/groups/update_group.go
@@ -42,7 +42,7 @@ type groupUpdateInput struct {
 
 	// Can be changed only from false to true
 	// (changing auto-rejects all pending join/leave requests and withdraws all pending invitations)
-	FrozenMembership bool `json:"frozen_membership"  validate:"changing_requires_can_manage_at_least=memberships,frozen_membership"`
+	FrozenMembership bool `json:"frozen_membership" validate:"changing_requires_can_manage_at_least=memberships,frozen_membership"`
 	// Cannot be set to null when enforce_max_participant is true
 	MaxParticipants *int `json:"max_participants" validate:"changing_requires_can_manage_at_least=memberships,max_participants"`
 	// Cannot be set to true when max_participants is null
@@ -427,7 +427,11 @@ func validateUpdateGroupInput(
 	formData.RegisterTranslation("null|gte=0", "can be null or an integer between 0 and 2147483647 inclusively")
 
 	err := formData.ParseMapData(rawRequestData)
-	return formData, err
+	if err != nil {
+		return nil, err
+	}
+
+	return formData, nil
 }
 
 func int64PtrEqualValues(a, b *int64) bool {

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -480,7 +480,7 @@ func registerCanRequestHelpToCanGrantViewContent(
 		data,
 		"can_request_help_to_can_grant_view_content",
 		"the current user doesn't have the right to update can_request_help_to",
-		func(fl validator.FieldLevel) bool {
+		func(_ validator.FieldLevel) bool {
 			// The current user must have can_grant_view >= content.
 
 			return managerPermissions.CanGrantViewGeneratedValue >= s.PermissionsGranted().GrantViewIndexByName(content)

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -307,7 +307,7 @@ func constructAsRootOfGroupIDValidator(
 
 // constructParentItemTypeValidator constructs a validator checking that the parent item is not a Task.
 func constructParentItemTypeValidator(parentInfo *parentItemInfo) validator.Func {
-	return func(fl validator.FieldLevel) bool {
+	return func(_ validator.FieldLevel) bool {
 		return parentInfo.Type != task
 	}
 }

--- a/app/api/items/get_entry_state.go
+++ b/app/api/items/get_entry_state.go
@@ -308,7 +308,7 @@ func getEntryStateInfo(groupID, itemID int64, user *database.User, store *databa
 			canEnterQuery = canEnterQuery.WithExclusiveWriteLock()
 		}
 		service.MustNotBeError(canEnterQuery.Scan(&result.otherMembers).Error())
-		result.membersCount = int32(len(result.otherMembers))
+		result.membersCount = int32(len(result.otherMembers)) //nolint:gosec // G115: it's impossible to have more than 2^31-1 members
 
 		participatingSomewhereElseQuery := store.ActiveGroupGroups().Where("groups_groups_active.parent_group_id = ?", groupID).
 			Joins(`

--- a/app/api/items/get_parents.go
+++ b/app/api/items/get_parents.go
@@ -145,7 +145,11 @@ func (srv *Service) resolveGetParentsOrChildrenServiceParams(httpReq *http.Reque
 	params.participantID = service.ParticipantIDFromContext(httpReq.Context())
 
 	params.watchedGroupID, params.watchedGroupIDIsSet, err = srv.ResolveWatchedGroupID(httpReq)
-	return &params, err
+	if err != nil {
+		return nil, err
+	}
+
+	return &params, nil
 }
 
 func constructItemParentsQuery(dataStore *database.DataStore, childItemID, groupID, attemptID int64,

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -158,7 +158,7 @@ func constructItemListWithoutResultsQuery(dataStore *database.DataStore, groupID
 				Where("groups_ancestors_active.ancestor_group_id = ?", watchedGroupID).SubQuery()).SubQuery()
 	}
 
-	//nolint:gomnd // in the end, we append 4 more values
+	//nolint:mnd // in the end, we append 4 more values
 	values := make([]interface{}, len(columnListValues), len(columnListValues)+4)
 	copy(values, columnListValues)
 	canWatchResultEnumIndex := dataStore.PermissionsGranted().WatchIndexByName("result")

--- a/app/app.go
+++ b/app/app.go
@@ -44,7 +44,7 @@ func New() (*Application, error) {
 		panic("cannot seed the randomizer")
 	}
 	// Init the PRNG with a random value
-	rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+	rand.Seed(int64(binary.LittleEndian.Uint64(b[:]))) //nolint:gosec // G115: we don't care if a big number becomes negative
 
 	if err := application.Reset(config); err != nil {
 		return nil, err

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -153,7 +153,7 @@ func TestMiddlewares_OnPanic(t *testing.T) {
 	// check that the error has been handled by the recover
 	assert.Equal(http.StatusInternalServerError, response.StatusCode)
 	assert.Equal("Internal Server Error\n", string(respBody))
-	assert.Equal("text/plain; charset=utf-8", response.Header.Get("Content-type"))
+	assert.Equal("text/plain; charset=utf-8", response.Header.Get("Content-Type"))
 	allLogs := hook.AllEntries()
 	assert.Equal(2, len(allLogs)-nbLogsBeforeRequest)
 	// check that the req id is correct
@@ -174,7 +174,7 @@ func TestMiddlewares_OnSuccess(t *testing.T) {
 	defer restoreFct()
 	app, _ := New()
 	router := app.HTTPHandler
-	router.Get("/dummy", func(w http.ResponseWriter, r *http.Request) {
+	router.Get("/dummy", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("{\"data\":\"datadatadata\"}"))
@@ -192,7 +192,7 @@ func TestMiddlewares_OnSuccess(t *testing.T) {
 		return
 	}
 	defer func() { _ = response.Body.Close() }()
-	assert.NotNil(response.Header.Get("Content-type"))
+	assert.NotNil(response.Header.Get("Content-Type"))
 	assert.Equal("application/json", response.Header.Get("Content-Type"))
 	allLogs := hook.AllEntries()
 	assert.Equal(2, len(allLogs)-nbLogsBeforeRequest)

--- a/app/auth/middleware.go
+++ b/app/auth/middleware.go
@@ -63,7 +63,7 @@ func ValidatesUserAuthentication(service GetStorer, w http.ResponseWriter, r *ht
 	accessToken, cookieAttributes := ParseSessionCookie(r)
 
 	for _, authValue := range r.Header["Authorization"] {
-		//nolint:gomnd // credentials = "Bearer" 1*SP b64token (see https://tools.ietf.org/html/rfc6750#section-2.1)
+		//nolint:mnd // credentials = "Bearer" 1*SP b64token (see https://tools.ietf.org/html/rfc6750#section-2.1)
 		parsedAuthValue := strings.SplitN(authValue, " ", 3)
 		if len(parsedAuthValue) == 2 && parsedAuthValue[0] == "Bearer" {
 			accessToken = parsedAuthValue[1]

--- a/app/auth/random_test.go
+++ b/app/auth/random_test.go
@@ -29,7 +29,7 @@ func TestGenerateKey(t *testing.T) {
 
 func TestGenerateKey_HandlesError(t *testing.T) {
 	expectedError := errors.New("some error")
-	monkey.Patch(rand.Int, func(rand io.Reader, max *big.Int) (n *big.Int, err error) {
+	monkey.Patch(rand.Int, func(_ io.Reader, _ *big.Int) (n *big.Int, err error) {
 		return nil, expectedError
 	})
 	defer monkey.UnpatchAll()

--- a/app/config.go
+++ b/app/config.go
@@ -73,9 +73,8 @@ func loadConfigFrom(filename, directory string) *viper.Viper {
 		if appenv.IsEnvTest() {
 			fmt.Fprintf(os.Stderr, "Cannot read the %q config file: %s", environment, err)
 			panic("Cannot read the test config file")
-		} else {
-			fmt.Fprintf(os.Stderr, "Cannot merge %q config file, ignoring it: %s", environment, err)
 		}
+		fmt.Fprintf(os.Stderr, "Cannot merge %q config file, ignoring it: %s", environment, err)
 	}
 
 	return config

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -231,7 +231,7 @@ func TestDBConfig_StructToMapError(t *testing.T) {
 func TestTokenConfig_Success(t *testing.T) {
 	assert := assertlib.New(t)
 	globalConfig := viper.New()
-	monkey.Patch(token.Initialize, func(config *viper.Viper) (*token.Config, error) {
+	monkey.Patch(token.Initialize, func(_ *viper.Viper) (*token.Config, error) {
 		return &token.Config{PlatformName: "test"}, nil
 	})
 	defer monkey.UnpatchAll()

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -91,7 +91,7 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 	}
 
 	// For every object marked as processing, we compute all its ancestors
-	recomputeQueries := make([]string, 0, 3) //nolint:gomnd // we expect recomputeQueries to contain three elements
+	recomputeQueries := make([]string, 0, 3) //nolint:mnd // we expect recomputeQueries to contain three elements
 	recomputeQueries = append(recomputeQueries, `
 		DELETE `+objectName+`_ancestors
 		FROM `+objectName+`_ancestors

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -19,8 +19,7 @@ import (
 func TestDataStore_WithForeignKeyChecksDisabled(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
-	rawDB, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	rawDB := testhelpers.OpenRawDBConnection()
 	db, err := database.Open(rawDB)
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -64,8 +63,7 @@ func TestDataStore_WithNamedLock_WorksOutsideOfTransaction(t *testing.T) {
 
 	testHook, restoreFunc := logging.MockSharedLoggerHook()
 	defer restoreFunc()
-	rawDB, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	rawDB := testhelpers.OpenRawDBConnection()
 	db, err := database.OpenWithLogConfig(rawDB, database.LogConfig{LogSQLQueries: false}, true)
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -75,7 +73,7 @@ func TestDataStore_WithNamedLock_WorksOutsideOfTransaction(t *testing.T) {
 	defer close(resultCh)
 	for i := 0; i < 100; i++ {
 		go func() {
-			assert.NoError(t, s.WithNamedLock("test", 1*time.Second, func(store *database.DataStore) error {
+			assert.NoError(t, s.WithNamedLock("test", 1*time.Second, func(_ *database.DataStore) error {
 				return nil
 			}))
 			resultCh <- struct{}{}

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -227,7 +227,7 @@ func TestDataStore_InTransaction_ContextAndTxOptions(t *testing.T) {
 	mock.ExpectCommit()
 
 	store := NewDataStoreWithTable(db, "myTable")
-	gotError := store.InTransaction(func(s *DataStore) error {
+	gotError := store.InTransaction(func(_ *DataStore) error {
 		return nil
 	}, txOptions)
 
@@ -468,7 +468,7 @@ func TestDataStore_RetryOnDuplicatePrimaryKeyError(t *testing.T) {
 	retryCount := 0
 	err := NewDataStore(db).RetryOnDuplicatePrimaryKeyError("users", func(store *DataStore) error {
 		retryCount++
-		return db.Exec("INSERT INTO users (id) VALUES (?)", retryCount).Error()
+		return store.Exec("INSERT INTO users (id) VALUES (?)", retryCount).Error()
 	})
 
 	assert.NoError(t, err)
@@ -492,7 +492,7 @@ func TestDataStore_RetryOnDuplicateKeyError(t *testing.T) {
 	retryCount := 0
 	err := NewDataStore(db).RetryOnDuplicateKeyError("users", "login", "login", func(store *DataStore) error {
 		retryCount++
-		return db.Exec("INSERT INTO users (login) VALUES (?)", retryCount).Error()
+		return store.Exec("INSERT INTO users (login) VALUES (?)", retryCount).Error()
 	})
 
 	assert.NoError(t, err)

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -100,10 +100,14 @@ func OpenWithLogConfig(source interface{}, lc LogConfig, rawSQLQueriesLoggingEna
 		_ = dbConn.CommonDB().(*sqlDBWrapper).sqlDB.Close()
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	// we log queries and errors ourselves
 	dbConn.LogMode(false)
 
-	return newDB(dbConn, nil), err
+	return newDB(dbConn, nil), nil
 }
 
 // OpenRawDBConnection creates a new DB connection.
@@ -209,7 +213,7 @@ func isRetryableError(err error) bool {
 
 func (conn *DB) sleepBeforeStartingTransactionIfNeeded(count int64) {
 	if count > 0 && conn.ctx().Value(retryEachTransactionContextKey) == nil {
-		time.Sleep(time.Duration(float64(transactionDelayBetweenRetries) * (1.0 + (rand.Float64()-0.5)*0.1))) //nolint:gomnd // ±5%
+		time.Sleep(time.Duration(float64(transactionDelayBetweenRetries) * (1.0 + (rand.Float64()-0.5)*0.1))) //nolint:mnd // ±5%
 	}
 }
 
@@ -944,7 +948,7 @@ func Default() interface{} {
 // by adding the escape character before percent signs (%), and underscore signs (_).
 func EscapeLikeString(v string, escapeCharacter byte) string {
 	pos := 0
-	buf := make([]byte, len(v)*2) //nolint:gomnd // in the worst case, where every character is escaped, we need twice as many bytes
+	buf := make([]byte, len(v)*2) //nolint:mnd // in the worst case, where every character is escaped, we need twice as many bytes
 
 	for i := 0; i < len(v); i++ {
 		c := v[i]

--- a/app/database/db_enums.go
+++ b/app/database/db_enums.go
@@ -23,7 +23,7 @@ var (
 )
 
 func (conn *DB) loadDBEnum(fullColumnName string) {
-	parsedColumn := strings.SplitN(fullColumnName, ".", 2) //nolint:gomnd // two parts: tableName.columnName
+	parsedColumn := strings.SplitN(fullColumnName, ".", 2) //nolint:mnd // two parts: tableName.columnName
 	tableName := parsedColumn[0]
 	columnName := parsedColumn[1]
 

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -184,7 +184,7 @@ func Test_Deadline(t *testing.T) {
 					rows, err := stmt.QueryContext(s.ctx())
 					if rows != nil {
 						_ = rows.Err() // ignore the error as err is expected to be non-nil
-						_ = rows.Close()
+						defer func() { _ = rows.Close() }()
 					}
 					return err
 				})

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -132,7 +132,7 @@ func Test_Deadline(t *testing.T) {
 		{
 			name: "Before_Commit_InTransaction",
 			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
-				return s.InTransaction(func(s *DataStore) error {
+				return s.InTransaction(func(_ *DataStore) error {
 					cancel()
 					return nil
 				})
@@ -217,7 +217,7 @@ func Test_Deadline(t *testing.T) {
 			name: "Before releasing a named lock inside a transaction",
 			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
 				return s.InTransaction(func(s *DataStore) error {
-					return s.WithNamedLock("test_lock", time.Second, func(s *DataStore) error {
+					return s.WithNamedLock("test_lock", time.Second, func(_ *DataStore) error {
 						cancel()
 						return nil
 					})
@@ -238,7 +238,7 @@ func Test_Deadline(t *testing.T) {
 			funcToCall: func(s *DataStore, cancel context.CancelFunc) error {
 				return s.InTransaction(func(s *DataStore) error {
 					cancel()
-					return s.WithNamedLock("test_lock", time.Second, func(s *DataStore) error {
+					return s.WithNamedLock("test_lock", time.Second, func(_ *DataStore) error {
 						return nil
 					})
 				})

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -60,7 +60,7 @@ func TestGroupGroupStore_CreateRelation(t *testing.T) {
 
 	var resultsPropagationScheduled bool
 	monkey.PatchInstanceMethod(reflect.TypeOf(&DataStore{}), "ScheduleResultsPropagation",
-		func(s *DataStore) { resultsPropagationScheduled = true })
+		func(_ *DataStore) { resultsPropagationScheduled = true })
 	defer monkey.UnpatchAll()
 
 	const (

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -333,7 +333,7 @@ func (approvals *GroupApprovals) FromString(s string) {
 
 // ToArray converts GroupApprovals to a list of approvals.
 func (approvals *GroupApprovals) ToArray() []string {
-	approvalsList := make([]string, 0, 3) //nolint:gomnd // 3 possible approvals
+	approvalsList := make([]string, 0, 3) //nolint:mnd // 3 possible approvals
 	if approvals.PersonalInfoViewApproval {
 		approvalsList = append(approvalsList, "personal_info_view")
 	}
@@ -496,7 +496,7 @@ func insertRelations(dataStore *DataStore, idsToInsertRelation *golang.Set[int64
 			strings.Repeat(valuesTemplate+", ", len(idsToInsertRelation)-1) +
 			valuesTemplate // #nosec
 		insertQuery += " ON DUPLICATE KEY UPDATE expires_at = '9999-12-31 23:59:59'"
-		values := make([]interface{}, 0, len(idsToInsertRelation)*5) //nolint:gomnd // 5 values per row
+		values := make([]interface{}, 0, len(idsToInsertRelation)*5) //nolint:mnd // 5 values per row
 		for _, id := range idsToInsertRelation {
 			personalInfoViewApprovedAt, lockMembershipApprovedAt, watchApprovedAt := resolveApprovalTimesForGroupsGroups(
 				oldStatesMap, id, approvals,
@@ -584,7 +584,7 @@ func insertGroupPendingRequests(dataStore *DataStore, idsToInsertPending map[int
 		insertQuery += " VALUES " +
 			strings.Repeat(valuesTemplate+", ", len(idsToInsertPending)-1) +
 			valuesTemplate // #nosec
-		values := make([]interface{}, 0, len(idsToInsertPending)*6) //nolint:gomnd // 6 values per row
+		values := make([]interface{}, 0, len(idsToInsertPending)*6) //nolint:mnd // 6 values per row
 		for id, groupMembershipAction := range idsToInsertPending {
 			values = append(values, parentGroupID, id, groupMembershipAction.PendingType(),
 				approvals[id].PersonalInfoViewApproval, approvals[id].LockMembershipApproval,
@@ -609,7 +609,7 @@ func insertGroupMembershipChanges(dataStore *DataStore, idsChanged map[int64]Gro
 			for id, toAction := range idsChanged {
 				values = append(values, parentGroupID, id, toAction[strings.LastIndex(string(toAction), ",")+1:], performedByUserID)
 			}
-			return dataStore.db.Exec(insertQuery, values...).Error
+			return db.Exec(insertQuery, values...).Error()
 		}))
 	}
 }

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -81,7 +81,7 @@ func (s *ItemStore) participationHierarchyForParentAttempt(
 
 	if len(ids) > 1 {
 		subQuery = subQuery.
-			Where(fmt.Sprintf("attempts%d.id = ?", len(ids)-2), parentAttemptID) //nolint:gomnd // the second last item is the parent of the last one
+			Where(fmt.Sprintf("attempts%d.id = ?", len(ids)-2), parentAttemptID) //nolint:mnd // the second last item is the parent of the last one
 	}
 
 	return subQuery.Select(columnsList).

--- a/app/database/mock_db_test.go
+++ b/app/database/mock_db_test.go
@@ -29,7 +29,7 @@ func TestNewDBMock_ExitsOnGettingErrorFromSQLMockNew(t *testing.T) {
 
 			var patch *monkey.PatchGuard
 			patch = monkey.Patch(sqlmock.New, reflect.MakeFunc(reflect.TypeOf(sqlmock.New),
-				func(args []reflect.Value) (results []reflect.Value) {
+				func(_ []reflect.Value) (results []reflect.Value) {
 					patch.Unpatch()
 					_, mock, _ := sqlmock.New()
 					patch.Restore()

--- a/app/database/mysql_connection_wrapper_integration_test.go
+++ b/app/database/mysql_connection_wrapper_integration_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestMysqlConnectionWrapper_ResetSession(t *testing.T) {
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -47,8 +46,7 @@ func TestMysqlConnectionWrapper_ResetSession(t *testing.T) {
 }
 
 func TestMysqlConnectionWrapper_ResetSession_ResetsForeignKeyChecks(t *testing.T) {
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -76,8 +74,7 @@ func TestMysqlConnectionWrapper_ResetSession_ResetsForeignKeyChecks(t *testing.T
 }
 
 func TestMysqlConnectionWrapper_ResetSession_FailsOnClosedConnection(t *testing.T) {
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -93,16 +90,15 @@ func TestMysqlConnectionWrapper_ResetSession_FailsOnClosedConnection(t *testing.
 }
 
 type resetter = interface {
-	Reset(context.Context) error
+	Reset(ctx context.Context) error
 }
 
 func TestMysqlConnectionWrapper_Reset_FailsOnClosedConnection(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
-		func(_ *viper.Viper, key string) bool { return false })
+		func(_ *viper.Viper, _ string) bool { return false })
 	defer monkey.UnpatchAll()
 
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -119,11 +115,10 @@ func TestMysqlConnectionWrapper_Reset_FailsOnClosedConnection(t *testing.T) {
 
 func TestMysqlConnectionWrapper_Reset_FailsWhenContextIsCancelled(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
-		func(_ *viper.Viper, key string) bool { return false })
+		func(_ *viper.Viper, _ string) bool { return false })
 	defer monkey.UnpatchAll()
 
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -140,11 +135,10 @@ func TestMysqlConnectionWrapper_Reset_FailsWhenContextIsCancelled(t *testing.T) 
 
 func TestMysqlConnectionWrapper_Reset_FailsWhenWriteCommandPacketFails(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(&viper.Viper{}), "GetBool",
-		func(_ *viper.Viper, key string) bool { return false })
+		func(_ *viper.Viper, _ string) bool { return false })
 	defer monkey.UnpatchAll()
 
-	db, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	db := testhelpers.OpenRawDBConnection()
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/app/database/mysql_connection_wrapper_test.go
+++ b/app/database/mysql_connection_wrapper_test.go
@@ -19,17 +19,17 @@ type stmtMock struct{}
 
 func (stmt *stmtMock) Close() error                               { return nil }
 func (stmt *stmtMock) NumInput() int                              { return 0 }
-func (stmt *stmtMock) Exec([]driver.Value) (driver.Result, error) { return nil, nil }
-func (stmt *stmtMock) Query([]driver.Value) (driver.Rows, error)  { return nil, nil }
+func (stmt *stmtMock) Exec([]driver.Value) (driver.Result, error) { return nil, nil } //nolint:nilnil // It's just a mock.
+func (stmt *stmtMock) Query([]driver.Value) (driver.Rows, error)  { return nil, nil } //nolint:nilnil // It's just a mock.
 
 var _ driver.Stmt = &stmtMock{}
 
 type connMock struct{}
 
 func (conn *connMock) Prepare(string) (driver.Stmt, error) {
-	return &stmtMock{}, errors.New("error")
+	return &stmtMock{}, errors.New("error") //nolint:nilnil // We return the value among with the error for test purposes.
 }
-func (conn *connMock) Begin() (driver.Tx, error) { return nil, nil }
+func (conn *connMock) Begin() (driver.Tx, error) { return nil, nil } //nolint:nilnil // It's just a mock.
 func (conn *connMock) Close() error              { return nil }
 
 var _ driver.Conn = &connMock{}
@@ -42,7 +42,7 @@ func Test_mysqlConnWrapper_Prepare(t *testing.T) {
 	monkey.Patch(mysqlConnPrepare, func(c unsafe.Pointer, query string) (driver.Stmt, error) {
 		assert.Equal(t, conn, (*mysqlConnWrapper)(c))
 		assert.Equal(t, expectedQuery, query)
-		return expectedStmt, expectedErr
+		return expectedStmt, expectedErr //nolint:nilnil // We return the value among with the error for test purposes.
 	})
 	defer monkey.UnpatchAll()
 	stmt, err := conn.Prepare(expectedQuery)

--- a/app/database/mysql_driver_wrapper_test.go
+++ b/app/database/mysql_driver_wrapper_test.go
@@ -36,6 +36,7 @@ func Test_mysqlDriverWrapper_Open(t *testing.T) {
 type driverMockWithError struct{}
 
 func (d *driverMockWithError) Open(name string) (driver.Conn, error) {
+	//nolint:nilnil // we return the value for test purposes
 	return &connMockWithName{&connMock{}, name}, fmt.Errorf("error for %s", name)
 }
 
@@ -52,11 +53,12 @@ func Test_mysqlDriverWrapper_Open_Error(t *testing.T) {
 
 type driverConnectorMockWithError struct{}
 
-func (d *driverConnectorMockWithError) Open(string) (driver.Conn, error) { return nil, nil }
+func (d *driverConnectorMockWithError) Open(string) (driver.Conn, error) { return nil, nil } //nolint:nilnil // It's just a mock.
 
 var _ driver.Driver = &driverConnectorMockWithError{}
 
 func (d *driverConnectorMockWithError) OpenConnector(name string) (driver.Connector, error) {
+	//nolint:nilnil // we return the value for test purposes
 	return &mysqlConnectorWrapper{}, fmt.Errorf("error for %s", name)
 }
 

--- a/app/database/propagation_steps.go
+++ b/app/database/propagation_steps.go
@@ -50,7 +50,7 @@ type BeforePropagationStepHookFunc func(step PropagationStep)
 
 var (
 	// beforePropagationStepHook is a hook that is called before each propagation step.
-	beforePropagationStepHook BeforePropagationStepHookFunc = func(step PropagationStep) {}
+	beforePropagationStepHook BeforePropagationStepHookFunc = func(_ PropagationStep) {}
 	// beforePropagationStepMutex protects beforePropagationStepHook.
 	beforePropagationStepMutex sync.RWMutex
 )

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -22,7 +22,7 @@ func Test_fileWithLineNum(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectCommit()
 
-	require.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
+	require.NoError(t, NewDataStore(db).InTransaction(func(_ *DataStore) error {
 		assert.Contains(t, fileWithLineNum(), "/query_logger_test.go:")
 		return nil
 	}))
@@ -132,7 +132,7 @@ type timeType time.Time
 // Value returns a timeType Value (*time.Time).
 func (t *timeType) Value() (driver.Value, error) {
 	if t == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // return nil for nil receiver
 	}
 	return (*time.Time)(t).UTC().Format("2006-01-02 15:04:05.999999"), nil
 }

--- a/app/database/raw_db_logger.go
+++ b/app/database/raw_db_logger.go
@@ -34,7 +34,7 @@ func NewRawDBLogger() instrumentedsql.Logger {
 }
 
 func prepareRawDBLoggerValuesMap(keyvals []interface{}) map[string]interface{} {
-	valuesMap := make(map[string]interface{}, len(keyvals)/2) //nolint:gomnd // keyvals are key-value pairs
+	valuesMap := make(map[string]interface{}, len(keyvals)/2) //nolint:mnd // keyvals are key-value pairs
 	for index := 0; index < len(keyvals); index += 2 {
 		valuesMap[keyvals[index].(string)] = keyvals[index+1]
 	}

--- a/app/database/raw_db_logger_integration_test.go
+++ b/app/database/raw_db_logger_integration_test.go
@@ -25,8 +25,7 @@ func Test_RawSQLQueryLogging_Duration(t *testing.T) {
 		func(_ *viper.Viper, key string) bool { return key == "LogRawSQLQueries" || key == "LogSQLQueries" })
 	defer monkey.UnpatchAll()
 
-	sqlDB, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	sqlDB := testhelpers.OpenRawDBConnection()
 	defer func() { _ = sqlDB.Close() }()
 
 	db, err := database.OpenWithLogConfig(sqlDB, database.LogConfig{LogSQLQueries: true}, true)
@@ -67,8 +66,7 @@ func Test_RawSQLQueryLogging_ResetSession(t *testing.T) {
 		func(_ *logging.Logger) bool { return true })
 	defer monkey.UnpatchAll()
 
-	sqlDB, err := testhelpers.OpenRawDBConnection()
-	require.NoError(t, err)
+	sqlDB := testhelpers.OpenRawDBConnection()
 	defer func() { _ = sqlDB.Close() }()
 
 	loggerHook, loggerRestoreFunc := logging.MockSharedLoggerHook()

--- a/app/database/session_store.go
+++ b/app/database/session_store.go
@@ -38,7 +38,7 @@ func (s *SessionStore) GetUserAndSessionIDByValidAccessToken(token string) (user
 }
 
 // DeleteOldSessionsToKeepMaximum deletes old sessions to keep the maximum number of sessions.
-func (s *SessionStore) DeleteOldSessionsToKeepMaximum(userID int64, max int) {
+func (s *SessionStore) DeleteOldSessionsToKeepMaximum(userID int64, keepUpTo int) {
 	// Sessions without access tokens are treated as the oldest ones.
 	// So they will be deleted first when the maximum number of sessions is reached.
 	sessionsWithoutAccessTokensQuery := s.
@@ -65,7 +65,7 @@ func (s *SessionStore) DeleteOldSessionsToKeepMaximum(userID int64, max int) {
 		Select("session_id").
 		Order("issued_at DESC, session_id").
 		Limit(infinity). // Offset requires a limit in MySQL.
-		Offset(max).
+		Offset(keepUpTo).
 		SubQuery()
 
 	// The use of tmp_table is a workaround for the following MySQL error:

--- a/app/database/sql_db_wrapper.go
+++ b/app/database/sql_db_wrapper.go
@@ -44,6 +44,7 @@ func (sqlDB *sqlDBWrapper) Query(query string, args ...interface{}) (_ *sql.Rows
 	defer getSQLExecutionPlanLoggingFunc(sqlDB.ctx, sqlDB, sqlDB.logConfig, query, args...)()
 	defer getSQLQueryLoggingFunc(sqlDB.ctx, nil, &err, gorm.NowFunc(), query, args...)(sqlDB.logConfig)
 
+	//nolint:sqlclosecheck // The caller is responsible for closing the returned *sql.Rows.
 	return sqlDB.sqlDB.QueryContext(sqlDB.ctx, query, args...)
 }
 

--- a/app/database/sql_db_wrapper_test.go
+++ b/app/database/sql_db_wrapper_test.go
@@ -14,7 +14,9 @@ func TestSQLDBWrapper_Prepare_Panics(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	sqlDBWrapper := db.db.CommonDB().(*sqlDBWrapper)
-	assert.Panics(t, func() { _, _ = sqlDBWrapper.Prepare("SELECT 1") })
+	assert.Panics(t, func() {
+		_, _ = sqlDBWrapper.Prepare("SELECT 1") //nolint:sqlclosecheck // there is no statement to close as the Prepare should panic
+	})
 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/database/sql_stmt_wrapper.go
+++ b/app/database/sql_stmt_wrapper.go
@@ -58,7 +58,7 @@ func (s *SQLStmtWrapper) QueryContext(ctx context.Context, args ...interface{}) 
 	defer getSQLExecutionPlanLoggingFunc(ctx, s.db, s.logConfig, s.sql, args...)()
 	defer getSQLQueryLoggingFunc(ctx, nil, &err, gorm.NowFunc(), s.sql, args...)(s.logConfig)
 
-	rows, err = s.stmt.QueryContext(ctx, args...)
+	rows, err = s.stmt.QueryContext(ctx, args...) //nolint:sqlclosecheck // The caller is responsible for closing the returned *sql.Rows.
 	err = s.handleError(ctx, err)
 	return rows, err
 }

--- a/app/database/sql_stmt_wrapper.go
+++ b/app/database/sql_stmt_wrapper.go
@@ -42,7 +42,11 @@ func (s *SQLStmtWrapper) ExecContext(ctx context.Context, args ...interface{}) (
 
 	result, err = s.stmt.ExecContext(ctx, args...)
 	err = s.handleError(ctx, err)
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 /*
@@ -60,7 +64,11 @@ func (s *SQLStmtWrapper) QueryContext(ctx context.Context, args ...interface{}) 
 
 	rows, err = s.stmt.QueryContext(ctx, args...) //nolint:sqlclosecheck // The caller is responsible for closing the returned *sql.Rows.
 	err = s.handleError(ctx, err)
-	return rows, err
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
 }
 
 /*

--- a/app/database/sql_tx_wrapper.go
+++ b/app/database/sql_tx_wrapper.go
@@ -85,6 +85,7 @@ func (sqlTX *sqlTxWrapper) Query(query string, args ...interface{}) (rows *sql.R
 	defer getSQLExecutionPlanLoggingFunc(sqlTX.ctx, sqlTX, sqlTX.logConfig, query, args...)()
 	defer getSQLQueryLoggingFunc(sqlTX.ctx, nil, &err, gorm.NowFunc(), query, args...)(sqlTX.logConfig)
 
+	//nolint:sqlclosecheck // The caller is responsible for closing the returned *sql.Rows.
 	rows, err = sqlTX.sqlTx.QueryContext(sqlTX.ctx, query, args...)
 	err = sqlTX.handleError(err)
 	return rows, err

--- a/app/database/sql_tx_wrapper.go
+++ b/app/database/sql_tx_wrapper.go
@@ -50,7 +50,11 @@ func (sqlTX *sqlTxWrapper) Exec(query string, args ...interface{}) (result sql.R
 
 	result, err = sqlTX.sqlTx.ExecContext(sqlTX.ctx, query, args...)
 	err = sqlTX.handleError(err)
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // Prepare is not implemented intentionally and panics if called. Instead, use [prepare].
@@ -88,7 +92,11 @@ func (sqlTX *sqlTxWrapper) Query(query string, args ...interface{}) (rows *sql.R
 	//nolint:sqlclosecheck // The caller is responsible for closing the returned *sql.Rows.
 	rows, err = sqlTX.sqlTx.QueryContext(sqlTX.ctx, query, args...)
 	err = sqlTX.handleError(err)
-	return rows, err
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
 }
 
 // QueryRow executes a query that is expected to return at most one row.

--- a/app/database/sql_tx_wrapper_test.go
+++ b/app/database/sql_tx_wrapper_test.go
@@ -18,7 +18,9 @@ func TestSQLTxWrapper_Prepare_Panics(t *testing.T) {
 
 	assert.NoError(t, db.inTransaction(func(db *DB) error {
 		sqlTxWrapper := db.db.CommonDB().(*sqlTxWrapper)
-		assert.Panics(t, func() { _, _ = sqlTxWrapper.Prepare("SELECT 1") })
+		assert.Panics(t, func() {
+			_, _ = sqlTxWrapper.Prepare("SELECT 1") //nolint:sqlclosecheck // there is no statement to close as the Prepare should panic
+		})
 		return nil
 	}))
 

--- a/app/database/time.go
+++ b/app/database/time.go
@@ -26,7 +26,7 @@ func (t *Time) ScanString(str string) (err error) {
 	// Based on go-sql-driver/mysql.parseDateTime (see https://github.com/go-sql-driver/mysql/blob/master/utils.go#L109)
 	base := "0000-00-00 00:00:00.0000000"
 	switch len(str) {
-	//nolint:gomnd // we allow "YYYY-MM-DD", "YYYY-MM-DD HH:MM:SS", "YYYY-MM-DD HH:MM:SS.M"-"YYYY-MM-DD HH:MM:SS.MMMMMM" formats
+	//nolint:mnd // we allow "YYYY-MM-DD", "YYYY-MM-DD HH:MM:SS", "YYYY-MM-DD HH:MM:SS.M"-"YYYY-MM-DD HH:MM:SS.MMMMMM" formats
 	case 10, 19, 21, 22, 23, 24, 25, 26: // up to "YYYY-MM-DD HH:MM:SS.MMMMMM"
 		if str == base[:len(str)] {
 			return nil
@@ -46,7 +46,7 @@ func (t *Time) ScanString(str string) (err error) {
 // Value returns a database driver Value (*time.Time).
 func (t *Time) Value() (driver.Value, error) {
 	if t == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // return nil for nil receiver
 	}
 	return (*time.Time)(t).UTC().Format(timeFormat), nil
 }

--- a/app/database/user.go
+++ b/app/database/user.go
@@ -106,18 +106,18 @@ func (u *User) CanRequestHelpTo(s *DataStore, itemID, helperGroupID int64) bool 
 	return canRequestHelpTo
 }
 
-// GetManagedGroupsWithCanGrantGroupAccessIds retrieves all group ids that the user manages and for which
+// GetManagedGroupsWithCanGrantGroupAccessIDs retrieves all group ids that the user manages and for which
 // he can_grant_group_access.
-func (u *User) GetManagedGroupsWithCanGrantGroupAccessIds(store *DataStore) []int64 {
-	var managedGroupsWithCanGrantGroupAccessIds []int64
+func (u *User) GetManagedGroupsWithCanGrantGroupAccessIDs(store *DataStore) []int64 {
+	var managedGroupsWithCanGrantGroupAccessIDs []int64
 
 	store.ActiveGroupAncestors().ManagedByUser(u).
 		Group("groups_ancestors_active.child_group_id").
 		Having("MAX(group_managers.can_grant_group_access)").
 		Select("groups_ancestors_active.child_group_id AS id").
-		Pluck("id", &managedGroupsWithCanGrantGroupAccessIds)
+		Pluck("id", &managedGroupsWithCanGrantGroupAccessIDs)
 
-	return managedGroupsWithCanGrantGroupAccessIds
+	return managedGroupsWithCanGrantGroupAccessIDs
 }
 
 // CanWatchGroupMembers checks whether the user can watch a group / a participant.

--- a/app/database/user_store.go
+++ b/app/database/user_store.go
@@ -38,7 +38,7 @@ func (s *UserStore) DeleteTemporaryWithTraps(delay time.Duration) (err error) {
 			Joins(`
 				LEFT JOIN access_tokens ON access_tokens.session_id = sessions.session_id AND
 					access_tokens.expires_at > NOW() - INTERVAL ? SECOND`,
-				uint64(delay.Round(time.Second)/time.Second)).
+				int64(delay.Round(time.Second)/time.Second)).
 			Where("access_tokens.session_id IS NULL").
 			Where("temp_user = 1")
 		return store.Users().deleteWithTraps(userScope, true)

--- a/app/domain/middleware.go
+++ b/app/domain/middleware.go
@@ -29,7 +29,7 @@ func Middleware(domains []ConfigItem, domainOverride string) func(next http.Hand
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			domain := domainOverride
 			if domain == "" {
-				domain = strings.SplitN(r.Host, ":", 2)[0] //nolint:gomnd // get the domain from the request host, ignoring the port if any
+				domain = strings.SplitN(r.Host, ":", 2)[0] //nolint:mnd // get the domain from the request host, ignoring the port if any
 			}
 			configuration := domainsMap[domain]
 			if configuration == nil {

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -388,7 +388,7 @@ func traverseStructure(fn func(fieldValue reflect.Value, structField reflect.Str
 		squash := getJSONSquash(&structField)
 		result := true
 		if !squash {
-			if len(prefix) > 0 {
+			if prefix != "" {
 				jsonName = prefix + "." + jsonName
 			}
 

--- a/app/formdata/validations.go
+++ b/app/formdata/validations.go
@@ -22,9 +22,9 @@ func validateDuration(fl validator.FieldLevel) bool {
 	if field.Kind() != reflect.String {
 		return false
 	}
-	//nolint:gomnd // we want exactly 3 parts (hours:minutes:seconds), but allow the 4th part in case of error
+	//nolint:mnd // we want exactly 3 parts (hours:minutes:seconds), but allow the 4th part in case of error
 	hms := strings.SplitN(field.String(), ":", 4)
-	//nolint:gomnd // fail when the number of parts is not 3 (hours:minutes:seconds)
+	//nolint:mnd // fail when the number of parts is not 3 (hours:minutes:seconds)
 	if len(hms) != 3 {
 		return false
 	}

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -124,7 +124,7 @@ func TestLogger_Configure_OutputFileError(t *testing.T) {
 	conf := viper.New()
 	conf.Set("Format", "json")
 	conf.Set("Output", "file")
-	fakeFunc := func(name string, flag int, perm os.FileMode) (*os.File, error) {
+	fakeFunc := func(_ string, _ int, _ os.FileMode) (*os.File, error) {
 		return nil, errors.New("open error")
 	}
 	patch := monkey.Patch(os.OpenFile, fakeFunc)

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -66,10 +66,9 @@ func doRequest(forcePanic bool) {
 		GetLogEntry(r).Print("in service log")
 		if forcePanic {
 			panic("my panic msg")
-		} else {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("dummy body"))
 		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("dummy body"))
 	})
 	// use the chi `Recoverer` middleware to catch panic and log it
 	// use the chi `RequestID` middleware to include request id in it (appear in logs)

--- a/app/loggingtest/loggingtest.go
+++ b/app/loggingtest/loggingtest.go
@@ -23,7 +23,7 @@ func (hook *Hook) GetAllLogs() string {
 	logs := ""
 
 	for _, entry := range hook.AllEntries() {
-		if len(logs) > 0 {
+		if logs != "" {
 			logs += newLine
 		}
 
@@ -39,7 +39,7 @@ func (hook *Hook) GetAllStructuredLogs() string {
 	formatter := logging.NewTextFormatterForTests()
 
 	for _, entry := range hook.AllEntries() {
-		if len(logs) > 0 {
+		if logs != "" {
 			logs += newLine
 		}
 		logBytes, err := formatter.Format(entry)

--- a/app/loginmodule/client.go
+++ b/app/loginmodule/client.go
@@ -236,7 +236,7 @@ func Encode(data []byte, clientKey string) string {
 }
 
 func convertUserProfile(source map[string]interface{}) (map[string]interface{}, error) {
-	//nolint:gomnd // we are going to add two fields: public_first_name and public_last_name
+	//nolint:mnd // we are going to add two fields: public_first_name and public_last_name
 	dest := make(map[string]interface{}, len(source)+2)
 	/*
 	 We ignore fields: birthday_year, client_id, created_at, creator_client_id,

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -71,7 +71,7 @@ func TestServer_Start_HandlesKillingAfterListenerError(t *testing.T) {
 
 	monkey.PatchInstanceMethod(
 		reflect.TypeOf(&http.Server{}), //nolint:gosec // the instance of http.Server will never be used
-		"ListenAndServe", func(srv *http.Server) error {
+		"ListenAndServe", func(_ *http.Server) error {
 			err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 			assert.NoError(t, err)
 			select {

--- a/app/service/base_test.go
+++ b/app/service/base_test.go
@@ -16,7 +16,7 @@ import (
 func TestBase_GetUser(t *testing.T) {
 	middleware := auth.MockUserMiddleware(&database.User{GroupID: 42})
 	called := false
-	ts := httptest.NewServer(middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		called = true
 		srv := &Base{}
 		user := srv.GetUser(r)

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -46,7 +46,7 @@ func (e *APIError) httpResponse() render.Renderer {
 	}
 
 	result.ErrorText = e.EmbeddedError.Error()
-	if len(result.ErrorText) > 0 {
+	if result.ErrorText != "" {
 		result.ErrorText = strings.ToUpper(result.ErrorText[0:1]) + result.ErrorText[1:]
 	}
 

--- a/app/service/parameters_test.go
+++ b/app/service/parameters_test.go
@@ -136,7 +136,7 @@ func TestResolveURLQueryPathInt64Field(t *testing.T) {
 		t.Run(testCase.desc, func(t *testing.T) {
 			r := chi.NewRouter()
 			called := false
-			handler := func(w http.ResponseWriter, r *http.Request) {
+			handler := func(_ http.ResponseWriter, r *http.Request) {
 				called = true
 				value, err := ResolveURLQueryPathInt64Field(r, "id")
 				if testCase.expectedErrMsg != "" {
@@ -216,7 +216,7 @@ func TestResolveURLQueryPathInt64SliceField(t *testing.T) {
 		t.Run(testCase.desc, func(t *testing.T) {
 			called := false
 			r := chi.NewRouter()
-			handler := func(w http.ResponseWriter, r *http.Request) {
+			handler := func(_ http.ResponseWriter, r *http.Request) {
 				called = true
 				value, err := ResolveURLQueryPathInt64SliceField(r, "ids")
 				if testCase.expectedErrMsg != "" {

--- a/app/service/participant.go
+++ b/app/service/participant.go
@@ -27,7 +27,7 @@ func ParticipantMiddleware(srv GetStorer) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var participantID int64
 			var failed bool
-			AppHandler(func(w http.ResponseWriter, r *http.Request) error {
+			AppHandler(func(_ http.ResponseWriter, r *http.Request) error {
 				var err error
 				defer func() {
 					failed = err != nil

--- a/app/service/query_limiter_test.go
+++ b/app/service/query_limiter_test.go
@@ -77,7 +77,7 @@ func TestQueryLimiter_Apply(t *testing.T) {
 
 			r := chi.NewRouter()
 			called := false
-			handler := func(w http.ResponseWriter, r *http.Request) {
+			handler := func(_ http.ResponseWriter, r *http.Request) {
 				called = true
 				db, mock := database.NewDBMock()
 				defer func() { _ = db.Close() }()

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -213,13 +213,13 @@ func validateSortingField(
 func getFieldNameAndSortingTypeFromSortStatement(sortStatement string) (string, sortingType) {
 	var direction sortingDirection
 	var np nullPlacement
-	if len(sortStatement) > 0 && sortStatement[0] == '-' {
+	if sortStatement != "" && sortStatement[0] == '-' {
 		sortStatement = sortStatement[1:]
 		direction = desc
 	} else {
 		direction = asc
 	}
-	if len(sortStatement) > 0 && sortStatement[len(sortStatement)-1] == '$' {
+	if sortStatement != "" && sortStatement[len(sortStatement)-1] == '$' {
 		np = last
 		sortStatement = sortStatement[:len(sortStatement)-1]
 	}
@@ -307,7 +307,10 @@ func getFromValueForField(r *http.Request, fieldName string, fieldType FieldType
 		timeResult, err = ResolveURLQueryGetTimeField(r, fromFieldName)
 		result = (*database.Time)(&timeResult)
 	}
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 var safeColumnNameRegexp = regexp.MustCompile("[^a-zA-Z_0-9]")
@@ -346,7 +349,7 @@ func constructPagingConditions(usedFields []string, configuredFields map[string]
 	safeColumnNames = make([]string, usedFieldsNumber)
 	conditions = make([]string, 0, usedFieldsNumber)
 	queryValuesPart := make([]interface{}, 0, usedFieldsNumber)
-	//nolint:gomnd // sum of 1..usedFieldsNumber = usedFieldsNumber*(usedFieldsNumber+1)/2
+	//nolint:mnd // sum of 1..usedFieldsNumber = usedFieldsNumber*(usedFieldsNumber+1)/2
 	queryValues = make([]interface{}, 0, (usedFieldsNumber+1)*usedFieldsNumber/2)
 	var conditionPrefix string
 
@@ -356,7 +359,7 @@ func constructPagingConditions(usedFields []string, configuredFields map[string]
 		safeColumnName := safeColumnNameRegexp.ReplaceAllLiteralString(fieldName, "_")
 		safeColumnNames[index] = safeColumnName
 
-		if len(conditionPrefix) > 0 {
+		if conditionPrefix != "" {
 			conditionPrefix += " AND "
 		}
 		columnName := configuredFields[fieldName].ColumnName

--- a/app/token/abstract.go
+++ b/app/token/abstract.go
@@ -56,7 +56,7 @@ var _ json.Marshaler = (*abstract)(nil)
 // For example, a token's string description is `{ENCODED_TOKEN}`
 // while a token's JSON description is `"{ENCODED_TOKEN}"`.
 type UnmarshalStringer interface {
-	UnmarshalString(string) error
+	UnmarshalString(s string) error
 }
 
 // MarshalStringer is the interface implemented by types
@@ -70,7 +70,7 @@ type MarshalStringer interface {
 // Signer is the interface implemented by types
 // that can sign themselves returning a token in a string.
 type Signer interface {
-	Sign(*rsa.PrivateKey) (string, error)
+	Sign(privateKey *rsa.PrivateKey) (string, error)
 }
 
 var (

--- a/app/token/token.go
+++ b/app/token/token.go
@@ -67,7 +67,7 @@ func getKey(config *viper.Viper, keyType string) ([]byte, error) {
 var tokenPathTestRegexp = regexp.MustCompile(`.*([/\\]app(?:[/\\][a-z]+)*?)$`)
 
 func prepareFileName(fileName string) string {
-	if len(fileName) > 0 && fileName[0] == '/' {
+	if fileName != "" && fileName[0] == '/' {
 		return fileName
 	}
 

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -380,24 +380,27 @@ func Test_prepareFileName_StripsOnlyTheLastOccurrenceOfApp(t *testing.T) {
 	assert.Equal(t, "/app/something/app/ab/"+relFileName, preparedFileName)
 }
 
-func createTmpPublicKeyFile(key []byte) (*os.File, error) {
-	tmpFilePublic, err := os.CreateTemp("", "testPublicKey.pem")
+func createTmpKeyFile(key []byte, fileName string) (*os.File, error) {
+	tmpFile, err := os.CreateTemp("", fileName)
 	if err != nil {
-		return tmpFilePublic, err
+		return nil, err
 	}
 
-	_, err = tmpFilePublic.Write(key)
-	return tmpFilePublic, err
+	_, err = tmpFile.Write(key)
+	if err != nil {
+		_ = tmpFile.Close()
+		return nil, err
+	}
+
+	return tmpFile, nil
+}
+
+func createTmpPublicKeyFile(key []byte) (*os.File, error) {
+	return createTmpKeyFile(key, "testPublicKey.pem")
 }
 
 func createTmpPrivateKeyFile(key []byte) (*os.File, error) {
-	tmpFilePrivate, err := os.CreateTemp("", "testPrivateKey.pem")
-	if err != nil {
-		return tmpFilePrivate, err
-	}
-
-	_, err = tmpFilePrivate.Write(key)
-	return tmpFilePrivate, err
+	return createTmpKeyFile(key, "testPrivateKey.pem")
 }
 
 func Test_recoverPanics_and_mustNotBeError(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use: "AlgoreaBackend",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		application, err := app.New()
 		closeDB := func() {
 			if application != nil && application.Database != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -21,7 +21,7 @@ func init() { //nolint:gochecknoinits
 		Use:   "serve [environment]",
 		Short: "start http server",
 		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 
 			// if arg given, replace the env

--- a/testhelpers/db.go
+++ b/testhelpers/db.go
@@ -36,10 +36,7 @@ func init() { //nolint:gochecknoinits
 func SetupDBWithFixture(fixtureNames ...string) *database.DB {
 	appenv.ForceTestEnv()
 
-	rawDB, err := OpenRawDBConnection()
-	if err != nil {
-		panic(err)
-	}
+	rawDB := OpenRawDBConnection()
 
 	// Seed the DB
 	EmptyDB(rawDB)
@@ -48,8 +45,7 @@ func SetupDBWithFixture(fixtureNames ...string) *database.DB {
 	}
 
 	// Return a new db connection
-	var db *database.DB
-	db, err = database.Open(rawDB)
+	db, err := database.Open(rawDB)
 	if err != nil {
 		panic(err)
 	}
@@ -62,10 +58,7 @@ func SetupDBWithFixture(fixtureNames ...string) *database.DB {
 func SetupDBWithFixtureString(fixtures ...string) *database.DB {
 	appenv.ForceTestEnv()
 
-	rawDB, err := OpenRawDBConnection()
-	if err != nil {
-		panic(err)
-	}
+	rawDB := OpenRawDBConnection()
 
 	// Seed the DB
 	EmptyDB(rawDB)
@@ -75,8 +68,7 @@ func SetupDBWithFixtureString(fixtures ...string) *database.DB {
 	}
 
 	// Return a new db connection
-	var db *database.DB
-	db, err = database.Open(rawDB)
+	db, err := database.Open(rawDB)
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +77,7 @@ func SetupDBWithFixtureString(fixtures ...string) *database.DB {
 }
 
 // OpenRawDBConnection creates a new connection to the DB specified in the config.
-func OpenRawDBConnection() (*sql.DB, error) {
+func OpenRawDBConnection() *sql.DB {
 	appenv.ForceTestEnv()
 
 	// needs actual config for connection to DB
@@ -100,7 +92,7 @@ func OpenRawDBConnection() (*sql.DB, error) {
 	if err != nil {
 		panic(err)
 	}
-	return rawDB, err
+	return rawDB
 }
 
 // LoadFixture loads fixtures from `<current_pkg_dir>/testdata/<fileName>/` directory

--- a/testhelpers/db_time.go
+++ b/testhelpers/db_time.go
@@ -64,7 +64,7 @@ func patchDBMethods(nowReplacer func(string) string) {
 			prepareContextGuard.Unpatch()
 			defer prepareContextGuard.Restore()
 			nowRegexp.ReplaceAllStringFunc(query, nowReplacer)
-			return db.PrepareContext(c, query)
+			return db.PrepareContext(c, query) //nolint:sqlclosecheck // the caller is responsible for closing the statement
 		})
 	patchedMethods = append(patchedMethods, prepareContextGuard)
 	queryContextGuard = monkey.PatchInstanceMethod(
@@ -73,7 +73,7 @@ func patchDBMethods(nowReplacer func(string) string) {
 			queryContextGuard.Unpatch()
 			defer queryContextGuard.Restore()
 			query = nowRegexp.ReplaceAllStringFunc(query, nowReplacer)
-			return db.QueryContext(c, query, args...)
+			return db.QueryContext(c, query, args...) //nolint:sqlclosecheck // the caller is responsible for closing the rows
 		})
 	patchedMethods = append(patchedMethods, queryContextGuard)
 }

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -156,6 +156,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 				*parentOutputRestorerFunc = nil
 			}
 		}
-		return contextCtx, tearDownErr
+		return contextCtx, tearDownErr //nolint:nilnil // It looks like we really want to return the context even if there is an error.
 	})
 }

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -38,8 +38,8 @@ func (ctx *TestContext) DBHasTable(tableName string, data *godog.Table) error {
 
 		marksString := "(" + strings.Join(marks, ", ") + ")"
 		finalMarksString := marksString
-		if len(data.Rows) > 2 { //nolint:gomnd // finalMarksString = marksString when data is a header plus one row (two rows in total)
-			//nolint:gomnd // -2 = minus one row for the table's header, and minus one more row for a set of question marks in '+ finalMarksString'
+		if len(data.Rows) > 2 { //nolint:mnd // finalMarksString = marksString when data is a header plus one row (two rows in total)
+			//nolint:mnd // -2 = minus one row for the table's header, and minus one more row for a set of question marks in '+ finalMarksString'
 			finalMarksString = strings.Repeat(marksString+", ", len(data.Rows)-2) + finalMarksString
 		}
 		query := "INSERT INTO " + database.QuoteName(tableName) +

--- a/testhelpers/steps_misc.go
+++ b/testhelpers/steps_misc.go
@@ -214,7 +214,7 @@ func (ctx *TestContext) TheContextVariableIs(variableName, value string) error {
 	}
 
 	oldHTTPHandler := ctx.application.HTTPHandler
-	ctx.application.HTTPHandler = chi.NewRouter().With(func(next http.Handler) http.Handler {
+	ctx.application.HTTPHandler = chi.NewRouter().With(func(_ http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			oldHTTPHandler.ServeHTTP(writer, request.WithContext(context.WithValue(request.Context(),
 				service.APIServiceContextVariableName(variableName), preprocessed)))

--- a/testhelpers/steps_request.go
+++ b/testhelpers/steps_request.go
@@ -48,7 +48,7 @@ func (ctx *TestContext) iSendrequestGeneric(method, path, reqBody string) error 
 	}
 
 	// app server
-	httpHandler := chi.NewRouter().With(func(handler http.Handler) http.Handler {
+	httpHandler := chi.NewRouter().With(func(_ http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx.application.HTTPHandler.ServeHTTP(w, r.WithContext(database.ContextWithTransactionRetrying(r.Context())))
 		})

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -81,16 +81,16 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 		return reflect.ValueOf(time.Now().UTC().Format(a.Get(0).Interface().(string)))
 	})
 
-	set.AddGlobalFunc("currentTimeDB", func(a jet.Arguments) reflect.Value {
+	set.AddGlobalFunc("currentTimeDB", func(_ jet.Arguments) reflect.Value {
 		return reflect.ValueOf(time.Now().UTC().Truncate(time.Microsecond).Format("2006-01-02 15:04:05.999999"))
 	})
 
-	set.AddGlobalFunc("currentTimeDBMs", func(a jet.Arguments) reflect.Value {
+	set.AddGlobalFunc("currentTimeDBMs", func(_ jet.Arguments) reflect.Value {
 		return reflect.ValueOf(time.Now().UTC().Truncate(time.Millisecond).Format("2006-01-02 15:04:05.000"))
 	})
 
 	set.AddGlobalFunc("generateToken", func(a jet.Arguments) reflect.Value {
-		//nolint:gomnd // we require exactly two arguments: the payload and the private key
+		//nolint:mnd // we require exactly two arguments: the payload and the private key
 		a.RequireNumOfArguments("generateToken", 2, 2)
 		var privateKey *rsa.PrivateKey
 		privateKeyRefl := a.Get(1)
@@ -114,7 +114,7 @@ func (ctx *TestContext) constructTemplateSet() *jet.Set {
 				privateKey)))
 	})
 
-	set.AddGlobalFunc("app", func(a jet.Arguments) reflect.Value {
+	set.AddGlobalFunc("app", func(_ jet.Arguments) reflect.Value {
 		return reflect.ValueOf(ctx.application)
 	})
 

--- a/testhelpers/testoutput/suppress.go
+++ b/testhelpers/testoutput/suppress.go
@@ -18,7 +18,7 @@ import (
 // After the output is suppressed, t.Parallel() for the test will panic.
 //
 // Note: This function does nothing if the test is run in verbose mode.
-func SuppressIfPasses(t *testing.T) { //nolint:gocritic
+func SuppressIfPasses(t *testing.T) {
 	if testing.Verbose() {
 		return
 	}


### PR DESCRIPTION
1. Validate tokens returned by the login module (probably we should do that even if the login module have never returned invalid tokens): return 401, delete the session when we get an invalid token on refreshing. Also, refactor things related the `expires_in` field of tokens returned by the login module.
2. Update golangci-lint to v1.64.7 which adds new linters:
      gochecksumtype (exhaustiveness checks on type switch statements),
      inamedparam (reports interfaces with unnamed method parameters), 
      protogetter (use getters instead of fields in protobuf structs which we do not use anyway),
      sloglint (consistent code style when using log/slog),
      spancheck (checks usage of OpenTelemetry/Census spans which we do not use anyway),
      copyloopvar (detects places where loop variables are copied in go 1.22+ which we do not use for now),
      intrange (checks for loops that could use the Go 1.22 integer range feature, but we do not use go 1.22+ for now),
      fatcontext (detects nested contexts in loops or function literals),
      canonicalheader (checks the canonicality of http headers),
      iface (detects the overuse or misuse of interfaces),
      exptostd (detects functions from golang.org/x/exp/ that can be replaced by std functions),
      nilnesserr (detects returning an unrelated/nil-values error)
3. Disable some new linters added after 1.53.3 for now: testifylint, usetesting, perfsprint, recvcheck.
4. Enable more linters:
+ the paralleltest linter (detects missing usage of t.Parallel() method), but make it only report incorrect usage of t.Parallel(), ignoring missing calls
+ add a comment in .golangci.yml explaining why we are not going to enable the nonamedreturns linter
+ enable the sqlclosecheck linter (checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed)
+ enable the tagliatelle linter (validates case of struct tags (like json field names)) everywhere except for app/payloads where structs are inconsistent.

This PR is a part of #1142 