### PR TITLE
membershipsView: Show required approvals and allow filtering out memberships not requiring access to personal info + fix sorting

### DIFF
--- a/app/api/currentuser/get_group_memberships.feature
+++ b/app/api/currentuser/get_group_memberships.feature
@@ -127,7 +127,43 @@ Feature: Get group memberships for the current user
     ]
     """
 
-  Scenario: Request the first row
+  Scenario: Show memberships requiring access to personal info
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/group-memberships?only_requiring_personal_info_access_approval=1"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {
+          "id": "6",
+          "name": "Another Class",
+          "description": "Another class group",
+          "type": "Class",
+          "require_personal_info_access_approval": "edit",
+          "require_watch_approval": false
+        },
+        "member_since": "2017-07-29T06:38:38.001Z",
+        "action": "join_request_accepted",
+        "is_membership_locked": true
+      },
+      {
+        "group": {
+          "id": "9",
+          "name": "Some other friends",
+          "description": "Another friends group",
+          "type": "Friends",
+          "require_personal_info_access_approval": "view",
+          "require_watch_approval": false
+        },
+        "action": "added_directly",
+        "member_since": null,
+        "is_membership_locked": false
+      }
+    ]
+    """
+
+  Scenario: Request the first row of all memberships
     Given I am the user with id "21"
     When I send a GET request to "/current-user/group-memberships?limit=1"
     Then the response code should be 200
@@ -150,7 +186,7 @@ Feature: Get group memberships for the current user
     ]
     """
 
-  Scenario: Request the second row
+  Scenario: Request the second row of all memberships
     Given I am the user with id "21"
     When I send a GET request to "/current-user/group-memberships?limit=1&from.id=6"
     Then the response code should be 200
@@ -168,6 +204,29 @@ Feature: Get group memberships for the current user
         },
         "member_since": "2017-06-29T06:38:38.001Z",
         "action": "invitation_accepted",
+        "is_membership_locked": false
+      }
+    ]
+    """
+
+  Scenario: Request the second row of memberships requiring access to personal info
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/group-memberships?only_requiring_personal_info_access_approval=1&limit=1&from.id=6"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "group": {
+          "id": "9",
+          "name": "Some other friends",
+          "description": "Another friends group",
+          "type": "Friends",
+          "require_personal_info_access_approval": "view",
+          "require_watch_approval": false
+        },
+        "action": "added_directly",
+        "member_since": null,
         "is_membership_locked": false
       }
     ]

--- a/app/api/currentuser/get_group_memberships.robustness.feature
+++ b/app/api/currentuser/get_group_memberships.robustness.feature
@@ -16,3 +16,8 @@ Feature: Get group memberships for the current user - robustness
     Then the response code should be 400
     And the response error message should contain "Unallowed field in sorting parameters: "myname""
 
+  Scenario: only_requiring_personal_info_access_approval is incorrect
+    Given I am the user with id "21"
+    When I send a GET request to "/current-user/group-memberships?only_requiring_personal_info_access_approval=wrong"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for only_requiring_personal_info_access_approval (should have a boolean value (0 or 1))"


### PR DESCRIPTION
1. Display `require_personal_info_access_approval` and `require_watch_approval` for each group in membershipsView.
2. Allow filtering out group memberships not requiring access to personal info by setting only_requiring_personal_info_access_approval=1 parameter in membershipsView.
3. Fix sorting in membershipsView (support member_since=null).

Fixes #1297 