### PR TITLE
Partially synchronous propagation in itemCreate

### DIFF
--- a/app/api/currentuser/get_group_invitations.feature
+++ b/app/api/currentuser/get_group_invitations.feature
@@ -19,9 +19,9 @@ Feature: Get group invitations for the current user
       | 36 | Class   | Group without inviting user   | Group without inviting user   | edit                                  | null                                   | false                  |
     And the database has the following users:
       | group_id | login       | first_name  | last_name | grade |
-      | 21       | owner       | Jean-Michel | Blanquer  | 3     |
       | 12       | user        | John        | Doe       | 1     |
       | 13       | anotheruser | Another     | User      | 1     |
+      | 21       | owner       | Jean-Michel | Blanquer  | 3     |
     And the database has the following table "groups_groups":
       | parent_group_id | child_group_id |
       | 5               | 21             |
@@ -31,33 +31,33 @@ Feature: Get group invitations for the current user
     And the time now is "2020-01-01T01:00:00.001Z"
     And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                            | initiator_id |
+      | 1        | 12        | invitation_created    | {{relativeTimeDBMs("-170h")}} | 12           |
       | 1        | 21        | invitation_created    | {{relativeTimeDBMs("-169h")}} | 12           |
       | 2        | 21        | invitation_refused    | {{relativeTimeDBMs("-168h")}} | 21           |
       | 3        | 21        | join_request_created  | {{relativeTimeDBMs("-167h")}} | 21           |
-      | 33       | 21        | invitation_created    | {{relativeTimeDBMs("-167h")}} | 13           |
       | 4        | 21        | join_request_refused  | {{relativeTimeDBMs("-166h")}} | 12           |
-      | 34       | 21        | invitation_created    | {{relativeTimeDBMs("-190h")}} | 13           |
-      | 34       | 21        | invitation_refused    | {{relativeTimeDBMs("-180h")}} | 21           |
-      | 34       | 21        | invitation_created    | {{relativeTimeDBMs("-166h")}} | 12           |
-      | 35       | 21        | invitation_accepted   | {{relativeTimeDBMs("-186h")}} | 12           |
-      | 36       | 21        | invitation_created    | {{relativeTimeDBMs("-200h")}} | null         |
       | 5        | 21        | invitation_accepted   | {{relativeTimeDBMs("-165h")}} | 12           |
       | 6        | 21        | join_request_accepted | {{relativeTimeDBMs("-164h")}} | 12           |
       | 7        | 21        | removed               | {{relativeTimeDBMs("-163h")}} | 21           |
       | 8        | 21        | left                  | {{relativeTimeDBMs("-162h")}} | 21           |
       | 9        | 21        | added_directly        | {{relativeTimeDBMs("-161h")}} | 12           |
-      | 1        | 12        | invitation_created    | {{relativeTimeDBMs("-170h")}} | 12           |
       | 10       | 21        | joined_by_code        | {{relativeTimeDBMs("-180h")}} | null         |
       | 11       | 21        | joined_by_badge       | {{relativeTimeDBMs("-190h")}} | null         |
+      | 34       | 21        | invitation_created    | {{relativeTimeDBMs("-190h")}} | 13           |
+      | 33       | 21        | invitation_created    | {{relativeTimeDBMs("-167h")}} | 13           |
+      | 34       | 21        | invitation_created    | {{relativeTimeDBMs("-166h")}} | 12           |
+      | 34       | 21        | invitation_refused    | {{relativeTimeDBMs("-180h")}} | 21           |
+      | 35       | 21        | invitation_accepted   | {{relativeTimeDBMs("-186h")}} | 12           |
+      | 36       | 21        | invitation_created    | {{relativeTimeDBMs("-200h")}} | null         |
     And the database has the following table "group_pending_requests":
       | group_id | member_id | type         | at                            |
+      | 1        | 12        | invitation   | {{currentTimeDBMs()}}         |
       | 1        | 21        | invitation   | {{currentTimeDBMs()}}         |
+      | 3        | 21        | join_request | {{currentTimeDBMs()}}         |
       | 33       | 21        | invitation   | {{currentTimeDBMs()}}         |
       | 34       | 21        | invitation   | {{currentTimeDBMs()}}         |
       | 35       | 21        | invitation   | {{relativeTimeDBMs("-200h")}} |
       | 36       | 21        | invitation   | {{currentTimeDBMs()}}         |
-      | 3        | 21        | join_request | {{currentTimeDBMs()}}         |
-      | 1        | 12        | invitation   | {{currentTimeDBMs()}}         |
 
   Scenario: Show all invitations
     Given I am the user with id "21"
@@ -83,7 +83,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[15][at]"))}}"
       },
       {
         "group_id": "33",
@@ -121,7 +121,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": "{{timeDBToRFC3339(db("groups[1][require_lock_membership_approval_until]"))}}",
           "require_watch_approval": true
         },
-        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[1][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[2][at]"))}}"
       },
       {
         "group_id": "35",
@@ -135,7 +135,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC3339(db("group_pending_requests[4][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_pending_requests[6][at]"))}}"
       },
       {
         "group_id": "36",
@@ -149,7 +149,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[10][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[18][at]"))}}"
       }
     ]
     """
@@ -178,7 +178,7 @@ Feature: Get group invitations for the current user
           "require_lock_membership_approval_until": null,
           "require_watch_approval": false
         },
-        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[8][at]"))}}"
+        "at": "{{timeDBMsToRFC3339(db("group_membership_changes[15][at]"))}}"
       }
     ]
     """

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -55,23 +55,23 @@ Feature: Get requests for group_id
       | 15       | 22        | join_request | 2017-05-27 06:38:38         | true                        |
     And the database has the following table "group_membership_changes":
       | group_id | member_id | action                | at                          | initiator_id |
-      | 13       | 21        | invitation_created    | {{relativeTimeDB("-170h")}} | 11           |
       | 13       | 11        | invitation_refused    | {{relativeTimeDB("-169h")}} | null         |
+      | 13       | 21        | invitation_created    | {{relativeTimeDB("-170h")}} | 11           |
+      | 13       | 22        | join_request_refused  | {{relativeTimeDB("-167h")}} | 11           |
       | 13       | 31        | join_request_created  | {{relativeTimeDB("-168h")}} | 21           |
       | 13       | 41        | invitation_created    | {{relativeTimeDB("-166h")}} | 21           |
-      | 13       | 22        | join_request_refused  | {{relativeTimeDB("-167h")}} | 11           |
       | 13       | 51        | invitation_created    | {{relativeTimeDB("-164h")}} | 41           |
-      | 14       | 11        | invitation_created    | 2017-05-28 06:38:38         | 11           |
-      | 14       | 31        | invitation_refused    | 2017-05-26 06:38:38         | 31           |
-      | 14       | 21        | join_request_created  | 2017-05-27 06:38:38         | 21           |
-      | 14       | 22        | join_request_refused  | 2017-05-24 06:38:38         | 11           |
-      | 13       | 121       | invitation_accepted   | 2017-05-29 06:38:38         | 11           |
       | 13       | 111       | join_request_accepted | 2017-05-23 06:38:38         | 31           |
