### PR TITLE
Restore linters6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,6 @@ linters:
     - tenv             # Deprecated in golangci-lint v1.64.0, replaced by `usetesting`
     - wrapcheck        # Requires all errors from external packages are wrapped during return. (It requires many changes without any real benefit for now. Disabled by default in golangci-lint.)
     - exhaustruct      # Requires all structure fields to be initialized. (Requires many changes without any real benefit. Disabled by default in golangci-lint.)
-    - perfsprint
     - recvcheck
 
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,6 @@ linters:
     - tenv             # Deprecated in golangci-lint v1.64.0, replaced by `usetesting`
     - wrapcheck        # Requires all errors from external packages are wrapped during return. (It requires many changes without any real benefit for now. Disabled by default in golangci-lint.)
     - exhaustruct      # Requires all structure fields to be initialized. (Requires many changes without any real benefit. Disabled by default in golangci-lint.)
-    - recvcheck
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,6 @@ linters:
     - tenv             # Deprecated in golangci-lint v1.64.0, replaced by `usetesting`
     - wrapcheck        # Requires all errors from external packages are wrapped during return. (It requires many changes without any real benefit for now. Disabled by default in golangci-lint.)
     - exhaustruct      # Requires all structure fields to be initialized. (Requires many changes without any real benefit. Disabled by default in golangci-lint.)
-    - testifylint
     - perfsprint
     - recvcheck
 

