### PR TITLE
Set groups ancestors.child_group_type

### DIFF
--- a/db/migrations/2509092208_add_index_on_groups_ancestors_child_group_type.sql
+++ b/db/migrations/2509092208_add_index_on_groups_ancestors_child_group_type.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE `groups_ancestors` ADD INDEX `child_group_type` (`child_group_type`);
+
+-- +goose Down
+ALTER TABLE `groups_ancestors` DROP INDEX `child_group_type`;

--- a/db/migrations/2509092209_set_groups_ancestors_child_group_type.go
+++ b/db/migrations/2509092209_set_groups_ancestors_child_group_type.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() { //nolint:gochecknoinits // register the migration
+	goose.AddMigrationNoTxContext(SetGroupsAncestorsChildGroupTypeUp, SetGroupsAncestorsChildGroupTypeDown)
+}
+
+// SetGroupsAncestorsChildGroupTypeUp sets groups_ancestors.child_group_type by chunks.
+func SetGroupsAncestorsChildGroupTypeUp(ctx context.Context, db *sql.DB) error {
+	for {
+		result, err := db.ExecContext(ctx, `
+			UPDATE groups_ancestors
+			JOIN (
+				SELECT ancestor_group_id, child_group_id
+				FROM groups_ancestors
+				WHERE child_group_type IS NULL
+				LIMIT 100
+			) AS ga1 USING(ancestor_group_id, child_group_id)
+			JOIN `+"`groups`"+` ON groups.id = groups_ancestors.child_group_id
+			SET groups_ancestors.child_group_type = groups.type`)
+		if err != nil {
+			return err
+		}
+
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+
+		if rowsAffected == 0 {
+			return nil
+		}
+	}
+}
+
+// SetGroupsAncestorsChildGroupTypeDown is a no-op migration reversing SetGroupsAncestorsChildGroupTypeUp.
+func SetGroupsAncestorsChildGroupTypeDown(_ context.Context, _ *sql.DB) error {
+	return nil
+}

--- a/db/migrations/2509092211_drop_index_on_groups_ancestors_child_group_type.sql
+++ b/db/migrations/2509092211_drop_index_on_groups_ancestors_child_group_type.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE `groups_ancestors` DROP INDEX `child_group_type`;
+
+-- +goose Down
+ALTER TABLE `groups_ancestors` ADD INDEX `child_group_type` (`child_group_type`);


### PR DESCRIPTION
Here are three DB migrations to apply:

1. Create an index on groups_ancestors.child_group_type.
2. Set `groups_ancestors.child_group_type` for the whole `groups_ancestors` table splitting it into chunks of 100 rows.
3. Drop the index on `groups_groups.child_group_type`.

This PR implements subtasks implements the second half of the subtask 6 of #1296.

This PR should be deployed after #1329 is deployed and after all DB migrations of #1329 are applied.

The second DB migration may take several minutes to perform, but it will not block the DB.