### PR TITLE
Optimize permissions marking in after_update_items_items even more

### DIFF
--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -111,15 +111,15 @@ func TestItemItemStore_TriggerAfterUpdate_MarksPermissionsForRecomputing(t *test
 				Order("group_id, item_id").Scan(&markedPermissions).Error())
 			require.Empty(t, markedPermissions)
 
-			assert.NoError(t, dataStore.ItemItems().Where("parent_item_id=4 AND child_item_id=1").
+			assert.NoError(t, dataStore.ItemItems().Where("parent_item_id=1 AND child_item_id=11").
 				UpdateColumn(test.column, test.newValue).Error())
 
 			require.NoError(t, dataStore.Table("permissions_propagate").
 				Select("group_id, item_id, propagate_to").
 				Order("group_id, item_id").Scan(&markedPermissions).Error())
 			assert.Equal(t, []groupItemsResultRow{
-				{GroupID: 1, ItemID: 1, PropagateTo: "self"},
-				{GroupID: 2, ItemID: 1, PropagateTo: "self"},
+				{GroupID: 1, ItemID: 11, PropagateTo: "self"},
+				{GroupID: 2, ItemID: 11, PropagateTo: "self"},
 			}, markedPermissions)
 		})
 	}

--- a/db/migrations/2507011120_rework_marking_permissions_for_recomputing_in_after_update_items_items_trigger.sql
+++ b/db/migrations/2507011120_rework_marking_permissions_for_recomputing_in_after_update_items_items_trigger.sql
@@ -8,9 +8,9 @@ CREATE TRIGGER `after_update_items_items` AFTER UPDATE ON `items_items` FOR EACH
         OLD.`watch_propagation` != NEW.`watch_propagation` OR
         OLD.`edit_propagation` != NEW.`edit_propagation`) THEN
         REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
-        SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'self' as `propagate_to`
+        SELECT `permissions_generated`.`group_id`, NEW.`child_item_id`, 'self' as `propagate_to`
         FROM `permissions_generated`
-        WHERE `permissions_generated`.`item_id` = NEW.`child_item_id`;
+        WHERE `permissions_generated`.`item_id` = NEW.`parent_item_id`;
     END IF;
     IF (OLD.`category` != NEW.`category` OR OLD.`score_weight` != NEW.`score_weight`) THEN
         INSERT INTO `results_propagate`


### PR DESCRIPTION
Instead of marking generated permissions related to the child item as 'propagate_to=self', we will, for each generated permissions related to the parent item, mark the (group_id, child item's id) pair as 'propagate_to=self' (this will work better if we decide to remove permissions_generated having none/zero in all the permission-related columns).