--- a/app/api/answers/list_answers.go
+++ b/app/api/answers/list_answers.go
@@ -1,7 +1,7 @@
 package answers
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -115,7 +115,7 @@ func (srv *Service) listAnswers(responseWriter http.ResponseWriter, httpRequest 
 	if !authorIDIsSet { // attempt_id
 		attemptIDIsSet := len(httpRequest.URL.Query()["attempt_id"]) > 0
 		if !attemptIDIsSet {
-			return service.ErrInvalidRequest(fmt.Errorf("either author_id or attempt_id must be present"))
+			return service.ErrInvalidRequest(errors.New("either author_id or attempt_id must be present"))
 		}
 
 		attemptID, attemptIDError := service.ResolveURLQueryGetInt64Field(httpRequest, "attempt_id")

--- a/app/api/auth/refresh_access_token_test.go
+++ b/app/api/auth/refresh_access_token_test.go
@@ -117,8 +117,8 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 		} else {
 			assert.Equal(t, 201, response.StatusCode)
 			body, _ := io.ReadAll(response.Body)
-			assert.Equal(t,
-				`{"success":true,"message":"created","data":{"access_token":"newaccesstoken","expires_in":78901234}}`+"\n",
+			assert.JSONEq(t,
+				`{"success":true,"message":"created","data":{"access_token":"newaccesstoken","expires_in":78901234}}`,
 				string(body))
 		}
 		assert.NoError(t, mock.ExpectationsWereMet())

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/currentuser"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -186,7 +187,7 @@ func Test_checkPreconditionsForGroupRequests(t *testing.T) {
 
 			store := database.NewDataStore(db)
 			var err error
-			assert.NoError(t, store.InTransaction(func(transactionStore *database.DataStore) error {
+			require.NoError(t, store.InTransaction(func(transactionStore *database.DataStore) error {
 				err = currentuser.CheckPreconditionsForGroupRequests(transactionStore,
 					&database.User{GroupID: 10}, 1, "createJoinRequest")
 				return nil

--- a/app/api/currentuser/get_full_dump_test.go
+++ b/app/api/currentuser/get_full_dump_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
@@ -32,13 +33,14 @@ func TestService_getDump_ReturnsErrorRightInsideTheResponseBody(t *testing.T) {
 			srv := &Service{Base: baseService}
 			router.Get("/current-user/full-dump", service.AppHandler(srv.getFullDump).ServeHTTP)
 		})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 200, response.StatusCode)
 	assert.Equal(t, "attachment; filename=user_data.json", response.Header.Get("Content-Disposition"))
 	assert.Equal(t, "application/json; charset=utf-8", response.Header.Get("Content-Type"))
 	body, _ := io.ReadAll(response.Body)
 	_ = response.Body.Close()
+	//nolint:testifylint // Note that the response is a malformed JSON in case of error
 	assert.Equal(t, `{"current_user":{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`+"\n",
-		string(body)) // Note that the response is a malformed JSON in case of error
+		string(body))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/api/groups/create_code_test.go
+++ b/app/api/groups/create_code_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
@@ -22,7 +23,7 @@ import (
 func TestGenerateGroupCode(t *testing.T) {
 	got, err := GenerateGroupCode()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, got, 10)
 	assert.Regexp(t, `^[3-9a-kmnp-y]+$`, got)
 }

--- a/app/api/groups/create_invitations_integration_test.go
+++ b/app/api/groups/create_invitations_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/groups"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -263,7 +264,7 @@ func Test_filterOtherTeamsMembersOut(t *testing.T) {
 
 			store := database.NewDataStore(db)
 			var got []int64
-			assert.NoError(t, store.InTransaction(func(transactionStore *database.DataStore) error {
+			require.NoError(t, store.InTransaction(func(transactionStore *database.DataStore) error {
 				got = groups.FilterOtherTeamsMembersOutForLogins(transactionStore, 1, tt.groupsToInvite, results, groupIDToLoginMap)
 				return nil
 			}))

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
@@ -121,7 +122,7 @@ func assertUpdateGroupFailsOnDBErrorInTransaction(t *testing.T, setMockExpectati
 	if err == nil {
 		_ = response.Body.Close()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 500, response.StatusCode)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/api/groups/update_permissions_test.go
+++ b/app/api/groups/update_permissions_test.go
@@ -1,7 +1,6 @@
 package groups
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -176,7 +175,7 @@ func Test_checkIfPossibleToModifyCanGrantView_SolutionWithGrant(t *testing.T) {
 	dataStore := database.NewDataStore(db)
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
-	assert.Equal(t, true, checkIfPossibleToModifyCanGrantView(
+	assert.True(t, checkIfPossibleToModifyCanGrantView(
 		solutionWithGrant,
 		&userPermissions{
 			CanGrantViewValue: permissionGrantedStore.GrantViewIndexByName(solution),
@@ -187,7 +186,7 @@ func Test_checkIfPossibleToModifyCanGrantView_SolutionWithGrant(t *testing.T) {
 			CanGrantViewGeneratedValue: permissionGrantedStore.GrantViewIndexByName(solutionWithGrant),
 		}, dataStore))
 
-	assert.Equal(t, false, checkIfPossibleToModifyCanGrantView(
+	assert.False(t, checkIfPossibleToModifyCanGrantView(
 		solutionWithGrant,
 		&userPermissions{
 			CanGrantViewValue: permissionGrantedStore.GrantViewIndexByName(solution),
@@ -198,7 +197,7 @@ func Test_checkIfPossibleToModifyCanGrantView_SolutionWithGrant(t *testing.T) {
 			CanGrantViewGeneratedValue: permissionGrantedStore.GrantViewIndexByName(solutionWithGrant),
 		}, dataStore))
 
-	assert.Equal(t, false, checkIfPossibleToModifyCanGrantView(
+	assert.False(t, checkIfPossibleToModifyCanGrantView(
 		solutionWithGrant,
 		&userPermissions{
 			CanGrantViewValue: permissionGrantedStore.GrantViewIndexByName(solution),
@@ -428,7 +427,7 @@ func Test_checkIfPossibleToModifyCanEdit_AllWithGrant(t *testing.T) {
 	dataStore := database.NewDataStore(db)
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
-	assert.Equal(t, true, checkIfPossibleToModifyCanEdit(
+	assert.True(t, checkIfPossibleToModifyCanEdit(
 		allWithGrant,
 		&userPermissions{CanViewValue: permissionGrantedStore.ViewIndexByName(content)},
 		&managerGeneratedPermissions{
@@ -436,7 +435,7 @@ func Test_checkIfPossibleToModifyCanEdit_AllWithGrant(t *testing.T) {
 			CanEditGeneratedValue: permissionGrantedStore.EditIndexByName(allWithGrant),
 		}, dataStore))
 
-	assert.Equal(t, false, checkIfPossibleToModifyCanEdit(
+	assert.False(t, checkIfPossibleToModifyCanEdit(
 		allWithGrant,
 		&userPermissions{CanViewValue: permissionGrantedStore.ViewIndexByName(info)},
 		&managerGeneratedPermissions{
@@ -444,7 +443,7 @@ func Test_checkIfPossibleToModifyCanEdit_AllWithGrant(t *testing.T) {
 			CanEditGeneratedValue: permissionGrantedStore.EditIndexByName(allWithGrant),
 		}, dataStore))
 
-	assert.Equal(t, false, checkIfPossibleToModifyCanEdit(
+	assert.False(t, checkIfPossibleToModifyCanEdit(
 		allWithGrant,
 		&userPermissions{CanViewValue: permissionGrantedStore.ViewIndexByName(content)},
 		&managerGeneratedPermissions{
@@ -487,13 +486,13 @@ func Test_checkIfPossibleToModifyCanMakeSessionOfficial_AllowsSettingLowerOrSame
 	defer database.ClearAllDBEnums()
 	dataStore := database.NewDataStore(db)
 
-	assert.Equal(t, true, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.True(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		false, &userPermissions{CanMakeSessionOfficial: false}, &managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, true, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.True(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		false, &userPermissions{CanMakeSessionOfficial: true}, &managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, true, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.True(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		true, &userPermissions{CanMakeSessionOfficial: true}, &managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, false, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.False(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		true, &userPermissions{CanMakeSessionOfficial: false}, &managerGeneratedPermissions{}, dataStore))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -530,11 +529,11 @@ func Test_checkIfPossibleToModifyCanMakeSessionOfficial_RequiresManagerToBeOwner
 	dataStore := database.NewDataStore(db)
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
-	assert.Equal(t, true, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.True(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		true,
 		&userPermissions{CanViewValue: permissionGrantedStore.ViewIndexByName(info)},
 		&managerGeneratedPermissions{IsOwnerGenerated: true}, dataStore))
-	assert.Equal(t, false, checkIfPossibleToModifyCanMakeSessionOfficial(
+	assert.False(t, checkIfPossibleToModifyCanMakeSessionOfficial(
 		true,
 		&userPermissions{CanViewValue: permissionGrantedStore.ViewIndexByName(info)},
 		&managerGeneratedPermissions{IsOwnerGenerated: false}, dataStore))
@@ -551,11 +550,11 @@ func Test_checkIfPossibleToModifyCanEnterFrom_AllowsSettingGreaterOrSameValue(t 
 
 	timestamp := time.Date(2019, 5, 30, 11, 0, 0, 1, time.UTC)
 	timestampPlus := timestamp.Add(time.Nanosecond)
-	assert.Equal(t, true, checkIfPossibleToModifyCanEnterFrom(
+	assert.True(t, checkIfPossibleToModifyCanEnterFrom(
 		timestampPlus, &userPermissions{CanEnterFrom: database.Time(timestampPlus)}, &managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, true, checkIfPossibleToModifyCanEnterFrom(
+	assert.True(t, checkIfPossibleToModifyCanEnterFrom(
 		timestamp, &userPermissions{CanEnterFrom: database.Time(timestamp)}, &managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, false, checkIfPossibleToModifyCanEnterFrom(
+	assert.False(t, checkIfPossibleToModifyCanEnterFrom(
 		timestamp, &userPermissions{CanEnterFrom: database.Time(timestampPlus)}, &managerGeneratedPermissions{}, dataStore))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -607,15 +606,15 @@ func Test_checkIfPossibleToModifyCanEnterUntil_AllowsSettingSmallerOrSameValue(t
 	defer database.ClearAllDBEnums()
 	dataStore := database.NewDataStore(db)
 
-	assert.Equal(t, true, checkIfPossibleToModifyCanEnterUntil(
+	assert.True(t, checkIfPossibleToModifyCanEnterUntil(
 		time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC),
 		&userPermissions{CanEnterUntil: database.Time(time.Date(2019, 5, 30, 11, 0, 0, 1, time.UTC))},
 		&managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, true, checkIfPossibleToModifyCanEnterUntil(
+	assert.True(t, checkIfPossibleToModifyCanEnterUntil(
 		time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC),
 		&userPermissions{CanEnterUntil: database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))},
 		&managerGeneratedPermissions{}, dataStore))
-	assert.Equal(t, false, checkIfPossibleToModifyCanEnterUntil(
+	assert.False(t, checkIfPossibleToModifyCanEnterUntil(
 		time.Date(2019, 5, 30, 11, 0, 0, 1, time.UTC),
 		&userPermissions{CanEnterUntil: database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))},
 		&managerGeneratedPermissions{}, dataStore))
@@ -640,7 +639,7 @@ func Test_IsOwnerValidator_AllowsSettingIsOwnerToFalseOrSameValue(t *testing.T) 
 	currentPermissions := &userPermissions{}
 	dataMap, modified, err := parsePermissionsInputData(dataStore, &managerGeneratedPermissions{}, currentPermissions,
 		&database.User{}, 0, map[string]interface{}{"is_owner": false})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.False(t, modified)
 	assert.Equal(t, &userPermissions{}, currentPermissions)
 	assert.Equal(t, map[string]interface{}{"is_owner": false}, dataMap)
@@ -648,14 +647,14 @@ func Test_IsOwnerValidator_AllowsSettingIsOwnerToFalseOrSameValue(t *testing.T) 
 	currentPermissions = &userPermissions{IsOwner: true}
 	dataMap, modified, err = parsePermissionsInputData(dataStore, &managerGeneratedPermissions{},
 		currentPermissions, &database.User{}, 0, map[string]interface{}{"is_owner": false})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, modified)
 	assert.Equal(t, map[string]interface{}{"is_owner": false}, dataMap)
 
 	currentPermissions = &userPermissions{IsOwner: true}
 	dataMap, modified, err = parsePermissionsInputData(dataStore, &managerGeneratedPermissions{},
 		currentPermissions, &database.User{}, 0, map[string]interface{}{"is_owner": true})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.False(t, modified)
 	assert.Equal(t, map[string]interface{}{"is_owner": true}, dataMap)
 
@@ -664,7 +663,7 @@ func Test_IsOwnerValidator_AllowsSettingIsOwnerToFalseOrSameValue(t *testing.T) 
 		currentPermissions, &database.User{}, 0, map[string]interface{}{"is_owner": true})
 	require.IsType(t, (*service.APIError)(nil), err)
 	var apiError *service.APIError
-	assert.True(t, errors.As(err, &apiError))
+	require.ErrorAs(t, err, &apiError)
 	assert.Equal(t, http.StatusBadRequest, apiError.HTTPStatusCode)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -681,14 +680,14 @@ func Test_IsOwnerValidator_RequiresManagerToBeOwnerToMakeSomebodyAnOwner(t *test
 		&database.User{}, 0, map[string]interface{}{"is_owner": true})
 	require.IsType(t, (*service.APIError)(nil), err)
 	var apiError *service.APIError
-	assert.True(t, errors.As(err, &apiError))
+	require.ErrorAs(t, err, &apiError)
 	assert.Equal(t, http.StatusBadRequest, apiError.HTTPStatusCode)
 
 	currentPermissions = &userPermissions{}
 	dataMap, modified, err := parsePermissionsInputData(dataStore,
 		&managerGeneratedPermissions{IsOwnerGenerated: true}, currentPermissions,
 		&database.User{}, 0, map[string]interface{}{"is_owner": true})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, modified)
 	assert.Equal(t, map[string]interface{}{"is_owner": true}, dataMap)
 
@@ -735,7 +734,7 @@ func testValidatorSetsModifiedFlagAndUpdatesCurrentPermissions(
 				dataMap, modified, err := parsePermissionsInputData(dataStore,
 					&managerGeneratedPermissions{}, currentPermissions, &database.User{}, 0,
 					map[string]interface{}{fieldName: newValue})
-				assert.Nil(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, newValue != currentValue, modified)
 				assert.Equal(t, map[string]interface{}{fieldName: newValue}, dataMap)
 				assert.Equal(t, currentPermissionsGenerator(newValue, permissionGrantedStore), currentPermissions)
@@ -767,7 +766,7 @@ func testValidatorFailsWhenCheckReturnsFalse(t *testing.T, parsedBody map[string
 		&managerGeneratedPermissions{}, &userPermissions{}, &database.User{}, 0, parsedBody)
 	require.IsType(t, (*service.APIError)(nil), err)
 	var apiError *service.APIError
-	assert.True(t, errors.As(err, &apiError))
+	require.ErrorAs(t, err, &apiError)
 	assert.Equal(t, http.StatusBadRequest, apiError.HTTPStatusCode)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -837,14 +836,14 @@ func Test_CanEnterFromValidator_SetsModifiedFlag(t *testing.T) {
 	dataMap, modified, err := parsePermissionsInputData(dataStore,
 		&managerGeneratedPermissions{}, currentPermissions, &database.User{}, 0,
 		map[string]interface{}{"can_enter_from": "2019-05-30T11:00:00Z"})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, modified)
 	assert.Equal(t, map[string]interface{}{"can_enter_from": timestamp}, dataMap)
 
 	dataMap, modified, err = parsePermissionsInputData(dataStore,
 		&managerGeneratedPermissions{}, currentPermissions, &database.User{}, 0,
 		map[string]interface{}{"can_enter_from": "2019-05-30T11:00:01Z"})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.False(t, modified)
 	assert.Equal(t, map[string]interface{}{"can_enter_from": timestampPlus}, dataMap)
 
@@ -871,7 +870,7 @@ func Test_CanEnterUntilValidator_SetsModifiedFlag(t *testing.T) {
 	dataMap, modified, err := parsePermissionsInputData(dataStore,
 		&managerGeneratedPermissions{}, currentPermissions, &database.User{}, 0,
 		map[string]interface{}{"can_enter_until": "2019-05-30T11:00:00Z"})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, modified)
 	assert.Equal(t, map[string]interface{}{
 		"can_enter_until": time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC),
@@ -880,7 +879,7 @@ func Test_CanEnterUntilValidator_SetsModifiedFlag(t *testing.T) {
 	dataMap, modified, err = parsePermissionsInputData(dataStore,
 		&managerGeneratedPermissions{}, currentPermissions, &database.User{}, 0,
 		map[string]interface{}{"can_enter_until": "2019-05-30T11:00:01Z"})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.False(t, modified)
 	assert.Equal(t, map[string]interface{}{
 		"can_enter_until": time.Date(2019, 5, 30, 11, 0, 1, 0, time.UTC),
@@ -918,7 +917,7 @@ func Test_parsePermissionsInputData_ChecksCanViewFirstAndUsesItsNewValue(t *test
 			"can_edit":                  "all_with_grant",
 			"can_make_session_official": true,
 		})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, modified)
 	assert.Equal(t, &userPermissions{
 		CanViewValue:           permissionGrantedStore.ViewIndexByName(solution),

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -114,7 +114,7 @@ func (srv *Service) askHint(responseWriter http.ResponseWriter, httpRequest *htt
 		}
 
 		// Get the previous hints requested JSON data
-		var hintsRequestedParsed []formdata.Anything
+		var hintsRequestedParsed []*formdata.Anything
 		hintsRequestedParsed, err = queryAndParsePreviouslyRequestedHints(&requestData.TaskToken.Payload, store, httpRequest)
 		if gorm.IsRecordNotFoundError(err) {
 			return service.ErrNotFound(errors.New("no result or the attempt is expired")) // rollback
@@ -165,12 +165,12 @@ func (srv *Service) askHint(responseWriter http.ResponseWriter, httpRequest *htt
 
 func queryAndParsePreviouslyRequestedHints(
 	taskTokenPayload *payloads.TaskToken, store *database.DataStore, httpRequest *http.Request,
-) ([]formdata.Anything, error) {
+) ([]*formdata.Anything, error) {
 	hintsInfo, err := store.Results().GetHintsInfoForActiveAttempt(
 		taskTokenPayload.Converted.ParticipantID,
 		taskTokenPayload.Converted.AttemptID,
 		taskTokenPayload.Converted.LocalItemID)
-	var hintsRequestedParsed []formdata.Anything
+	var hintsRequestedParsed []*formdata.Anything
 	if err == nil && hintsInfo.HintsRequested != nil {
 		hintsErr := json.Unmarshal([]byte(*hintsInfo.HintsRequested), &hintsRequestedParsed)
 		if hintsErr != nil {
@@ -187,7 +187,7 @@ func queryAndParsePreviouslyRequestedHints(
 	return hintsRequestedParsed, err
 }
 
-func addHintToListIfNeeded(hintsList []formdata.Anything, hintToAdd formdata.Anything) []formdata.Anything {
+func addHintToListIfNeeded(hintsList []*formdata.Anything, hintToAdd *formdata.Anything) []*formdata.Anything {
 	var hintFound bool
 	for _, hint := range hintsList {
 		if bytes.Equal(hint.Bytes(), hintToAdd.Bytes()) {

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -260,7 +260,7 @@ func (requestData *AskHintRequest) unmarshalHintToken(wrapper *askHintRequestWra
 func (requestData *AskHintRequest) Bind(_ *http.Request) error {
 	if len(requestData.HintToken.Payload.AskedHint.Bytes()) == 0 ||
 		bytes.Equal([]byte("null"), requestData.HintToken.Payload.AskedHint.Bytes()) {
-		return fmt.Errorf("asked hint should not be empty")
+		return errors.New("asked hint should not be empty")
 	}
 	return nil
 }

--- a/app/api/items/ask_hint.robustness.feature
+++ b/app/api/items/ask_hint.robustness.feature
@@ -300,7 +300,7 @@ Feature: Ask for a hint - robustness
     And the response error message should contain "No result or the attempt is expired"
     And the table "attempts" should remain unchanged
 
-  Scenario: missing askedHint
+  Scenario Outline: missing askedHint
     Given "priorUserTaskToken" is a token signed by the app with the following payload:
       """
       {
@@ -318,6 +318,7 @@ Feature: Ask for a hint - robustness
         "idItemLocal": "50",
         "idAttempt": "101/0",
         "itemURL": "https://platformwithkey/50"
+        <asked_hint_json_part>
       }
       """
     When I send a POST request to "/items/ask-hint" with the following body:
@@ -330,6 +331,10 @@ Feature: Ask for a hint - robustness
     Then the response code should be 400
     And the response error message should contain "Asked hint should not be empty"
     And the table "attempts" should remain unchanged
+  Examples:
+    | asked_hint_json_part |
+    |                      |
+    | , "askedHint": null  |
 
   Scenario: The attempt is expired (doesn't allow submissions anymore)
     Given "priorUserTaskToken" is a token signed by the app with the following payload:

--- a/app/api/items/ask_hint_test.go
+++ b/app/api/items/ask_hint_test.go
@@ -10,6 +10,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloads"
@@ -148,7 +149,7 @@ func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
 			}
 			err := askHintRequest.UnmarshalJSON(tt.raw)
 			if tt.wantErr == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				if err == nil {
 					assert.Equal(t, tt.wantErr, err)

--- a/app/api/items/items_integration_test.go
+++ b/app/api/items/items_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -39,7 +40,7 @@ func Test_createParticipantsGroupForItemRequiringExplicitEntry_Duplicate(t *test
 		Name string
 	}
 	var group groupData
-	assert.NoError(t, dataStore.Groups().Take(&group, "id = ?", groupID).Error())
+	require.NoError(t, dataStore.Groups().Take(&group, "id = ?", groupID).Error())
 	assert.Equal(t, groupData{
 		Type: "ContestParticipants",
 		Name: "123-participants",

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -7,6 +7,7 @@ import (
 	_ "unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/items"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -697,9 +698,9 @@ func Test_findItemPaths(t *testing.T) {
 			db := testhelpers.SetupDBWithFixtureString(globalFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)
-			assert.NoError(t, store.InTransaction(func(s *database.DataStore) error {
-				assert.NoError(t, s.GroupGroups().CreateNewAncestors())
-				assert.NoError(t, s.ItemItems().CreateNewAncestors())
+			require.NoError(t, store.InTransaction(func(s *database.DataStore) error {
+				require.NoError(t, s.GroupGroups().CreateNewAncestors())
+				require.NoError(t, s.ItemItems().CreateNewAncestors())
 				s.SchedulePermissionsPropagation()
 				s.ScheduleResultsPropagation()
 				return nil

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -303,7 +303,7 @@ func (requestData *saveGradeRequestParsed) unmarshalScoreToken(wrapper *saveGrad
 
 	localItemIDUnsafeString, ok := localItemIDUnsafeRaw.(string)
 	if !ok {
-		return fmt.Errorf("invalid score_token: invalid idItemLocal: should be a string")
+		return errors.New("invalid score_token: invalid idItemLocal: should be a string")
 	}
 
 	localItemIDUnsafe, err := strconv.ParseInt(localItemIDUnsafeString, 10, 64)

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/api/items"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -445,8 +446,8 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)
 			var got []map[string]interface{}
-			assert.NoError(t, store.InTransaction(func(s *database.DataStore) error {
-				assert.NoError(t, s.GroupGroups().CreateNewAncestors())
+			require.NoError(t, store.InTransaction(func(s *database.DataStore) error {
+				require.NoError(t, s.GroupGroups().CreateNewAncestors())
 				got = items.GetDataForResultPathStart(s, tt.args.participantID, tt.args.ids)
 				return nil
 			}))

--- a/app/api/threads/update_thread_test.go
+++ b/app/api/threads/update_thread_test.go
@@ -11,9 +11,9 @@ import (
 func Test_userCanChangeThreadStatus_EdgeCases(t *testing.T) {
 	user := database.User{}
 
-	assert.Equal(t, false, userCanChangeThreadStatus(&user, "not_started", "", 1, &threadInfo{}))
-	assert.Equal(t, true, userCanChangeThreadStatus(
+	assert.False(t, userCanChangeThreadStatus(&user, "not_started", "", 1, &threadInfo{}))
+	assert.True(t, userCanChangeThreadStatus(
 		&user, "waiting_for_trainer", "waiting_for_trainer", 1, &threadInfo{}))
-	assert.Equal(t, true, userCanChangeThreadStatus(
+	assert.True(t, userCanChangeThreadStatus(
 		&user, "closed", "closed", 1, &threadInfo{}))
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"bou.ke/monkey"
@@ -238,7 +239,7 @@ func TestNew_DisableResultsPropagation(t *testing.T) {
 	for _, configSettingValue := range []bool{true, false} {
 		configSettingValue := configSettingValue
 		t.Run(fmt.Sprintf("disableResultsPropagation=%t", configSettingValue), func(t *testing.T) {
-			t.Setenv("ALGOREA_SERVER__DISABLERESULTSPROPAGATION", fmt.Sprintf("%t", configSettingValue))
+			t.Setenv("ALGOREA_SERVER__DISABLERESULTSPROPAGATION", strconv.FormatBool(configSettingValue))
 			app, _ := New()
 			assert.Equal(t, configSettingValue, database.NewDataStore(app.Database).IsResultsPropagationProhibited())
 

--- a/app/auth/mocks_test.go
+++ b/app/auth/mocks_test.go
@@ -7,30 +7,27 @@ import (
 	"strconv"
 	"testing"
 
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 )
 
 func TestMiddlewareMock(t *testing.T) {
-	assert := assertlib.New(t)
 	middleware := MockUserMiddleware(&database.User{GroupID: 42})
 	testServer := httptest.NewServer(middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user := UserFromContext(r.Context())
-		assert.NotNil(SessionCookieAttributesFromContext(r.Context()))
+		assert.NotNil(t, SessionCookieAttributesFromContext(r.Context()))
 		_, _ = w.Write([]byte(strconv.FormatInt(user.GroupID, 10)))
 	})))
 	defer testServer.Close()
 
 	request, _ := http.NewRequest(http.MethodGet, testServer.URL, http.NoBody)
 	response, err := http.DefaultClient.Do(request)
-	assert.NoError(err)
-	if err != nil {
-		return
-	}
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 
 	respBody, err := io.ReadAll(response.Body)
-	assert.NoError(err)
-	assert.Equal("42", string(respBody))
+	require.NoError(t, err)
+	assert.Equal(t, "42", string(respBody))
 }

--- a/app/auth/random_test.go
+++ b/app/auth/random_test.go
@@ -9,18 +9,19 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateKey(t *testing.T) {
 	got1, err := GenerateKey()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, got1, 32)
 	assert.Regexp(t, `^[0-9a-z]{32}$`, got1)
 
 	got2, err := GenerateKey()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, got2, 32)
 	assert.Regexp(t, `^[0-9a-z]{32}$`, got2)
 

--- a/app/auth/user_test.go
+++ b/app/auth/user_test.go
@@ -16,7 +16,7 @@ func TestUserFromContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxUser, myUser)
 	user := UserFromContext(ctx)
 
-	assert.False(myUser == user)
+	assert.NotSame(myUser, user)
 	assert.EqualValues(myUser, user)
 }
 
@@ -43,7 +43,7 @@ func TestSessionCookieAttributesFromContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxSessionCookieAttributes, expectedCookieAttributes)
 	cookieAttributes := SessionCookieAttributesFromContext(ctx)
 
-	assert.False(expectedCookieAttributes == cookieAttributes)
+	assert.NotSame(expectedCookieAttributes, cookieAttributes)
 	assert.EqualValues(expectedCookieAttributes, cookieAttributes)
 
 	ctx = context.WithValue(context.Background(), ctxSessionCookieAttributes, nil)

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -191,7 +191,7 @@ func TestDBConfig_UnmarshallingError(t *testing.T) {
 	globalConfig := viper.New()
 	monkey.PatchInstanceMethod(reflect.TypeOf(globalConfig), "Unmarshal",
 		func(_ *viper.Viper, _ interface{}, _ ...viper.DecoderConfigOption) error {
-			return fmt.Errorf("unmarshalling error")
+			return errors.New("unmarshalling error")
 		},
 	)
 	defer monkey.UnpatchAll()
@@ -203,7 +203,7 @@ func TestDBConfig_StructToMapError(t *testing.T) {
 	// unexpected error, must monkey patch it
 	globalConfig := viper.New()
 	monkey.Patch(mapstructure.Decode, func(_ interface{}, _ interface{}) error {
-		return fmt.Errorf("struct2map error")
+		return errors.New("struct2map error")
 	})
 	defer monkey.UnpatchAll()
 	_, err := DBConfig(globalConfig)

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -12,7 +12,8 @@ import (
 	"bou.ke/monkey"
 	"github.com/France-ioi/mapstructure"
 	"github.com/spf13/viper"
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/domain"
@@ -26,8 +27,6 @@ func init() { //nolint:gochecknoinits
 var devEnv = "dev"
 
 func TestLoadConfigFrom(t *testing.T) {
-	assert := assertlib.New(t)
-
 	// the test environment doesn't allow the merge of the config with a main config file for security reasons
 	// so here we mock the function that returns the current environment, because we want to test the merge
 	// of the config with the main config file
@@ -36,37 +35,35 @@ func TestLoadConfigFrom(t *testing.T) {
 	defer monkey.UnpatchAll()
 
 	// create a temp config dir
-	tmpDir, deferFunc := createTmpDir("conf-*", assert)
-	defer deferFunc()
+	tmpDir := t.TempDir()
 
 	// create a temp config file
 	err := os.WriteFile(tmpDir+"/config.yaml", []byte("server:\n  port: 1234\n"), 0o600)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	// change default config values
 	err = os.WriteFile(tmpDir+"/config.dev.yaml", []byte("server:\n  rootpath: '/test/'"), 0o600)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	t.Setenv("ALGOREA_SERVER__WRITETIMEOUT", "999")
 	conf := loadConfigFrom("config", tmpDir)
+	require.NotNil(t, conf)
 
 	// test config override
-	assert.EqualValues(1234, conf.Sub(serverConfigKey).GetInt("port"))
+	assert.EqualValues(t, 1234, conf.Sub(serverConfigKey).GetInt("port"))
 
 	// test env variables
-	assert.EqualValues(999, conf.GetInt("server.WriteTimeout")) // does not work with Sub!
+	assert.EqualValues(t, 999, conf.GetInt("server.WriteTimeout")) // does not work with Sub!
 
 	// test 'test' section
-	assert.EqualValues("/test/", conf.Sub(serverConfigKey).GetString("rootPath"))
+	assert.EqualValues(t, "/test/", conf.Sub(serverConfigKey).GetString("rootPath"))
 
 	// test live env changes
 	t.Setenv("ALGOREA_SERVER__WRITETIMEOUT", "777")
-	assert.EqualValues(777, conf.GetInt("server.WriteTimeout"))
+	assert.EqualValues(t, 777, conf.GetInt("server.WriteTimeout"))
 }
 
 func TestLoadConfigFrom_ShouldLogWarningWhenNonTestEnvAndNoMainConfigFile(t *testing.T) {
-	assert := assertlib.New(t)
-
 	origStdErr := os.Stderr
 	stdErrReader, stdErrWriter, _ := os.Pipe()
 	os.Stderr = stdErrWriter
@@ -81,81 +78,74 @@ func TestLoadConfigFrom_ShouldLogWarningWhenNonTestEnvAndNoMainConfigFile(t *tes
 	defer monkey.UnpatchAll()
 
 	// create a temp config file
-	tmpFile, deferFunc := createTmpFile("config-*.dev.yaml", assert)
+	tmpFile, deferFunc := createTmpFile(t, "config-*.dev.yaml")
 	defer deferFunc()
 
 	fileName := filepath.Base(tmpFile.Name())
 	configName := fileName[:len(fileName)-8] // strip the ".dev.yaml"
 
 	conf := loadConfigFrom(configName, os.TempDir())
-	assert.NotNil(conf)
+	require.NotNil(t, conf)
 
 	_ = stdErrWriter.Close()
 	buf := new(bytes.Buffer)
 	_, _ = io.Copy(buf, stdErrReader)
 
-	assert.Contains(buf.String(), "Cannot read the main config file, ignoring it")
+	assert.Contains(t, buf.String(), "Cannot read the main config file, ignoring it")
 }
 
 func TestLoadConfigFrom_IgnoresMainConfigFileIfMissing(t *testing.T) {
-	assert := assertlib.New(t)
 	appenv.SetDefaultEnvToTest() // to ensure it tries to find the config.test file
 
 	// create a temp config file
-	tmpFile, deferFunc := createTmpFile("config-*.test.yaml", assert)
+	tmpFile, deferFunc := createTmpFile(t, "config-*.test.yaml")
 	defer deferFunc()
 
 	fileName := filepath.Base(tmpFile.Name())
 	configName := fileName[:len(fileName)-10] // strip the ".test.yaml"
 
 	conf := loadConfigFrom(configName, os.TempDir())
-	assert.NotNil(conf)
+	assert.NotNil(t, conf)
 }
 
 func TestLoadConfigFrom_MustNotUseMainConfigFileInTestEnv(t *testing.T) {
-	assert := assertlib.New(t)
 	appenv.ForceTestEnv() // to ensure it tries to find the config.test file
 
 	// create a temp dir to hold the config files
-	tmpDir, deferFunc := createTmpDir("conf-*", assert)
-	defer deferFunc()
+	tmpDir := t.TempDir()
 
 	// create a main config file inside the tmp dir, and define two distinct yaml parameters in it
 	err := os.WriteFile(tmpDir+"/config.yaml", []byte("param1: 1\nparam2: 2"), 0o600)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	// create a temp test config file inside the tmp dir, and define only one of the two parameters in it
 	err = os.WriteFile(tmpDir+"/config.test.yaml", []byte("param1: 3"), 0o600)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	conf := loadConfigFrom("config", tmpDir)
-	assert.NotNil(conf)
+	require.NotNil(t, conf)
 
 	// the config of the test file should be used, and the one in the main file should not be used at all
-	assert.EqualValues(3, conf.GetInt("param1"))
-	assert.False(conf.IsSet("param2"))
+	assert.EqualValues(t, 3, conf.GetInt("param1"))
+	assert.False(t, conf.IsSet("param2"))
 }
 
 func TestLoadConfigFrom_ShouldCrashIfTestEnvAndConfigTestNotPresent(t *testing.T) {
-	assert := assertlib.New(t)
 	appenv.SetDefaultEnvToTest() // to ensure it tries to find the config.test file
 
 	// create a temp config dir
-	tmpDir, deferFunc := createTmpDir("conf-*", assert)
-	defer deferFunc()
+	tmpDir := t.TempDir()
 
 	// create a temp config file
 	err := os.WriteFile(tmpDir+"/config.yaml", []byte("param1: 1"), 0o600)
-	assert.NoError(err)
+	require.NoError(t, err)
 
-	assert.Panics(func() {
+	assert.Panics(t, func() {
 		_ = loadConfigFrom("config", tmpDir)
 	})
 }
 
 func TestLoadConfigFrom_IgnoresEnvConfigFileIfMissing(t *testing.T) {
-	assert := assertlib.New(t)
-
 	// the test environment doesn't allow the merge of the config with a main config file for security reasons
 	// so here we mock the function that returns the current environment, because we want to test the merge
 	// of the config with the main config file
@@ -164,7 +154,7 @@ func TestLoadConfigFrom_IgnoresEnvConfigFileIfMissing(t *testing.T) {
 	defer monkey.UnpatchAll()
 
 	// create a temp config file
-	tmpFile, deferFunc := createTmpFile("config-*.yaml", assert)
+	tmpFile, deferFunc := createTmpFile(t, "config-*.yaml")
 	defer deferFunc()
 
 	fileName := filepath.Base(tmpFile.Name())
@@ -172,14 +162,13 @@ func TestLoadConfigFrom_IgnoresEnvConfigFileIfMissing(t *testing.T) {
 
 	conf := loadConfigFrom(configName, os.TempDir())
 
-	assert.NotNil(conf)
+	assert.NotNil(t, conf)
 }
 
 func TestLoadConfig_Concurrent(t *testing.T) {
 	_ = os.Unsetenv("ALGOREA_ENV")
 	appenv.SetDefaultEnvToTest()
-	assert := assertlib.New(t)
-	assert.NotPanics(func() {
+	assert.NotPanics(t, func() {
 		LoadConfig()
 		for i := 0; i < 1000; i++ {
 			go func() { LoadConfig() }()
@@ -188,19 +177,17 @@ func TestLoadConfig_Concurrent(t *testing.T) {
 }
 
 func TestDBConfig_Success(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("database.collation", "stuff")
 	t.Setenv("ALGOREA_DATABASE__TLSCONFIG", "v99") // env var which was not defined before
 	dbConfig, err := DBConfig(globalConfig)
-	assert.NoError(err)
-	assert.Equal("stuff", dbConfig.Collation)
-	assert.Equal("v99", dbConfig.TLSConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "stuff", dbConfig.Collation)
+	assert.Equal(t, "v99", dbConfig.TLSConfig)
 }
 
 func TestDBConfig_UnmarshallingError(t *testing.T) {
 	// don't know if it is really possible to get this error
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	monkey.PatchInstanceMethod(reflect.TypeOf(globalConfig), "Unmarshal",
 		func(_ *viper.Viper, _ interface{}, _ ...viper.DecoderConfigOption) error {
@@ -209,73 +196,70 @@ func TestDBConfig_UnmarshallingError(t *testing.T) {
 	)
 	defer monkey.UnpatchAll()
 	_, err := DBConfig(globalConfig)
-	assert.EqualError(err, "unmarshalling error")
+	assert.EqualError(t, err, "unmarshalling error")
 }
 
 func TestDBConfig_StructToMapError(t *testing.T) {
 	// unexpected error, must monkey patch it
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	monkey.Patch(mapstructure.Decode, func(_ interface{}, _ interface{}) error {
 		return fmt.Errorf("struct2map error")
 	})
 	defer monkey.UnpatchAll()
 	_, err := DBConfig(globalConfig)
-	assert.EqualError(err, "struct2map error")
+	assert.EqualError(t, err, "struct2map error")
 }
 
 func TestTokenConfig_Success(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	monkey.Patch(token.BuildConfig, func(_ *viper.Viper) (*token.Config, error) {
 		return &token.Config{PlatformName: "test"}, nil
 	})
 	defer monkey.UnpatchAll()
 	config, err := TokenConfig(globalConfig)
-	assert.NoError(err)
-	assert.Equal("test", config.PlatformName)
+	require.NoError(t, err)
+	assert.Equal(t, "test", config.PlatformName)
 }
 
 func TestTokenConfig_Error(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("token.PublicKeyFile", "notafile")
 	_, err := TokenConfig(globalConfig)
-	assert.Contains(err.Error(), "no such file or directory")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
 }
 
 func TestAuthConfig(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("auth.anykey", 42)
 	config := AuthConfig(globalConfig)
-	assert.Equal(42, config.GetInt("anykey"))
+	require.NotNil(t, config)
+	assert.Equal(t, 42, config.GetInt("anykey"))
 	t.Setenv("ALGOREA_AUTH__ANYKEY", "999")
-	assert.Equal(999, config.GetInt("anykey"))
+	assert.Equal(t, 999, config.GetInt("anykey"))
 }
 
 func TestLoggingConfig(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("logging.anykey", 42)
 	config := LoggingConfig(globalConfig)
-	assert.Equal(42, config.GetInt("anykey"))
+	require.NotNil(t, config)
+	assert.Equal(t, 42, config.GetInt("anykey"))
 	t.Setenv("ALGOREA_LOGGING__ANYKEY", "999")
-	assert.Equal(999, config.GetInt("anykey"))
+	assert.Equal(t, 999, config.GetInt("anykey"))
 }
 
 func TestServerConfig(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("server.anykey", 42)
 	config := ServerConfig(globalConfig)
-	assert.Equal(42, config.GetInt("anykey"))
+	require.NotNil(t, config)
+	assert.Equal(t, 42, config.GetInt("anykey"))
 	t.Setenv("ALGOREA_SERVER__ANYKEY", "999")
-	assert.Equal(999, config.GetInt("anykey"))
+	assert.Equal(t, 999, config.GetInt("anykey"))
 }
 
 func TestDomainsConfig_Success(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	sampleDomain := domain.ConfigItem{
 		Domains:           []string{"localhost", "other"},
@@ -285,41 +269,37 @@ func TestDomainsConfig_Success(t *testing.T) {
 	}
 	globalConfig.Set("domains", []domain.ConfigItem{sampleDomain})
 	config, err := DomainsConfig(globalConfig)
-	assert.NoError(err)
-	assert.Len(config, 1)
-	assert.Equal(sampleDomain, config[0])
+	require.NoError(t, err)
+	assert.Len(t, config, 1)
+	assert.Equal(t, sampleDomain, config[0])
 }
 
 func TestDomainsConfig_Empty(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("domains", []string{})
 	config, err := DomainsConfig(globalConfig)
-	assert.NoError(err)
-	assert.Len(config, 0)
+	require.NoError(t, err)
+	assert.Empty(t, config)
 }
 
 func TestDomainsConfig_Error(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("domains", []int{1, 2})
 	_, err := DomainsConfig(globalConfig)
-	assert.EqualError(err, "2 error(s) decoding:\n\n* '[0]' expected a map, got 'int'\n* '[1]' expected a map, got 'int'")
+	assert.EqualError(t, err, "2 error(s) decoding:\n\n* '[0]' expected a map, got 'int'\n* '[1]' expected a map, got 'int'")
 }
 
 func TestReplaceAuthConfig(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("auth.ClientID", "42")
 	application, err := New()
-	assert.NoError(err)
+	require.NoError(t, err)
 	application.ReplaceAuthConfig(globalConfig)
-	assert.Equal("42", application.Config.Get("auth.ClientID"))
+	assert.Equal(t, "42", application.Config.Get("auth.ClientID"))
 	// not tested: that it is been pushed to the API
 }
 
 func TestReplaceDomainsConfig(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("domains", []map[string]interface{}{{"domains": []string{"localhost", "other"}}})
 	application, _ := New()
@@ -331,16 +311,15 @@ func TestReplaceDomainsConfig(t *testing.T) {
 		NonTempUsersGroup: 0,
 	}}
 	config, _ := DomainsConfig(application.Config)
-	assert.Equal(expected, config)
+	assert.Equal(t, expected, config)
 	// not tested: that it is been pushed to the API
 }
 
 func TestReplaceDomainsConfig_Panic(t *testing.T) {
-	assert := assertlib.New(t)
 	globalConfig := viper.New()
 	globalConfig.Set("domains", []int{1, 2})
 	application := &Application{Config: viper.New()}
-	assert.Panics(func() {
+	assert.Panics(t, func() {
 		application.ReplaceDomainsConfig(globalConfig)
 	})
 }
@@ -349,21 +328,17 @@ func Test_configDirectory_StripsOnlyTheLastOccurrenceOfApp(t *testing.T) {
 	monkey.Patch(os.Getwd, func() (string, error) { return "/app/something/app/ab/app/token", nil })
 	defer monkey.UnpatchAll()
 	dir := configDirectory()
-	assertlib.Equal(t, "/app/something/app/ab/conf", dir)
+	assert.Equal(t, "/app/something/app/ab/conf", dir)
 }
 
-func createTmpFile(pattern string, assert *assertlib.Assertions) (tmpFile *os.File, deferFunc func()) {
+func createTmpFile(t *testing.T, pattern string) (tmpFile *os.File, deferFunc func()) {
+	t.Helper()
+
 	// create a temp config file
 	tmpFile, err := os.CreateTemp(os.TempDir(), pattern)
-	assert.NoError(err)
+	require.NoError(t, err)
 	return tmpFile, func() {
 		_ = os.Remove(tmpFile.Name())
 		_ = tmpFile.Close()
 	}
-}
-
-func createTmpDir(pattern string, assert *assertlib.Assertions) (name string, deferFun func()) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), pattern)
-	assert.NoError(err)
-	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }
 }

--- a/app/database/access_token_store_integration_test.go
+++ b/app/database/access_token_store_integration_test.go
@@ -66,7 +66,7 @@ func TestAccessTokenStore_GetMostRecentValidTokenForSession(t *testing.T) {
 
 	accessTokenStore := database.NewDataStore(db).AccessTokens()
 	token, err := accessTokenStore.GetMostRecentValidTokenForSession(456)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, database.MostRecentToken{
 		Token:              "token2",
 		SecondsUntilExpiry: 302,
@@ -74,7 +74,7 @@ func TestAccessTokenStore_GetMostRecentValidTokenForSession(t *testing.T) {
 	}, token)
 
 	token, err = accessTokenStore.GetMostRecentValidTokenForSession(457)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, database.MostRecentToken{
 		Token:              "token3",
 		SecondsUntilExpiry: 303,
@@ -110,20 +110,29 @@ func TestAccessTokenStore_DeleteExpiredTokensOfUser(t *testing.T) {
 	assert.NoError(t, accessTokenStore.Count(&count).Error())
 	assert.Equal(t, 2, count)
 
-	_, err := accessTokenStore.GetMostRecentValidTokenForSession(456)
-	assert.EqualError(t, err, "record not found")
-	token, err := accessTokenStore.GetMostRecentValidTokenForSession(457)
-	assert.NoError(t, err)
-	assert.Equal(t, database.MostRecentToken{
-		Token:              "token4",
-		SecondsUntilExpiry: 1,
-		TooNewToRefresh:    false,
-	}, token)
-	token, err = accessTokenStore.GetMostRecentValidTokenForSession(458)
-	assert.NoError(t, err)
-	assert.Equal(t, database.MostRecentToken{
-		Token:              "token5",
-		SecondsUntilExpiry: -3,
-		TooNewToRefresh:    false,
-	}, token)
+	t.Run("456", func(t *testing.T) {
+		testoutput.SuppressIfPasses(t)
+		_, err := accessTokenStore.GetMostRecentValidTokenForSession(456)
+		require.EqualError(t, err, "record not found")
+	})
+	t.Run("457", func(t *testing.T) {
+		testoutput.SuppressIfPasses(t)
+		token, err := accessTokenStore.GetMostRecentValidTokenForSession(457)
+		require.NoError(t, err)
+		assert.Equal(t, database.MostRecentToken{
+			Token:              "token4",
+			SecondsUntilExpiry: 1,
+			TooNewToRefresh:    false,
+		}, token)
+	})
+	t.Run("458", func(t *testing.T) {
+		testoutput.SuppressIfPasses(t)
+		token, err := accessTokenStore.GetMostRecentValidTokenForSession(458)
+		require.NoError(t, err)
+		assert.Equal(t, database.MostRecentToken{
+			Token:              "token5",
+			SecondsUntilExpiry: -3,
+			TooNewToRefresh:    false,
+		}, token)
+	})
 }

--- a/app/database/answer_store_integration_test.go
+++ b/app/database/answer_store_integration_test.go
@@ -45,7 +45,7 @@ func TestAnswerStore_SubmitNewAnswer(t *testing.T) {
 
 			newID, err := answerStore.SubmitNewAnswer(test.authorID, test.participantID, test.attemptID, test.itemID, test.answer)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotZero(t, newID)
 
 			type answer struct {
@@ -58,7 +58,7 @@ func TestAnswerStore_SubmitNewAnswer(t *testing.T) {
 				CreatedAtSet  bool
 			}
 			var insertedAnswer answer
-			assert.NoError(t,
+			require.NoError(t,
 				answerStore.ByID(newID).
 					Select("author_id, participant_id, attempt_id, item_id, type, answer, "+
 						"ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 AS created_at_set").
@@ -138,6 +138,6 @@ func TestAnswerStore_CreateNewAnswer_Duplicate(t *testing.T) {
 
 	answerStore := database.NewDataStore(db).Answers()
 	newID, err := answerStore.CreateNewAnswer(int64(121), int64(121), int64(56), int64(456), "Saved", "my answer", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), newID)
 }

--- a/app/database/approvals_test.go
+++ b/app/database/approvals_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
@@ -34,7 +35,7 @@ func TestDB_WithPersonalInfoViewApprovals(t *testing.T) {
 		Approved bool
 	}
 	var result []resultType
-	assert.NoError(t,
+	require.NoError(t,
 		NewDataStore(db).Users().WithPersonalInfoViewApprovals(&User{GroupID: 23}).
 			Select("*").Scan(&result).Error())
 	assert.Equal(t, []resultType{{ID: 123, Approved: true}}, result)

--- a/app/database/attempt_store_integration_test.go
+++ b/app/database/attempt_store_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
@@ -55,14 +56,14 @@ func TestAttemptStore_CreateNew_CreatesNewAttempt(t *testing.T) {
 
 	var newAttemptID int64
 	var err error
-	assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+	require.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 		newAttemptID, err = store.Attempts().CreateNew(10, 200, 20, 100)
 		return err
 	}))
 	assert.Equal(t, int64(1), newAttemptID)
 	var result resultType
 	expectedTime := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
-	assert.NoError(t, database.NewDataStore(db).Results().
+	require.NoError(t, database.NewDataStore(db).Results().
 		Where("attempt_id = ?", newAttemptID).
 		Where("participant_id = ?", 10).
 		Select("participant_id, attempt_id, item_id, started_at, latest_activity_at").Take(&result).Error())
@@ -74,7 +75,7 @@ func TestAttemptStore_CreateNew_CreatesNewAttempt(t *testing.T) {
 		LatestActivityAt: expectedTime,
 	}, result)
 	var attempt attemptType
-	assert.NoError(t, database.NewDataStore(db).Attempts().ByID(newAttemptID).
+	require.NoError(t, database.NewDataStore(db).Attempts().ByID(newAttemptID).
 		Where("participant_id = ?", 10).
 		Select("participant_id, id, creator_id, parent_attempt_id, root_item_id, created_at").Take(&attempt).Error())
 	assert.Equal(t, attemptType{

--- a/app/database/configdb/config_integration_test.go
+++ b/app/database/configdb/config_integration_test.go
@@ -209,7 +209,7 @@ groups_groups:
 			}
 
 			err = CreateMissingData(database.NewDataStore(db), domainConfig)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Once CreateMissingData() have been called, CheckConfig() should pass.
 			err = CheckConfig(database.NewDataStore(db), domainConfig)

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -25,9 +25,9 @@ func TestDataStore_WithForeignKeyChecksDisabled(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.WithForeignKeyChecksDisabled(func(store *database.DataStore) error {
+	require.NoError(t, store.WithForeignKeyChecksDisabled(func(store *database.DataStore) error {
 		assertForeignKeysDBVars(t, store, 1, 0)
-		assert.NoError(t, store.WithForeignKeyChecksDisabled(func(innerStore *database.DataStore) error {
+		require.NoError(t, store.WithForeignKeyChecksDisabled(func(innerStore *database.DataStore) error {
 			assertForeignKeysDBVars(t, innerStore, 2, 0)
 			return nil
 		}))
@@ -35,9 +35,9 @@ func TestDataStore_WithForeignKeyChecksDisabled(t *testing.T) {
 		return nil
 	}))
 	assertForeignKeysDBVars(t, store, 0, 1)
-	assert.NoError(t, store.InTransaction(func(store *database.DataStore) error {
+	require.NoError(t, store.InTransaction(func(store *database.DataStore) error {
 		assertForeignKeysDBVars(t, store, 0, 1)
-		assert.NoError(t, store.WithForeignKeyChecksDisabled(func(innerStore *database.DataStore) error {
+		require.NoError(t, store.WithForeignKeyChecksDisabled(func(innerStore *database.DataStore) error {
 			assertForeignKeysDBVars(t, innerStore, 1, 0)
 			return nil
 		}))
@@ -53,7 +53,7 @@ func assertForeignKeysDBVars(t *testing.T, store *database.DataStore, expectedSt
 		StackCount       int64
 		ForeignKeyChecks int64
 	}
-	assert.NoError(t,
+	require.NoError(t,
 		store.Raw("SELECT @foreign_key_checks_stack_count AS stack_count, @@SESSION.foreign_key_checks AS foreign_key_checks").
 			Scan(&result).Error())
 	assert.Equal(t, expectedStackCount, result.StackCount, "wrong @foreign_key_checks_stack_count")

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -176,7 +176,7 @@ func TestDataStore_InTransaction_NoErrors(t *testing.T) {
 		return db.Raw("SELECT 1 AS id").Scan(&result).Error()
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []resultStruct{{1}}, result)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -231,8 +231,8 @@ func TestDataStore_InTransaction_ContextAndTxOptions(t *testing.T) {
 		return nil
 	}, txOptions)
 
-	assert.Nil(t, gotError)
-	assert.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, gotError)
+	require.NoError(t, mock.ExpectationsWereMet())
 	assert.Equal(t, 1, callsCount)
 }
 
@@ -337,8 +337,8 @@ func TestDataStore_WithForeignKeyChecksDisabled_WithTxOptions(t *testing.T) {
 		return nil
 	}, txOptions)
 
-	assert.Nil(t, gotError)
-	assert.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, gotError)
+	require.NoError(t, mock.ExpectationsWereMet())
 	assert.Equal(t, 1, callsCount)
 }
 
@@ -735,7 +735,7 @@ func TestNewDataStoreWithContext_WithSQLDBWrapper(t *testing.T) {
 	//nolint:gosec // unsafe.Pointer is used to access the private field of gorm.Dialect
 	assert.Equal(t, dbWrapper, (*gormDialectDBAccessor)(unsafe.Pointer(&dialect)).v.db)
 
-	assert.Nil(t, mock.ExpectationsWereMet())
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestNewDataStoreWithContext_WithSQLTxWrapper(t *testing.T) {
@@ -767,7 +767,7 @@ func TestNewDataStoreWithContext_WithSQLTxWrapper(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Nil(t, mock.ExpectationsWereMet())
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDataStore_EnsureTransaction(t *testing.T) {
@@ -817,10 +817,10 @@ func TestDataStore_SetPropagationsModeToSync(t *testing.T) {
 
 	require.Nil(t, db.ctx().Value(propagationsAreSyncContextKey))
 
-	assert.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
+	require.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
 		require.NoError(t, store.SetPropagationsModeToSync())
-		assert.Equal(t, store.DB.ctx().Value(propagationsAreSyncContextKey), true)
-		assert.Equal(t, store.DB.db.CommonDB().(*sqlTxWrapper).ctx.Value(propagationsAreSyncContextKey), true)
+		assert.Equal(t, true, store.DB.ctx().Value(propagationsAreSyncContextKey))
+		assert.Equal(t, true, store.DB.db.CommonDB().(*sqlTxWrapper).ctx.Value(propagationsAreSyncContextKey))
 		return nil
 	}))
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -48,7 +48,7 @@ func TestDB_inTransaction_NoErrors(t *testing.T) {
 		return db.Raw("SELECT 1 AS id").Scan(&result).Error()
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []resultStruct{{1}}, result)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -198,12 +198,12 @@ func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutErrors(t *testing.T
 				WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
 			mock.ExpectCommit()
 
-			assert.NoError(t, db.inTransaction(func(db *DB) error {
+			require.NoError(t, db.inTransaction(func(db *DB) error {
 				var result []interface{}
 				return db.Raw("SELECT 1").Scan(&result).Error()
 			}))
 			assert.InEpsilon(t, transactionDelayBetweenRetries, duration, 0.05)
-			assert.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, mock.ExpectationsWereMet())
 
 			logs := (&loggingtest.Hook{Hook: logHook}).GetAllStructuredLogs()
 			assert.Contains(t, logs, fmt.Sprintf("Retrying transaction (count: 1) after Error %d:", errorNumber))
@@ -262,7 +262,7 @@ func TestDB_inTransaction_RetriesOnDeadlockAndLockWaitTimeoutPanic(t *testing.T)
 				WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
 			mock.ExpectCommit()
 
-			assert.NoError(t, db.inTransaction(func(db *DB) error {
+			require.NoError(t, db.inTransaction(func(db *DB) error {
 				var result []interface{}
 				mustNotBeError(db.Raw("SELECT 1").Scan(&result).Error())
 				return nil
@@ -413,7 +413,7 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Panic(t *testing.T) {
 				WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
 			mock.ExpectCommit()
 
-			assert.NoError(t, db.inTransaction(func(db *DB) error {
+			require.NoError(t, db.inTransaction(func(db *DB) error {
 				var result []interface{}
 				mustNotBeError(db.Raw("SELECT 1").Scan(&result).Error())
 				return nil
@@ -447,7 +447,7 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Error(t *testing.T) {
 				WillReturnRows(mock.NewRows([]string{"1"}).AddRow(1))
 			mock.ExpectCommit()
 
-			assert.NoError(t, db.inTransaction(func(db *DB) error {
+			require.NoError(t, db.inTransaction(func(db *DB) error {
 				var result []interface{}
 				return db.Raw("SELECT 1").Scan(&result).Error()
 			}))
@@ -489,7 +489,7 @@ func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Panic(t *testing.T) 
 					return nil
 				}))
 			assert.InEpsilon(t, transactionRetriesLimit*transactionDelayBetweenRetries, duration, transactionRetriesLimit*0.05)
-			assert.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, mock.ExpectationsWereMet())
 
 			require.Len(t, loggerHook.AllEntries(), 1)
 			assert.Equal(t, "error", loggerHook.LastEntry().Level.String())
@@ -531,7 +531,7 @@ func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Error(t *testing.T) 
 					return db.Raw("SELECT 1").Scan(&result).Error()
 				}))
 			assert.InEpsilon(t, transactionRetriesLimit*transactionDelayBetweenRetries, duration, transactionRetriesLimit*0.05)
-			assert.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, mock.ExpectationsWereMet())
 
 			require.Len(t, loggerHook.AllEntries(), 1)
 			assert.Equal(t, "error", loggerHook.LastEntry().Level.String())
@@ -705,7 +705,7 @@ func TestDB_Count(t *testing.T) {
 	countDB := db.Count(&result)
 
 	assert.NotEqual(t, countDB, db)
-	assert.NoError(t, countDB.Error())
+	require.NoError(t, countDB.Error())
 	assert.Equal(t, db.ctx(), countDB.ctx())
 	assert.Nil(t, countDB.ctes)
 	assert.Equal(t, db.logConfig(), countDB.logConfig())
@@ -753,7 +753,7 @@ func TestDB_Take(t *testing.T) {
 	takeDB := db.Take(&result, "id = 1")
 
 	assert.NotEqual(t, takeDB, db)
-	assert.NoError(t, takeDB.Error())
+	require.NoError(t, takeDB.Error())
 	assert.Equal(t, db.ctx(), takeDB.ctx())
 	assert.Nil(t, takeDB.ctes)
 	assert.Equal(t, db.logConfig(), takeDB.logConfig())
@@ -776,7 +776,7 @@ func TestDB_HasRows(t *testing.T) {
 
 	found, err := db.Where("id = 1").HasRows()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -795,7 +795,7 @@ func TestDB_HasRows_NoRows(t *testing.T) {
 
 	found, err := db.Where("id = 1").HasRows()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, found)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -838,7 +838,7 @@ func TestDB_Pluck(t *testing.T) {
 	pluckDB := db.Pluck("id", &result)
 
 	assert.NotEqual(t, pluckDB, db)
-	assert.NoError(t, pluckDB.Error())
+	require.NoError(t, pluckDB.Error())
 	assert.Equal(t, db.ctx(), pluckDB.ctx())
 	assert.Nil(t, pluckDB.ctes)
 	assert.Equal(t, db.logConfig(), pluckDB.logConfig())
@@ -926,7 +926,7 @@ func TestDB_PluckFirst(t *testing.T) {
 	pluckFirstDB := db.PluckFirst("id", &result)
 
 	assert.NotEqual(t, pluckFirstDB, db)
-	assert.NoError(t, pluckFirstDB.Error())
+	require.NoError(t, pluckFirstDB.Error())
 	assert.Equal(t, db.ctx(), pluckFirstDB.ctx())
 	assert.Nil(t, pluckFirstDB.ctes)
 	assert.Equal(t, db.logConfig(), pluckFirstDB.logConfig())
@@ -998,7 +998,7 @@ func TestDB_Scan(t *testing.T) {
 	scanDB := db.Scan(&result)
 
 	assert.NotEqual(t, scanDB, db)
-	assert.NoError(t, scanDB.Error())
+	require.NoError(t, scanDB.Error())
 	assert.Equal(t, db.ctx(), scanDB.ctx())
 	assert.Nil(t, scanDB.ctes)
 	assert.Equal(t, db.logConfig(), scanDB.logConfig())
@@ -1026,7 +1026,7 @@ func TestDB_Scan_WipesOldData(t *testing.T) {
 	result := []resultType{{ID: 2, Value: "another value"}, {ID: 3, Value: "third value"}}
 	scanDB := db.Scan(&result)
 
-	assert.NoError(t, scanDB.Error())
+	require.NoError(t, scanDB.Error())
 	assert.Equal(t, []resultType{{ID: 1, Value: "value"}}, result)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -1041,8 +1041,8 @@ func TestDB_Scan_NonSlicePointer(t *testing.T) {
 	result := 1
 	scanDB := db.Scan(&result)
 
-	assert.EqualError(t, scanDB.Error(), "unsupported destination, should be slice or struct")
-	assert.NoError(t, mock.ExpectationsWereMet())
+	require.EqualError(t, scanDB.Error(), "unsupported destination, should be slice or struct")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDB_Scan_NonPointer(t *testing.T) {
@@ -1122,7 +1122,7 @@ func TestDB_Exec(t *testing.T) {
 	execDB := db.Exec(query, 1, 2)
 
 	assert.NotEqual(t, execDB, db)
-	assert.NoError(t, execDB.Error())
+	require.NoError(t, execDB.Error())
 	assert.Equal(t, db.ctx(), execDB.ctx())
 	assert.Nil(t, execDB.ctes)
 	assert.Equal(t, db.logConfig(), execDB.logConfig())
@@ -1237,7 +1237,7 @@ func TestDB_ScanIntoSlices(t *testing.T) {
 
 	dbScan := db.ScanIntoSlices(&ids, &fields)
 	assert.Equal(t, dbScan, db)
-	assert.NoError(t, dbScan.Error())
+	require.NoError(t, dbScan.Error())
 
 	assert.Equal(t, []int64{1, 2, 3}, ids)
 	assert.Equal(t, []*string{golang.Ptr("value"), golang.Ptr("another value"), nil}, fields)
@@ -1341,7 +1341,7 @@ func TestDB_ScanIntoSliceOfMaps(t *testing.T) {
 	var result []map[string]interface{}
 	dbScan := db.ScanIntoSliceOfMaps(&result)
 	assert.Equal(t, dbScan, db)
-	assert.NoError(t, dbScan.Error())
+	require.NoError(t, dbScan.Error())
 
 	assert.Equal(t, []map[string]interface{}{
 		{"id": int64(1), "Field": "value"},
@@ -1511,7 +1511,7 @@ func TestDB_UpdateColumn(t *testing.T) {
 
 	updateDB := db.UpdateColumn("name", someName)
 	assert.NotEqual(t, updateDB, db)
-	assert.NoError(t, updateDB.Error())
+	require.NoError(t, updateDB.Error())
 	assert.Equal(t, db.ctx(), updateDB.ctx())
 	assert.Nil(t, updateDB.ctes)
 	assert.Equal(t, db.logConfig(), updateDB.logConfig())
@@ -1534,7 +1534,7 @@ func TestDB_Set(t *testing.T) {
 
 	setDB := db.Set("gorm:query_option", "FOR UPDATE")
 	assert.NotEqual(t, setDB, db)
-	assert.NoError(t, setDB.Error())
+	require.NoError(t, setDB.Error())
 	assert.Equal(t, db.ctx(), setDB.ctx())
 	assert.Equal(t, db.ctes, setDB.ctes)
 	assert.Equal(t, db.logConfig(), setDB.logConfig())
@@ -1546,7 +1546,7 @@ func TestDB_Set(t *testing.T) {
 
 func TestOpenRawDBConnection(t *testing.T) {
 	db, err := OpenRawDBConnection("/db", true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, sql.Drivers(), "instrumented-mysql")
 	assertRawDBIsOK(t, db)
 }
@@ -1559,7 +1559,7 @@ func TestOpen_DSN(t *testing.T) {
 	defer patchGuard.Unpatch()
 
 	db, err := Open("/db")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, db)
 }
 

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/loggingtest"
@@ -272,12 +273,12 @@ func Test_Deadline(t *testing.T) {
 				(*cancelCtxInterface)(unsafe.Pointer(&ctx)).p.cause = nil
 			})
 
-			assert.EqualError(t, err, context.DeadlineExceeded.Error())
+			require.EqualError(t, err, context.DeadlineExceeded.Error())
 
 			assert.Eventually(t, func() bool {
 				return mock.ExpectationsWereMet() == nil
 			}, 3*time.Second, 10*time.Millisecond)
-			assert.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, mock.ExpectationsWereMet())
 
 			logs := (&loggingtest.Hook{Hook: logHook}).GetAllStructuredLogs()
 			assert.Contains(t, logs, "context deadline exceeded")

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -34,18 +34,18 @@ func TestGroupStore_CreateNew(t *testing.T) {
 			var newID int64
 			var err error
 			dataStore := database.NewDataStore(db)
-			assert.NoError(t, dataStore.InTransaction(func(store *database.DataStore) error {
+			require.NoError(t, dataStore.InTransaction(func(store *database.DataStore) error {
 				newID, err = store.Groups().CreateNew("Some group", test.groupType)
 				return err
 			}))
-			assert.True(t, newID > 0)
+			assert.Positive(t, newID)
 			type resultType struct {
 				Name         string
 				Type         string
 				CreatedAtSet bool
 			}
 			var result resultType
-			assert.NoError(t, dataStore.Groups().ByID(newID).
+			require.NoError(t, dataStore.Groups().ByID(newID).
 				Select("name, type, ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 AS created_at_set").
 				Take(&result).Error())
 			assert.Equal(t, resultType{
@@ -57,11 +57,11 @@ func TestGroupStore_CreateNew(t *testing.T) {
 			found, err := dataStore.GroupAncestors().
 				Where("ancestor_group_id = ?", newID).
 				Where("child_group_id = ?", newID).HasRows()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, found)
 
 			var attempts []map[string]interface{}
-			assert.NoError(t, dataStore.Attempts().
+			require.NoError(t, dataStore.Attempts().
 				Select(`
 					participant_id, id, creator_id, parent_attempt_id, root_item_id,
 					ABS(TIMESTAMPDIFF(SECOND, created_at, NOW())) < 3 AS created_at_set`).
@@ -392,9 +392,9 @@ func TestGroupStore_DeleteGroup(t *testing.T) {
 		return store.Groups().DeleteGroup(1234)
 	}))
 	var ids []int64
-	assert.NoError(t, groupStore.Pluck("id", &ids).Error())
+	require.NoError(t, groupStore.Pluck("id", &ids).Error())
 	assert.Empty(t, ids)
-	assert.NoError(t, groupStore.Table("groups_propagate").Pluck("id", &ids).Error())
+	require.NoError(t, groupStore.Table("groups_propagate").Pluck("id", &ids).Error())
 	assert.Empty(t, ids)
 }
 

--- a/app/database/groups_integration_test.go
+++ b/app/database/groups_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -112,14 +113,14 @@ func TestDataStore_GetGroupJoiningByCodeInfoByCode(t *testing.T) {
 			var found bool
 			var err error
 			if tt.withLock {
-				assert.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
+				require.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
 					got, found, err = trStore.GetGroupJoiningByCodeInfoByCode(tt.code, tt.withLock)
 					return err
 				}))
 			} else {
 				got, found, err = store.GetGroupJoiningByCodeInfoByCode(tt.code, tt.withLock)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantFound, found)
 			assert.Equal(t, tt.want, got)
 		})

--- a/app/database/item_item_store_ancestors_integration_test.go
+++ b/app/database/item_item_store_ancestors_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -38,7 +39,7 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 
 	itemItemStore := database.NewDataStore(db).ItemItems()
 	var result []itemAncestorsResultRow
-	assert.NoError(t, itemItemStore.ItemAncestors().Order("child_item_id, ancestor_item_id").Scan(&result).Error())
+	require.NoError(t, itemItemStore.ItemAncestors().Order("child_item_id, ancestor_item_id").Scan(&result).Error())
 
 	assert.Equal(t, []itemAncestorsResultRow{
 		{ChildItemID: 2, AncestorItemID: 1},
@@ -50,7 +51,7 @@ func TestItemItemStore_CreateNewAncestors_Concurrent(t *testing.T) {
 	}, result)
 
 	var propagateResult []itemPropagateResultRow
-	assert.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
+	require.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
 	assert.Equal(t, []itemPropagateResultRow{
 		{ID: 2, AncestorsComputationState: "done"},
 		{ID: 3, AncestorsComputationState: "done"},
@@ -77,7 +78,7 @@ func TestItemItemStore_CreateNewAncestors_Cyclic(t *testing.T) {
 	}, result)
 
 	var propagateResult []itemPropagateResultRow
-	assert.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
+	require.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
 	assert.Equal(t, []itemPropagateResultRow{
 		{ID: 1, AncestorsComputationState: "todo"},
 		{ID: 2, AncestorsComputationState: "todo"},
@@ -95,7 +96,7 @@ func TestItemItemStore_CreateNewAncestors_IgnoresDoneItems(t *testing.T) {
 	itemItemStore := database.NewDataStore(db).ItemItems()
 
 	for i := 1; i <= 4; i++ {
-		assert.NoError(t, itemItemStore.Exec(
+		require.NoError(t, itemItemStore.Exec(
 			"INSERT INTO items_propagate (id, ancestors_computation_state) VALUES (?, 'done') "+
 				"ON DUPLICATE KEY UPDATE ancestors_computation_state='done'", i).
 			Error())
@@ -113,7 +114,7 @@ func TestItemItemStore_CreateNewAncestors_IgnoresDoneItems(t *testing.T) {
 	}, result)
 
 	var propagateResult []itemPropagateResultRow
-	assert.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
+	require.NoError(t, itemItemStore.Table("items_propagate").Order("id").Scan(&propagateResult).Error())
 	assert.Equal(t, []itemPropagateResultRow{
 		{ID: 1, AncestorsComputationState: "done"},
 		{ID: 2, AncestorsComputationState: "done"},

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -23,7 +23,7 @@ func TestItemItemStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) {
 	dataStore := database.NewDataStore(db)
 	assertResultsMarkedAsChanged(t, dataStore, []resultPrimaryKeyAndState{})
 
-	assert.NoError(t, dataStore.ItemItems().InsertMap(map[string]interface{}{
+	require.NoError(t, dataStore.ItemItems().InsertMap(map[string]interface{}{
 		"parent_item_id": 1, "child_item_id": 2, "child_order": 1,
 	}))
 

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
@@ -49,7 +50,7 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 			}
 			db = reflect.ValueOf(itemStore).MethodByName(testCase.methodToCall).
 				Call(parameters)[0].Interface().(*database.DB).Pluck(testCase.column, &result)
-			assert.NoError(t, db.Error())
+			require.NoError(t, db.Error())
 
 			assert.Equal(t, testCase.expected, result)
 		})
@@ -386,7 +387,7 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 	`)
 	defer func() { _ = db.Close() }()
 
-	assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+	require.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 		return store.GroupGroups().CreateNewAncestors()
 	}))
 
@@ -859,7 +860,7 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 	`)
 	defer func() { _ = db.Close() }()
 
-	assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+	require.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
 		return store.GroupGroups().CreateNewAncestors()
 	}))
 
@@ -1281,17 +1282,17 @@ func Test_ItemStore_DeleteItem(t *testing.T) {
 	`)
 	defer func() { _ = db.Close() }()
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.InTransaction(func(store *database.DataStore) error {
+	require.NoError(t, store.InTransaction(func(store *database.DataStore) error {
 		return store.Items().DeleteItem(1235)
 	}))
 	var ids []int64
-	assert.NoError(t, store.Items().Pluck("id", &ids).Error())
+	require.NoError(t, store.Items().Pluck("id", &ids).Error())
 	assert.Equal(t, []int64{1234}, ids)
-	assert.NoError(t, store.ItemStrings().Pluck("item_id", &ids).Error())
+	require.NoError(t, store.ItemStrings().Pluck("item_id", &ids).Error())
 	assert.Equal(t, []int64{1234}, ids)
-	assert.NoError(t, store.Table("items_propagate").
+	require.NoError(t, store.Table("items_propagate").
 		Where("ancestors_computation_state != 'done'").Pluck("id", &ids).Error())
 	assert.Empty(t, ids)
-	assert.NoError(t, store.Table("permissions_propagate").Pluck("item_id", &ids).Error())
+	require.NoError(t, store.Table("permissions_propagate").Pluck("item_id", &ids).Error())
 	assert.Empty(t, ids)
 }

--- a/app/database/item_store_test.go
+++ b/app/database/item_store_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
@@ -39,7 +40,7 @@ func TestItemStore_TimeLimitedByIDManagedByUser(t *testing.T) {
 	var id int64
 	err := NewDataStore(db).Items().TimeLimitedByIDManagedByUser(123, &User{GroupID: 2}).
 		PluckFirst("items.id", &id).Error()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(123), id)
 }
 

--- a/app/database/items.go
+++ b/app/database/items.go
@@ -1,7 +1,5 @@
 package database
 
-import "fmt"
-
 // WhereUserHasViewPermissionOnItems returns a subview of the items
 // on that the given user has `can_view_generated` >= `viewPermission`
 // basing on the given view.
@@ -43,7 +41,7 @@ func (conn *DB) WhereGroupHasPermissionOnItems(groupID int64, permissionKind, ne
 	itemsPerms := NewDataStore(conn.New()).Permissions().
 		MatchingGroupAncestors(groupID).
 		Where("permissions.item_id = items.id").
-		Where(fmt.Sprintf("%s >= ?", permissionColumnByKind(permissionKind)),
+		Where(permissionColumnByKind(permissionKind)+" >= ?",
 			NewDataStore(conn).PermissionsGranted().PermissionIndexByKindAndName(permissionKind, neededPermission)).
 		Select("1").Limit(1)
 	return conn.Where("EXISTS(?)", itemsPerms.QueryExpr())

--- a/app/database/mysql_connection_wrapper_test.go
+++ b/app/database/mysql_connection_wrapper_test.go
@@ -40,7 +40,7 @@ func Test_mysqlConnWrapper_Prepare(t *testing.T) {
 	expectedStmt := &stmtMock{}
 	expectedErr := errors.New("error")
 	monkey.Patch(mysqlConnPrepare, func(c unsafe.Pointer, query string) (driver.Stmt, error) {
-		assert.Equal(t, conn, (*mysqlConnWrapper)(c))
+		assert.Equal(t, conn, (*mysqlConnWrapper)(c)) //nolint:testifylint // conn is expected
 		assert.Equal(t, expectedQuery, query)
 		return expectedStmt, expectedErr //nolint:nilnil // We return the value among with the error for test purposes.
 	})

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -35,7 +36,7 @@ func TestPermissionGeneratedStore_MatchingUserAncestors(t *testing.T) {
 
 	permissionsStore := database.NewDataStore(db).Permissions()
 	var result []map[string]interface{}
-	assert.NoError(t, permissionsStore.MatchingUserAncestors(&database.User{GroupID: 5}).
+	require.NoError(t, permissionsStore.MatchingUserAncestors(&database.User{GroupID: 5}).
 		Select("item_id, can_view_generated").
 		ScanIntoSliceOfMaps(&result).Error())
 	assert.Equal(t, []map[string]interface{}{
@@ -208,14 +209,14 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			defer func() { _ = db.Close() }()
 
 			dataStore := database.NewDataStoreWithTable(db, "permissions_generated")
-			assert.NoError(t, dataStore.InTransaction(func(store *database.DataStore) error {
+			require.NoError(t, dataStore.InTransaction(func(store *database.DataStore) error {
 				return store.GroupGroups().CreateNewAncestors()
 			}))
 			result := dataStore.Where("group_id = ?", test.groupID).
 				Where("item_id = ?", test.itemID).UpdateColumn(map[string]interface{}{
 				"can_view_generated": test.canView,
 			})
-			assert.NoError(t, result.Error())
+			require.NoError(t, result.Error())
 
 			if test.noChanges {
 				assert.Zero(t, result.RowsAffected())
@@ -243,8 +244,8 @@ func TestPermissionGeneratedStore_TriggerBeforeUpdate_RefusesToModifyGroupIDOrIt
 	dataStore := database.NewDataStoreWithTable(db, "permissions_generated")
 	result := dataStore.Where("group_id = 1 AND item_id = 2").
 		UpdateColumn("group_id", 3)
-	assert.EqualError(t, result.Error(), expectedErrorMessage)
+	require.EqualError(t, result.Error(), expectedErrorMessage)
 	result = dataStore.Where("group_id = 1 AND item_id = 2").
 		UpdateColumn("item_id", 3)
-	assert.EqualError(t, result.Error(), expectedErrorMessage)
+	require.EqualError(t, result.Error(), expectedErrorMessage)
 }

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -3,7 +3,7 @@
 package database_test
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -713,7 +713,7 @@ func testPropagates(t *testing.T, column, propagationColumn, valueForParent stri
 	t.Helper()
 
 	t.Run(valueForParent+" as "+expectedValue, func(t *testing.T) {
-		grantViewPropagationString := fmt.Sprint(propagationMode)
+		grantViewPropagationString := strconv.FormatBool(propagationMode)
 		testGeneratedPermission(t, `
 				items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
 				groups: [{id: 1}]

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -53,7 +54,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *test
 	assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
 
 	var result []permissionsGeneratedResultRow
-	assert.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
+	require.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
 	assertPermissionsGeneratedResultRowsEqual(t, []permissionsGeneratedResultRow{
 		{
 			GroupID:          1,
@@ -120,7 +121,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t
 	assert.NoError(t, permissionGrantedStore.ItemItems().UpdateColumn(map[string]interface{}{
 		"content_view_propagation": "as_info",
 	}).Error())
-	assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
+	require.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
 		ds.SchedulePermissionsPropagation()
 		return nil
 	}))
@@ -128,7 +129,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t
 	assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
 
 	var result []permissionsGeneratedResultRow
-	assert.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
+	require.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
 	assertPermissionsGeneratedResultRowsEqual(t, []permissionsGeneratedResultRow{
 		{
 			GroupID:          1,
@@ -203,7 +204,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 			assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
 
 			var result []permissionsGeneratedResultRow
-			assert.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
+			require.NoError(t, permissionGeneratedStore.Order("group_id, item_id").Scan(&result).Error())
 			assertPermissionsGeneratedResultRowsEqual(t, []permissionsGeneratedResultRow{
 				{
 					GroupID:          1,
@@ -361,15 +362,19 @@ func testGeneratedPermission(t *testing.T, fixture string, testCase ...generated
 	defer func() { _ = db.Close() }()
 
 	permissionStore := database.NewDataStore(db).Permissions()
-	assert.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
+	require.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
 		ds.SchedulePermissionsPropagation()
 		return nil
 	}))
 	var result string
 	for _, test := range testCase {
-		assert.NoError(t, permissionStore.Where(test.where).
-			PluckFirst(test.columnToExamine, &result).Error())
-		assert.Equal(t, test.expectedValue, result)
+		test := test
+		t.Run(test.where, func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+			require.NoError(t, permissionStore.Where(test.where).
+				PluckFirst(test.columnToExamine, &result).Error())
+			assert.Equal(t, test.expectedValue, result)
+		})
 	}
 }
 
@@ -740,6 +745,6 @@ func assertAllPermissionsGeneratedAreDone(t *testing.T, permissionGeneratedStore
 	t.Helper()
 
 	var cnt int
-	assert.NoError(t, permissionGeneratedStore.Table("permissions_propagate").Count(&cnt).Error())
+	require.NoError(t, permissionGeneratedStore.Table("permissions_propagate").Count(&cnt).Error())
 	assert.Zero(t, cnt, "found not done group-item pairs")
 }

--- a/app/database/permission_granted_store_compute_all_access_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -49,7 +50,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_Concurrency(t *testing.T) {
 		{GroupID: 2, ItemID: 12, PropagateTo: "done"},
 	}
 
-	assert.NoError(t, permissionsGeneratedStore.Joins("LEFT JOIN permissions_propagate USING(group_id, item_id)").
+	require.NoError(t, permissionsGeneratedStore.Joins("LEFT JOIN permissions_propagate USING(group_id, item_id)").
 		Order("group_id, item_id").
 		Select(`
 			group_id,

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -74,7 +75,7 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
 			var result []map[string]interface{}
-			assert.NoError(t, itemStore.Select("items.id, permissions.*").
+			require.NoError(t, itemStore.Select("items.id, permissions.*").
 				JoinsPermissionsForGroupToItems(5).
 				Where("items.id IN (?)", test.ids).Order("items.id").
 				ScanIntoSliceOfMaps(&result).Error())
@@ -143,7 +144,7 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 			testoutput.SuppressIfPasses(t)
 
 			var result []map[string]interface{}
-			assert.NoError(t, itemStore.Select("items.id, permissions.*").
+			require.NoError(t, itemStore.Select("items.id, permissions.*").
 				JoinsPermissionsForGroupToItemsWherePermissionAtLeast(5, test.permissionKind, test.neededPermission).
 				Where("items.id IN (?)", test.ids).Order("items.id").
 				ScanIntoSliceOfMaps(&result).Error())

--- a/app/database/propagation_steps_test.go
+++ b/app/database/propagation_steps_test.go
@@ -34,7 +34,7 @@ func TestPropagationStepSets(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.set.Size(), len(test.expectedContent))
+			assert.Len(t, test.expectedContent, test.set.Size())
 			for _, step := range test.expectedContent {
 				assert.True(t, test.set.Contains(step), "step %q not found in the set", step)
 			}

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -27,7 +27,7 @@ func Test_fileWithLineNum(t *testing.T) {
 		return nil
 	}))
 
-	assert.Nil(t, mock.ExpectationsWereMet())
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func Test_fileWithLineNum_ReturnsEmptyStringWhenNoSuitableCallerFound(t *testing.T) {

--- a/app/database/raw_db_logger_integration_test.go
+++ b/app/database/raw_db_logger_integration_test.go
@@ -50,10 +50,8 @@ func Test_RawSQLQueryLogging_Duration(t *testing.T) {
 			assert.IsType(t, "", duration)
 			if durationStr, ok := duration.(string); ok {
 				parsedDuration, err := time.ParseDuration(durationStr)
-				assert.NoError(t, err)
-				if err == nil {
-					assert.Greater(t, parsedDuration, 0*time.Second)
-				}
+				require.NoError(t, err)
+				assert.Greater(t, parsedDuration, 0*time.Second)
 			}
 		}
 	}
@@ -94,10 +92,8 @@ func Test_RawSQLQueryLogging_ResetSession(t *testing.T) {
 			assert.IsType(t, "", duration)
 			if durationStr, ok := duration.(string); ok {
 				parsedDuration, err := time.ParseDuration(durationStr)
-				assert.NoError(t, err)
-				if err == nil {
-					assert.Greater(t, parsedDuration, 0*time.Second)
-				}
+				require.NoError(t, err)
+				assert.Greater(t, parsedDuration, 0*time.Second)
 			}
 		}
 	}

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -70,12 +71,12 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 			}).Error())
 
 			err := resultStore.InTransaction(func(s *database.DataStore) error {
-				assert.NoError(t, resultStore.Exec(
+				require.NoError(t, resultStore.Exec(
 					"INSERT IGNORE INTO results_propagate SELECT participant_id, attempt_id, item_id, 'to_be_propagated' AS state FROM results").Error())
 				s.ScheduleResultsPropagation()
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := []aggregatesResultRow{
 				{
@@ -124,7 +125,7 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedLatestActivityAt1 := database.Time(time.Date(2019, 5, 29, 11, 0, 0, 0, time.UTC))
 	expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
@@ -147,7 +148,7 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 	expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))
 
 	resultStore := database.NewDataStore(db).Results()
-	assert.NoError(t, resultStore.Where("participant_id = 101 AND attempt_id = 1 AND item_id = 2").UpdateColumn(map[string]interface{}{
+	require.NoError(t, resultStore.Where("participant_id = 101 AND attempt_id = 1 AND item_id = 2").UpdateColumn(map[string]interface{}{
 		"latest_activity_at": time.Time(expectedLatestActivityAt2),
 	}).Error())
 
@@ -155,7 +156,7 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := []aggregatesResultRow{
 		{ParticipantID: 101, AttemptID: 1, ItemID: 1, State: "done", LatestActivityAt: expectedLatestActivityAt1},
@@ -201,7 +202,7 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 				s.ScheduleResultsPropagation()
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expectedLatestActivityAt1 := database.Time(time.Date(2019, 5, 29, 11, 0, 0, 0, time.UTC))
 			expectedLatestActivityAt2 := database.Time(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC))

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
@@ -69,7 +70,7 @@ func testResultStorePropagateCreatesNew(t *testing.T, testCase *resultStorePropa
 	defer func() { _ = db.Close() }()
 
 	if testCase.rootItemID != nil {
-		assert.NoError(t, database.NewDataStore(db).Attempts().Where("participant_id = 3 AND id = 1").
+		require.NoError(t, database.NewDataStore(db).Attempts().Where("participant_id = 3 AND id = 1").
 			UpdateColumn("root_item_id", testCase.rootItemID).Error())
 	}
 	resultStore := database.NewDataStore(db).Results()
@@ -77,7 +78,7 @@ func testResultStorePropagateCreatesNew(t *testing.T, testCase *resultStorePropa
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	const expectedDate = "2019-05-30 11:00:00"
 	for i := range testCase.expectedNewResults {

--- a/app/database/result_store_propagate_recomputes_items_integration_test.go
+++ b/app/database/result_store_propagate_recomputes_items_integration_test.go
@@ -58,10 +58,10 @@ func TestResultStore_Propagate_RecomputesResultsForItemsFromTableResultsRecomput
 		}), "Results Propagation failed")
 
 	hasRows, err := dataStore.Table("results_recompute_for_items").HasRows()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, hasRows)
 	hasRows, err = dataStore.Table("results_propagate").HasRows()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, hasRows)
 
 	expectedTime, _ := time.Parse(time.DateTime, "2019-05-30 11:00:00")

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -66,7 +67,7 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validationDateResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
@@ -100,7 +101,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validationDateResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
@@ -135,7 +136,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validationDateResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
@@ -175,7 +176,7 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validationDateResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")
@@ -198,22 +199,22 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	oldDatePlusOneDay := oldDate.Add(24 * time.Hour)
 
 	itemStore := database.NewDataStore(db).Items()
-	assert.NoError(t, resultStore.Where("item_id = 3 AND participant_id = 101 AND attempt_id = 1").
+	require.NoError(t, resultStore.Where("item_id = 3 AND participant_id = 101 AND attempt_id = 1").
 		UpdateColumn("validated_at", oldDate).Error())
-	assert.NoError(t, resultStore.Where("item_id = 4 AND participant_id = 101 AND attempt_id = 1").
+	require.NoError(t, resultStore.Where("item_id = 4 AND participant_id = 101 AND attempt_id = 1").
 		UpdateColumn("validated_at", oldDate).Error())
-	assert.NoError(t, resultStore.Where("item_id = 3 AND participant_id = 101 AND attempt_id = 2").
+	require.NoError(t, resultStore.Where("item_id = 3 AND participant_id = 101 AND attempt_id = 2").
 		UpdateColumn("validated_at", oldDatePlusOneDay).Error()) // should be ignored
-	assert.NoError(t, resultStore.Where("attempt_id = 1 AND item_id = 1 AND participant_id = 101").
+	require.NoError(t, resultStore.Where("attempt_id = 1 AND item_id = 1 AND participant_id = 101").
 		UpdateColumn("validated_at", expectedDate).Error())
-	assert.NoError(t, itemStore.Where("id=2").UpdateColumn("validation_type", "Categories").Error())
-	assert.NoError(t, database.NewDataStore(db).ItemItems().Where("parent_item_id = 2 AND child_item_id IN (1, 3, 4)").
+	require.NoError(t, itemStore.Where("id=2").UpdateColumn("validation_type", "Categories").Error())
+	require.NoError(t, database.NewDataStore(db).ItemItems().Where("parent_item_id = 2 AND child_item_id IN (1, 3, 4)").
 		UpdateColumn("category", "Validation").Error())
 
-	assert.NoError(t, itemStore.Where("id=1").UpdateColumn(map[string]interface{}{
+	require.NoError(t, itemStore.Where("id=1").UpdateColumn(map[string]interface{}{
 		"type": "Task",
 	}).Error())
-	assert.NoError(t, itemStore.Where("id=3").UpdateColumn(map[string]interface{}{
+	require.NoError(t, itemStore.Where("id=3").UpdateColumn(map[string]interface{}{
 		"no_score": true,
 	}).Error())
 
@@ -221,7 +222,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validationDateResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated_at")

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -40,7 +41,7 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 	defer func() { _ = db.Close() }()
 
 	resultStore := database.NewDataStore(db).Results()
-	assert.NoError(t,
+	require.NoError(t,
 		resultStore.Items().Where("id=2").
 			UpdateColumn("validation_type", validationType).Error())
 	if prepareFunc != nil {
@@ -51,7 +52,7 @@ func testResultStorePropagateValidated(t *testing.T, fixtures []string,
 		s.ScheduleResultsPropagation()
 		return nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var result []validatedResultRow
 	queryResultsAndStatesForTests(t, resultStore, &result, "validated")
@@ -219,9 +220,9 @@ func TestResultStore_Propagate_Validated(t *testing.T) {
 				t.Helper()
 
 				itemStore := resultStore.Items()
-				assert.NoError(t, itemStore.Where("id=4").UpdateColumn("no_score", true).Error())
+				require.NoError(t, itemStore.Where("id=4").UpdateColumn("no_score", true).Error())
 				markResultAsValidated(t, resultStore, "participant_id = 101 AND attempt_id = 1 AND item_id IN (1, 3)")
-				assert.NoError(t, resultStore.ItemItems().Where("parent_item_id = 2 AND child_item_id IN (3, 4)").
+				require.NoError(t, resultStore.ItemItems().Where("parent_item_id = 2 AND child_item_id IN (3, 4)").
 					UpdateColumn("category", "Validation").Error())
 			},
 			expectedResults: buildExpectedValidatedResultRows(map[string]bool{

--- a/app/database/result_store_test.go
+++ b/app/database/result_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
@@ -24,7 +25,7 @@ func TestResultStore_ByID(t *testing.T) {
 
 	var result []map[string]interface{}
 	err := NewDataStore(db).Results().ByID(1, 2, 3).ScanIntoSliceOfMaps(&result).Error()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []map[string]interface{}{{"id": int64(123)}}, result)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/database/time_test.go
+++ b/app/database/time_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTime_ScanString(t *testing.T) {
@@ -71,20 +72,20 @@ func TestTime_ScanString(t *testing.T) {
 func TestTime_Value(t *testing.T) {
 	tm := &time.Time{}
 	value, err := (*Time)(tm).Value()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0001-01-01 00:00:00", value)
 }
 
 func TestTime_Value_Nil(t *testing.T) {
 	tm := (*Time)(nil)
 	value, err := tm.Value()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, value)
 }
 
 func TestTime_MarshalJSON(t *testing.T) {
 	tm := Time(time.Date(2019, 5, 30, 11, 30, 15, 0, time.UTC))
 	result, err := (&tm).MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte(`"2019-05-30T11:30:15Z"`), result)
 }

--- a/app/database/user_integration_test.go
+++ b/app/database/user_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -98,7 +99,7 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 			defer func() { _ = db.Close() }()
 			store := database.NewDataStore(db)
 			user := &database.User{}
-			assert.NoError(t, user.LoadByID(store, test.userID))
+			require.NoError(t, user.LoadByID(store, test.userID))
 
 			canSeeAnswer := user.CanSeeAnswer(store, test.participantID, test.itemID)
 			assert.Equal(t, test.expectedResult, canSeeAnswer)

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -65,7 +65,7 @@ func TestUserStore_DeleteWithTraps(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.Users().DeleteWithTraps(
+	require.NoError(t, store.Users().DeleteWithTraps(
 		&database.User{GroupID: 5001}, false))
 
 	assertUserRelatedTablesAfterDeletingWithTraps(t, db, golang.NewSet[int64](5001), golang.NewSet[int64](2))
@@ -82,7 +82,7 @@ func TestUserStore_DeleteWithTrapsByScope(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.Users().DeleteWithTrapsByScope(func(store *database.DataStore) *database.DB {
+	require.NoError(t, store.Users().DeleteWithTrapsByScope(func(store *database.DataStore) *database.DB {
 		return store.Users().Where("group_id % 2 = 0")
 	}, false))
 
@@ -194,7 +194,7 @@ func assertTableColumn(t *testing.T, db *database.DB, table, column string, expe
 	t.Helper()
 
 	reflValues := reflect.New(reflect.TypeOf(expectedValues))
-	assert.NoError(t, db.Table(table).Order(column).Pluck("DISTINCT "+column, reflValues.Interface()).Error())
+	require.NoError(t, db.Table(table).Order(column).Pluck("DISTINCT "+column, reflValues.Interface()).Error())
 	assert.EqualValues(t, expectedValues, reflValues.Elem().Interface(), "wrong %s in %s", column, table)
 }
 
@@ -238,7 +238,7 @@ func assertUserRelatedTablesAfterDeletingWithTraps(
 
 	store := database.NewDataStore(db)
 	found, err := store.GroupAncestors().Where("ancestor_group_id = 1 AND child_group_id = 7000").HasRows()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found, "No row for 1->7000 in groups_ancestors")
 }
 

--- a/app/database/user_test.go
+++ b/app/database/user_test.go
@@ -17,12 +17,12 @@ func TestUser_Clone(t *testing.T) {
 		IsTempUser: true, IsAdmin: true, GroupID: 2, AccessGroupID: golang.Ptr(int64(4)), NotificationsReadAt: (*Time)(&ts),
 	}
 	userClone := user.Clone()
-	assert.False(t, userClone == user)
-	assert.False(t, user.NotificationsReadAt == userClone.NotificationsReadAt)
+	assert.NotSame(t, userClone, user)
+	assert.NotSame(t, user.NotificationsReadAt, userClone.NotificationsReadAt)
 	assert.Equal(t, *user.NotificationsReadAt, *userClone.NotificationsReadAt)
-	assert.False(t, user.LoginID == userClone.LoginID)
+	assert.NotSame(t, user.LoginID, userClone.LoginID)
 	assert.Equal(t, *user.LoginID, *userClone.LoginID)
-	assert.False(t, user.AccessGroupID == userClone.AccessGroupID)
+	assert.NotSame(t, user.AccessGroupID, userClone.AccessGroupID)
 	assert.Equal(t, *user.AccessGroupID, *userClone.AccessGroupID)
 	userClone.NotificationsReadAt = nil
 	userClone.LoginID = nil

--- a/app/database/users_integration_test.go
+++ b/app/database/users_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
@@ -101,14 +102,14 @@ func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(
 				var got bool
 				var err error
 				if withLock {
-					assert.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
+					require.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
 						got, err = trStore.CheckIfTeamParticipationsConflictWithExistingUserMemberships(tt.teamID, tt.userID, true)
 						return err
 					}))
 				} else {
 					got, err = store.CheckIfTeamParticipationsConflictWithExistingUserMemberships(tt.teamID, tt.userID, false)
 				}
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			})
 		}

--- a/app/domain/domain_test.go
+++ b/app/domain/domain_test.go
@@ -12,7 +12,7 @@ func TestConfigFromContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxDomainConfig, expectedConfig)
 	conf := ConfigFromContext(ctx)
 
-	assert.False(t, expectedConfig == conf)
+	assert.NotSame(t, expectedConfig, conf)
 	assert.EqualValues(t, expectedConfig, conf)
 }
 

--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -127,7 +128,7 @@ func assertMiddleware(t *testing.T, domains []ConfigItem, domainOverride string,
 		_ = response.Body.Close()
 		body = string(bodyData)
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedBody, body)
 	assert.Equal(t, expectedStatusCode, response.StatusCode)
 	assert.Equal(t, shouldEnterService, enteredService)

--- a/app/formdata/anything.go
+++ b/app/formdata/anything.go
@@ -2,44 +2,63 @@ package formdata
 
 import (
 	"encoding/json"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 // Anything represents a value of any type serialized as JSON.
 type Anything struct {
-	raw []byte
+	raw *[]byte
 }
 
 // AnythingFromString creates an instance of Anything with data from the given string.
 func AnythingFromString(s string) *Anything {
-	return &Anything{raw: []byte(s)}
+	return &Anything{raw: golang.Ptr([]byte(s))}
 }
 
 // AnythingFromBytes creates an instance of Anything with data from the given bytes slice.
 func AnythingFromBytes(bytes []byte) *Anything {
-	return &Anything{raw: bytes}
+	return &Anything{raw: golang.Ptr(bytes)}
 }
 
 // Bytes returns stored bytes.
-func (a Anything) Bytes() []byte {
-	return a.raw
+func (a *Anything) Bytes() []byte {
+	if a == nil {
+		return nil
+	}
+	//nolint:gosec // here we use atomic operations to access the raw pointer safely
+	rawPtr := (*[]byte)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&a.raw))))
+	if rawPtr == nil {
+		return nil
+	}
+	return *rawPtr
 }
 
 // UnmarshalJSON of Anything just copies the JSON data.
 func (a *Anything) UnmarshalJSON(raw []byte) error {
-	a.raw = make([]byte, len(raw))
-	copy(a.raw, raw)
+	newRaw := make([]byte, len(raw))
+	copy(newRaw, raw)
+	//nolint:gosec // here we use atomic operations to update the raw pointer safely
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&a.raw)), unsafe.Pointer(&newRaw))
 	return nil
 }
 
 // MarshalJSON of Anything copies the stored JSON data back.
-func (a Anything) MarshalJSON() ([]byte, error) {
-	if len(a.raw) == 0 {
+func (a *Anything) MarshalJSON() ([]byte, error) {
+	if a == nil {
 		return []byte("null"), nil
 	}
-	return a.raw, nil
+	//nolint:gosec // here we use atomic operations to access the raw pointer safely
+	rawPtr := (*[]byte)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&a.raw))))
+	if rawPtr == nil || len(*rawPtr) == 0 {
+		return []byte("null"), nil
+	}
+	return *rawPtr, nil
 }
 
 var (
 	_ = json.Unmarshaler(&Anything{})
-	_ = json.Marshaler(Anything{})
+	_ = json.Marshaler(&Anything{})
 )

--- a/app/formdata/anything_test.go
+++ b/app/formdata/anything_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
 func TestAnything_MarshalJSON(t *testing.T) {
@@ -14,8 +16,22 @@ func TestAnything_MarshalJSON(t *testing.T) {
 	assert.Equal(t, []byte(`"value"`), result)
 }
 
-func TestAnything_MarshalJSON_EmptyValue(t *testing.T) {
+func TestAnything_MarshalJSON_NilReceiver(t *testing.T) {
+	anything := (*Anything)(nil)
+	result, err := anything.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`null`), result)
+}
+
+func TestAnything_MarshalJSON_NilPointer(t *testing.T) {
 	anything := Anything{raw: nil}
+	result, err := anything.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`null`), result)
+}
+
+func TestAnything_MarshalJSON_EmptyValue(t *testing.T) {
+	anything := Anything{raw: golang.Ptr([]byte{})}
 	result, err := anything.MarshalJSON()
 	require.NoError(t, err)
 	assert.Equal(t, []byte(`null`), result)
@@ -32,4 +48,14 @@ func TestAnything_UnmarshalJSON(t *testing.T) {
 func TestAnything_Bytes(t *testing.T) {
 	anything := AnythingFromString(`"value"`)
 	assert.Equal(t, []byte(`"value"`), anything.Bytes())
+}
+
+func TestAnything_Bytes_NilReceiver(t *testing.T) {
+	anything := (*Anything)(nil)
+	assert.Equal(t, []byte(nil), anything.Bytes())
+}
+
+func TestAnything_Bytes_NilPointer(t *testing.T) {
+	anything := &Anything{raw: nil}
+	assert.Equal(t, []byte(nil), anything.Bytes())
 }

--- a/app/formdata/anything_test.go
+++ b/app/formdata/anything_test.go
@@ -4,19 +4,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnything_MarshalJSON(t *testing.T) {
 	anything := AnythingFromString(`"value"`)
 	result, err := anything.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte(`"value"`), result)
 }
 
 func TestAnything_MarshalJSON_EmptyValue(t *testing.T) {
 	anything := Anything{raw: nil}
 	result, err := anything.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte(`null`), result)
 }
 
@@ -24,7 +25,7 @@ func TestAnything_UnmarshalJSON(t *testing.T) {
 	raw := []byte(`"value"`)
 	anything := AnythingFromString("")
 	err := anything.UnmarshalJSON(raw)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, AnythingFromString(`"value"`), anything)
 }
 

--- a/app/formdata/form_data_integration_test.go
+++ b/app/formdata/form_data_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/France-ioi/mapstructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/formdata"
 )
@@ -325,12 +326,10 @@ func TestFormData_ParseJSONRequestData(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
 			err := f.ParseJSONRequestData(req)
 			if tt.wantErr != "" {
-				assert.NotNil(t, err, "Should produce an error, but it did not")
-				if err != nil {
-					assert.Equal(t, tt.wantErr, err.Error())
-				}
+				require.Error(t, err, "Should produce an error, but it did not")
+				assert.Equal(t, tt.wantErr, err.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			if tt.wantFieldErrors != nil {
 				assert.IsType(t, formdata.FieldErrorsError{}, err)
@@ -509,12 +508,12 @@ func TestFormData_ParseMapData(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			err := f.ParseMapData(tt.sourceMap)
 			if tt.wantErr != "" {
-				assert.NotNil(t, err, "Should produce an error, but it did not")
+				require.Error(t, err, "Should produce an error, but it did not")
 				if err != nil {
 					assert.Equal(t, tt.wantErr, err.Error())
 				}
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			if tt.wantFieldErrors != nil {
 				assert.IsType(t, formdata.FieldErrorsError{}, err)
@@ -677,7 +676,7 @@ func TestFormData_ConstructMapForDB(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
-			assert.Nil(t, f.ParseJSONRequestData(req))
+			require.NoError(t, f.ParseJSONRequestData(req))
 
 			got := f.ConstructMapForDB()
 			assert.Equal(t, tt.want, got)
@@ -737,7 +736,7 @@ func TestFormData_ConstructPartialMapForDB(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
-			assert.Nil(t, f.ParseJSONRequestData(req))
+			require.NoError(t, f.ParseJSONRequestData(req))
 
 			got := f.ConstructPartialMapForDB("Struct")
 			assert.Equal(t, tt.want, got)
@@ -789,7 +788,7 @@ func Test_toAnythingHookFunc(t *testing.T) {
 			hook := formdata.ToAnythingHookFunc()
 			converted, err := mapstructure.DecodeHookExec(hook, tt.typeFrom, tt.typeTo, tt.data)
 			if tt.wantErr == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.want, converted)
 			} else {
 				assert.Equal(t, tt.wantErr, err)
@@ -821,7 +820,7 @@ func Test_stringToInt64HookFunc(t *testing.T) {
 			hook := formdata.StringToInt64HookFunc()
 			converted, err := mapstructure.DecodeHookExec(hook, tt.typeFrom, tt.typeTo, tt.data)
 			if tt.wantErr == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.want, converted)
 			} else {
 				assert.Equal(t, tt.wantErr, err)

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -37,7 +37,7 @@ func TestMiddleware_Success(t *testing.T) {
 	checkCommon(assert, entryData)
 	assert.Equal("request complete", hook.AllEntries()[2].Message)
 	assert.Equal(10, entryData["resp_bytes_length"])
-	assert.True(entryData["resp_elapsed_ms"].(float64) < 3000.0, "Expected <3.0s, got: %f", entryData["resp_elapsed_ms"].(float64))
+	assert.Less(entryData["resp_elapsed_ms"].(float64), 3000.0, "Expected <3.0s, got: %f", entryData["resp_elapsed_ms"].(float64))
 	assert.Equal(200, entryData["resp_status"])
 }
 

--- a/app/loginmodule/client.go
+++ b/app/loginmodule/client.go
@@ -310,7 +310,7 @@ func convertUserProfile(source map[string]interface{}) (map[string]interface{}, 
 
 	err := convertBadges(source, dest)
 	if err != nil {
-		return nil, fmt.Errorf("invalid badges data")
+		return nil, errors.New("invalid badges data")
 	}
 
 	return dest, nil

--- a/app/loginmodule/client_test.go
+++ b/app/loginmodule/client_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thingful/httpmock"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -480,13 +481,13 @@ func TestClient_AccountsManagerEndpoints(t *testing.T) {
 					responder := httpmock.NewStringResponder(tt.responseCode, tt.response)
 
 					parsedParams, err := url.ParseQuery(testSuite.params)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					paramsMap := make(map[string]string, len(parsedParams))
 					for key := range parsedParams {
 						paramsMap[key] = parsedParams.Get(key)
 					}
 					requestBody, err := EncodeBody(paramsMap, "clientID", "clientKeyclientKey")
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					httpmock.RegisterStubRequests(httpmock.NewStubRequest("POST",
 						moduleURL+"/platform_api/"+testSuite.endpoint, responder,
@@ -618,13 +619,13 @@ func TestClient_CreateUsers(t *testing.T) {
 			}
 
 			parsedParams, err := url.ParseQuery(tt.loginModuleParams)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			paramsMap := make(map[string]string, len(parsedParams))
 			for key := range parsedParams {
 				paramsMap[key] = parsedParams.Get(key)
 			}
 			requestBody, err := EncodeBody(paramsMap, "clientID", "clientKeyclientKey")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			httpmock.RegisterStubRequests(httpmock.NewStubRequest("POST",
 				moduleURL+"/platform_api/accounts_manager/create", responder,
@@ -665,23 +666,23 @@ func TestEncodeBody(t *testing.T) {
 	const clientID = "1234"
 	const clientKey = "abcdefghijklmnop"
 	encoded, err := EncodeBody(params, clientID, clientKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var unmarshaled map[string]string
 	err = json.Unmarshal(encoded, &unmarshaled)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, clientID, unmarshaled["client_id"])
-	assert.Equal(t, 2, len(unmarshaled))
+	assert.Len(t, unmarshaled, 2)
 	assert.Contains(t, unmarshaled, "data")
 	decodedData := make([]byte, base64.StdEncoding.DecodedLen(len(unmarshaled["data"])))
 	n, err := base64.StdEncoding.Decode(decodedData, []byte(unmarshaled["data"]))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decodedData = decodedData[0:n]
 	decryptedData := decryptAes128Ecb(decodedData, []byte(clientKey)[:16])
 	decoder := json.NewDecoder(bytes.NewReader(decryptedData))
 	decoder.UseNumber()
 	var parsedData map[string]string
 	err = decoder.Decode(&parsedData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, params, parsedData)
 }
 
@@ -710,7 +711,7 @@ func TestEncode(t *testing.T) {
 			assert.Len(t, got, tt.expectedLen)
 			decodedData := make([]byte, base64.StdEncoding.DecodedLen(len(got)))
 			n, err := base64.StdEncoding.Decode(decodedData, []byte(got))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			decodedData = decodedData[0:n]
 			decryptedData := decryptAes128Ecb(decodedData, []byte(clientKey)[:16])
 			assert.Equal(t, tt.data, decryptedData)

--- a/app/payloads/answer_token_test.go
+++ b/app/payloads/answer_token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnswerToken_Bind(t *testing.T) {
@@ -86,10 +87,10 @@ func TestAnswerToken_Bind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.answerToken.Bind()
 			if tt.wantErr == nil {
-				assert.NoError(t, got)
+				require.NoError(t, got)
 				assert.Equal(t, tt.wantConverted, tt.answerToken.Converted)
 			} else {
-				assert.Equal(t, got, tt.wantErr)
+				assert.Equal(t, tt.wantErr, got)
 			}
 		})
 	}

--- a/app/payloads/common.go
+++ b/app/payloads/common.go
@@ -72,15 +72,24 @@ func ConvertIntoMap(source interface{}) map[string]interface{} {
 	return out
 }
 
+const (
+	anythingTypeName = "Anything"
+	anythingPkgPath  = "github.com/France-ioi/AlgoreaBackend/v2/app/formdata"
+)
+
 func shouldConvert(fieldValue reflect.Value) bool {
 	return fieldValue.Kind() == reflect.Struct &&
-		(fieldValue.Type().Name() != "Anything" ||
-			fieldValue.Type().PkgPath() != "github.com/France-ioi/AlgoreaBackend/v2/app/formdata")
+		(fieldValue.Type().Name() != anythingTypeName || fieldValue.Type().PkgPath() != anythingPkgPath)
 }
 
 func resolvePointer(fieldValue reflect.Value) reflect.Value {
 	for fieldValue.IsValid() && fieldValue.Type().Kind() == reflect.Ptr && !fieldValue.IsNil() {
-		fieldValue = fieldValue.Elem()
+		newFieldValue := fieldValue.Elem()
+		if newFieldValue.Kind() == reflect.Struct &&
+			newFieldValue.Type().Name() == anythingTypeName && newFieldValue.Type().PkgPath() == anythingPkgPath {
+			return fieldValue
+		}
+		fieldValue = newFieldValue
 	}
 	return fieldValue
 }

--- a/app/payloads/common_test.go
+++ b/app/payloads/common_test.go
@@ -78,7 +78,7 @@ func TestPayloads_ParseMap(t *testing.T) {
 				Date:      "02-05-2019",
 				UserID:    "556371821693219925",
 				ItemURL:   "http://taskplatform.mblockelet.info/task.html?taskId=212873689338185696",
-				AskedHint: *formdata.AnythingFromString("1"),
+				AskedHint: formdata.AnythingFromString("1"),
 				Converted: HintTokenConverted{
 					UserID: 556371821693219925,
 				},
@@ -89,14 +89,14 @@ func TestPayloads_ParseMap(t *testing.T) {
 			raw: map[string]interface{}{
 				"itemUrl":   "http://taskplatform.mblockelet.info/task.html?taskId=212873689338185696",
 				"idUser":    "556371821693219925",
-				"askedHint": *formdata.AnythingFromString(`{"rotorIndex":0,"cellRank":1}`),
+				"askedHint": formdata.AnythingFromString(`{"rotorIndex":0,"cellRank":1}`),
 				"date":      "02-05-2019",
 			},
 			want: &HintToken{
 				Date:      "02-05-2019",
 				UserID:    "556371821693219925",
 				ItemURL:   "http://taskplatform.mblockelet.info/task.html?taskId=212873689338185696",
-				AskedHint: *formdata.AnythingFromString(`{"rotorIndex":0,"cellRank":1}`),
+				AskedHint: formdata.AnythingFromString(`{"rotorIndex":0,"cellRank":1}`),
 				Converted: HintTokenConverted{
 					UserID: 556371821693219925,
 				},

--- a/app/payloads/hint_token.go
+++ b/app/payloads/hint_token.go
@@ -10,13 +10,13 @@ import (
 
 // HintToken represents data inside a hint token.
 type HintToken struct {
-	Date        string            `json:"date"             validate:"dmy-date"` // dd-mm-yyyy
-	UserID      string            `json:"idUser,omitempty"`
-	ItemID      *string           `json:"idItem,omitempty"`
-	LocalItemID string            `json:"idItemLocal"`
-	ItemURL     string            `json:"itemUrl"`
-	AttemptID   string            `json:"idAttempt"`
-	AskedHint   formdata.Anything `json:"askedHint"`
+	Date        string             `json:"date"             validate:"dmy-date"` // dd-mm-yyyy
+	UserID      string             `json:"idUser,omitempty"`
+	ItemID      *string            `json:"idItem,omitempty"`
+	LocalItemID string             `json:"idItemLocal"`
+	ItemURL     string             `json:"itemUrl"`
+	AttemptID   string             `json:"idAttempt"`
+	AskedHint   *formdata.Anything `json:"askedHint"`
 
 	Converted HintTokenConverted
 }
@@ -28,7 +28,7 @@ type HintTokenConverted struct {
 
 // UnmarshalJSON unmarshals the hint token payload from JSON.
 func (tt *HintToken) UnmarshalJSON(raw []byte) error {
-	preparsedHintToken := map[string]formdata.Anything{}
+	preparsedHintToken := map[string]*formdata.Anything{}
 	if err := json.Unmarshal(raw, &preparsedHintToken); err != nil {
 		return err
 	}

--- a/app/payloads/hint_token_test.go
+++ b/app/payloads/hint_token_test.go
@@ -14,7 +14,7 @@ func TestHintToken_UnmarshalJSON_InvalidJSON(t *testing.T) {
 	tt := &HintToken{}
 	err := tt.UnmarshalJSON([]byte("[]"))
 	require.Error(t, err)
-	assert.Equal(t, "json: cannot unmarshal array into Go value of type map[string]formdata.Anything", err.Error())
+	assert.Equal(t, "json: cannot unmarshal array into Go value of type map[string]*formdata.Anything", err.Error())
 }
 
 func TestHintToken_UnmarshalJSON_WrongUserID(t *testing.T) {
@@ -30,7 +30,7 @@ func TestHintToken_UnmarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &HintToken{
 		UserID:    "10",
-		AskedHint: *formdata.AnythingFromString("false"),
+		AskedHint: formdata.AnythingFromString("false"),
 		Converted: HintTokenConverted{
 			UserID: 10,
 		},
@@ -42,7 +42,7 @@ func TestHintToken_MarshalJSON(t *testing.T) {
 		UserID:      "10",
 		AttemptID:   "100",
 		LocalItemID: "200",
-		AskedHint:   *formdata.AnythingFromString("false"),
+		AskedHint:   formdata.AnythingFromString("false"),
 	}
 	result, err := json.Marshal(ConvertIntoMap(tt))
 	require.NoError(t, err)

--- a/app/payloads/hint_token_test.go
+++ b/app/payloads/hint_token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/formdata"
 )
@@ -12,25 +13,21 @@ import (
 func TestHintToken_UnmarshalJSON_InvalidJSON(t *testing.T) {
 	tt := &HintToken{}
 	err := tt.UnmarshalJSON([]byte("[]"))
-	assert.NotNil(t, err)
-	if err != nil {
-		assert.Equal(t, "json: cannot unmarshal array into Go value of type map[string]formdata.Anything", err.Error())
-	}
+	require.Error(t, err)
+	assert.Equal(t, "json: cannot unmarshal array into Go value of type map[string]formdata.Anything", err.Error())
 }
 
 func TestHintToken_UnmarshalJSON_WrongUserID(t *testing.T) {
 	tt := &HintToken{}
 	err := tt.UnmarshalJSON([]byte(`{"idUser":"abc"}`))
-	assert.NotNil(t, err)
-	if err != nil {
-		assert.Equal(t, "wrong idUser", err.Error())
-	}
+	require.Error(t, err)
+	assert.Equal(t, "wrong idUser", err.Error())
 }
 
 func TestHintToken_UnmarshalJSON(t *testing.T) {
 	tt := &HintToken{}
 	err := tt.UnmarshalJSON([]byte(`{"idUser":"10", "askedHint":   false}`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &HintToken{
 		UserID:    "10",
 		AskedHint: *formdata.AnythingFromString("false"),
@@ -48,6 +45,6 @@ func TestHintToken_MarshalJSON(t *testing.T) {
 		AskedHint:   *formdata.AnythingFromString("false"),
 	}
 	result, err := json.Marshal(ConvertIntoMap(tt))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte(`{"askedHint":false,"date":"","idAttempt":"100","idItemLocal":"200","idUser":"10","itemUrl":""}`), result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"askedHint":false,"date":"","idAttempt":"100","idItemLocal":"200","idUser":"10","itemUrl":""}`, string(result))
 }

--- a/app/payloads/score_token_test.go
+++ b/app/payloads/score_token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScoreToken_Bind(t *testing.T) {
@@ -104,10 +105,10 @@ func TestScoreToken_Bind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.scoreToken.Bind()
 			if tt.wantErr == nil {
-				assert.NoError(t, got)
+				require.NoError(t, got)
 				assert.Equal(t, tt.wantConverted, tt.scoreToken.Converted)
 			} else {
-				assert.Equal(t, got, tt.wantErr)
+				assert.Equal(t, tt.wantErr, got)
 			}
 		})
 	}

--- a/app/payloads/task_token_test.go
+++ b/app/payloads/task_token_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
@@ -48,10 +49,10 @@ func TestTaskToken_Bind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.taskToken.Bind()
 			if tt.wantErr == nil {
-				assert.NoError(t, got)
+				require.NoError(t, got)
 				assert.Equal(t, tt.wantConverted, tt.taskToken.Converted)
 			} else {
-				assert.Equal(t, got, tt.wantErr)
+				assert.Equal(t, tt.wantErr, got)
 			}
 		})
 	}
@@ -64,8 +65,8 @@ func TestTaskToken_MarshalJSON(t *testing.T) {
 		AccessSolutions: golang.Ptr(true),
 	}
 	result, err := json.Marshal(ConvertIntoMap(tt))
-	assert.NoError(t, err)
-	assert.Equal(t, []byte(
+	require.NoError(t, err)
+	assert.JSONEq(t,
 		`{"bAccessSolutions":true,"date":"","idAttempt":"200","idItemLocal":"","idUser":"10","itemUrl":"","platformName":"","randomSeed":""}`,
-	), result)
+		string(result))
 }

--- a/app/rand/rand_test.go
+++ b/app/rand/rand_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestFloat64(t *testing.T) {
 	Seed(1)
-	assert.Equal(t, 0.6046602879796196, Float64())
-	assert.Equal(t, 0.9405090880450124, Float64())
+	assert.InDelta(t, 0.6046602879796196, Float64(), math.SmallestNonzeroFloat64)
+	assert.InDelta(t, 0.9405090880450124, Float64(), math.SmallestNonzeroFloat64)
 	Seed(2)
-	assert.Equal(t, 0.16729663442585624, Float64())
-	assert.Equal(t, 0.2650543054337802, Float64())
+	assert.InDelta(t, 0.16729663442585624, Float64(), math.SmallestNonzeroFloat64)
+	assert.InDelta(t, 0.2650543054337802, Float64(), math.SmallestNonzeroFloat64)
 	Seed(1)
-	assert.Equal(t, 0.6046602879796196, Float64())
+	assert.InDelta(t, 0.6046602879796196, Float64(), math.SmallestNonzeroFloat64)
 }
 
 func TestInt31n(t *testing.T) {

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -13,13 +13,14 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer_Start(t *testing.T) {
 	app, err := New()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv, err := NewServer(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check defaults are applied correctly
 	assert.True(t, strings.HasSuffix(srv.Addr, ":8088"))
@@ -30,11 +31,11 @@ func TestServer_Start(t *testing.T) {
 	defer close(doneChannel)
 
 	err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case err = <-doneChannel:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		assert.Fail(t, "Timeout on waiting for server to stop")
 	}
@@ -42,17 +43,17 @@ func TestServer_Start(t *testing.T) {
 
 func TestServer_Start_HandlesListenerError(t *testing.T) {
 	app, err := New()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	app.Config.Set("server.port", -1)
 	srv, err := NewServer(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	doneChannel := srv.Start()
 	defer close(doneChannel)
 
 	select {
 	case err = <-doneChannel:
-		assert.EqualError(t, err, "server returned an error: listen tcp: address -1: invalid port")
+		require.EqualError(t, err, "server returned an error: listen tcp: address -1: invalid port")
 	case <-time.After(3 * time.Second):
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 		assert.Fail(t, "Timeout on waiting for server to stop")
@@ -61,9 +62,9 @@ func TestServer_Start_HandlesListenerError(t *testing.T) {
 
 func TestServer_Start_HandlesKillingAfterListenerError(t *testing.T) {
 	app, err := New()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv, err := NewServer(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedError := errors.New("some error")
 
@@ -97,7 +98,7 @@ func TestServer_Start_HandlesKillingAfterListenerError(t *testing.T) {
 
 	select {
 	case err = <-doneChannel:
-		assert.EqualError(t, err, "server returned an error: some error")
+		require.EqualError(t, err, "server returned an error: some error")
 	case <-time.After(3 * time.Second):
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 		assert.Fail(t, "Timeout on waiting for server to stop")
@@ -106,9 +107,9 @@ func TestServer_Start_HandlesKillingAfterListenerError(t *testing.T) {
 
 func TestServer_Start_CanBeStoppedByShutdown(t *testing.T) {
 	app, err := New()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv, err := NewServer(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	doneChannel := srv.Start()
 	defer close(doneChannel)
@@ -117,7 +118,7 @@ func TestServer_Start_CanBeStoppedByShutdown(t *testing.T) {
 
 	select {
 	case err := <-doneChannel:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		assert.Fail(t, "Timeout on waiting for server to stop")
 	}
@@ -125,9 +126,9 @@ func TestServer_Start_CanBeStoppedByShutdown(t *testing.T) {
 
 func TestServer_Start_HandlesShutdownError_OnKilling(t *testing.T) {
 	app, err := New()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv, err := NewServer(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedError := errors.New("some error")
 	var patchGuard *monkey.PatchGuard
@@ -146,7 +147,7 @@ func TestServer_Start_HandlesShutdownError_OnKilling(t *testing.T) {
 	defer close(doneChannel)
 
 	err = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	select {
 	case err := <-doneChannel:

--- a/app/service/base_test.go
+++ b/app/service/base_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/auth"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -26,7 +27,7 @@ func TestBase_GetUser(t *testing.T) {
 
 	request, _ := http.NewRequest(http.MethodGet, testServer.URL, http.NoBody)
 	response, err := http.DefaultClient.Do(request)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if err == nil {
 		_ = response.Body.Close()
 	}

--- a/app/service/errors_test.go
+++ b/app/service/errors_test.go
@@ -46,21 +46,21 @@ func responseForHandler(appHandler service.AppHandler) *httptest.ResponseRecorde
 func TestNoErrorWithAPIError(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(&service.APIError{HTTPStatusCode: http.StatusConflict, EmbeddedError: nil})
-	assert.Equal(`{"success":false,"message":"Conflict"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Conflict"}`, recorder.Body.String())
 	assert.Equal(http.StatusConflict, recorder.Code)
 }
 
 func TestInvalidRequest(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrInvalidRequest(errors.New("sample invalid req")))
-	assert.Equal(`{"success":false,"message":"Bad Request","error_text":"Sample invalid req"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Bad Request","error_text":"Sample invalid req"}`, recorder.Body.String())
 	assert.Equal(http.StatusBadRequest, recorder.Code)
 }
 
 func TestUnprocessableEntityRequest(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrUnprocessableEntity(errors.New(someErrorMessage)))
-	assert.Equal(`{"success":false,"message":"Unprocessable Entity","error_text":"Some error"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Unprocessable Entity","error_text":"Some error"}`, recorder.Body.String())
 	assert.Equal(http.StatusUnprocessableEntity, recorder.Code)
 }
 
@@ -90,35 +90,35 @@ func TestInvalidRequest_WithFormErrors(t *testing.T) {
 func TestForbidden(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrForbidden(errors.New("sample forbidden resp")))
-	assert.Equal(`{"success":false,"message":"Forbidden","error_text":"Sample forbidden resp"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Forbidden","error_text":"Sample forbidden resp"}`, recorder.Body.String())
 	assert.Equal(http.StatusForbidden, recorder.Code)
 }
 
 func TestUnexpected(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrUnexpected(errors.New("unexp err")))
-	assert.Equal(`{"success":false,"message":"Internal Server Error","error_text":"Unexp err"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Internal Server Error","error_text":"Unexp err"}`, recorder.Body.String())
 	assert.Equal(http.StatusInternalServerError, recorder.Code)
 }
 
 func TestNotFound(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrNotFound(errors.New(someErrorMessage)))
-	assert.Equal(`{"success":false,"message":"Not Found","error_text":"Some error"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Not Found","error_text":"Some error"}`, recorder.Body.String())
 	assert.Equal(http.StatusNotFound, recorder.Code)
 }
 
 func TestRequestTimeout(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrRequestTimeout())
-	assert.Equal(`{"success":false,"message":"Request Timeout"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Request Timeout"}`, recorder.Body.String())
 	assert.Equal(http.StatusRequestTimeout, recorder.Code)
 }
 
 func TestConflict(t *testing.T) {
 	assert := assertlib.New(t)
 	recorder := responseForError(service.ErrConflict(errors.New("conflict error")))
-	assert.Equal(`{"success":false,"message":"Conflict","error_text":"Conflict error"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Conflict","error_text":"Conflict error"}`, recorder.Body.String())
 	assert.Equal(http.StatusConflict, recorder.Code)
 }
 
@@ -131,7 +131,7 @@ func TestRendersErrUnexpectedOnPanicWithError(t *testing.T) {
 	defer restoreFunc()
 
 	recorder := responseForHTTPHandler(handler)
-	assert.Equal(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`+"\n",
+	assert.JSONEq(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`,
 		recorder.Body.String())
 	assert.Equal(http.StatusInternalServerError, recorder.Code)
 	assert.Contains(hook.GetAllLogs(), "unexpected error: some error")
@@ -146,7 +146,7 @@ func TestRendersRecoveredAPIErrorOnPanicWithAPIError(t *testing.T) {
 	defer restoreFunc()
 
 	recorder := responseForHTTPHandler(handler)
-	assert.Equal(`{"success":false,"message":"Forbidden","error_text":"Insufficient access rights"}`+"\n",
+	assert.JSONEq(`{"success":false,"message":"Forbidden","error_text":"Insufficient access rights"}`,
 		recorder.Body.String())
 	assert.Equal(http.StatusForbidden, recorder.Code)
 	assert.NotContains(strings.ToLower(hook.GetAllLogs()), "error")
@@ -162,7 +162,7 @@ func TestRendersErrUnexpectedOnPanicWithSomeValue(t *testing.T) {
 	defer restoreFunc()
 
 	recorder := responseForHTTPHandler(handler)
-	assert.Equal(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`+"\n",
+	assert.JSONEq(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`,
 		recorder.Body.String())
 	assert.Equal(http.StatusInternalServerError, recorder.Code)
 	assert.Contains(hook.GetAllLogs(), "unexpected error: some error")
@@ -177,7 +177,7 @@ func TestRendersErrRequestTimeoutOnPanicContextDeadlineExceeded(t *testing.T) {
 	defer restoreFunc()
 
 	recorder := responseForHTTPHandler(handler)
-	assert.Equal(`{"success":false,"message":"Request Timeout"}`+"\n", recorder.Body.String())
+	assert.JSONEq(`{"success":false,"message":"Request Timeout"}`, recorder.Body.String())
 	assert.Equal(http.StatusRequestTimeout, recorder.Code)
 }
 
@@ -191,7 +191,7 @@ func TestRendersErrUnexpectedOnReturningNonAPIError(t *testing.T) {
 	defer restoreFunc()
 
 	recorder := responseForHTTPHandler(handler)
-	assert.Equal(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`+"\n",
+	assert.JSONEq(`{"success":false,"message":"Internal Server Error","error_text":"Unknown error"}`,
 		recorder.Body.String())
 	assert.Equal(http.StatusInternalServerError, recorder.Code)
 	assert.Contains(hook.GetAllLogs(), "unexpected error: some error")

--- a/app/service/handler.go
+++ b/app/service/handler.go
@@ -30,12 +30,12 @@ func (fn AppHandler) ServeHTTP(responseWriter http.ResponseWriter, httpRequest *
 				if errors.Is(err, context.DeadlineExceeded) {
 					apiErr = ErrRequestTimeout()
 				} else {
-					apiErr = ErrUnexpected(fmt.Errorf("unknown error"))
+					apiErr = ErrUnexpected(errors.New("unknown error"))
 					shouldLogError = true
 					errorToLog = err.Error()
 				}
 			default:
-				apiErr = ErrUnexpected(fmt.Errorf("unknown error"))
+				apiErr = ErrUnexpected(errors.New("unknown error"))
 				errorToLog = fmt.Sprintf("%+v", err)
 				shouldLogError = true
 			}
@@ -50,7 +50,7 @@ func (fn AppHandler) ServeHTTP(responseWriter http.ResponseWriter, httpRequest *
 	err := fn(responseWriter, httpRequest)
 	if err != nil {
 		if !errors.As(err, &apiErr) {
-			apiErr = ErrUnexpected(fmt.Errorf("unknown error"))
+			apiErr = ErrUnexpected(errors.New("unknown error"))
 			shouldLogError = true
 			errorToLog = err.Error()
 		}

--- a/app/service/not_found_test.go
+++ b/app/service/not_found_test.go
@@ -5,16 +5,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNotFound(t *testing.T) {
-	assert := assertlib.New(t)
 	req, _ := http.NewRequest(http.MethodGet, "/dummy", http.NoBody)
 	recorder := httptest.NewRecorder()
 
 	NotFound(recorder, req)
 
-	assert.Equal(`{"success":false,"message":"Not Found"}`+"\n", recorder.Body.String())
-	assert.Equal(http.StatusNotFound, recorder.Code)
+	assert.JSONEq(t, `{"success":false,"message":"Not Found"}`, recorder.Body.String())
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }

--- a/app/service/parameters_test.go
+++ b/app/service/parameters_test.go
@@ -14,6 +14,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveURLQueryGetInt64SliceField(t *testing.T) {
@@ -78,9 +79,9 @@ func TestResolveURLQueryGetInt64SliceField(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetInt64SliceField(req, "ids")
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedList, list)
 		})
@@ -271,9 +272,9 @@ func TestResolveURLQueryGetStringField(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringField(req, "name")
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedValue, list)
 		})
@@ -324,9 +325,9 @@ func TestResolveURLQueryGetBoolField(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetBoolField(req, "flag")
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedValue, list)
 		})
@@ -397,9 +398,9 @@ func TestResolveURLQueryGetBoolFieldWithDefault(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetBoolFieldWithDefault(req, "flag", testCase.defaultValue)
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedValue, list)
 		})
@@ -442,9 +443,9 @@ func TestResolveURLQueryGetTimeField(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			dateTime, err := ResolveURLQueryGetTimeField(req, "time")
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.True(t, testCase.expectedValue.Equal(dateTime))
 		})
@@ -501,9 +502,9 @@ func TestResolveURLQueryGetStringSliceField(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringSliceField(req, "values")
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, testCase.expectedList, list)
 		})
@@ -579,9 +580,9 @@ func TestResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(t *testi
 			list, err := ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(req, "fruits",
 				map[string]bool{"apple": true, "orange": true, "pear": true})
 			if testCase.expectedErrMsg != "" {
-				assert.EqualError(t, err, testCase.expectedErrMsg)
+				require.EqualError(t, err, testCase.expectedErrMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			sort.Strings(list)
 			sort.Strings(testCase.expectedList)

--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
@@ -29,7 +30,7 @@ func TestGetParticipantIDFromRequest(t *testing.T) {
 	`)
 	defer func() { _ = db.Close() }()
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
+	require.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
 		return trStore.GroupGroups().CreateNewAncestors()
 	}))
 

--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -3,7 +3,7 @@
 package service_test
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -43,17 +43,17 @@ func TestGetParticipantIDFromRequest(t *testing.T) {
 		{
 			name:          "no team",
 			query:         "as_team_id=404",
-			expectedError: service.ErrForbidden(fmt.Errorf("can't use given as_team_id as a user's team")),
+			expectedError: service.ErrForbidden(errors.New("can't use given as_team_id as a user's team")),
 		},
 		{
 			name:          "as_team_id is not a team",
 			query:         "param&as_team_id=1",
-			expectedError: service.ErrForbidden(fmt.Errorf("can't use given as_team_id as a user's team")),
+			expectedError: service.ErrForbidden(errors.New("can't use given as_team_id as a user's team")),
 		},
 		{
 			name:          "the current user is not a member of as_team_id",
 			query:         "as_team_id=2",
-			expectedError: service.ErrForbidden(fmt.Errorf("can't use given as_team_id as a user's team")),
+			expectedError: service.ErrForbidden(errors.New("can't use given as_team_id as a user's team")),
 		},
 		{
 			name:           "okay",

--- a/app/service/participant_test.go
+++ b/app/service/participant_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +37,7 @@ func TestGetParticipantIDFromRequest_InvalidAsTeamID(t *testing.T) {
 	participantID, err := GetParticipantIDFromRequest(
 		&http.Request{URL: &url.URL{RawQuery: "as_team_id=abc"}}, &database.User{GroupID: 123}, database.NewDataStore(db))
 	assert.Equal(t, int64(0), participantID)
-	assert.Equal(t, ErrInvalidRequest(fmt.Errorf("wrong value for as_team_id (should be int64)")), err)
+	assert.Equal(t, ErrInvalidRequest(errors.New("wrong value for as_team_id (should be int64)")), err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/app/service/participant_test.go
+++ b/app/service/participant_test.go
@@ -14,6 +14,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/auth"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -27,7 +28,7 @@ func TestGetParticipantIDFromRequest_NoAsTeamID(t *testing.T) {
 	participantID, err := GetParticipantIDFromRequest(
 		&http.Request{URL: &url.URL{}}, &database.User{GroupID: 123}, database.NewDataStore(db))
 	assert.Equal(t, int64(123), participantID)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -103,7 +104,7 @@ func TestParticipantMiddleware(t *testing.T) {
 			assert.Equal(t, tt.expectedServiceWasCalled, result.serviceWasCalled)
 			assert.Equal(t, result.actualUserID, tt.userID)
 			assert.Contains(t, string(bodyBytes), tt.expectedBody)
-			assert.NoError(t, result.mock.ExpectationsWereMet())
+			require.NoError(t, result.mock.ExpectationsWereMet())
 			assert.Contains(t, result.logsHook.GetAllLogs(), tt.logContains)
 		})
 	}

--- a/app/service/propagation_integration_test.go
+++ b/app/service/propagation_integration_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -51,7 +52,7 @@ func TestSchedulePropagation(t *testing.T) {
 				endpoint: "https://example.com",
 			},
 			loggedError:     "Propagation endpoint error: Get \"https://example.com?types=permissions\": error",
-			endpointCallErr: fmt.Errorf("error"),
+			endpointCallErr: errors.New("error"),
 			propagated:      false,
 		},
 		{

--- a/app/service/propagation_integration_test.go
+++ b/app/service/propagation_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thingful/httpmock"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
@@ -110,7 +111,7 @@ func TestSchedulePropagation(t *testing.T) {
 			service.SchedulePropagation(store, tt.args.endpoint, []string{"permissions"})
 
 			exists, err := store.Permissions().Where("item_id = 1").HasRows()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.propagated, exists)
 
 			// Verify that all stubs were called.

--- a/app/service/responses_test.go
+++ b/app/service/responses_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/render"
-	assertlib "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func httpResponseForResponse(renderer render.Renderer) *httptest.ResponseRecorder {
@@ -24,54 +24,46 @@ func httpResponseForResponse(renderer render.Renderer) *httptest.ResponseRecorde
 }
 
 func TestCreationSuccess(t *testing.T) {
-	assert := assertlib.New(t)
-
 	data := struct {
 		ItemID int64 `json:"id"`
 	}{42}
 
 	recorder := httpResponseForResponse(CreationSuccess(data))
-	assert.Equal(`{"success":true,"message":"created","data":{"id":42}}`+"\n", recorder.Body.String())
-	assert.Equal(http.StatusCreated, recorder.Code)
+	assert.JSONEq(t, `{"success":true,"message":"created","data":{"id":42}}`, recorder.Body.String())
+	assert.Equal(t, http.StatusCreated, recorder.Code)
 }
 
 func TestUpdateSuccess(t *testing.T) {
-	assert := assertlib.New(t)
-
 	data := struct {
 		Info string `json:"info"`
 	}{"some info"}
 
 	recorder := httpResponseForResponse(UpdateSuccess(data))
-	assert.Equal(`{"success":true,"message":"updated","data":{"info":"some info"}}`+"\n", recorder.Body.String())
-	assert.Equal(http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"success":true,"message":"updated","data":{"info":"some info"}}`, recorder.Body.String())
+	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
 func TestDeletionSuccess(t *testing.T) {
-	assert := assertlib.New(t)
-
 	data := struct {
 		Info string `json:"info"`
 	}{"some info"}
 
 	recorder := httpResponseForResponse(DeletionSuccess(data))
-	assert.Equal(`{"success":true,"message":"deleted","data":{"info":"some info"}}`+"\n", recorder.Body.String())
-	assert.Equal(http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"success":true,"message":"deleted","data":{"info":"some info"}}`, recorder.Body.String())
+	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
 func TestUnchangedSuccess(t *testing.T) {
-	assert := assertlib.New(t)
-
 	recorder := httpResponseForResponse(UnchangedSuccess(http.StatusResetContent))
-	assert.Equal(`{"success":true,"message":"unchanged","data":{"changed":false}}`+"\n", recorder.Body.String())
-	assert.Equal(http.StatusResetContent, recorder.Code)
+	assert.JSONEq(t, `{"success":true,"message":"unchanged","data":{"changed":false}}`, recorder.Body.String())
+	assert.Equal(t, http.StatusResetContent, recorder.Code)
 }
 
 func TestResponse_Render(t *testing.T) {
 	response := &Response[*struct{}]{HTTPStatusCode: http.StatusOK, Message: "", Success: true}
 	recorder := httpResponseForResponse(response)
-	assertlib.Equal(t, `{"success":true,"message":"success"}`+"\n", recorder.Body.String())
-	assertlib.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"success":true,"message":"success"}`, recorder.Body.String())
+	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
 func TestCheckInt64JsonHasStringTag(t *testing.T) {
@@ -289,9 +281,9 @@ func TestCheckInt64JsonHasStringTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				assertlib.Panics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
+				assert.Panics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
 			} else {
-				assertlib.NotPanics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
+				assert.NotPanics(t, func() { CheckInt64JsonHasStringTag(tt.definitionStructure) })
 			}
 		})
 	}

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -399,7 +399,7 @@ func joinSubQueryForPaging(query *database.DB, usedFields []string, configuredFi
 		}
 		for fieldName := range fromValues {
 			startFromRowQuery = startFromRowQuery.
-				Where(fmt.Sprintf("%s <=> ?", configuredFields[fieldName].ColumnName), fromValues[fieldName])
+				Where(configuredFields[fieldName].ColumnName+" <=> ?", fromValues[fieldName])
 		}
 		startFromRowQuery = startFromRowQuery.Select(strings.Join(fieldsToSelect, ", "))
 		startFromRowSubQuery = startFromRowQuery.Limit(1).SubQuery()

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
@@ -32,7 +33,7 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	`)
 	defer func() { _ = db.Close() }()
 	store := database.NewDataStore(db)
-	assert.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
+	require.NoError(t, store.InTransaction(func(trStore *database.DataStore) error {
 		return trStore.GroupGroups().CreateNewAncestors()
 	}))
 

--- a/app/token/config_test.go
+++ b/app/token/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/tokentest"
 )
@@ -18,25 +19,25 @@ func TestBuildConfig_LoadsKeysFromFile(t *testing.T) {
 	if tmpFilePublic != nil {
 		defer func() { _ = os.Remove(tmpFilePublic.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilePrivate, err := createTmpPrivateKeyFile(tokentest.AlgoreaPlatformPrivateKey)
 	if tmpFilePrivate != nil {
 		defer func() { _ = os.Remove(tmpFilePrivate.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedPrivateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedPublicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
 	config.Set("PublicKeyFile", tmpFilePublic.Name())
 	config.Set("PlatformName", "my platform")
 	tokenConfig, err := BuildConfig(config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &Config{
 		PrivateKey:   expectedPrivateKey,
 		PublicKey:    expectedPublicKey,
@@ -46,16 +47,16 @@ func TestBuildConfig_LoadsKeysFromFile(t *testing.T) {
 
 func TestBuildConfig_LoadsKeysFromString(t *testing.T) {
 	expectedPrivateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedPublicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKey", tokentest.AlgoreaPlatformPrivateKey)
 	config.Set("PublicKey", tokentest.AlgoreaPlatformPublicKey)
 	config.Set("PlatformName", "my platform")
 	tokenConfig, err := BuildConfig(config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, &Config{
 		PrivateKey:   expectedPrivateKey,
 		PublicKey:    expectedPublicKey,
@@ -68,7 +69,7 @@ func TestBuildConfig_CannotLoadPublicKey(t *testing.T) {
 	if tmpFilePrivate != nil {
 		defer func() { _ = os.Remove(tmpFilePrivate.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
@@ -83,7 +84,7 @@ func TestBuildConfig_CannotLoadPrivateKey(t *testing.T) {
 	if tmpFilePublic != nil {
 		defer func() { _ = os.Remove(tmpFilePublic.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKeyFile", "nosuchfile.pem")
@@ -99,13 +100,13 @@ func TestBuildConfig_CannotParsePublicKey(t *testing.T) {
 	if tmpFilePrivate != nil {
 		defer func() { _ = os.Remove(tmpFilePrivate.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilePublic, err := createTmpPublicKeyFile([]byte{})
 	if tmpFilePublic != nil {
 		defer func() { _ = os.Remove(tmpFilePublic.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())
@@ -121,13 +122,13 @@ func TestBuildConfig_CannotParsePrivateKey(t *testing.T) {
 	if tmpFilePrivate != nil {
 		defer func() { _ = os.Remove(tmpFilePrivate.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilePublic, err := createTmpPublicKeyFile(tokentest.AlgoreaPlatformPublicKey)
 	if tmpFilePublic != nil {
 		defer func() { _ = os.Remove(tmpFilePublic.Name()) }()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	config := viper.New()
 	config.Set("PrivateKeyFile", tmpFilePrivate.Name())

--- a/app/token/encoding_test.go
+++ b/app/token/encoding_test.go
@@ -10,6 +10,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloadstest"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/tokentest"
@@ -121,12 +122,12 @@ func TestParseAndValidate(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return tt.currentTime })
 			defer monkey.UnpatchAll()
 			publicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			payload, err := ParseAndValidate(tt.token, publicKey)
 			if tt.wantError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, tt.wantError.Error())
+				require.EqualError(t, err, tt.wantError.Error())
 			}
 			assert.Equal(t, tt.wantPayload, payload)
 		})
@@ -167,12 +168,12 @@ func TestGenerate(t *testing.T) {
 
 			var err error
 			privateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			publicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			token := Generate(patchedPayload, privateKey)
 			payload, err := ParseAndValidate(token, publicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.payload, payload)
 		})
 	}

--- a/app/token/hint_test.go
+++ b/app/token/hint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloadstest"
@@ -16,23 +17,23 @@ import (
 func TestToken_HintToken_UnmarshalString(t *testing.T) {
 	hint := Token[payloads.HintToken]{}
 	err := payloads.ParseMap(payloadstest.HintPayloadFromTaskPlatform, &hint.Payload)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	hint.PrivateKey, err = crypto.ParseRSAPrivateKeyFromPEM(tokentest.TaskPlatformPrivateKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	hint.PublicKey, err = crypto.ParseRSAPublicKeyFromPEM(tokentest.TaskPlatformPublicKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	marshaled, err := hint.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var marshaledString string
-	assert.NoError(t, json.Unmarshal(marshaled, &marshaledString))
+	require.NoError(t, json.Unmarshal(marshaled, &marshaledString))
 
 	result := Token[payloads.HintToken]{PublicKey: hint.PublicKey, PrivateKey: hint.PrivateKey}
 	err = result.UnmarshalString(marshaledString)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	hint.Payload.Date = result.Payload.Date
 	hint.Payload.Converted.UserID, _ = strconv.ParseInt(hint.Payload.UserID, 10, 64)

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -11,6 +11,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloads"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/payloadstest"
@@ -68,26 +69,26 @@ func TestToken_MarshalJSON(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()
 			privateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			publicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			payloadRefl := reflect.New(test.payloadType)
 			payload := payloadRefl.Interface()
-			assert.NoError(t, payloads.ParseMap(test.payloadMap, payload))
+			require.NoError(t, payloads.ParseMap(test.payloadMap, payload))
 			tokenStructRefl := reflect.New(test.structType)
 			tokenStructRefl.Elem().FieldByName("Payload").Set(payloadRefl.Elem())
 			tokenStructRefl.Elem().FieldByName("PublicKey").Set(reflect.ValueOf(publicKey))
 			tokenStructRefl.Elem().FieldByName("PrivateKey").Set(reflect.ValueOf(privateKey))
 			tokenStruct := tokenStructRefl.Interface()
 			token, err := tokenStruct.(json.Marshaler).MarshalJSON()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			resultRefl := reflect.New(test.structType)
 			resultRefl.Elem().FieldByName("PublicKey").Set(reflect.ValueOf(publicKey))
 			resultRefl.Elem().FieldByName("PrivateKey").Set(reflect.ValueOf(privateKey))
 			result := resultRefl.Interface().(json.Unmarshaler)
-			assert.NoError(t, result.UnmarshalJSON(token))
+			require.NoError(t, result.UnmarshalJSON(token))
 			assert.Equal(t, tokenStruct, result)
 		})
 	}
@@ -100,25 +101,25 @@ func TestToken_Sign(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()
 			privateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			publicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			tokenStructRefl := reflect.New(test.structType)
 			payloadRefl := reflect.New(test.payloadType)
 			payload := payloadRefl.Interface()
-			assert.NoError(t, payloads.ParseMap(test.payloadMap, payload))
+			require.NoError(t, payloads.ParseMap(test.payloadMap, payload))
 			tokenStructRefl.Elem().FieldByName("Payload").Set(payloadRefl.Elem())
 			tokenStructRefl.Elem().FieldByName("PublicKey").Set(reflect.ValueOf(publicKey))
 			tokenStruct := tokenStructRefl.Interface()
 			token, err := tokenStruct.(Signer).Sign(privateKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			resultRefl := reflect.New(test.structType)
 			resultRefl.Elem().FieldByName("PublicKey").Set(reflect.ValueOf(publicKey))
 			resultRefl.Elem().FieldByName("PrivateKey").Set(reflect.ValueOf(privateKey))
 			result := resultRefl.Interface().(UnmarshalStringer)
-			assert.NoError(t, result.UnmarshalString(token))
+			require.NoError(t, result.UnmarshalString(token))
 			assert.Equal(t, tokenStruct, result)
 		})
 	}
@@ -131,9 +132,9 @@ func TestToken_MarshalString(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()
 			privateKey, err := crypto.ParseRSAPrivateKeyFromPEM(tokentest.AlgoreaPlatformPrivateKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			publicKey, err := crypto.ParseRSAPublicKeyFromPEM(tokentest.AlgoreaPlatformPublicKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			payloadRefl := reflect.New(test.payloadType)
 			tokenStructRefl := reflect.New(test.structType)
@@ -141,20 +142,20 @@ func TestToken_MarshalString(t *testing.T) {
 			tokenStructRefl.Elem().FieldByName("PrivateKey").Set(reflect.ValueOf(privateKey))
 			tokenStruct := tokenStructRefl.Interface()
 			payload := payloadRefl.Interface()
-			assert.NoError(t, payloads.ParseMap(test.payloadMap, payload))
+			require.NoError(t, payloads.ParseMap(test.payloadMap, payload))
 			tokenStructRefl.Elem().FieldByName("Payload").Set(payloadRefl.Elem())
 			token, err := tokenStruct.(MarshalStringer).MarshalString()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			tokenJSON, err := tokenStruct.(json.Marshaler).MarshalJSON()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			assert.Equal(t, string(tokenJSON), fmt.Sprintf("%q", token))
+			assert.JSONEq(t, string(tokenJSON), fmt.Sprintf("%q", token))
 
 			resultRefl := reflect.New(test.structType)
 			resultRefl.Elem().FieldByName("PublicKey").Set(reflect.ValueOf(publicKey))
 			resultRefl.Elem().FieldByName("PrivateKey").Set(reflect.ValueOf(privateKey))
 			result := resultRefl.Interface().(UnmarshalStringer)
-			assert.NoError(t, result.UnmarshalString(token))
+			require.NoError(t, result.UnmarshalString(token))
 			assert.Equal(t, tokenStruct, result)
 		})
 	}

--- a/golang/if_test.go
+++ b/golang/if_test.go
@@ -11,7 +11,7 @@ func TestIfElse(t *testing.T) {
 	assert.Equal(t, 2, IfElse(false, 1, 2))
 	assert.Equal(t, "a", IfElse(true, "a", "b"))
 	assert.Equal(t, "b", IfElse(false, "a", "b"))
-	assert.Equal(t, true, IfElse(true, true, false))
+	assert.True(t, IfElse(true, true, false))
 }
 
 func TestIf(t *testing.T) {
@@ -22,8 +22,8 @@ func TestIf(t *testing.T) {
 	assert.Equal(t, 0, If(false, 1))
 	assert.Equal(t, "a", If(true, "a"))
 	assert.Equal(t, "", If(false, "a"))
-	assert.Equal(t, true, If(true, true))
-	assert.Equal(t, false, If(false, true))
+	assert.True(t, If(true, true))
+	assert.False(t, If(false, true))
 	assert.Equal(t, (*string)(nil), If(false, strPtr))
 }
 

--- a/golang/zero_test.go
+++ b/golang/zero_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestZero(t *testing.T) {
-	assert.Equal(t, false, Zero[bool]())
+	assert.False(t, Zero[bool]())
 	assert.Equal(t, 0, Zero[int]())
 	assert.Equal(t, int64(0), Zero[int64]())
 	assert.Equal(t, "", Zero[string]())

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -4,6 +4,7 @@ package testhelpers
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -638,7 +639,7 @@ func (ctx *TestContext) dataTableShouldMatchDBResult(data *godog.Table, dbResult
 
 	// check that there are no rows in the test data table left for checking (this means there are fewer rows in the SQL result)
 	if iDataRow < len(data.Rows) {
-		return fmt.Errorf("there are fewer rows in the SQL result than expected")
+		return errors.New("there are fewer rows in the SQL result than expected")
 	}
 
 	return nil


### PR DESCRIPTION
1. Enable the testifylint linter (checks usage of github.com/stretchr/testify), fix found issues.
2. Enable the perfsprint linter (checks if fmt.Sprintf can be replaced with a faster alternative), fix found issues.
3. 
 * Rework formdata.Anything:
   1) all its methods should have pointer receivers;
   2) Bytes() and MarshalJSON() should allow nil receivers (as unmarshalling to *Anything can result in a nil pointer),
   3) make it thread-safe (use atomic pointer loading and storing, make it store a pointer to a slice instead of a slice for the reason);
  * Replace formdata.Anything with *formdata.Anything everywhere, add support for this in payloads.ConvertIntoMap() (it should not resolve pointers to formdata.Anything anymore).
4. Enable the recvcheck linter (checks for receiver type consistency).
   