+      | 13       | 121       | invitation_accepted   | 2017-05-29 06:38:38         | 11           |
       | 13       | 131       | removed               | 2017-05-22 06:38:38         | 21           |
       | 13       | 122       | left                  | 2017-05-21 06:38:38         | 11           |
       | 13       | 123       | added_directly        | 2017-05-20 06:38:38         | 11           |
       | 13       | 124       | joined_by_code        | 2017-05-19 06:38:38         | 11           |
       | 13       | 125       | joined_by_badge       | 2017-05-19 06:38:38         | 11           |
+      | 14       | 11        | invitation_created    | 2017-05-28 06:38:38         | 11           |
+      | 14       | 21        | join_request_created  | 2017-05-27 06:38:38         | 21           |
+      | 14       | 22        | join_request_refused  | 2017-05-24 06:38:38         | 11           |
+      | 14       | 31        | invitation_refused    | 2017-05-26 06:38:38         | 31           |
 
   Scenario: User is a manager of the group (default sort)
     Given I am the user with id "21"
@@ -91,35 +91,35 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -136,14 +136,14 @@ Feature: Get requests for group_id
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
@@ -157,21 +157,21 @@ Feature: Get requests for group_id
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       }
     ]
@@ -188,7 +188,7 @@ Feature: Get requests for group_id
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "join_request_created"
       },
       {
@@ -202,28 +202,28 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -264,28 +264,28 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_created"
       }
     ]
@@ -293,7 +293,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by joining user's login, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=joining_user.login&from.member_id=31&from.at={{from_at}}"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -310,28 +310,28 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "21",
         "inviting_user": {"first_name": "John", "group_id": "11", "last_name": "Doe", "login": "user"},
         "joining_user": {"first_name": "Jean-Michel", "grade": 3, "group_id": "21", "last_name": "Blanquer", "login": "owner"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
         "action": "invitation_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       },
       {
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_refused"
       }
     ]
@@ -339,7 +339,7 @@ Feature: Get requests for group_id
 
   Scenario: User is a manager of the group (sort by action, start from the second row)
     Given I am the user with id "21"
-    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}"
+    And the template constant "from_at" is "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}"
     When I send a GET request to "/groups/13/requests?sort=action&from.at={{from_at}}&from.member_id=21"
     Then the response code should be 200
     And the response body should be, in JSON:
@@ -349,7 +349,7 @@ Feature: Get requests for group_id
         "member_id": "41",
         "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
         "joining_user": {"first_name": "Mark", "grade": 2, "group_id": "41", "last_name": "Moe", "login": "mark"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
         "action": "invitation_created"
       },
       {
@@ -363,21 +363,21 @@ Feature: Get requests for group_id
         "member_id": "11",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "11", "login": "user"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[1][at]"))}}",
         "action": "invitation_refused"
       },
       {
         "member_id": "31",
         "inviting_user": null,
         "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[4][at]"))}}",
         "action": "join_request_created"
       },
       {
         "member_id": "22",
         "inviting_user": null,
         "joining_user": {"grade": 1, "group_id": "22", "login": "richard"},
-        "at": "{{timeDBToRFC3339(db("group_membership_changes[5][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_membership_changes[3][at]"))}}",
         "action": "join_request_refused"
       }
     ]

--- a/app/api/groups/get_user_requests.feature
+++ b/app/api/groups/get_user_requests.feature
@@ -47,10 +47,10 @@ Feature: Get pending requests for managed groups
     And the groups ancestors are computed
     And the database has the following table "group_pending_requests":
       | group_id | member_id | type          | at                          | personal_info_view_approved |
+      | 13       | 11        | leave_request | {{relativeTimeDB("-171h")}} | false                       |
       | 13       | 21        | invitation    | {{relativeTimeDB("-170h")}} | true                        |
       | 13       | 31        | join_request  | {{relativeTimeDB("-168h")}} | false                       |
       | 13       | 41        | join_request  | {{relativeTimeDB("-169h")}} | true                        |
-      | 13       | 11        | leave_request | {{relativeTimeDB("-171h")}} | false                       |
       | 14       | 11        | invitation    | 2017-05-28 06:38:38         | false                       |
       | 14       | 21        | join_request  | 2017-05-27 06:38:38         | false                       |
       | 14       | 31        | leave_request | 2017-05-27 06:38:38         | false                       |
@@ -75,7 +75,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -90,7 +90,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -115,7 +115,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -130,7 +130,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       },
       {
@@ -185,7 +185,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -200,7 +200,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -225,7 +225,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -240,7 +240,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -265,7 +265,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       },
       {
@@ -295,7 +295,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -320,7 +320,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -345,7 +345,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -360,7 +360,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -400,7 +400,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -415,7 +415,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -440,7 +440,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -455,7 +455,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       }
     ]
@@ -516,7 +516,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[1][at]"))}}",
         "type": "leave_request"
       }
     ]
@@ -541,7 +541,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Doe",
           "login": "jane"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[2][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
         "type": "join_request"
       },
       {
@@ -556,7 +556,7 @@ Feature: Get pending requests for managed groups
           "last_name": "Roe",
           "login": "richard"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[3][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
         "type": "join_request"
       },
       {
@@ -569,7 +569,7 @@ Feature: Get pending requests for managed groups
           "group_id": "11",
           "login": "user"
         },
-        "at": "{{timeDBToRFC3339(db("group_pending_requests[4][at]"))}}",
+        "at": "{{timeDBToRFC3339(db("group_pending_requests[1][at]"))}}",
         "type": "leave_request"
       }
     ]

--- a/app/api/items/create_item.feature
+++ b/app/api/items/create_item.feature
@@ -71,6 +71,10 @@ Feature: Create item
     And the table "groups" should remain unchanged
     And the table "attempts" should remain unchanged
     And the table "results" should remain unchanged
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario: Valid when as_root_of_group_id is given, but parent_item_id is not given (not a skill)
     Given I am the user with id "11"
@@ -120,6 +124,10 @@ Feature: Create item
       | 11 | jdoe    | User    | null                | null          |
     And the table "attempts" should remain unchanged
     And the table "results" should remain unchanged
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario: Valid when as_root_of_group_id is given, but parent_item_id is not given (skill with children)
     Given I am the user with id "11"
@@ -187,6 +195,10 @@ Feature: Create item
       | 11 | jdoe    | User    | null             | null                |
     And the table "attempts" should remain unchanged
     And the table "results" should remain unchanged
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario: Set can_request_help for children
     Given I am the user with id "11"
@@ -370,7 +382,10 @@ Feature: Create item
       | attempt_id | participant_id | item_id |
       | 0          | 11             | 12      |
       | 0          | 11             | 21      |
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
     And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
   Examples:
     | grant_view_propagation | watch_propagation | edit_propagation | request_help_propagation |
     | true                   | false             | true             | true                     |
@@ -454,6 +469,10 @@ Feature: Create item
       | 11                  | 34                  | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | 0                  |
       | 11                  | 50                  | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | 0                  |
       | 11                  | 5577006791947779410 | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | 1                  |
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_sync" should be empty
 
   Scenario: Recomputes the score of a parent item
     Given the database table "items" also has the following rows:

