### PR TITLE
Do not wipe out the list of applied migrations during test runs

### DIFF
--- a/testhelpers/db.go
+++ b/testhelpers/db.go
@@ -235,6 +235,7 @@ func emptyDB(ctx context.Context, db *sql.DB, dbName string) error {
                          WHERE  table_type   = 'BASE TABLE'
                            AND  table_schema = '`+dbName+`'
                            AND  table_name  != 'gorp_migrations'
+                           AND  table_name  != 'goose_db_version'
                            AND  table_name  != 'user_batches'
                          ORDER BY table_name`)
 	if err != nil {


### PR DESCRIPTION
Skip the goose_db_version table in testhelpers.emptyDB()