### PR TITLE
Optimize permissions marking in before_delete_items_items even more

### DIFF
--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -178,7 +178,9 @@ Background:
       | 5577006791947779410 | 50      | content  | none           | none      | none     | false    | 5577006791947779410 | 1                                                       |
     And the table "permissions_generated" should be:
       | group_id            | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
+      | 10                  | 21      | none               | none                     | none                | none               | false              |
       | 10                  | 50      | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | true               |
+      | 10                  | 60      | none               | none                     | none                | none               | false              |
       | 10                  | 112     | info               | none                     | none                | none               | false              |
       | 10                  | 134     | solution           | solution                 | answer              | all                | false              |
       | 11                  | 21      | content            | none                     | none                | none               | false              |

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -143,13 +143,13 @@ func TestItemItemStore_TriggerBeforeDelete_MarksPermissionsForRecomputing(t *tes
 		Order("group_id, item_id").Scan(&markedPermissions).Error())
 	require.Empty(t, markedPermissions)
 
-	assert.NoError(t, dataStore.ItemItems().Delete("parent_item_id=4 AND child_item_id=1").Error())
+	assert.NoError(t, dataStore.ItemItems().Delete("parent_item_id=1 AND child_item_id=11").Error())
 
 	require.NoError(t, dataStore.Table("permissions_propagate").
 		Select("group_id, item_id, propagate_to").
 		Order("group_id, item_id").Scan(&markedPermissions).Error())
 	assert.Equal(t, []groupItemsResultRow{
-		{GroupID: 1, ItemID: 1, PropagateTo: "self"},
-		{GroupID: 2, ItemID: 1, PropagateTo: "self"},
+		{GroupID: 1, ItemID: 11, PropagateTo: "self"},
+		{GroupID: 2, ItemID: 11, PropagateTo: "self"},
 	}, markedPermissions)
 }

--- a/db/migrations/2507011113_fix_and_rework_marking_permissions_for_recomputing_in_before_delete_items_items_trigger.sql
+++ b/db/migrations/2507011113_fix_and_rework_marking_permissions_for_recomputing_in_before_delete_items_items_trigger.sql
@@ -6,9 +6,9 @@ CREATE TRIGGER `before_delete_items_items` BEFORE DELETE ON `items_items` FOR EA
   VALUES (OLD.child_item_id, 'todo') ON DUPLICATE KEY UPDATE `ancestors_computation_state` = 'todo';
 
   REPLACE INTO `permissions_propagate` (`group_id`, `item_id`, `propagate_to`)
-  SELECT `permissions_generated`.`group_id`, `permissions_generated`.`item_id`, 'self' as `propagate_to`
+  SELECT `permissions_generated`.`group_id`, OLD.`child_item_id`, 'self' as `propagate_to`
   FROM `permissions_generated`
-  WHERE `permissions_generated`.`item_id` = OLD.`child_item_id`;
+  WHERE `permissions_generated`.`item_id` = OLD.`parent_item_id`;
 
   -- Some results' ancestors should probably be removed
   -- DELETE FROM `results` WHERE ...


### PR DESCRIPTION
Instead of marking generated permissions related to the child item as 'propagate_to=self', for each generated permissions related to the parent item, mark the (group_id, child item's id) pair as 'propagate_to=self' (we only want to recompute those generated permissions of the child item that have been propagated from the parent item, we do not want to recompute all the generated permission of the child item)