--- a/app/api/items/create_item.sync_propagation.feature
+++ b/app/api/items/create_item.sync_propagation.feature
@@ -1,0 +1,165 @@
+Feature: Create item
+  Background:
+    Given the database has the following table "groups":
+      | id | name    | type    | root_activity_id | root_skill_id |
+      | 10 | Friends | Friends | null             | null          |
+    And the database has the following user:
+      | group_id | login |
+      | 11       | jdoe  |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_manage            |
+      | 10       | 11         | memberships_and_group |
+    And the database has the following table "items":
+      | id | default_language_tag |
+      | 21 | fr                   |
+      | 22 | fr                   |
+    And the database has the following table "items_items":
+      | parent_item_id | child_item_id | child_order |
+      | 21             | 22            | 0           |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_edit_generated |
+      | 10       | 21      | content            | none               |
+      | 11       | 21      | solution           | children           |
+    And the database has the following table "permissions_granted":
+      | group_id | item_id | can_view | can_edit | source_group_id | latest_update_at    |
+      | 11       | 21      | solution | children | 11              | 2019-05-30 11:00:00 |
+    And the database has the following table "attempts":
+      | id | participant_id |
+      | 0  | 10             |
+      | 1  | 11             |
+    And the database has the following table "results":
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 10             | 21      | 100            |
+      | 0          | 10             | 22      | 100            |
+      | 1          | 11             | 21      | 100            |
+      | 1          | 11             | 22      | 100            |
+    And the database has the following table "languages":
+      | tag |
+      | sl  |
+    And the generated permissions are computed
+    And the application config is:
+    """
+    server:
+      propagation_endpoint: "/not_found" # set a non-empty propagation_endpoint pointing to nowhere to disable the async propagation
+    """
+
+  Scenario: Synchronously recomputes results of the current user linked to the parent item
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Task",
+        "language_tag": "sl",
+        "title": "my title 🐱",
+        "image_url":"http://bit.ly/1234",
+        "subtitle": "hard task 🐱",
+        "description": "the goal of this task is ... 🐱",
+        "parent": {"item_id": "21"}
+      }
+      """
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": { "id": "5577006791947779410" }
+      }
+      """
+    And the table "results" should remain unchanged, regardless of the rows with item_id "21"
+    And the table "results" at item_id "21" should be:
+      | attempt_id | participant_id | score_computed |
+      | 0          | 10             | 100            |
+      | 1          | 11             | 50             |
+    And the table "results_propagate_sync" should be empty
+    # inserted by after_insert_items_items
+    And the table "results_propagate" should be:
+      | participant_id | attempt_id | item_id | state            |
+      | 10             | 0          | 21      | to_be_recomputed |
+      | 11             | 1          | 21      | to_be_recomputed |
+
+  Scenario: Synchronously propagates newly created permissions for the current user on the new item (no parent, no children)
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Task",
+        "language_tag": "sl",
+        "title": "my title",
+        "image_url":"http://bit.ly/1234",
+        "subtitle": "hard task",
+        "description": "the goal of this task is ...",
+        "as_root_of_group_id": "10"
+      }
+      """
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": { "id": "5577006791947779410" }
+      }
+      """
+    And the table "permissions_generated" should remain unchanged, regardless of the rows with group_id "11"
+    And the table "permissions_generated" at group_id "11" should be:
+      | item_id             | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
+      | 21                  | solution           | none                     | none                | children           | 0                  |
+      | 22                  | none               | none                     | none                | none               | 0                  |
+      | 5577006791947779410 | solution           | solution_with_grant      | answer_with_grant   | all_with_grant     | 1                  |
+    And the table "permissions_propagate" should be empty
+    And the table "permissions_propagate_sync" should be empty
+
+  Scenario: Synchronously propagates results of the current user linked to child items
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id | default_language_tag |
+      | 12 | fr                   |
+      | 34 | fr                   |
+    And the database table "permissions_granted" also has the following rows:
+      | group_id | item_id | can_view                 | can_grant_view      | can_watch         | can_edit       | is_owner | source_group_id | latest_update_at    |
+      | 11       | 12      | content_with_descendants | solution            | answer            | all            | 0        | 11              | 2019-05-30 11:00:00 |
+      | 11       | 34      | solution                 | solution_with_grant | answer_with_grant | all_with_grant | 0        | 11              | 2019-05-30 11:00:00 |
+    And the generated permissions are computed
+    And the database table "results" also has the following rows:
+      | attempt_id | participant_id | item_id | score_computed |
+      | 0          | 10             | 12      | 60             |
+      | 1          | 11             | 12      | 60             |
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Chapter",
+        "language_tag": "sl",
+        "title": "my title",
+        "image_url":"http://bit.ly/1234",
+        "subtitle": "hard task",
+        "description": "the goal of this task is ...",
+        "as_root_of_group_id": "10",
+        "children": [
+          {"item_id": "12", "order": 0},
+          {"item_id": "34", "order": 1, "category": "Application", "score_weight": 2}
+        ]
+      }
+      """
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": { "id": "5577006791947779410" }
+      }
+      """
+    And the table "results" should remain unchanged, regardless of the rows with participant_id "11"
+    And the table "results" at participant_id "11" should be:
+      | attempt_id | item_id             | score_computed |
+      | 1          | 12                  | 60             |
+      | 1          | 21                  | 100            |
+      | 1          | 22                  | 100            |
+      | 1          | 5577006791947779410 | 20             |
+    # inserted by after_insert_items_items
+    And the table "results_propagate" should be:
+      | participant_id | attempt_id | item_id | state            |
+      | 10             | 0          | 12      | to_be_propagated |
+      | 11             | 1          | 12      | to_be_propagated |
+    And the table "results_propagate_sync" should be empty

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -704,8 +704,8 @@ func Test_findItemPaths(t *testing.T) {
 			require.NoError(t, store.InTransaction(func(s *database.DataStore) error {
 				require.NoError(t, s.GroupGroups().CreateNewAncestors())
 				require.NoError(t, s.ItemItems().CreateNewAncestors())
-				s.SchedulePermissionsPropagation()
-				s.ScheduleResultsPropagation()
+				require.NoError(t, s.PermissionsGranted().ComputeAllAccess())
+				require.NoError(t, s.Results().Propagate())
 				return nil
 			}))
 			got := findItemPaths(store, tt.args.participantID, tt.args.itemID, tt.args.limit)

--- a/app/config.go
+++ b/app/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/domain"
-	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
 )
 
@@ -92,22 +91,6 @@ func configDirectory() string {
 		}
 	}
 	return filepath.Dir(cwd + "/conf/")
