### PR TITLE
Handle foreign key constraint failures even if the current DB user doesn't have table-level privileges for parent tables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
     environment:
       ALGOREA_ENV: test
       ALGOREA_DATABASE__ADDR: 127.0.0.1
-      ALGOREA_DATABASE__USER: algorea
-      ALGOREA_DATABASE__PASSWD: dummy_password
+      ALGOREA_DATABASE__USER: root
+      ALGOREA_DATABASE__PASSWD: root
       ALGOREA_DATABASE__DBNAME: ci_db
       ALGOREA_LOGGING__FORMAT: json
       ALGOREA_LOGGING__OUTPUT: file
@@ -54,9 +54,6 @@ jobs:
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 30s
       - run:
           name: Seed database
-          environment:
-            ALGOREA_DATABASE__USER: root
-            ALGOREA_DATABASE__PASSWD: root
           command: |
             make db-restore
             make db-migrate

--- a/app/api/items/delete_item_string.go
+++ b/app/api/items/delete_item_string.go
@@ -77,7 +77,7 @@ func (srv *Service) deleteItemString(responseWriter http.ResponseWriter, httpReq
 		}
 
 		result := store.ItemStrings().Delete("item_id = ? AND language_tag = ?", itemID, languageTag)
-		if database.IsRowIsReferenced2Error(result.Error()) {
+		if database.IsKindOfRowIsReferencedError(result.Error()) {
 			return service.ErrUnprocessableEntity(
 				errors.New("the item string cannot be deleted because its language is the default language of the item"))
 		}

--- a/app/api/items/delete_item_string.go
+++ b/app/api/items/delete_item_string.go
@@ -77,7 +77,7 @@ func (srv *Service) deleteItemString(responseWriter http.ResponseWriter, httpReq
 		}
 
 		result := store.ItemStrings().Delete("item_id = ? AND language_tag = ?", itemID, languageTag)
-		if database.IsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError(result.Error()) {
+		if database.IsRowIsReferenced2Error(result.Error()) {
 			return service.ErrUnprocessableEntity(
 				errors.New("the item string cannot be deleted because its language is the default language of the item"))
 		}

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -231,7 +231,7 @@ func saveNewScoreIntoGradings(store *database.DataStore, requestData *saveGradeR
 	})
 
 	// ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (the answer has been removed)
-	if insertError != nil && database.IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(insertError) {
+	if insertError != nil && database.IsNoReferencedRow2Error(insertError) {
 		return false
 	}
 

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -231,7 +231,7 @@ func saveNewScoreIntoGradings(store *database.DataStore, requestData *saveGradeR
 	})
 
 	// ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (the answer has been removed)
-	if insertError != nil && database.IsNoReferencedRow2Error(insertError) {
+	if insertError != nil && database.IsKindOfNoReferencedRowError(insertError) {
 		return false
 	}
 

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -221,7 +221,7 @@ func updateItemInDB(
 			return service.ErrForbidden(formdata.FieldErrorsError{"text_id": []string{
 				"text_id must be unique",
 			}})
-		} else if database.IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(err) {
+		} else if database.IsNoReferencedRow2Error(err) {
 			return service.ErrInvalidRequest(formdata.FieldErrorsError{"default_language_tag": []string{
 				"default language should exist and there should be item's strings in this language",
 			}})

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -221,7 +221,7 @@ func updateItemInDB(
 			return service.ErrForbidden(formdata.FieldErrorsError{"text_id": []string{
 				"text_id must be unique",
 			}})
-		} else if database.IsNoReferencedRow2Error(err) {
+		} else if database.IsKindOfNoReferencedRowError(err) {
 			return service.ErrInvalidRequest(formdata.FieldErrorsError{"default_language_tag": []string{
 				"default language should exist and there should be item's strings in this language",
 			}})

--- a/app/database/errors.go
+++ b/app/database/errors.go
@@ -16,16 +16,18 @@ func IsDuplicateEntryErrorForKey(err error, table, key string) bool {
 	return IsDuplicateEntryError(err) && mysqldb.ErrorContains(err, fmt.Sprintf("for key '%s.%s'", table, key))
 }
 
-// IsRowIsReferenced2Error checks whether an error corresponds to a foreign key constraint failure
-// on deleting/updating a parent row when the current DB user has table-level privileges for all parent tables.
-func IsRowIsReferenced2Error(err error) bool {
-	return mysqldb.IsMysqlError(err, mysqldb.RowIsReferenced2)
+// IsKindOfRowIsReferencedError checks whether an error corresponds to a foreign key constraint failure
+// on deleting/updating a parent row no matter if the current DB user has table-level privileges for all parent tables
+// or not.
+func IsKindOfRowIsReferencedError(err error) bool {
+	return mysqldb.IsMysqlError(err, mysqldb.RowIsReferenced) || mysqldb.IsMysqlError(err, mysqldb.RowIsReferenced2)
 }
 
-// IsNoReferencedRow2Error checks whether an error corresponds to a foreign key constraint failure
-// on inserting/updating a child row when the current DB user has table-level privileges for all parent tables.
-func IsNoReferencedRow2Error(err error) bool {
-	return mysqldb.IsMysqlError(err, mysqldb.NoReferencedRow2)
+// IsKindOfNoReferencedRowError checks whether an error corresponds to a foreign key constraint failure
+// on inserting/updating a child row no matter if the current DB user has table-level privileges for all parent tables
+// or not.
+func IsKindOfNoReferencedRowError(err error) bool {
+	return mysqldb.IsMysqlError(err, mysqldb.NoReferencedRow) || mysqldb.IsMysqlError(err, mysqldb.NoReferencedRow2)
 }
 
 // IsDeadlockError checks whether an error corresponds to a deadlock when trying to get a lock.

--- a/app/database/errors.go
+++ b/app/database/errors.go
@@ -16,16 +16,16 @@ func IsDuplicateEntryErrorForKey(err error, table, key string) bool {
 	return IsDuplicateEntryError(err) && mysqldb.ErrorContains(err, fmt.Sprintf("for key '%s.%s'", table, key))
 }
 
-// IsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError checks whether an error corresponds to a foreign key constraint failure
-// on deleting/updating a parent row.
-func IsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError(err error) bool {
-	return mysqldb.IsMysqlError(err, mysqldb.ForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError)
+// IsRowIsReferenced2Error checks whether an error corresponds to a foreign key constraint failure
+// on deleting/updating a parent row when the current DB user has table-level privileges for all parent tables.
+func IsRowIsReferenced2Error(err error) bool {
+	return mysqldb.IsMysqlError(err, mysqldb.RowIsReferenced2)
 }
 
-// IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError checks whether an error corresponds to a foreign key constraint failure
-// on inserting/updating a child row.
-func IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(err error) bool {
-	return mysqldb.IsMysqlError(err, mysqldb.ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError)
+// IsNoReferencedRow2Error checks whether an error corresponds to a foreign key constraint failure
+// on inserting/updating a child row when the current DB user has table-level privileges for all parent tables.
+func IsNoReferencedRow2Error(err error) bool {
+	return mysqldb.IsMysqlError(err, mysqldb.NoReferencedRow2)
 }
 
 // IsDeadlockError checks whether an error corresponds to a deadlock when trying to get a lock.

--- a/app/database/errors_integration_test.go
+++ b/app/database/errors_integration_test.go
@@ -1,0 +1,123 @@
+//go:build !unit
+
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database/mysqldb"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers"
+	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
+)
+
+func TestIsKindOfErrors(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db := testhelpers.SetupDBWithFixtureString(testhelpers.CreateTestContext())
+	defer func() { _ = db.Close() }()
+
+	require.NoError(t, db.Exec("CREATE TABLE test_fk_parent (id INT PRIMARY KEY)").Error())
+	defer func() {
+		_ = db.Exec("DROP TABLE test_fk_parent").Error()
+	}()
+	require.NoError(t,
+		db.Exec(`
+			CREATE TABLE test_fk_child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY (parent_id)
+				REFERENCES test_fk_parent(id))`).Error())
+	defer func() {
+		_ = db.Exec("DROP TABLE test_fk_child").Error()
+	}()
+	require.NoError(t, db.Exec("INSERT INTO test_fk_parent (id) VALUES (1)").Error())
+	require.NoError(t, db.Exec("INSERT INTO test_fk_child (id, parent_id) VALUES (1, 1)").Error())
+
+	require.NoError(t, db.Exec("CREATE USER 'another_user'@'%' IDENTIFIED BY 'another_password'").Error())
+	defer func() {
+		_ = db.Exec("DROP USER 'another_user'@'%'").Error()
+	}()
+	require.NoError(t, db.Exec("GRANT SELECT, DELETE ON test_fk_parent TO 'another_user'@'%'").Error())
+	db1, err := database.Open(db.GetContext(), openRawDBConnectionForAnotherUser(db.GetContext(), "another_user", "another_password"))
+	require.NoError(t, err)
+	defer func() { _ = db1.Close() }()
+
+	t.Run("IsKindOfRowIsReferencedError", func(t *testing.T) {
+		testoutput.SuppressIfPasses(t)
+		defer func() {
+			require.NoError(t, db.Exec("REVOKE SELECT, DELETE ON test_fk_parent FROM 'another_user'@'%'").Error())
+		}()
+		t.Run("with REFERENCES privilege", func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+			testIsKindOfRowIsReferencedErrorWithDB(t, db, mysqldb.RowIsReferenced2)
+		})
+		t.Run("without REFERENCES privilege", func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+			testIsKindOfRowIsReferencedErrorWithDB(t, db1, mysqldb.RowIsReferenced)
+		})
+	})
+	t.Run("IsKindOfNoReferencedRowError", func(t *testing.T) {
+		testoutput.SuppressIfPasses(t)
+		require.NoError(t, db.Exec("GRANT INSERT ON test_fk_child TO 'another_user'@'%'").Error())
+		defer func() {
+			require.NoError(t, db.Exec("REVOKE INSERT ON test_fk_child FROM 'another_user'@'%'").Error())
+		}()
+		t.Run("with REFERENCES privilege", func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+			testIsKindOfNoReferencedRowErrorWithDB(t, db, mysqldb.NoReferencedRow2)
+		})
+		t.Run("without REFERENCES privilege", func(t *testing.T) {
+			testoutput.SuppressIfPasses(t)
+			testIsKindOfNoReferencedRowErrorWithDB(t, db1, mysqldb.NoReferencedRow)
+		})
+	})
+}
+
+func testIsKindOfRowIsReferencedErrorWithDB(t *testing.T, db *database.DB, expectedErrorNumber mysqldb.MysqlErrorNumber) {
+	t.Helper()
+
+	// Attempt to delete a parent row that is referenced by a child row
+	err := db.Exec("DELETE FROM test_fk_parent WHERE id = 1").Error()
+	require.Error(t, err)
+
+	require.True(t, mysqldb.IsMysqlError(err, expectedErrorNumber),
+		"expected error number %d for error: %v", expectedErrorNumber, err)
+	assert.True(t, database.IsKindOfRowIsReferencedError(err))
+}
+
+func testIsKindOfNoReferencedRowErrorWithDB(t *testing.T, db *database.DB, expectedErrorNumber mysqldb.MysqlErrorNumber) {
+	t.Helper()
+
+	// Attempt to insert a child row with a non-existing parent_id
+	err := db.Exec("INSERT INTO test_fk_child (id, parent_id) VALUES (2, 999)").Error()
+	require.Error(t, err)
+
+	require.True(t, mysqldb.IsMysqlError(err, expectedErrorNumber),
+		"expected error number %d for error: %v", expectedErrorNumber, err)
+	require.True(t, database.IsKindOfNoReferencedRowError(err))
+}
+
+func openRawDBConnectionForAnotherUser(ctx context.Context, userName, userPassword string) *sql.DB {
+	// needs actual config for connection to DB
+	config := testhelpers.GetConfigFromContext(ctx)
+	dbConfig, _ := app.DBConfig(config)
+	if dbConfig.Params == nil {
+		dbConfig.Params = make(map[string]string, 1)
+	}
+	dbConfig.Params["charset"] = "utf8mb4"
+
+	dbConfig.User = userName
+	dbConfig.Passwd = userPassword
+
+	logger := logging.LoggerFromContext(ctx)
+	rawDB, err := database.OpenRawDBConnection(dbConfig.FormatDSN(), logger.IsRawSQLQueriesLoggingEnabled())
+	if err != nil {
+		panic(err)
+	}
+	return rawDB
+}

--- a/app/database/errors_test.go
+++ b/app/database/errors_test.go
@@ -15,7 +15,7 @@ const (
 	DuplicateEntryErrorKey   = "key"
 )
 
-func TestIsDuplicateEntryError_matchError(t *testing.T) {
+func TestIsDuplicateEntryError_MatchingError(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
@@ -26,7 +26,7 @@ func TestIsDuplicateEntryError_matchError(t *testing.T) {
 	}
 }
 
-func TestIsDuplicateEntryError_otherErrors(t *testing.T) {
+func TestIsDuplicateEntryError_OtherErrors(t *testing.T) {
 	lockDeadlockError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DeadlockError),
 		Message: "Lock Deadlock Error",
@@ -42,7 +42,7 @@ func TestIsDuplicateEntryError_otherErrors(t *testing.T) {
 	}
 }
 
-func TestIsDuplicateEntryErrorForKey_matchError(t *testing.T) {
+func TestIsDuplicateEntryErrorForKey_MatchingError(t *testing.T) {
 	table := DuplicateEntryErrorTable
 	key := DuplicateEntryErrorKey
 	duplicateEntryError := mysql.MySQLError{
@@ -55,7 +55,7 @@ func TestIsDuplicateEntryErrorForKey_matchError(t *testing.T) {
 	}
 }
 
-func TestIsDuplicateEntryErrorForKey_matchDuplicateButWithOtherKey(t *testing.T) {
+func TestIsDuplicateEntryErrorForKey_ShouldNotMatchDuplicateWithAnotherKey(t *testing.T) {
 	table := DuplicateEntryErrorTable
 	otherKey := "otherkey"
 	duplicateEntryError := mysql.MySQLError{
@@ -68,7 +68,7 @@ func TestIsDuplicateEntryErrorForKey_matchDuplicateButWithOtherKey(t *testing.T)
 	}
 }
 
-func TestIsDuplicateEntryErrorForKey_matchDuplicateButWithOtherTable(t *testing.T) {
+func TestIsDuplicateEntryErrorForKey_ShouldNotMatchDuplicateWithAnotherTable(t *testing.T) {
 	otherTable := "othertable"
 	key := DuplicateEntryErrorKey
 	duplicateEntryError := mysql.MySQLError{
@@ -81,7 +81,7 @@ func TestIsDuplicateEntryErrorForKey_matchDuplicateButWithOtherTable(t *testing.
 	}
 }
 
-func TestIsDuplicateEntryErrorForKey_otherErrors(t *testing.T) {
+func TestIsDuplicateEntryErrorForKey_OtherErrors(t *testing.T) {
 	table := DuplicateEntryErrorTable
 	key := DuplicateEntryErrorKey
 
@@ -100,7 +100,7 @@ func TestIsDuplicateEntryErrorForKey_otherErrors(t *testing.T) {
 	}
 }
 
-func TestIsRowIsReferenced2Error_matchError(t *testing.T) {
+func TestIsRowIsReferenced2Error_MatchingError(t *testing.T) {
 	foreignKeyConstraintFailedError := mysql.MySQLError{
 		Number:  uint16(mysqldb.RowIsReferenced2),
 		Message: "Some message",
@@ -111,7 +111,7 @@ func TestIsRowIsReferenced2Error_matchError(t *testing.T) {
 	}
 }
 
-func TestIsRowIsReferenced2Error_otherError(t *testing.T) {
+func TestIsRowIsReferenced2Error_OtherErrors(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
@@ -127,7 +127,7 @@ func TestIsRowIsReferenced2Error_otherError(t *testing.T) {
 	}
 }
 
-func TestIsNoReferencedRow2Error_matchError(t *testing.T) {
+func TestIsNoReferencedRow2Error_MatchingError(t *testing.T) {
 	foreignKeyConstraintError := mysql.MySQLError{
 		Number:  uint16(mysqldb.NoReferencedRow2),
 		Message: "Some message",
@@ -138,7 +138,7 @@ func TestIsNoReferencedRow2Error_matchError(t *testing.T) {
 	}
 }
 
-func TestIsNoReferencedRow2Error_otherError(t *testing.T) {
+func TestIsNoReferencedRow2Error_OtherErrors(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
@@ -154,7 +154,7 @@ func TestIsNoReferencedRow2Error_otherError(t *testing.T) {
 	}
 }
 
-func TestIsLockDeadlockError_matchError(t *testing.T) {
+func TestIsLockDeadlockError_MatchingError(t *testing.T) {
 	lockDeadlockError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DeadlockError),
 		Message: "Lock Deadlock Error",
@@ -165,7 +165,7 @@ func TestIsLockDeadlockError_matchError(t *testing.T) {
 	}
 }
 
-func TestIsLockDeadlockError_otherError(t *testing.T) {
+func TestIsLockDeadlockError_OtherErrors(t *testing.T) {
 	foreignKeyConstraintError := mysql.MySQLError{
 		Number:  uint16(mysqldb.NoReferencedRow2),
 		Message: "Some message",

--- a/app/database/errors_test.go
+++ b/app/database/errors_test.go
@@ -100,56 +100,60 @@ func TestIsDuplicateEntryErrorForKey_OtherErrors(t *testing.T) {
 	}
 }
 
-func TestIsRowIsReferenced2Error_MatchingError(t *testing.T) {
-	foreignKeyConstraintFailedError := mysql.MySQLError{
-		Number:  uint16(mysqldb.RowIsReferenced2),
-		Message: "Some message",
-	}
+func TestIsKindOfRowIsReferencedError_MatchingErrors(t *testing.T) {
+	for _, errorNumber := range []mysqldb.MysqlErrorNumber{mysqldb.RowIsReferenced, mysqldb.RowIsReferenced2} {
+		foreignKeyConstraintError := mysql.MySQLError{
+			Number:  uint16(errorNumber),
+			Message: "Some message",
+		}
 
-	if !IsRowIsReferenced2Error(error(&foreignKeyConstraintFailedError)) {
-		t.Error("should be a RowIsReferenced2")
+		if !IsKindOfRowIsReferencedError(error(&foreignKeyConstraintError)) {
+			t.Errorf("%d should be kind of RowIsReferenced error", foreignKeyConstraintError.Number)
+		}
 	}
 }
 
-func TestIsRowIsReferenced2Error_OtherErrors(t *testing.T) {
+func TestIsKindOfRowIsReferencedError_OtherErrors(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
 	}
 
-	if IsRowIsReferenced2Error(error(&duplicateEntryError)) {
+	if IsKindOfRowIsReferencedError(error(&duplicateEntryError)) {
 		t.Error("should not match a Duplicate Entry Error")
 	}
 
 	nonMysqlError := errors.New("other error")
-	if IsRowIsReferenced2Error(nonMysqlError) {
+	if IsKindOfRowIsReferencedError(nonMysqlError) {
 		t.Error("should not match a non-mysql error")
 	}
 }
 
-func TestIsNoReferencedRow2Error_MatchingError(t *testing.T) {
-	foreignKeyConstraintError := mysql.MySQLError{
-		Number:  uint16(mysqldb.NoReferencedRow2),
-		Message: "Some message",
-	}
+func TestIsKindOfNoReferencedRowError_MatchingErrors(t *testing.T) {
+	for _, errorNumber := range []mysqldb.MysqlErrorNumber{mysqldb.NoReferencedRow, mysqldb.NoReferencedRow2} {
+		foreignKeyConstraintError := mysql.MySQLError{
+			Number:  uint16(errorNumber),
+			Message: "Some message",
+		}
 
-	if !IsNoReferencedRow2Error(error(&foreignKeyConstraintError)) {
-		t.Error("should be a NoReferencedRow2")
+		if !IsKindOfNoReferencedRowError(error(&foreignKeyConstraintError)) {
+			t.Errorf("%d should be a NoReferencedRow error", foreignKeyConstraintError.Number)
+		}
 	}
 }
 
-func TestIsNoReferencedRow2Error_OtherErrors(t *testing.T) {
+func TestIsKindOfNoReferencedRowError_OtherErrors(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
 	}
 
-	if IsNoReferencedRow2Error(error(&duplicateEntryError)) {
+	if IsKindOfNoReferencedRowError(error(&duplicateEntryError)) {
 		t.Error("should not match a Duplicate Entry Error")
 	}
 
 	nonMysqlError := errors.New("other error")
-	if IsNoReferencedRow2Error(nonMysqlError) {
+	if IsKindOfNoReferencedRowError(nonMysqlError) {
 		t.Error("should not match a non-mysql error")
 	}
 }

--- a/app/database/errors_test.go
+++ b/app/database/errors_test.go
@@ -100,56 +100,56 @@ func TestIsDuplicateEntryErrorForKey_otherErrors(t *testing.T) {
 	}
 }
 
-func TestIsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError_matchError(t *testing.T) {
+func TestIsRowIsReferenced2Error_matchError(t *testing.T) {
 	foreignKeyConstraintFailedError := mysql.MySQLError{
-		Number:  uint16(mysqldb.ForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError),
+		Number:  uint16(mysqldb.RowIsReferenced2),
 		Message: "Some message",
 	}
 
-	if !IsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError(error(&foreignKeyConstraintFailedError)) {
-		t.Error("should be a ForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError")
+	if !IsRowIsReferenced2Error(error(&foreignKeyConstraintFailedError)) {
+		t.Error("should be a RowIsReferenced2")
 	}
 }
 
-func TestIsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError_otherError(t *testing.T) {
+func TestIsRowIsReferenced2Error_otherError(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
 	}
 
-	if IsForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError(error(&duplicateEntryError)) {
+	if IsRowIsReferenced2Error(error(&duplicateEntryError)) {
 		t.Error("should not match a Duplicate Entry Error")
 	}
 
 	nonMysqlError := errors.New("other error")
-	if IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(nonMysqlError) {
+	if IsRowIsReferenced2Error(nonMysqlError) {
 		t.Error("should not match a non-mysql error")
 	}
 }
 
-func TestIsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError_matchError(t *testing.T) {
+func TestIsNoReferencedRow2Error_matchError(t *testing.T) {
 	foreignKeyConstraintError := mysql.MySQLError{
-		Number:  uint16(mysqldb.ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError),
+		Number:  uint16(mysqldb.NoReferencedRow2),
 		Message: "Some message",
 	}
 
-	if !IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(error(&foreignKeyConstraintError)) {
-		t.Error("should be a ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError")
+	if !IsNoReferencedRow2Error(error(&foreignKeyConstraintError)) {
+		t.Error("should be a NoReferencedRow2")
 	}
 }
 
-func TestIsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError_otherError(t *testing.T) {
+func TestIsNoReferencedRow2Error_otherError(t *testing.T) {
 	duplicateEntryError := mysql.MySQLError{
 		Number:  uint16(mysqldb.DuplicateEntryError),
 		Message: "Duplicate Error",
 	}
 
-	if IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(error(&duplicateEntryError)) {
+	if IsNoReferencedRow2Error(error(&duplicateEntryError)) {
 		t.Error("should not match a Duplicate Entry Error")
 	}
 
 	nonMysqlError := errors.New("other error")
-	if IsForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError(nonMysqlError) {
+	if IsNoReferencedRow2Error(nonMysqlError) {
 		t.Error("should not match a non-mysql error")
 	}
 }
@@ -167,7 +167,7 @@ func TestIsLockDeadlockError_matchError(t *testing.T) {
 
 func TestIsLockDeadlockError_otherError(t *testing.T) {
 	foreignKeyConstraintError := mysql.MySQLError{
-		Number:  uint16(mysqldb.ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError),
+		Number:  uint16(mysqldb.NoReferencedRow2),
 		Message: "Some message",
 	}
 

--- a/app/database/mysqldb/errors.go
+++ b/app/database/mysqldb/errors.go
@@ -19,6 +19,12 @@ const (
 	// DeadlockError represents the mysql error "Deadlock found when trying to get lock; try restarting transaction".
 	DeadlockError MysqlErrorNumber = 1213
 
+	// NoReferencedRow represents a mysql foreign constraint error
+	// of adding or updating a child row when the current DB user doesn't have table-level privileges for all parent tables.
+	NoReferencedRow MysqlErrorNumber = 1216
+	// RowIsReferenced represents a mysql foreign constraint error
+	// of deleting or updating a parent row when the current DB user doesn't have table-level privileges for all parent tables.
+	RowIsReferenced MysqlErrorNumber = 1217
 	// RowIsReferenced2 represents a mysql foreign constraint error
 	// of deleting or updating a parent row when the current DB user has table-level privileges for all parent tables.
 	RowIsReferenced2 MysqlErrorNumber = 1451

--- a/app/database/mysqldb/errors.go
+++ b/app/database/mysqldb/errors.go
@@ -18,12 +18,13 @@ const (
 	LockWaitTimeoutExceededError MysqlErrorNumber = 1205
 	// DeadlockError represents the mysql error "Deadlock found when trying to get lock; try restarting transaction".
 	DeadlockError MysqlErrorNumber = 1213
-	// ForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError represents a mysql foreign constraint error
-	// of deleting or updating a parent row.
-	ForeignKeyConstraintFailedOnDeletingOrUpdatingParentRowError MysqlErrorNumber = 1451
-	// ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError represents a mysql foreign constraint error
-	// of adding or updating a child row.
-	ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError MysqlErrorNumber = 1452
+
+	// RowIsReferenced2 represents a mysql foreign constraint error
+	// of deleting or updating a parent row when the current DB user has table-level privileges for all parent tables.
+	RowIsReferenced2 MysqlErrorNumber = 1451
+	// NoReferencedRow2 represents a mysql foreign constraint error
+	// of adding or updating a child row when the current DB user has table-level privileges for all parent tables.
+	NoReferencedRow2 MysqlErrorNumber = 1452
 )
 
 // IsMysqlError checks whether an error is a Mysql error of a certain type.

--- a/app/database/mysqldb/errors_test.go
+++ b/app/database/mysqldb/errors_test.go
@@ -24,8 +24,8 @@ func TestIsMysqlError_shouldNotMatchDifferentMysqlError(t *testing.T) {
 		Message: "Duplicate Error",
 	}
 
-	if IsMysqlError(error(&duplicateEntryError), ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError) {
-		t.Error("DuplicateEntryError should not match a ForeignKeyConstraintFailedOnAddingOrUpdatingChildRowError")
+	if IsMysqlError(error(&duplicateEntryError), NoReferencedRow2) {
+		t.Error("DuplicateEntryError should not match a NoReferencedRow2")
 	}
 }
 


### PR DESCRIPTION
Fixes #1334 