-}
-
-// ReplaceAuthConfig replaces the auth part of the config by the given one.
-// loggerOptional is an optional logger to use, if not provided, a new logger will be created from the config.
-func (app *Application) ReplaceAuthConfig(newGlobalConfig *viper.Viper, loggerOptional ...*logging.Logger) {
-	app.Config.Set(authConfigKey, newGlobalConfig.Get(authConfigKey))
-	_ = app.Reset(app.Config, loggerOptional...) // cannot return an error in this case
-}
-
-// ReplaceDomainsConfig replaces the domains part of the config by the given one.
-// loggerOptional is an optional logger to use, if not provided, a new logger will be created from the config.
-func (app *Application) ReplaceDomainsConfig(newGlobalConfig *viper.Viper, loggerOptional ...*logging.Logger) {
-	app.Config.Set(domainsConfigKey, newGlobalConfig.Get(domainsConfigKey))
-	if err := app.Reset(app.Config, loggerOptional...); err != nil {
-		panic(err)
-	}
 }
 
 //

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/appenv"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/domain"
-	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
@@ -311,58 +310,6 @@ func TestDomainsConfig_Error(t *testing.T) {
 	globalConfig.Set("domains", []int{1, 2})
 	_, err := DomainsConfig(globalConfig)
 	assert.EqualError(t, err, "2 error(s) decoding:\n\n* '[0]' expected a map, got 'int'\n* '[1]' expected a map, got 'int'")
-}
-
-func TestReplaceAuthConfig(t *testing.T) {
-	testoutput.SuppressIfPasses(t)
-
-	mockDatabaseOpen()
-	defer monkey.UnpatchAll()
-
-	globalConfig := viper.New()
-	globalConfig.Set("auth.ClientID", "42")
-	logger, _ := logging.NewMockLogger()
-	application, err := New(logger)
-	require.NoError(t, err)
-	application.ReplaceAuthConfig(globalConfig, logger)
-	assert.Equal(t, "42", application.Config.Get("auth.ClientID"))
-	// not tested: that it is been pushed to the API
-}
-
-func TestReplaceDomainsConfig(t *testing.T) {
-	testoutput.SuppressIfPasses(t)
-
-	mockDatabaseOpen()
-	defer monkey.UnpatchAll()
-
-	globalConfig := viper.New()
-	globalConfig.Set("domains", []map[string]interface{}{{"domains": []string{"localhost", "other"}}})
-	logger, _ := logging.NewMockLogger()
-	application, _ := New(logger)
-	application.ReplaceDomainsConfig(globalConfig, logger)
-	expected := []domain.ConfigItem{{
-		Domains:           []string{"localhost", "other"},
-		AllUsersGroup:     0,
-		TempUsersGroup:    0,
-		NonTempUsersGroup: 0,
-	}}
-	config, _ := DomainsConfig(application.Config)
-	assert.Equal(t, expected, config)
-	// not tested: that it is been pushed to the API
-}
-
-func TestReplaceDomainsConfig_Panic(t *testing.T) {
-	testoutput.SuppressIfPasses(t)
-
-	mockDatabaseOpen()
-	defer monkey.UnpatchAll()
-
-	globalConfig := viper.New()
-	globalConfig.Set("domains", []int{1, 2})
-	application := &Application{Config: viper.New()}
-	assert.Panics(t, func() {
-		application.ReplaceDomainsConfig(globalConfig)
-	})
 }
 
 func Test_configDirectory_StripsOnlyTheLastOccurrenceOfApp(t *testing.T) {

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -181,8 +181,7 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 			assert.NoError(t, dataStore.Table("groups_propagate").UpdateColumn("ancestors_computation_state", "done").Error())
 
 			assert.NoError(t, dataStore.InTransaction(func(s *database.DataStore) error {
-				s.SchedulePermissionsPropagation()
-				return nil
+				return s.PermissionsGranted().ComputeAllAccess()
 			}))
 			err := dataStore.InTransaction(func(s *database.DataStore) error {
 				return s.GroupGroups().DeleteRelation(1, 2, tt.shouldDeleteOrphans)

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -58,8 +58,7 @@ func TestItemItemStore_TriggerAfterInsert_MarksPermissionsForRecomputing(t *test
 
 	dataStore := database.NewDataStore(db)
 	require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
-		dataStore.SchedulePermissionsPropagation()
-		return nil
+		return dataStore.PermissionsGranted().ComputeAllAccess()
 	}))
 
 	var markedPermissions []groupItemsResultRow
@@ -104,8 +103,7 @@ func TestItemItemStore_TriggerAfterUpdate_MarksPermissionsForRecomputing(t *test
 
 			dataStore := database.NewDataStore(db)
 			require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
-				dataStore.SchedulePermissionsPropagation()
-				return nil
+				return dataStore.PermissionsGranted().ComputeAllAccess()
 			}))
 
 			var markedPermissions []groupItemsResultRow
@@ -136,8 +134,7 @@ func TestItemItemStore_TriggerBeforeDelete_MarksPermissionsForRecomputing(t *tes
 
 	dataStore := database.NewDataStore(db)
 	require.NoError(t, dataStore.InTransaction(func(dataStore *database.DataStore) error {
-		dataStore.SchedulePermissionsPropagation()
-		return nil
+		return dataStore.PermissionsGranted().ComputeAllAccess()
 	}))
 
 	var markedPermissions []groupItemsResultRow

--- a/app/database/permission_granted_store_compute_all_access.go
+++ b/app/database/permission_granted_store_compute_all_access.go
@@ -158,3 +158,15 @@ func (s *PermissionGrantedStore) computeAllAccess() {
 		}))
 	}
 }
+
+// ComputeAllAccess allows to call computeAllAccess() from outside.
+//
+// Note: The method propagates permissions synchronously. It does not use propagations scheduling.
+// Callers probably want to call this method inside a transaction and mark the transaction with DataStore.SetPropagationsModeToSync()
+// to ensure it will not process permissions that are marked for propagation by other transactions.
+func (s *PermissionGrantedStore) ComputeAllAccess() (err error) {
+	defer recoverPanics(&err)
+
+	s.computeAllAccess()
+	return nil
+}

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -49,8 +49,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccess(t *test
 	assert.NoError(t, permissionGrantedStore.Where("group_id=2 AND item_id=11").
 		UpdateColumn("can_view", "content").Error())
 	assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
-		return nil
+		return ds.PermissionsGranted().ComputeAllAccess()
 	}))
 
 	assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
@@ -124,8 +123,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesContentAccessAsInfo(t
 		"content_view_propagation": "as_info",
 	}).Error())
 	require.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
-		return nil
+		return ds.PermissionsGranted().ComputeAllAccess()
 	}))
 
 	assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
@@ -202,8 +200,7 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 			assert.NoError(t, permissionGrantedStore.Where("group_id=2 AND item_id=11").
 				UpdateColumn("can_view", access).Error())
 			assert.NoError(t, permissionGrantedStore.InTransaction(func(ds *database.DataStore) error {
-				ds.SchedulePermissionsPropagation()
-				return nil
+				return ds.PermissionsGranted().ComputeAllAccess()
 			}))
 
 			assertAllPermissionsGeneratedAreDone(t, permissionGeneratedStore)
@@ -368,8 +365,7 @@ func testGeneratedPermission(t *testing.T, fixture string, testCase ...generated
 
 	permissionStore := database.NewDataStore(db).Permissions()
 	require.NoError(t, permissionStore.InTransaction(func(ds *database.DataStore) error {
-		ds.SchedulePermissionsPropagation()
-		return nil
+		return ds.PermissionsGranted().ComputeAllAccess()
 	}))
 	var result string
 	for _, test := range testCase {

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -84,8 +84,7 @@ func TestResultStore_Propagate(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
 			err := database.NewDataStore(db).InTransaction(func(s *database.DataStore) error {
-				s.ScheduleResultsPropagation()
-				return nil
+				return s.Results().Propagate()
 			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResultStore.propagate() error = %v, wantErr %v", err, tt.wantErr)

--- a/app/database/result_store_propagate.go
+++ b/app/database/result_store_propagate.go
@@ -45,6 +45,18 @@ func (s *ResultStore) PropagateAndCollectUnlockedItemsForParticipant(participant
 	return s.Results().propagate(&participantID)
 }
 
+// Propagate recomputes fields of results and propagates permissions for unlocked items.
+//
+// Note: The method propagates results and permissions synchronously. It does not use propagations scheduling.
+// Callers probably want to call this method inside a transaction and mark the transaction with DataStore.SetPropagationsModeToSync()
+// to ensure it will not process results and permissions that are marked for propagation by other transactions.
+//
+// Note 2: The method does not process the results_recompute_for_items table.
+func (s *ResultStore) Propagate() error {
+	_, err := s.Results().propagate(nil)
+	return err
+}
+
 // propagate recomputes fields of results
 // For results marked as 'to_be_propagated':
 //  1. We take the first chunk of them and mark them as 'propagating'.

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -79,8 +79,7 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 					SELECT participant_id, attempt_id, item_id, 'to_be_propagated' AS state
 					FROM results
 					ON DUPLICATE KEY UPDATE state = IF(state='propagating', 'to_be_propagated', state)`).Error())
-				store.ScheduleResultsPropagation()
-				return nil
+				return store.Results().Propagate()
 			})
 			require.NoError(t, err)
 
@@ -128,8 +127,7 @@ func TestResultStore_Propagate_Aggregates_OnCommonData(t *testing.T) {
 
 	resultStore := database.NewDataStore(db).Results()
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -159,8 +157,7 @@ func TestResultStore_Propagate_Aggregates_KeepsLastActivityAtIfItIsGreater(t *te
 	}).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -208,8 +205,7 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 				}).Error())
 
 			err := resultStore.InTransaction(func(s *database.DataStore) error {
-				s.ScheduleResultsPropagation()
-				return nil
+				return s.Results().Propagate()
 			})
 			require.NoError(t, err)
 

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -76,8 +76,7 @@ func testResultStorePropagateCreatesNew(ctx context.Context, t *testing.T, testC
 	}
 	resultStore := database.NewDataStore(db).Results()
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 

--- a/app/database/result_store_propagate_recomputes_items_integration_test.go
+++ b/app/database/result_store_propagate_recomputes_items_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
-func TestResultStore_Propagate_RecomputesResultsForItemsFromTableResultsRecomputeForItems(t *testing.T) {
+func TestResultStore_ScheduledResultsPropagationRecomputesResultsForItemsFromTableResultsRecomputeForItems(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
 	db := testhelpers.SetupDBWithFixtureString(testhelpers.CreateTestContext(), `

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -69,8 +69,7 @@ func TestResultStore_Propagate_Unlocks_KeepsOldGrants(t *testing.T) {
 	prepareDependencies(t, db)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -131,8 +130,7 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_EverythingHas
 	prepareDependencies(t, db)
 	dataStore := database.NewDataStore(db)
 	err := dataStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	assert.NoError(t, err)
 	var result []map[string]interface{}

--- a/app/database/result_store_propagate_validated_at_integration_test.go
+++ b/app/database/result_store_propagate_validated_at_integration_test.go
@@ -64,8 +64,7 @@ func TestResultStore_Propagate_NonCategories_SetsValidatedAtToMaxOfChildrenValid
 		UpdateColumn("validated_at", skippedDate).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -98,8 +97,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 			Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -133,8 +131,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToNull_IfSomeCategories
 		UpdateColumn("category", "Validation").Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -173,8 +170,7 @@ func TestResultStore_Propagate_Categories_ValidatedAtShouldBeMaxOfChildrensWithC
 		UpdateColumn("category", "Validation").Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 
@@ -219,8 +215,7 @@ func TestResultStore_Propagate_Categories_SetsValidatedAtToMaxOfValidatedAtsOfCh
 	}).Error())
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -50,8 +50,7 @@ func testResultStorePropagateValidated(ctx context.Context, t *testing.T, fixtur
 	}
 
 	err := resultStore.InTransaction(func(s *database.DataStore) error {
-		s.ScheduleResultsPropagation()
-		return nil
+		return s.Results().Propagate()
 	})
 	require.NoError(t, err)
 

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -160,7 +160,9 @@ func setupDBForDeleteWithTrapsTests(t *testing.T, currentTime time.Time) *databa
 		if err := trStore.GroupGroups().CreateNewAncestors(); err != nil {
 			return err
 		}
-		trStore.SchedulePermissionsPropagation()
+		if err := trStore.PermissionsGranted().ComputeAllAccess(); err != nil {
+			return err
+		}
 		return nil
 	}))
 	return db

--- a/cmd/db_recompute.go
+++ b/cmd/db_recompute.go
@@ -54,15 +54,15 @@ func init() { //nolint:gochecknoinits
 
 func recomputeDBCaches(cmd *cobra.Command, gormDB *database.DB) error {
 	return database.NewDataStore(gormDB).InTransaction(func(store *database.DataStore) error {
-		cmd.Print("Recalculating groups ancestors\n")
+		cmd.Print("Recalculating ancestors of marked groups and their descendants\n")
 		if err := store.GroupGroups().CreateNewAncestors(); err != nil {
-			return fmt.Errorf("cannot compute groups_groups: %w", err)
+			return fmt.Errorf("cannot compute groups ancestors: %w", err)
 		}
-		cmd.Print("Recalculating items ancestors\n")
+		cmd.Print("Recalculating ancestors of marked items and their descendants\n")
 		if err := store.ItemItems().CreateNewAncestors(); err != nil {
-			return fmt.Errorf("cannot compute items_items: %w", err)
+			return fmt.Errorf("cannot compute items ancestors: %w", err)
 		}
-		cmd.Print("Running propagation of permissions and results\n")
+		cmd.Print("Recomputing/propagating permissions and results marked to be recomputed/propagated\n")
 		store.SchedulePermissionsPropagation()
 		store.ScheduleResultsPropagation()
 		return nil

--- a/testhelpers/app_language_db.go
+++ b/testhelpers/app_language_db.go
@@ -20,7 +20,7 @@ func (ctx *TestContext) databaseCountRows(table string, datamap map[string]strin
 		default:
 			var processedValue interface{} = value
 			if value[0] == referencePrefix {
-				processedValue = ctx.getIDOfReference(value)
+				processedValue = ctx.getIDByReference(value)
 			}
 			query = query.Where(columnName+" = ?", processedValue)
 		}

--- a/testhelpers/app_language_group_pending_requests.go
+++ b/testhelpers/app_language_group_pending_requests.go
@@ -32,8 +32,8 @@ func (ctx *TestContext) getGroupPendingRequestPrimaryKey(groupID, memberID int64
 
 // addGroup adds a group to the database.
 func (ctx *TestContext) addGroupPendingRequest(group, member, requestType string) {
-	groupID := ctx.getIDOfReference(group)
-	memberID := ctx.getIDOfReference(member)
+	groupID := ctx.getIDOrIDByReference(group)
+	memberID := ctx.getIDOrIDByReference(member)
 
 	primaryKey := ctx.getGroupPendingRequestPrimaryKey(groupID, memberID)
 

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -33,7 +33,7 @@ func (ctx *TestContext) registerFeaturesForGroups(scenarioContext *godog.Scenari
 
 // getGroupPrimaryKey returns the primary key of a group.
 func (ctx *TestContext) getGroupPrimaryKey(groupID int64) map[string]string {
-	return map[string]string{"id": strconv.FormatInt(groupID, 10)}
+	return map[string]string{idString: strconv.FormatInt(groupID, 10)}
 }
 
 // addGroup adds a group to the database.
@@ -45,7 +45,7 @@ func (ctx *TestContext) addGroup(group, groupType string) {
 		ctx.needPopulateDatabase = true
 		err := ctx.DBHasTable("groups",
 			constructGodogTableFromData([]stringKeyValuePair{
-				{"id", strconv.FormatInt(groupID, 10)},
+				{idString, strconv.FormatInt(groupID, 10)},
 				{"name", "Group " + referenceToName(group)},
 				{"type", groupType},
 				{"require_personal_info_access_approval", "none"},
@@ -191,8 +191,8 @@ func (ctx *TestContext) UserIsAMemberOfTheGroupWhoHasApprovedAccessToHisPersonal
 // TheFieldOfTheGroupShouldBe checks that the field of a group in the database is equal to a value.
 func (ctx *TestContext) TheFieldOfTheGroupShouldBe(field, group, value string) error {
 	resultCount := ctx.databaseCountRows("groups", map[string]string{
-		"id":  group,
-		field: value,
+		idString: group,
+		field:    value,
 	})
 
 	if resultCount != 1 {

--- a/testhelpers/app_language_groups.go
+++ b/testhelpers/app_language_groups.go
@@ -38,7 +38,7 @@ func (ctx *TestContext) getGroupPrimaryKey(groupID int64) map[string]string {
 
 // addGroup adds a group to the database.
 func (ctx *TestContext) addGroup(group, groupType string) {
-	groupID := ctx.getIDOfReference(group)
+	groupID := ctx.getIDOrIDByReference(group)
 	primaryKey := ctx.getGroupPrimaryKey(groupID)
 
 	if !ctx.isInDatabase("groups", primaryKey) {
@@ -67,7 +67,7 @@ func (ctx *TestContext) setGroupFieldInDatabase(primaryKey map[string]string, fi
 func (ctx *TestContext) ThereAreTheFollowingGroups(groups *godog.Table) error {
 	for i := 1; i < len(groups.Rows); i++ {
 		group := ctx.getRowMap(i, groups)
-		groupID := ctx.getIDOfReference(group["group"])
+		groupID := ctx.getIDOrIDByReference(group["group"])
 
 		err := ctx.ThereIsAGroup(group["group"])
 		mustNotBeError(err)

--- a/testhelpers/app_language_sessions.go
+++ b/testhelpers/app_language_sessions.go
@@ -28,8 +28,8 @@ func (ctx *TestContext) registerFeaturesForSessions(scenarioContext *godog.Scena
 
 // addSession adds a session to the database.
 func (ctx *TestContext) addSession(session, user, refreshToken string) {
-	sessionID := ctx.getIDOfReference(session)
-	userID := ctx.getIDOfReference(user)
+	sessionID := ctx.getIDOrIDByReference(session)
+	userID := ctx.getIDOrIDByReference(user)
 
 	err := ctx.DBHasTable("sessions",
 		constructGodogTableFromData([]stringKeyValuePair{
@@ -44,7 +44,7 @@ func (ctx *TestContext) addSession(session, user, refreshToken string) {
 
 // addAccessToken adds an access token to the database.
 func (ctx *TestContext) addAccessToken(session, token, issuedAt, expiresAt string) {
-	sessionID := ctx.getIDOfReference(session)
+	sessionID := ctx.getIDOrIDByReference(session)
 
 	_, err := time.Parse(time.DateTime, issuedAt)
 	if err != nil {
@@ -75,7 +75,7 @@ func (ctx *TestContext) IAm(name string) error {
 		return err
 	}
 
-	err = ctx.IAmUserWithID(ctx.getIDOfReference(name))
+	err = ctx.IAmUserWithID(ctx.getIDOrIDByReference(name))
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func (ctx *TestContext) ThereAreTheFollowingSessions(sessions *godog.Table) erro
 
 // ThereAreCountSessionsForUser checks if there are a given number of sessions for a given user.
 func (ctx *TestContext) ThereAreCountSessionsForUser(count int, user string) error {
-	userID := ctx.getIDOfReference(user)
+	userID := ctx.getIDOrIDByReference(user)
 
 	var sessionCount int
 	err := ctx.application.Database.Table("sessions").Where("user_id = ?", userID).Count(&sessionCount).Error()
@@ -145,7 +145,7 @@ func (ctx *TestContext) ThereAreCountSessionsForUser(count int, user string) err
 
 // ThereIsNoSessionID checks that a session with given session ID doesn't exist.
 func (ctx *TestContext) ThereIsNoSessionID(session string) error {
-	sessionID := ctx.getIDOfReference(session)
+	sessionID := ctx.getIDOrIDByReference(session)
 
 	var sessionCount int
 	err := ctx.application.Database.Table("sessions").Where("session_id = ?", sessionID).Count(&sessionCount).Error()
@@ -178,7 +178,7 @@ func (ctx *TestContext) ThereAreTheFollowingAccessTokens(accessTokens *godog.Tab
 
 // ThereAreCountAccessTokensForUser checks if there are a given number of access tokens for a given user.
 func (ctx *TestContext) ThereAreCountAccessTokensForUser(count int, user string) error {
-	userID := ctx.getIDOfReference(user)
+	userID := ctx.getIDOrIDByReference(user)
 
 	var accessTokensCount int
 	err := ctx.application.Database.Table("access_tokens").

--- a/testhelpers/app_language_users.go
+++ b/testhelpers/app_language_users.go
@@ -21,7 +21,7 @@ func (ctx *TestContext) getUserPrimaryKey(groupID int64) map[string]string {
 
 // addUser adds a user to the database.
 func (ctx *TestContext) addUser(user string) {
-	userGroupID := ctx.getIDOfReference(user)
+	userGroupID := ctx.getIDOrIDByReference(user)
 	primaryKey := ctx.getUserPrimaryKey(userGroupID)
 
 	if !ctx.isInDatabase("users", primaryKey) {
@@ -60,7 +60,7 @@ func (ctx *TestContext) ThereAreTheFollowingUsers(users *godog.Table) error {
 	for i := 1; i < len(users.Rows); i++ {
 		user := ctx.getRowMap(i, users)
 
-		groupID := ctx.getIDOfReference(user["user"])
+		groupID := ctx.getIDOrIDByReference(user["user"])
 
 		err := ctx.ThereIsAUser(user["user"])
 		mustNotBeError(err)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -31,6 +31,8 @@ func InitializeScenario(scenarioContext *godog.ScenarioContext) {
 	scenarioContext.Step(`^the database table "([^"]+)"(?: also)? has the following rows?:$`, ctx.DBHasTable)
 	scenarioContext.Step(`^the database(?: also)? has the following users?:$`, ctx.DBHasUsers)
 	scenarioContext.Step(`^the groups ancestors are computed$`, ctx.DBGroupsAncestorsAreComputed)
+	scenarioContext.Step(`^the generated permissions are computed$`, ctx.DBGeneratedPermissionsAreComputed)
+	scenarioContext.Step(`^the results are computed$`, ctx.DBResultsAreComputed)
 
 	ctx.registerFeaturesForSessions(scenarioContext)
 	ctx.registerFeaturesForUsers(scenarioContext)

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	referencePrefix = '@'
+	idString        = "id"
 )
 
 // ctx.getParameterMap parses parameters in format key1=val1,key2=val2,... into a map.
@@ -208,7 +209,7 @@ func (ctx *TestContext) addAttempt(item, participant string) {
 	ctx.needPopulateDatabase = true
 	err := ctx.DBHasTable("attempts",
 		constructGodogTableFromData([]stringKeyValuePair{
-			{"id", strconv.FormatInt(itemID, 10)},
+			{idString, strconv.FormatInt(itemID, 10)},
 			{"participant_id", strconv.FormatInt(participantID, 10)},
 		}))
 	if err != nil {
@@ -290,11 +291,11 @@ func (ctx *TestContext) constructDBFieldsForAddItem(fields map[string]string) (
 	dbFields = make(map[string]string, len(fields))
 	for key, value := range fields {
 		if key == "item" {
-			key = "id"
+			key = idString
 		}
 
 		switch {
-		case strings.HasSuffix(key, "id"):
+		case strings.HasSuffix(key, idString):
 			dbFields[key] = strconv.FormatInt(ctx.getIDOrIDByReference(value), 10)
 		case value[0] == referencePrefix:
 			dbFields[key] = value[1:]
@@ -303,7 +304,7 @@ func (ctx *TestContext) constructDBFieldsForAddItem(fields map[string]string) (
 		}
 	}
 
-	primaryKey = map[string]string{"id": dbFields["id"]}
+	primaryKey = map[string]string{idString: dbFields[idString]}
 	oldRowIndex = ctx.getDBTableRowIndexForPrimaryKey("items", primaryKey)
 	ctx.setDefaultValuesInDBFieldsForAddItem(dbFields, fields, oldRowIndex)
 

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -100,8 +100,8 @@ func (ctx *TestContext) isInDatabase(tableName string, primaryKey map[string]str
 
 // addPersonalInfoViewApprovedFor adds a permission generated in the database.
 func (ctx *TestContext) addPersonalInfoViewApprovedFor(childGroup, parentGroup string) {
-	parentGroupID := ctx.getIDOfReference(parentGroup)
-	childGroupID := ctx.getIDOfReference(childGroup)
+	parentGroupID := ctx.getIDOrIDByReference(parentGroup)
+	childGroupID := ctx.getIDOrIDByReference(childGroup)
 
 	const groupGroupTable = "groups_groups"
 	key := ctx.getGroupGroupKey(parentGroupID, childGroupID)
@@ -122,8 +122,8 @@ func (ctx *TestContext) getGroupGroupKey(parentGroupID, childGroupID int64) map[
 
 // addGroupGroup adds a group-group in the database.
 func (ctx *TestContext) addGroupGroup(parentGroup, childGroup string) {
-	parentGroupID := ctx.getIDOfReference(parentGroup)
-	childGroupID := ctx.getIDOfReference(childGroup)
+	parentGroupID := ctx.getIDOrIDByReference(parentGroup)
+	childGroupID := ctx.getIDOrIDByReference(childGroup)
 
 	ctx.needPopulateDatabase = true
 	err := ctx.DBHasTable("groups_groups",
@@ -143,8 +143,8 @@ func (ctx *TestContext) addGroupManager(manager, group, canWatchMembers, canGran
 		return err
 	}
 
-	managerID := ctx.getIDOfReference(manager)
-	groupID := ctx.getIDOfReference(group)
+	managerID := ctx.getIDOrIDByReference(manager)
+	groupID := ctx.getIDOrIDByReference(group)
 
 	ctx.needPopulateDatabase = true
 	err = ctx.DBHasTable("group_managers",
@@ -163,9 +163,9 @@ func (ctx *TestContext) addGroupManager(manager, group, canWatchMembers, canGran
 
 // setGrantedPermission sets a granted permission in the database.
 func (ctx *TestContext) setGrantedPermission(group, item, sourceGroup, origin, permission, permissionValue string) {
-	groupIDString := strconv.FormatInt(ctx.getIDOfReference(group), 10)
-	sourceGroupIDString := strconv.FormatInt(ctx.getIDOfReference(sourceGroup), 10)
-	itemIDString := strconv.FormatInt(ctx.getIDOfReference(item), 10)
+	groupIDString := strconv.FormatInt(ctx.getIDOrIDByReference(group), 10)
+	sourceGroupIDString := strconv.FormatInt(ctx.getIDOrIDByReference(sourceGroup), 10)
+	itemIDString := strconv.FormatInt(ctx.getIDOrIDByReference(item), 10)
 
 	const permissionsGrantedTable = "permissions_granted"
 	primaryKey := map[string]string{
@@ -187,7 +187,7 @@ func (ctx *TestContext) setGrantedPermission(group, item, sourceGroup, origin, p
 	}
 
 	if permission == "can_request_help_to" {
-		canRequestHelpToGroupID := ctx.getIDOfReference(permissionValue)
+		canRequestHelpToGroupID := ctx.getIDOrIDByReference(permissionValue)
 
 		err := ctx.ThereIsAGroup(permissionValue)
 		if err != nil {
@@ -202,8 +202,8 @@ func (ctx *TestContext) setGrantedPermission(group, item, sourceGroup, origin, p
 
 // addAttempt adds an attempt to the database.
 func (ctx *TestContext) addAttempt(item, participant string) {
-	itemID := ctx.getIDOfReference(item)
-	participantID := ctx.getIDOfReference(participant)
+	itemID := ctx.getIDOrIDByReference(item)
+	participantID := ctx.getIDOrIDByReference(participant)
 
 	ctx.needPopulateDatabase = true
 	err := ctx.DBHasTable("attempts",
@@ -218,8 +218,8 @@ func (ctx *TestContext) addAttempt(item, participant string) {
 
 // addValidatedResult adds a validated result to the database.
 func (ctx *TestContext) addValidatedResult(attemptID, participant, item string, validatedAt time.Time) {
-	participantID := ctx.getIDOfReference(participant)
-	itemID := ctx.getIDOfReference(item)
+	participantID := ctx.getIDOrIDByReference(participant)
+	itemID := ctx.getIDOrIDByReference(item)
 
 	ctx.needPopulateDatabase = true
 	err := ctx.DBHasTable("results",
@@ -243,8 +243,8 @@ func (ctx *TestContext) getItemItemPrimaryKey(parentItemID, childItemID int64) m
 
 // addItemItem adds an item-item in the database.
 func (ctx *TestContext) addItemItem(parentItem, childItem string) {
-	parentItemID := ctx.getIDOfReference(parentItem)
-	childItemID := ctx.getIDOfReference(childItem)
+	parentItemID := ctx.getIDOrIDByReference(parentItem)
+	childItemID := ctx.getIDOrIDByReference(childItem)
 
 	ctx.needPopulateDatabase = true
 	err := ctx.DBHasTable("items_items",
@@ -259,7 +259,7 @@ func (ctx *TestContext) addItemItem(parentItem, childItem string) {
 }
 
 func (ctx *TestContext) addItemItemPropagation(parent, child, propagation, propagationValue string) {
-	primaryKey := ctx.getItemItemPrimaryKey(ctx.getIDOfReference(parent), ctx.getIDOfReference(child))
+	primaryKey := ctx.getItemItemPrimaryKey(ctx.getIDOrIDByReference(parent), ctx.getIDOrIDByReference(child))
 	ctx.setDBTableRowColumnValue("items_items", primaryKey, propagation, propagationValue)
 }
 
@@ -295,7 +295,7 @@ func (ctx *TestContext) constructDBFieldsForAddItem(fields map[string]string) (
 
 		switch {
 		case strings.HasSuffix(key, "id"):
-			dbFields[key] = strconv.FormatInt(ctx.getIDOfReference(value), 10)
+			dbFields[key] = strconv.FormatInt(ctx.getIDOrIDByReference(value), 10)
 		case value[0] == referencePrefix:
 			dbFields[key] = value[1:]
 		default:
@@ -343,9 +343,9 @@ func (ctx *TestContext) getThreadKey(itemID, participantID int64) map[string]str
 
 // addThread adds a thread to the database.
 func (ctx *TestContext) addThread(item, participant, helperGroup, status, messageCount, latestUpdateAt string) {
-	itemID := ctx.getIDOfReference(item)
-	participantID := ctx.getIDOfReference(participant)
-	helperGroupID := ctx.getIDOfReference(helperGroup)
+	itemID := ctx.getIDOrIDByReference(item)
+	participantID := ctx.getIDOrIDByReference(participant)
+	helperGroupID := ctx.getIDOrIDByReference(helperGroup)
 
 	_, err := time.Parse(time.DateTime, latestUpdateAt)
 	if err != nil {
@@ -713,8 +713,8 @@ func (ctx *TestContext) ThereIsAThreadWith(parameters string) error {
 	}
 
 	ctx.currentThreadKey = ctx.getThreadKey(
-		ctx.getIDOfReference(thread["item_id"]),
-		ctx.getIDOfReference(thread["participant_id"]),
+		ctx.getIDOrIDByReference(thread["item_id"]),
+		ctx.getIDOrIDByReference(thread["participant_id"]),
 	)
 
 	ctx.addThread(

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -87,12 +87,22 @@ func (ctx *TestContext) populateDatabase() error {
 		return nil
 	}
 
-	err := ctx.DBItemsAncestorsAndPermissionsAreComputed()
+	err := ctx.DBItemsAncestorsAreComputed()
 	if err != nil {
 		return err
 	}
 
-	return ctx.DBGroupsAncestorsAreComputed()
+	err = ctx.DBGroupsAncestorsAreComputed()
+	if err != nil {
+		return err
+	}
+
+	err = ctx.DBGeneratedPermissionsAreComputed()
+	if err != nil {
+		return err
+	}
+
+	return ctx.DBResultsAreComputed()
 }
 
 func (ctx *TestContext) isInDatabase(tableName string, primaryKey map[string]string) bool {

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -222,7 +222,7 @@ func (ctx *TestContext) DBHasUsers(data *godog.Table) error {
 		}
 		groupsToCreate.Rows[0] = &messages.PickleTableRow{
 			Cells: []*messages.PickleTableCell{
-				{Value: "id"}, {Value: "name"}, {Value: "type"},
+				{Value: idString}, {Value: "name"}, {Value: "type"},
 			},
 		}
 
@@ -238,7 +238,7 @@ func (ctx *TestContext) DBHasUsers(data *godog.Table) error {
 			if groupIDColumnIndex != -1 &&
 				ctx.getDBTableRowIndexForPrimaryKey(
 					"groups",
-					map[string]string{"id": data.Rows[rowIndex].Cells[groupIDColumnIndex].Value},
+					map[string]string{idString: data.Rows[rowIndex].Cells[groupIDColumnIndex].Value},
 				) == -1 {
 				groupsToCreate.Rows = append(groupsToCreate.Rows, &messages.PickleTableRow{
 					Cells: []*messages.PickleTableCell{

--- a/testhelpers/template.go
+++ b/testhelpers/template.go
@@ -24,12 +24,17 @@ var (
 	referenceRegexp = regexp.MustCompile(`(^|\W)(@\w+)`)
 )
 
-// getIDOfReference returns the ID of a reference.
-func (ctx *TestContext) getIDOfReference(reference string) int64 {
-	if id, err := strconv.ParseInt(reference, 10, 64); err == nil {
+// getIDOrIDByReference returns the ID if the ID is given, or the ID for the given reference otherwise.
+func (ctx *TestContext) getIDOrIDByReference(idOrReference string) int64 {
+	if id, err := strconv.ParseInt(idOrReference, 10, 64); err == nil {
 		return id
 	}
 
+	return ctx.getIDByReference(idOrReference)
+}
+
+// getIDByReference returns the ID of the given reference.
+func (ctx *TestContext) getIDByReference(reference string) int64 {
 	if value, ok := ctx.referenceToIDMap[reference]; ok {
 		return value
 	}
@@ -47,10 +52,10 @@ func (ctx *TestContext) replaceReferencesWithIDs(str string) string {
 		// - /@Reference (or another non-alphanum character in front)
 
 		if capture[0] == referencePrefix {
-			return strconv.FormatInt(ctx.getIDOfReference(capture), 10)
+			return strconv.FormatInt(ctx.getIDByReference(capture), 10)
 		}
 
-		return string(capture[0]) + strconv.FormatInt(ctx.getIDOfReference(capture[1:]), 10)
+		return string(capture[0]) + strconv.FormatInt(ctx.getIDByReference(capture[1:]), 10)
 	})
 }
 


### PR DESCRIPTION
This PR modifies the itemCreate service propagate/recompute some things synchronously:
1. Synchronously propagate newly created permissions of the current user on the new item,
2. Synchronously recompute and propagate results of the current user on the parent item (if specified),
3. Synchronously propagate results of the current user on descendants of the new item (if any).
(As discussed in https://github.com/France-ioi/AlgoreaBackend/issues/1311#issuecomment-3201987399, https://github.com/France-ioi/AlgoreaBackend/issues/1311#issuecomment-3202032726, https://github.com/France-ioi/AlgoreaBackend/issues/1311#issuecomment-3202106754)

Fixes #1311 

Also, some things related to cucumber tests were reworked/improved/added here. The most remarkable thing is sorting of TestContext.dbTableData tables which should allow to compose new cucumber tests easier.
