### PR TITLE
Upgrade golangci-lint to v2.4.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,145 +1,148 @@
-linters-settings:
-  govet:
-    shadow: true
-    settings:
-      printf:
-        funcs:
-          - (github.com/github.com/sirupsen/logrus.Entry).Debugf
-          - (github.com/github.com/sirupsen/logrus.Entry).Infof
-          - (github.com/github.com/sirupsen/logrus.Entry).Warnf
-          - (github.com/github.com/sirupsen/logrus.Entry).Errorf
-          - (github.com/github.com/sirupsen/logrus.Entry).Panicf
-          - (github.com/github.com/sirupsen/logrus.Entry).Fatalf
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 10
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  depguard:
-    rules:
-      main:
-        list-mode: original
-        deny:
-          # logging is allowed only by app/logging, logrus
-          # is allowed to be used only in app/logging package
-          - pkg: "github.com/sirupsen/logrus"
-            desc: not allowed
-              - github.com/sirupsen/logrus
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  goimports:
-    local-prefixes: github.com/France-ioi/AlgoreaBackend/v2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-      - experimental
-      - opinionated
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/France-ioi/AlgoreaBackend/v2/) # Custom section: groups all imports with the specified Prefix.
-    no-inline-comments: true
-    no-prefix-comments: true
-    custom-order: true
-    # Drops lexical ordering for custom sections.
-    # Default: false
-    no-lex-order: false
-  errchkjson:
-    check-error-free-encoding: true
-    report-no-exported: true
-  exhaustive:
-    default-signifies-exhaustive: true
-    package-scope-only: false
-  nilnil:
-    only-two: false
-    detect-opposite: true
-  paralleltest:
-    ignore-missing: true
-  tagliatelle:
-    case:
-      rules:
-        json: snake
-        yaml: camel
-        xml: camel
-        toml: camel
-        bson: camel
-        avro: snake
-        mapstructure: kebab
-        env: upperSnake
-        envconfig: upperSnake
-        whatever: snake
-      overrides:
-        - pkg: app/payloads
-          ignore: true
-  varnamelen:
-    ignore-names:
-      - db
-      - tx
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - testpackage      # Requires that go tests files are in a different package, but current tests are on private functions
-    - wsl              # Requires white lines between blocks. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - err113           # Doesn't allow dynamic errors, requires wrapped static errors. (Disabled by default in golangci-lint)
-    - contextcheck     # Checks whether a function uses a non-inherited context. (Many false positives. Disabled by default in golangci-lint)
-    - ireturn          # Forces functions to accept Interfaces and return concrete types. (Very subjective, complains about many implementations of interfaces from third-party libraries, the benefit is questionable. Disabled by default in golangci-lint)
-    - maintidx         # Measures the maintainability index of each function. (It only complains about some out test functions, but it is not very useful. Disabled by default in golangci-lint)
-    - nlreturn         # Checks for a new line before return and branch statements. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - nonamedreturns   # Doesn't allow named returns in functions. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
-    - tenv             # Deprecated in golangci-lint v1.64.0, replaced by `usetesting`
-    - wrapcheck        # Requires all errors from external packages are wrapped during return. (It requires many changes without any real benefit for now. Disabled by default in golangci-lint.)
-    - exhaustruct      # Requires all structure fields to be initialized. (Requires many changes without any real benefit. Disabled by default in golangci-lint.)
-
+    - contextcheck   # Checks whether a function uses a non-inherited context. (Many false positives. Disabled by default in golangci-lint)
+    - err113         # Doesn't allow dynamic errors, requires wrapped static errors. (Disabled by default in golangci-lint)
+    - exhaustruct    # Requires all structure fields to be initialized. (Requires many changes without any real benefit. Disabled by default in golangci-lint.)
+    - ireturn        # Forces functions to accept Interfaces and return concrete types. (Very subjective, complains about many implementations of interfaces from third-party libraries, the benefit is questionable. Disabled by default in golangci-lint)
+    - maintidx       # Measures the maintainability index of each function. (It only complains about some out test functions, but it is not very useful. Disabled by default in golangci-lint)
+    - nlreturn       # Checks for a new line before return and branch statements. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
+    - noinlineerr    # Disallows inline error handling (if err := ...; err != nil {). (Very subjective, no real benefit. Disabled by default in golangci-lint)
+    - nonamedreturns # Doesn't allow named returns in functions. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
+    - testpackage    # Requires that go tests files are in a different package, but current tests are on private functions
+    - wrapcheck      # Requires all errors from external packages are wrapped during return. (It requires many changes without any real benefit for now. Disabled by default in golangci-lint.)
+    - wsl            # Requires white lines between blocks. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
+    - wsl_v5         # Requires white lines between blocks. (Very subjective, requires many changes without any real benefit. Disabled by default in golangci-lint)
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: original
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+        # logrus is allowed to be used only in app/logging & loggingtest packages
+        logrus:
+          list-mode: original
+          files:
+            - "!${config-path}/app/logging*/**"
+          deny:
+            - pkg: github.com/sirupsen/logrus
+              desc: only app/logging and app/loggingtest are allowed to use logrus directly, use logging package instead
+    dupl:
+      threshold: 100
+    errchkjson:
+      check-error-free-encoding: true
+      report-no-exported: true
+    exhaustive:
+      default-signifies-exhaustive: true
+      package-scope-only: false
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - experimental
+        - opinionated
+    gocyclo:
+      min-complexity: 10
+    govet:
+      enable:
+        - printf
+      settings:
+        printf:
+          funcs:
+            - (github.com/github.com/sirupsen/logrus.Entry).Debugf
+            - (github.com/github.com/sirupsen/logrus.Entry).Infof
+            - (github.com/github.com/sirupsen/logrus.Entry).Warnf
+            - (github.com/github.com/sirupsen/logrus.Entry).Errorf
+            - (github.com/github.com/sirupsen/logrus.Entry).Panicf
+            - (github.com/github.com/sirupsen/logrus.Entry).Fatalf
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nilnil:
+      only-two: false
+      detect-opposite: true
+    paralleltest:
+      ignore-missing: true
+    tagliatelle:
+      case:
+        rules:
+          avro: snake
+          bson: camel
+          env: upperSnake
+          envconfig: upperSnake
+          json: snake
+          mapstructure: kebab
+          toml: camel
+          whatever: snake
+          xml: camel
+          yaml: camel
+        overrides:
+          - pkg: app/payloads
+            ignore: true
+    varnamelen:
+      ignore-names:
+        - db
+        - tx
+  exclusions:
+    generated: strict
+    warn-unused: true
+    rules:
+      - linters:
+          - noctx
+        path: _test\.go$
+      - linters:
+          - lll
+          - revive
+          - unused
+        path: ^app/doc/
+      - linters:
+          - varnamelen
+        path: _test\.go$
+        text: name 'tt' is too short for the scope of its usage
+      - linters:
+          - noctx
+        path: ^app/servicetest/
+      - linters:
+          - funlen
+        text: is too long
+      - linters:
+          - funlen
+        text: has too many statements
+      - linters:
+          - staticcheck
+        text: unknown JSON option "squash" # an option provided by the mapstructure library and the formdata package
+      - linters:
+          - dupword
+        text: Duplicate words \(.*[:,].*\) found
 issues:
-  exclude-use-default: false
-  exclude-dirs:
-    - ^db$
-    - ^app/database/testdata$
-    - ^test-results$
-    - ^pkg/golinters/goanalysis/(checker|passes)$
-    - ^app/doc$
-  exclude-rules:
-    - path: _test\.go$
-      linters:
-        - noctx
-    - path: _test\.go$
-      text: "name 'tt' is too short for the scope of its usage"
-      linters:
-        - varnamelen
-    - path: ^app/servicetest/
-      linters:
-        - noctx
-    - text: "is too long"
-      linters:
-        - funlen
-    - text: "has too many statements"
-      linters:
-        - funlen
-    - text: unknown JSON option "squash" # an option provided by the mapstructure library and the formdata package
-      linters:
-        - staticcheck
-    - text: "Duplicate words \\(.*[:,].*\\) found"
-      linters:
-        - dupword
   max-issues-per-linter: 0
   max-same-issues: 0
-  #fix: true # Enable to try auto fix.
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.64.7 # use the fixed version to not introduce new linters unexpectedly
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/France-ioi/AlgoreaBackend/v2/) # Custom section: groups all imports with the specified Prefix.
+      no-inline-comments: true
+      no-prefix-comments: true
+      custom-order: true
+      # Drops lexical ordering for custom sections.
+      # Default: false
+      no-lex-order: false
+    goimports:
+      local-prefixes:
+        - github.com/France-ioi/AlgoreaBackend/v2

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_BIN_DIR=./bin
 
 BIN_PATH=$(LOCAL_BIN_DIR)/$(BIN_NAME)
 GOLANGCILINT=$(LOCAL_BIN_DIR)/golangci-lint
-GOLANGCILINT_VERSION=1.64.7
+GOLANGCILINT_VERSION=2.4.0
 MYSQL_CONNECTOR_JAVA=$(LOCAL_BIN_DIR)/mysql-connector-java-8.jar
 SCHEMASPY=$(LOCAL_BIN_DIR)/schemaspy-6.0.0.jar
 PWD=$(shell pwd)
@@ -137,7 +137,7 @@ version:
 $(TEST_REPORT_DIR):
 	mkdir -p $(TEST_REPORT_DIR)
 $(GOLANGCILINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCAL_BIN_DIR) v$(GOLANGCILINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCAL_BIN_DIR) v$(GOLANGCILINT_VERSION)
 $(MYSQL_CONNECTOR_JAVA):
 	curl -sfL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.16.tar.gz | tar -xzf - mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar
 	mv mysql-connector-java-8.0.16/mysql-connector-java-8.0.16.jar $(MYSQL_CONNECTOR_JAVA)

--- a/app/api/answers/list_answers.go
+++ b/app/api/answers/list_answers.go
@@ -173,9 +173,10 @@ type rawAnswersData struct {
 }
 
 type answersResponseAnswerUser struct {
+	*structures.UserPersonalInfo
+
 	// required: true
 	Login string `json:"login"`
-	*structures.UserPersonalInfo
 }
 
 // swagger:model

--- a/app/api/answers/submit.go
+++ b/app/api/answers/submit.go
@@ -42,6 +42,7 @@ type answerSubmitResponse struct { //nolint:unused // used in swagger documentat
 	// description
 	// swagger:allOf
 	doc.CreatedResponse
+
 	// required:true
 	Data struct {
 		AnswerToken string `json:"answer_token"`

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -424,10 +424,11 @@ type CookieParameters struct {
 }
 
 type createAccessTokenRequestParameters struct {
+	*CookieParameters
+
 	Code         *string `json:"code"`
 	CodeVerifier *string `json:"code_verifier"`
 	RedirectURI  *string `json:"redirect_uri"`
-	*CookieParameters
 }
 
 func parseJSONParams(httpRequest *http.Request, requestParameters *createAccessTokenRequestParameters) error {

--- a/app/api/auth/refresh_access_token_integration_test.go
+++ b/app/api/auth/refresh_access_token_integration_test.go
@@ -323,10 +323,11 @@ func createLoginModuleStubServer(expectedRefreshToken string) (*httptest.Server,
 
 type cancelCtx struct {
 	context.Context //nolint:containedctx // it is not us who store the context in the structure
-	_               sync.Mutex
-	_               atomic.Value
-	_               map[interface{}]struct{}
-	err             error
+
+	_   sync.Mutex
+	_   atomic.Value
+	_   map[interface{}]struct{}
+	err error
 }
 
 type timerCtx struct {

--- a/app/api/currentuser/get_group_activities.go
+++ b/app/api/currentuser/get_group_activities.go
@@ -14,6 +14,8 @@ import (
 
 // rawRootItem represents one row with a root activity/skill returned from the DB.
 type rawRootItem struct {
+	*database.RawGeneratedPermissionFields
+
 	// groups
 	GroupID   int64
 	GroupName string
@@ -45,8 +47,6 @@ type rawRootItem struct {
 	BestScore float32
 
 	HasVisibleChildren bool
-
-	*database.RawGeneratedPermissionFields
 }
 
 type groupInfoForRootItem struct {

--- a/app/api/currentuser/get_group_activities.go
+++ b/app/api/currentuser/get_group_activities.go
@@ -220,7 +220,7 @@ func generateRootItemInfoFromRawData(store *database.DataStore, rawData *rawRoot
 			ID:          rawData.ItemID,
 			Type:        rawData.ItemType,
 			String:      structures.ItemString{Title: rawData.Title, LanguageTag: rawData.LanguageTag},
-			Permissions: *rawData.RawGeneratedPermissionFields.AsItemPermissions(store.PermissionsGranted()),
+			Permissions: *rawData.AsItemPermissions(store.PermissionsGranted()),
 		},
 		RequiresExplicitEntry: rawData.RequiresExplicitEntry,
 		EntryParticipantType:  rawData.EntryParticipantType,

--- a/app/api/currentuser/get_info_test.go
+++ b/app/api/currentuser/get_info_test.go
@@ -18,7 +18,7 @@ func TestService_getInfo_Returns403WhenUserNotFound(t *testing.T) {
 	mock.ExpectQuery("^SELECT").WillReturnRows(mock.NewRows([]string{"id"})) // no rows
 
 	srv := &Service{Base: &service.Base{}}
-	srv.Base.SetGlobalStore(database.NewDataStore(db))
+	srv.SetGlobalStore(database.NewDataStore(db))
 	patch := monkey.PatchInstanceMethod(reflect.TypeOf(srv.Base), "GetUser", func(*service.Base, *http.Request) *database.User {
 		return &database.User{GroupID: 123}
 	})

--- a/app/api/groups/create_code_test.go
+++ b/app/api/groups/create_code_test.go
@@ -76,5 +76,9 @@ func assertMockedChangeCodeRequest(t *testing.T,
 		})
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
-	return response, mock, logs, err
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return response, mock, logs, nil
 }

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -205,8 +205,7 @@ func (srv *Service) getChildren(responseWriter http.ResponseWriter, httpRequest 
 			result[index].ManagerPermissionsPart = nil
 			result[index].UserCountPart = nil
 		} else {
-			result[index].ManagerPermissionsPart.CurrentUserCanManage = groupManagerStore.
-				CanManageNameByIndex(result[index].CurrentUserCanManageValue)
+			result[index].CurrentUserCanManage = groupManagerStore.CanManageNameByIndex(result[index].CurrentUserCanManageValue)
 		}
 	}
 

--- a/app/api/groups/get_children.go
+++ b/app/api/groups/get_children.go
@@ -18,6 +18,9 @@ type UserCountPart struct {
 
 // swagger:model groupChildrenViewResponseRow
 type groupChildrenViewResponseRow struct {
+	*ManagerPermissionsPart
+	*UserCountPart
+
 	// The sub-group's `groups.id`
 	// required:true
 	ID int64 `json:"id,string"`
@@ -37,8 +40,6 @@ type groupChildrenViewResponseRow struct {
 	IsEmpty *bool `json:"is_empty,omitempty"`
 	// required:true
 	CurrentUserIsManager bool `json:"current_user_is_manager"`
-	*ManagerPermissionsPart
-	*UserCountPart
 }
 
 // swagger:operation GET /groups/{group_id}/children group-memberships groupChildrenView

--- a/app/api/groups/get_granted_permissions.go
+++ b/app/api/groups/get_granted_permissions.go
@@ -19,6 +19,7 @@ type grantedPermissionsViewResultRowGroup struct {
 
 type grantedPermissionsViewResultPermissions struct {
 	structures.ItemPermissions
+
 	// required: true
 	CanMakeSessionOfficial bool `json:"can_make_session_official"`
 	// required: true

--- a/app/api/groups/get_group.go
+++ b/app/api/groups/get_group.go
@@ -214,7 +214,7 @@ func (srv *Service) getGroup(responseWriter http.ResponseWriter, httpRequest *ht
 		result.GroupGetResponseCodePart = nil
 		result.ManagerPermissionsPart = nil
 	} else {
-		result.ManagerPermissionsPart.CurrentUserCanManage = store.GroupManagers().CanManageNameByIndex(result.CurrentUserCanManageValue)
+		result.CurrentUserCanManage = store.GroupManagers().CanManageNameByIndex(result.CurrentUserCanManageValue)
 	}
 
 	if result.CurrentUserMembership != "none" {

--- a/app/api/groups/get_group.go
+++ b/app/api/groups/get_group.go
@@ -41,6 +41,10 @@ type ManagerPermissionsPart struct {
 
 // swagger:model groupGetResponse
 type groupGetResponse struct {
+	*structures.GroupShortInfo
+	*GroupGetResponseCodePart
+	*ManagerPermissionsPart
+
 	// required:true
 	Grade int32 `json:"grade"`
 	// required:true
@@ -79,10 +83,6 @@ type groupGetResponse struct {
 	// list of descendant (excluding the group itself) non-user groups that the current user (or his ancestor groups) is manager of
 	// required:true
 	DescendantsCurrentUserIsManagerOf []structures.GroupShortInfo `json:"descendants_current_user_is_manager_of"`
-
-	*structures.GroupShortInfo
-	*GroupGetResponseCodePart
-	*ManagerPermissionsPart
 
 	// required: true
 	IsMembershipLocked bool `json:"is_membership_locked"`

--- a/app/api/groups/get_managers.go
+++ b/app/api/groups/get_managers.go
@@ -33,17 +33,17 @@ type GroupManagersViewResponseRowThroughAncestorGroups struct {
 
 // swagger:model groupManagersViewResponseRow
 type groupManagersViewResponseRow struct {
+	// only for users
+	*GroupManagersViewResponseRowUser
+	// only when include_managers_of_ancestor_groups=1
+	*GroupManagersViewResponseRowThroughAncestorGroups
+
 	// `groups.id`
 	// required: true
 	ID int64 `json:"id,string"`
 	// `groups.name`
 	// required: true
 	Name string `json:"name"`
-
-	// only for users
-	*GroupManagersViewResponseRowUser
-	// only when include_managers_of_ancestor_groups=1
-	*GroupManagersViewResponseRowThroughAncestorGroups
 
 	// null when a manager is not a direct manager of the group
 	// enum: none,memberships,memberships_and_group

--- a/app/api/groups/get_members.go
+++ b/app/api/groups/get_members.go
@@ -21,13 +21,14 @@ type groupsMembersViewResponseRow struct {
 	Action *string `json:"action,omitempty"`
 	// required: true
 	User struct {
+		*structures.UserPersonalInfo
+
 		// `users.group_id`
 		// required: true
 		GroupID int64 `json:"group_id,string"`
 		// required: true
 		Login string `json:"login"`
 
-		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 
 		// required: true

--- a/app/api/groups/get_participant_progress.go
+++ b/app/api/groups/get_participant_progress.go
@@ -74,12 +74,12 @@ type groupParticipantProgressResponse struct {
 }
 
 type rawParticipantProgressRaw struct {
+	*database.RawGeneratedPermissionFields
+
 	// items
 	ItemID  int64 `gorm:"column:id"`
 	Type    string
 	NoScore bool
-
-	*database.RawGeneratedPermissionFields
 
 	// from items_strings: in the user’s default language or (if not available) default language of the item
 	StringLanguageTag string  `gorm:"column:language_tag"`

--- a/app/api/groups/get_permissions.go
+++ b/app/api/groups/get_permissions.go
@@ -28,6 +28,7 @@ const (
 
 type permissionsStruct struct {
 	structures.ItemPermissions
+
 	// required: true
 	CanMakeSessionOfficial bool `json:"can_make_session_official"`
 }
@@ -47,6 +48,7 @@ type canRequestHelpTo struct {
 // Permissions granted directly to the group via `origin` = 'group_membership' and `source_group_id` = `{source_group_id}`.
 type grantedPermissionsStruct struct {
 	permissionsStruct
+
 	// required: true
 	CanEnterFrom string `json:"can_enter_from"`
 	// required: true
@@ -57,6 +59,7 @@ type grantedPermissionsStruct struct {
 
 type aggregatedPermissionsWithCanEnterFromStruct struct {
 	permissionsStruct
+
 	// The next time the group can enter the item (>= NOW())
 	// required: true
 	CanEnterFrom string `json:"can_enter_from"`

--- a/app/api/groups/get_requests.go
+++ b/app/api/groups/get_requests.go
@@ -24,13 +24,14 @@ type groupRequestsViewResponseRow struct {
 
 	// required: true
 	JoiningUser struct {
+		*structures.UserPersonalInfo
+
 		// `users.group_id`
 		// required: true
 		GroupID int64 `json:"group_id,string"`
 		// required: true
 		Login string `json:"login"`
 
-		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 
 		// required: true

--- a/app/api/groups/get_team_descendants.go
+++ b/app/api/groups/get_team_descendants.go
@@ -152,10 +152,11 @@ func (srv *Service) getTeamDescendants(responseWriter http.ResponseWriter, httpR
 }
 
 type teamDescendantMember struct {
+	*structures.UserPersonalInfo
+
 	// required:true
 	GroupID int64 `json:"group_id,string"`
 
-	*structures.UserPersonalInfo
 	ShowPersonalInfo bool `json:"-"`
 
 	// required:true

--- a/app/api/groups/get_user_descendants.go
+++ b/app/api/groups/get_user_descendants.go
@@ -135,6 +135,7 @@ func (srv *Service) getUserDescendants(responseWriter http.ResponseWriter, httpR
 
 type userDescendantUser struct {
 	*structures.UserPersonalInfo
+
 	ShowPersonalInfo bool `json:"-"`
 
 	// required:true

--- a/app/api/groups/get_user_requests.go
+++ b/app/api/groups/get_user_requests.go
@@ -31,13 +31,14 @@ type groupUserRequestsViewResponseRow struct {
 
 	// required: true
 	User struct {
+		*structures.UserPersonalInfo
+
 		// `users.group_id`
 		// required: true
 		GroupID *int64 `json:"group_id,string"`
 		// required: true
 		Login string `json:"login"`
 
-		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 
 		// required: true

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -119,10 +119,8 @@ func assertUpdateGroupFailsOnDBErrorInTransaction(t *testing.T, setMockExpectati
 			router.Put("/groups/{group_id}", service.AppHandler(srv.updateGroup).ServeHTTP)
 		})
 
-	if err == nil {
-		_ = response.Body.Close()
-	}
 	require.NoError(t, err)
+	_ = response.Body.Close()
 	assert.Equal(t, 500, response.StatusCode)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/api/items/ask_hint.go
+++ b/app/api/items/ask_hint.go
@@ -231,6 +231,15 @@ func (requestData *AskHintRequest) UnmarshalJSON(raw []byte) error {
 	return requestData.unmarshalHintToken(&wrapper)
 }
 
+// Bind of AskHintRequest checks that the asked hint is present.
+func (requestData *AskHintRequest) Bind(_ *http.Request) error {
+	if len(requestData.HintToken.Payload.AskedHint.Bytes()) == 0 ||
+		bytes.Equal([]byte("null"), requestData.HintToken.Payload.AskedHint.Bytes()) {
+		return errors.New("asked hint should not be empty")
+	}
+	return nil
+}
+
 func (requestData *AskHintRequest) unmarshalHintToken(wrapper *askHintRequestWrapper) error {
 	if wrapper.HintRequestedToken == nil {
 		return errors.New("missing hint_requested")
@@ -253,14 +262,5 @@ func (requestData *AskHintRequest) unmarshalHintToken(wrapper *askHintRequestWra
 		return fmt.Errorf("no public key available for the platform linked to item %d", itemID)
 	}
 
-	return nil
-}
-
-// Bind of AskHintRequest checks that the asked hint is present.
-func (requestData *AskHintRequest) Bind(_ *http.Request) error {
-	if len(requestData.HintToken.Payload.AskedHint.Bytes()) == 0 ||
-		bytes.Equal([]byte("null"), requestData.HintToken.Payload.AskedHint.Bytes()) {
-		return errors.New("asked hint should not be empty")
-	}
 	return nil
 }

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -64,6 +64,7 @@ type Item struct {
 // ItemWithRequiredType represents common item fields plus the required type field.
 type ItemWithRequiredType struct {
 	Item `json:"item,squash"`
+
 	// Can be equal to 'Skill' only if the parent's type is 'Skill'
 	// required: true
 	// enum: Chapter,Task,Skill
@@ -106,10 +107,11 @@ type itemParent struct {
 // NewItemRequest is the expected input for new created item
 // swagger:model itemCreateRequest
 type NewItemRequest struct {
+	newItemString `json:"string,squash"`
+
 	// `default_language_tag` of the item
 	// required: true
-	LanguageTag   string `json:"language_tag"  validate:"set,language_tag"`
-	newItemString `json:"string,squash"`
+	LanguageTag string `json:"language_tag" validate:"set,language_tag"`
 
 	Parent          itemParent `json:"parent"`
 	AsRootOfGroupID int64      `json:"as_root_of_group_id,string" validate:"as_root_of_group_id"`

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -116,6 +116,7 @@ type NewItemRequest struct {
 	Parent          itemParent `json:"parent"`
 	AsRootOfGroupID int64      `json:"as_root_of_group_id,string" validate:"as_root_of_group_id"`
 
+	//nolint:embeddedstructfieldcheck // it's important that this embedded field goes after Parent otherwise validation won't work correctly
 	ItemWithRequiredType `json:"item,squash"`
 
 	Children []itemChild `json:"children" validate:"children,children_allowed,dive,child_type_non_skill"`

--- a/app/api/items/get_activity_log.go
+++ b/app/api/items/get_activity_log.go
@@ -42,12 +42,13 @@ type itemActivityLogResponseRow struct {
 		Type string `json:"type"`
 	} `json:"participant" gorm:"embedded;embedded_prefix:participant__"`
 	User *struct {
+		*structures.UserPersonalInfo
+
 		// required: true
 		ID *int64 `json:"id,string"`
 		// required: true
 		Login string `json:"login"`
 
-		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 	} `gorm:"embedded;embedded_prefix:user__" json:"user,omitempty"`
 	// required: true

--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -111,10 +111,10 @@ func (srv *Service) getBreadcrumbs(responseWriter http.ResponseWriter, httpReque
 		attemptIDMap, attemptNumberMap, err = store.Items().BreadcrumbsHierarchyForParentAttempt(
 			params.ids, params.participantID, params.parentAttemptID, false)
 	}
-	service.MustNotBeError(err)
-	if attemptIDMap == nil {
+	if errors.Is(err, database.ErrHierarchyNotFound) {
 		return service.ErrForbidden(errors.New("item ids hierarchy is invalid or insufficient access rights"))
 	}
+	service.MustNotBeError(err)
 
 	idsInterface := make([]interface{}, 0, len(params.ids))
 	for _, id := range params.ids {

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -16,14 +16,14 @@ type listItemStringNotInfo struct {
 }
 
 type listItemString struct {
+	*listItemStringNotInfo
+
 	// required: true
 	LanguageTag string `json:"language_tag"`
 	// required: true
 	Title *string `json:"title"`
 	// required: true
 	ImageURL *string `json:"image_url"`
-
-	*listItemStringNotInfo
 }
 
 // only for visible items.
@@ -70,6 +70,8 @@ type visibleChildItemFields struct {
 
 // swagger:model childItem
 type childItem struct {
+	*visibleChildItemFields
+
 	// required: true
 	ID int64 `json:"id,string"`
 	// required: true
@@ -111,13 +113,13 @@ type childItem struct {
 	Permissions structures.ItemPermissions `json:"permissions"`
 
 	WatchedGroup *itemWatchedGroupStat `json:"watched_group,omitempty"`
-
-	*visibleChildItemFields
 }
 
 // RawListItem contains raw fields common for itemChildrenView & itemParentsView.
 type RawListItem struct {
 	*RawCommonItemFields
+	*RawItemResultFields
+	*RawWatchedGroupStatFields
 
 	// from items_strings: in the user’s default language or (if not available) default language of the item
 	StringLanguageTag string  `sql:"column:language_tag"`
@@ -131,9 +133,6 @@ type RawListItem struct {
 
 	// max from results of the current participant
 	BestScore float32
-
-	*RawItemResultFields
-	*RawWatchedGroupStatFields
 }
 
 type rawListChildItem struct {

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -368,7 +368,7 @@ func childItemsFromRawData(
 			if rawData[index].CanViewGeneratedValue >= permissionGrantedStore.ViewIndexByName("content") {
 				child.String.listItemStringNotInfo = &listItemStringNotInfo{Subtitle: rawData[index].StringSubtitle}
 			}
-			child.WatchedGroup = rawData[index].RawWatchedGroupStatFields.asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
+			child.WatchedGroup = rawData[index].asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
 			result = append(result, child)
 			currentChild = &result[len(result)-1]
 		}

--- a/app/api/items/get_entry_state.go
+++ b/app/api/items/get_entry_state.go
@@ -13,6 +13,7 @@ import (
 
 type itemGetEntryStateOtherMember struct {
 	*structures.UserPersonalInfo
+
 	ShowPersonalInfo bool `json:"-"` // required: true
 
 	Login string `json:"login"`

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -111,6 +111,7 @@ type itemResponseWatchedGroupItemInfo struct {
 // swagger:model itemResponse
 type itemResponse struct {
 	commonItemFields
+	*itemRootNodeNotChapterFields
 
 	// required: true
 	Permissions getItemItemPermissions `json:"permissions"`
@@ -152,8 +153,6 @@ type itemResponse struct {
 
 	// required: true
 	String itemStringRoot `json:"string"`
-
-	*itemRootNodeNotChapterFields
 
 	WatchedGroup *itemResponseWatchedGroupItemInfo `json:"watched_group,omitempty"`
 }

--- a/app/api/items/get_navigation.go
+++ b/app/api/items/get_navigation.go
@@ -253,7 +253,7 @@ func fillItemCommonFieldsWithDBData(store *database.DataStore, rawData *rawNavig
 		ID:          rawData.ID,
 		Type:        rawData.Type,
 		String:      structures.ItemString{Title: rawData.Title, LanguageTag: rawData.LanguageTag},
-		Permissions: *rawData.RawGeneratedPermissionFields.AsItemPermissions(store.PermissionsGranted()),
+		Permissions: *rawData.AsItemPermissions(store.PermissionsGranted()),
 	}
 	return result
 }

--- a/app/api/items/get_parents.go
+++ b/app/api/items/get_parents.go
@@ -192,7 +192,7 @@ func parentItemsFromRawData(rawData []RawListItem, watchedGroupIDIsSet bool,
 	result := make([]parentItem, 0, len(rawData))
 	for index := range rawData {
 		item := parentItem{
-			commonItemFields: rawData[index].RawCommonItemFields.asItemCommonFields(permissionGrantedStore),
+			commonItemFields: rawData[index].asItemCommonFields(permissionGrantedStore),
 			BestScore:        rawData[index].BestScore,
 			Result:           rawData[index].asItemResult(),
 			String: listItemString{
@@ -206,7 +206,7 @@ func parentItemsFromRawData(rawData []RawListItem, watchedGroupIDIsSet bool,
 		if rawData[index].CanViewGeneratedValue >= permissionGrantedStore.ViewIndexByName("content") {
 			item.String.listItemStringNotInfo = &listItemStringNotInfo{Subtitle: rawData[index].StringSubtitle}
 		}
-		item.WatchedGroup = rawData[index].RawWatchedGroupStatFields.asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
+		item.WatchedGroup = rawData[index].asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
 		result = append(result, item)
 	}
 	return result

--- a/app/api/items/get_prerequisites.go
+++ b/app/api/items/get_prerequisites.go
@@ -32,6 +32,7 @@ type prerequisiteOrDependencyItem struct {
 
 type rawPrerequisiteOrDependencyItem struct {
 	*RawCommonItemFields
+	*RawWatchedGroupStatFields
 
 	// from items_strings: in the user’s default language or (if not available) default language of the item
 	StringLanguageTag string  `sql:"column:language_tag"`
@@ -45,8 +46,6 @@ type rawPrerequisiteOrDependencyItem struct {
 	// from item_dependencies
 	DependencyRequiredScore    int
 	DependencyGrantContentView bool
-
-	*RawWatchedGroupStatFields
 }
 
 // swagger:operation GET /items/{item_id}/prerequisites items itemPrerequisitesView

--- a/app/api/items/get_prerequisites.go
+++ b/app/api/items/get_prerequisites.go
@@ -170,7 +170,7 @@ func prerequisiteOrDependencyItemsFromRawData(
 	result := make([]prerequisiteOrDependencyItem, 0, len(rawData))
 	for index := range rawData {
 		item := prerequisiteOrDependencyItem{
-			commonItemFields: rawData[index].RawCommonItemFields.asItemCommonFields(permissionGrantedStore),
+			commonItemFields: rawData[index].asItemCommonFields(permissionGrantedStore),
 			BestScore:        rawData[index].BestScore,
 			String: listItemString{
 				LanguageTag: rawData[index].StringLanguageTag,
@@ -183,7 +183,7 @@ func prerequisiteOrDependencyItemsFromRawData(
 		if rawData[index].CanViewGeneratedValue >= permissionGrantedStore.ViewIndexByName("content") {
 			item.String.listItemStringNotInfo = &listItemStringNotInfo{Subtitle: rawData[index].StringSubtitle}
 		}
-		item.WatchedGroup = rawData[index].RawWatchedGroupStatFields.asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
+		item.WatchedGroup = rawData[index].asItemWatchedGroupStat(watchedGroupIDIsSet, permissionGrantedStore)
 		result = append(result, item)
 	}
 	return result

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -114,6 +114,7 @@ type Permission struct {
 
 type permissionAndType struct {
 	*Permission
+
 	Type string
 }
 

--- a/app/api/items/list_attempts.go
+++ b/app/api/items/list_attempts.go
@@ -33,10 +33,11 @@ type attemptsListResponseRow struct {
 	HelpRequested bool `json:"help_requested"`
 	// required: true
 	UserCreator *struct {
+		*structures.UserPersonalInfo
+
 		// required: true
 		Login string `json:"login"`
 
-		*structures.UserPersonalInfo
 		ShowPersonalInfo bool `json:"-"`
 
 		// required: true

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -9,6 +9,10 @@ import (
 
 // rawNavigationItem represents one row of a navigation subtree returned from the DB.
 type rawNavigationItem struct {
+	*RawItemResultFields
+	*database.RawGeneratedPermissionFields
+	*RawWatchedGroupStatFields
+
 	// items
 	ID                    int64
 	Type                  string
@@ -20,17 +24,12 @@ type rawNavigationItem struct {
 	Title       *string
 	LanguageTag string
 
-	*RawItemResultFields
-
 	// max from results of the current participant.
 	BestScore float32
 
 	// items_items.
 	ParentItemID       int64
 	HasVisibleChildren bool
-
-	*database.RawGeneratedPermissionFields
-	*RawWatchedGroupStatFields
 }
 
 // getRawNavigationData reads a navigation subtree from the DB and returns an array of rawNavigationItem's.

--- a/app/api/items/raw_common_item_fields.go
+++ b/app/api/items/raw_common_item_fields.go
@@ -6,6 +6,8 @@ import (
 
 // RawCommonItemFields represents DB data fields that are common for itemView & itemChildrenView.
 type RawCommonItemFields struct {
+	*database.RawGeneratedPermissionFields
+
 	// items
 	ID                     int64
 	Type                   string
@@ -19,8 +21,6 @@ type RawCommonItemFields struct {
 	NoScore                bool
 	DefaultLanguageTag     string
 	RequiresExplicitEntry  bool
-
-	*database.RawGeneratedPermissionFields
 }
 
 func (raw *RawCommonItemFields) asItemCommonFields(permissionGrantedStore *database.PermissionGrantedStore) *commonItemFields {

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -289,6 +289,11 @@ func (requestData *saveGradeRequestParsed) UnmarshalJSON(raw []byte) error {
 	return requestData.unmarshalScoreToken(&wrapper)
 }
 
+// Bind of saveGradeRequestParsed does nothing.
+func (requestData *saveGradeRequestParsed) Bind(*http.Request) error {
+	return nil
+}
+
 func (requestData *saveGradeRequestParsed) unmarshalScoreToken(wrapper *saveGradeRequest) error {
 	if wrapper.ScoreToken == nil {
 		return requestData.reconstructScoreTokenData(wrapper)
@@ -374,10 +379,5 @@ func (requestData *saveGradeRequestParsed) reconstructScoreTokenData(wrapper *sa
 		AttemptID:   requestData.AnswerToken.Payload.AttemptID,
 		LocalItemID: requestData.AnswerToken.Payload.LocalItemID,
 	}}
-	return nil
-}
-
-// Bind of saveGradeRequestParsed does nothing.
-func (requestData *saveGradeRequestParsed) Bind(*http.Request) error {
 	return nil
 }

--- a/app/api/items/search_for_items.go
+++ b/app/api/items/search_for_items.go
@@ -34,11 +34,11 @@ type itemSearchResponseRow struct {
 }
 
 type itemSearchResponseRowRaw struct {
+	*database.RawGeneratedPermissionFields
+
 	ID    int64
 	Title *string
 	Type  string
-
-	*database.RawGeneratedPermissionFields
 }
 
 // swagger:operation GET /items/search items itemSearch

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -244,8 +244,7 @@ func updateChildrenAndRunListeners(
 ) (propagationsToRun []string, err error) {
 	if formData.IsSet("children") {
 		err = store.ItemItems().WithItemsRelationsLock(func(lockedStore *database.DataStore) error {
-			deleteStatement := lockedStore.ItemItems().DB.
-				Where("parent_item_id = ?", itemID)
+			deleteStatement := lockedStore.ItemItems().Where("parent_item_id = ?", itemID)
 			newChildrenIDs := input.childrenIDs()
 			if len(newChildrenIDs) > 0 {
 				deleteStatement = deleteStatement.Where("child_item_id NOT IN(?)", newChildrenIDs)

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -16,6 +16,7 @@ import (
 // ItemWithDefaultLanguageTag represents common item fields plus 'default_language_tag'.
 type ItemWithDefaultLanguageTag struct {
 	Item `json:"item,squash"`
+
 	// new `default_language_tag` of the item can only be set to a language
 	// for that an `items_strings` row exists
 	// minLength: 1
@@ -27,7 +28,8 @@ type ItemWithDefaultLanguageTag struct {
 // swagger:model itemEditRequest
 type updateItemRequest struct {
 	ItemWithDefaultLanguageTag `json:"item,squash"`
-	Children                   []itemChild `json:"children"    validate:"children,children_allowed,dive,child_type_non_skill"`
+
+	Children []itemChild `json:"children" validate:"children,children_allowed,dive,child_type_non_skill"`
 
 	childrenIDsCache []int64
 }

--- a/app/api/threads/list_threads.go
+++ b/app/api/threads/list_threads.go
@@ -41,12 +41,13 @@ type item struct {
 }
 
 type participant struct {
+	*structures.UserPersonalInfo
+
 	// required:true
 	ID int64 `json:"id,string"`
 	// required:true
 	Login string `json:"login"`
 
-	*structures.UserPersonalInfo
 	ShowPersonalInfo bool `json:"-"`
 }
 

--- a/app/api/threads/update_thread.go
+++ b/app/api/threads/update_thread.go
@@ -329,7 +329,7 @@ func excludeIncrementIfMessageCountSetValidator(messageCountField validator.Fiel
 	//nolint:forcetypeassert // we know MessageCountIncrement is *int
 	messageCountIncrementPtr := messageCountField.Top().Elem().FieldByName("MessageCountIncrement").Interface().(*int)
 
-	return !(messageCountPtr != nil && messageCountIncrementPtr != nil)
+	return messageCountPtr == nil || messageCountIncrementPtr == nil
 }
 
 // userCanChangeThreadStatus checks whether a user can change the status of a thread

--- a/app/api/users/get_user.go
+++ b/app/api/users/get_user.go
@@ -35,6 +35,9 @@ type ManagerPermissionsPart struct {
 
 // swagger:model
 type userViewResponse struct {
+	*structures.UserPersonalInfo
+	*ManagerPermissionsPart
+
 	// required: true
 	GroupID int64 `json:"group_id,string"`
 	// required: true
@@ -46,14 +49,11 @@ type userViewResponse struct {
 	// required: true
 	WebSite *string `json:"web_site"`
 
-	*structures.UserPersonalInfo
 	ShowPersonalInfo bool `json:"-"`
 
 	// list of ancestor (excluding the user himself) groups that the current user (or his ancestor groups) is manager of
 	// required:true
 	AncestorsCurrentUserIsManagerOf []structures.GroupShortInfo `json:"ancestors_current_user_is_manager_of"`
-
-	*ManagerPermissionsPart
 
 	// required: true
 	IsCurrentUser bool `json:"is_current_user"`

--- a/app/auth/middleware.go
+++ b/app/auth/middleware.go
@@ -85,7 +85,7 @@ func ValidatesUserAuthentication(service GetStorer, responseWriter http.Response
 		if err != nil && !gorm.IsRecordNotFoundError(err) {
 			logging.EntryFromContext(httpRequest.Context()).Errorf("Can't validate an access token: %s", err)
 
-			return httpRequest.Context(), false, "", err
+			return nil, false, "", err
 		}
 	}
 

--- a/app/auth/user_test.go
+++ b/app/auth/user_test.go
@@ -17,7 +17,7 @@ func TestUserFromContext(t *testing.T) {
 	user := UserFromContext(ctx)
 
 	assert.NotSame(myUser, user)
-	assert.EqualValues(myUser, user)
+	assert.Equal(myUser, user)
 }
 
 func TestBearerTokenFromContext(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSessionCookieAttributesFromContext(t *testing.T) {
 	cookieAttributes := SessionCookieAttributesFromContext(ctx)
 
 	assert.NotSame(expectedCookieAttributes, cookieAttributes)
-	assert.EqualValues(expectedCookieAttributes, cookieAttributes)
+	assert.Equal(expectedCookieAttributes, cookieAttributes)
 
 	ctx = context.WithValue(context.Background(), ctxSessionCookieAttributes, nil)
 	assert.Nil(SessionCookieAttributesFromContext(ctx))

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -49,17 +49,17 @@ func TestLoadConfigFrom(t *testing.T) {
 	require.NotNil(t, conf)
 
 	// test config override
-	assert.EqualValues(t, 1234, conf.Sub(serverConfigKey).GetInt("port"))
+	assert.Equal(t, 1234, conf.Sub(serverConfigKey).GetInt("port"))
 
 	// test env variables
-	assert.EqualValues(t, 999, conf.GetInt("server.WriteTimeout")) // does not work with Sub!
+	assert.Equal(t, 999, conf.GetInt("server.WriteTimeout")) // does not work with Sub!
 
 	// test 'test' section
-	assert.EqualValues(t, "/test/", conf.Sub(serverConfigKey).GetString("rootPath"))
+	assert.Equal(t, "/test/", conf.Sub(serverConfigKey).GetString("rootPath"))
 
 	// test live env changes
 	t.Setenv("ALGOREA_SERVER__WRITETIMEOUT", "777")
-	assert.EqualValues(t, 777, conf.GetInt("server.WriteTimeout"))
+	assert.Equal(t, 777, conf.GetInt("server.WriteTimeout"))
 }
 
 func TestLoadConfigFrom_ShouldLogWarningWhenNonTestEnvAndNoMainConfigFile(t *testing.T) {
@@ -131,7 +131,7 @@ func TestLoadConfigFrom_MustNotUseMainConfigFileInTestEnv(t *testing.T) {
 	require.NotNil(t, conf)
 
 	// the config of the test file should be used, and the one in the main file should not be used at all
-	assert.EqualValues(t, 3, conf.GetInt("param1"))
+	assert.Equal(t, 3, conf.GetInt("param1"))
 	assert.False(t, conf.IsSet("param2"))
 }
 

--- a/app/database/answer_store_test.go
+++ b/app/database/answer_store_test.go
@@ -47,7 +47,7 @@ func TestAnswerStore_WithMethods(t *testing.T) {
 			newStore := resultValue.Interface().(*AnswerStore)
 
 			assert.NotEqual(t, store, newStore)
-			assert.Equal(t, "answers", newStore.DataStore.tableName)
+			assert.Equal(t, "answers", newStore.tableName)
 
 			var result []interface{}
 			err := newStore.Scan(&result).Error()

--- a/app/database/data_store.go
+++ b/app/database/data_store.go
@@ -16,6 +16,7 @@ import (
 // DataStore gather all stores for database operations on business data.
 type DataStore struct {
 	*DB
+
 	tableName string
 }
 

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -729,14 +729,14 @@ func TestNewDataStoreWithContext_WithSQLDBWrapper(t *testing.T) {
 	assert.Equal(t, db.logConfig(), dataStore.logConfig())
 	assert.Equal(t, ctx, dataStore.ctx())
 
-	dbWrapper, ok := dataStore.DB.db.CommonDB().(*sqlDBWrapper)
+	dbWrapper, ok := dataStore.db.CommonDB().(*sqlDBWrapper)
 	require.True(t, ok)
 	assert.Equal(t, ctx, dbWrapper.ctx)
 	assert.Equal(t, db.logConfig(), dbWrapper.logConfig)
 	dbDBWrapper, ok := db.db.CommonDB().(*sqlDBWrapper)
 	require.True(t, ok)
 	assert.Equal(t, dbDBWrapper.sqlDB, dbWrapper.sqlDB)
-	dialect := dataStore.DB.db.Dialect()
+	dialect := dataStore.db.Dialect()
 	//nolint:gosec // unsafe.Pointer is used to access the private field of gorm.Dialect
 	assert.Equal(t, dbWrapper, (*gormDialectDBAccessor)(unsafe.Pointer(&dialect)).v.db)
 
@@ -760,14 +760,14 @@ func TestNewDataStoreWithContext_WithSQLTxWrapper(t *testing.T) {
 		assert.Equal(t, db.logConfig(), dataStore.logConfig())
 		assert.Equal(t, ctx, dataStore.ctx())
 
-		txWrapper, ok := dataStore.DB.db.CommonDB().(*sqlTxWrapper)
+		txWrapper, ok := dataStore.db.CommonDB().(*sqlTxWrapper)
 		require.True(t, ok)
 		assert.Equal(t, db.logConfig(), txWrapper.logConfig)
 		assert.Equal(t, ctx, txWrapper.ctx)
 		dbTxWrapper, ok := db.db.CommonDB().(*sqlTxWrapper)
 		require.True(t, ok)
 		assert.Equal(t, dbTxWrapper.sqlTx, txWrapper.sqlTx)
-		dialect := dataStore.DB.db.Dialect()
+		dialect := dataStore.db.Dialect()
 		//nolint:gosec // unsafe.Pointer is used to access the private field of gorm.Dialect
 		assert.Equal(t, txWrapper, (*gormDialectDBAccessor)(unsafe.Pointer(&dialect)).v.db)
 
@@ -828,7 +828,7 @@ func TestDataStore_SetPropagationsModeToSync(t *testing.T) {
 	require.NoError(t, NewDataStore(db).InTransaction(func(store *DataStore) error {
 		require.NoError(t, store.SetPropagationsModeToSync())
 		assert.Equal(t, true, store.DB.ctx().Value(propagationsAreSyncContextKey))
-		txWrapper, ok := store.DB.db.CommonDB().(*sqlTxWrapper)
+		txWrapper, ok := store.db.CommonDB().(*sqlTxWrapper)
 		require.True(t, ok)
 		assert.Equal(t, true, txWrapper.ctx.Value(propagationsAreSyncContextKey))
 		return nil

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -711,8 +711,8 @@ func TestDataStore_IsInTransaction_ReturnsFalse(t *testing.T) {
 type gormDialectDBAccessor struct {
 	_ unsafe.Pointer
 	v *struct {
-		db gorm.SQLCommon
-		gorm.DefaultForeignKeyNamer
+		db                          gorm.SQLCommon
+		gorm.DefaultForeignKeyNamer //nolint:embeddedstructfieldcheck // we should use the same order of fields as in gorm.commonDialect
 	}
 }
 

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -234,6 +234,7 @@ func cloneGormDB(db *gorm.DB) *gorm.DB {
 
 type gormDBAccessor struct {
 	sync.RWMutex
+
 	Value        interface{}
 	Error        error
 	RowsAffected int64

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -20,11 +20,12 @@ import (
 
 type cancelCtx struct {
 	context.Context //nolint:containedctx // it is not us who store the context in the structure
-	_               sync.Mutex
-	_               atomic.Value
-	_               map[interface{}]struct{}
-	err             error
-	cause           error
+
+	_     sync.Mutex
+	_     atomic.Value
+	_     map[interface{}]struct{}
+	err   error
+	cause error
 }
 
 type timerCtx struct {

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -629,6 +629,7 @@ type ResultPrimaryKey struct {
 
 type resultPrimaryKeyAndState struct {
 	ResultPrimaryKey
+
 	State string
 }
 

--- a/app/database/group_group_store_transitions.go
+++ b/app/database/group_group_store_transitions.go
@@ -54,6 +54,20 @@ const (
 	NoRelation GroupMembershipAction = ""
 )
 
+// PendingType converts the GroupMembershipAction into `group_pending_requests.type`.
+func (groupMembershipAction GroupMembershipAction) PendingType() string {
+	switch groupMembershipAction {
+	case InvitationCreated:
+		return "invitation"
+	case JoinRequestCreated:
+		return "join_request"
+	case LeaveRequestCreated:
+		return "leave_request"
+	default:
+		panic("groupMembershipAction should be of pending kind in PendingType()")
+	}
+}
+
 func (groupMembershipAction GroupMembershipAction) isActive() bool {
 	switch groupMembershipAction {
 	case JoinedByBadge, InvitationAccepted, JoinRequestAccepted, JoinedByCode, IsMember,
@@ -75,20 +89,6 @@ func (groupMembershipAction GroupMembershipAction) isPending() bool {
 
 func (groupMembershipAction GroupMembershipAction) hasApprovals() bool {
 	return groupMembershipAction == JoinRequestCreated
-}
-
-// PendingType converts the GroupMembershipAction into `group_pending_requests.type`.
-func (groupMembershipAction GroupMembershipAction) PendingType() string {
-	switch groupMembershipAction {
-	case InvitationCreated:
-		return "invitation"
-	case JoinRequestCreated:
-		return "join_request"
-	case LeaveRequestCreated:
-		return "leave_request"
-	default:
-		panic("groupMembershipAction should be of pending kind in PendingType()")
-	}
 }
 
 // GroupGroupTransitionAction represents a groups_groups relation transition action.

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -1476,7 +1476,7 @@ func assertGeneratedPermissionsEqual(
 	var generatedPermissions []permissionsGeneratedResultRow
 	require.NoError(t, permissionGeneratedStore.Select("group_id, item_id, can_view_generated").
 		Order("group_id, item_id").Scan(&generatedPermissions).Error())
-	assert.EqualValues(t, expected, generatedPermissions)
+	assert.Equal(t, expected, generatedPermissions)
 }
 
 func Test_insertGroupMembershipChanges_Duplicate(t *testing.T) {

--- a/app/database/item_access_details.go
+++ b/app/database/item_access_details.go
@@ -13,8 +13,9 @@ type ItemAccessDetails struct {
 
 // ItemAccessDetailsWithID represents access rights for an item + ItemID.
 type ItemAccessDetailsWithID struct {
-	ItemID int64
 	ItemAccessDetails
+
+	ItemID int64
 }
 
 // IsInfo returns true when can_view_generated = 'info'.

--- a/app/database/item_ancestor_store_test.go
+++ b/app/database/item_ancestor_store_test.go
@@ -25,7 +25,7 @@ func TestItemAncestorStore_DescendantsOf(t *testing.T) {
 	newStore := store.DescendantsOf(ancestorItemID)
 
 	assert.NotEqual(t, newStore, store)
-	assert.Equal(t, "items_ancestors", newStore.DataStore.tableName)
+	assert.Equal(t, "items_ancestors", newStore.tableName)
 
 	err := newStore.Scan(&result).Error()
 	assert.NoError(t, err)

--- a/app/database/item_item_store.go
+++ b/app/database/item_item_store.go
@@ -20,7 +20,7 @@ func (s *ItemItemStore) ChildrenOf(parentID int64) *ItemItemStore {
 func (s *ItemItemStore) CreateNewAncestors() (err error) {
 	s.mustBeInTransaction()
 	defer recoverPanics(&err)
-	s.DataStore.createNewAncestors("items", "item")
+	s.createNewAncestors("items", "item")
 	return nil
 }
 

--- a/app/database/item_item_store_test.go
+++ b/app/database/item_item_store_test.go
@@ -26,7 +26,7 @@ func TestItemItemStore_ChildrenOf(t *testing.T) {
 	store := NewDataStore(db).ItemItems()
 	newStore := store.ChildrenOf(parentItemID)
 	assert.NotEqual(t, store, newStore)
-	assert.Equal(t, "items_items", newStore.DataStore.tableName)
+	assert.Equal(t, "items_items", newStore.tableName)
 
 	var result []interface{}
 	err := newStore.Scan(&result).Error()

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -606,9 +606,13 @@ func assertBreadcrumbsHierarchy(t *testing.T,
 ) {
 	t.Helper()
 
+	if wantAttemptIDMap != nil {
+		require.NoError(t, err)
+	} else {
+		require.Equal(t, err, database.ErrHierarchyNotFound)
+	}
 	assert.Equal(t, wantAttemptIDMap, gotIDs)
 	assert.Equal(t, wantAttemptNumberMap, gotNumbers)
-	assert.NoError(t, err)
 }
 
 func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {

--- a/app/database/mysql_driver_wrapper_test.go
+++ b/app/database/mysql_driver_wrapper_test.go
@@ -11,6 +11,7 @@ import (
 
 type connMockWithName struct {
 	*connMock
+
 	name string
 }
 

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -31,7 +31,7 @@ func Test_fileWithLineNum(t *testing.T) {
 }
 
 func Test_fileWithLineNum_ReturnsEmptyStringWhenNoSuitableCallerFound(t *testing.T) {
-	assert.Equal(t, "", fileWithLineNum())
+	assert.Empty(t, fileWithLineNum())
 }
 
 func Test_getSQLExecutionPlanLoggingFunc_DoesNothingDependingOnParameters(t *testing.T) {

--- a/app/database/sql_db_wrapper.go
+++ b/app/database/sql_db_wrapper.go
@@ -127,6 +127,12 @@ func (sqlDB *sqlDBWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*s
 // We intentionally do not implement the 'sqlDb' interface to avoid Gorm from calling 'Begin' method.
 // var _ sqlDb = &sqlDBWrapper{}
 
+func (sqlDB *sqlDBWrapper) Close() error {
+	return sqlDB.sqlDB.Close()
+}
+
+var _ interface{ Close() error } = &sqlDBWrapper{}
+
 type queryRowWithoutLogging interface {
 	queryRowWithoutLogging(query string, args ...interface{}) *sql.Row
 }
@@ -166,12 +172,6 @@ func (sqlDB *sqlDBWrapper) getLogConfig() *LogConfig {
 }
 
 var _ logConfigGetter = &sqlDBWrapper{}
-
-func (sqlDB *sqlDBWrapper) Close() error {
-	return sqlDB.sqlDB.Close()
-}
-
-var _ interface{ Close() error } = &sqlDBWrapper{}
 
 func (sqlDB *sqlDBWrapper) conn(ctx context.Context) (*sqlConnWrapper, error) {
 	conn, err := sqlDB.sqlDB.Conn(ctx)

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -197,7 +197,7 @@ func assertTableColumn(t *testing.T, db *database.DB, table, column string, expe
 
 	reflValues := reflect.New(reflect.TypeOf(expectedValues))
 	require.NoError(t, db.Table(table).Order(column).Pluck("DISTINCT "+column, reflValues.Interface()).Error())
-	assert.EqualValues(t, expectedValues, reflValues.Elem().Interface(), "wrong %s in %s", column, table)
+	assert.Equal(t, expectedValues, reflValues.Elem().Interface(), "wrong %s in %s", column, table)
 }
 
 func assertUserRelatedTablesAfterDeletingWithTraps(

--- a/app/doc/errors.go
+++ b/app/doc/errors.go
@@ -25,6 +25,7 @@ type genericError struct {
 
 type badRequest struct {
 	genericError
+
 	// required: true
 	// enum: Bad Request
 	Message string `json:"message"`
@@ -35,6 +36,7 @@ type badRequest struct {
 
 type unauthorized struct {
 	genericError
+
 	// required: true
 	// enum: Unauthorized
 	Message string `json:"message"`
@@ -42,6 +44,7 @@ type unauthorized struct {
 
 type forbidden struct {
 	genericError
+
 	// required: true
 	// enum: Forbidden
 	Message string `json:"message"`
@@ -49,6 +52,7 @@ type forbidden struct {
 
 type conflict struct {
 	genericError
+
 	// required: true
 	// enum: Conflict
 	Message string `json:"message"`
@@ -56,6 +60,7 @@ type conflict struct {
 
 type notFound struct {
 	genericError
+
 	// required: true
 	// enum: Not Found
 	Message string `json:"message"`
@@ -63,6 +68,7 @@ type notFound struct {
 
 type requestTimeout struct {
 	genericError
+
 	// required: true
 	// enum: Request Timeout
 	Message string `json:"message"`
@@ -70,6 +76,7 @@ type requestTimeout struct {
 
 type unprocessableEntity struct {
 	genericError
+
 	// required: true
 	// enum: Unprocessable Entity
 	Message string `json:"message"`
@@ -77,6 +84,7 @@ type unprocessableEntity struct {
 
 type unprocessableEntityWithMissingApprovals struct {
 	genericError
+
 	// required: true
 	// enum: Unprocessable Entity
 	Message string                                      `json:"message"`
@@ -91,6 +99,7 @@ type unprocessableEntityWithMissingApprovalsData struct {
 
 type internalError struct {
 	genericError
+
 	// required: true
 	// enum: Internal Server Error
 	Message string `json:"message"`

--- a/app/doc/models.go
+++ b/app/doc/models.go
@@ -18,6 +18,7 @@ type userCreateTmpResponse struct {
 	// description
 	// swagger:allOf
 	CreatedResponse
+
 	// required:true
 	Data struct {
 		// Only if the cookie is not enabled

--- a/app/domain/domain_test.go
+++ b/app/domain/domain_test.go
@@ -13,7 +13,7 @@ func TestConfigFromContext(t *testing.T) {
 	conf := ConfigFromContext(ctx)
 
 	assert.NotSame(t, expectedConfig, conf)
-	assert.EqualValues(t, expectedConfig, conf)
+	assert.Equal(t, expectedConfig, conf)
 }
 
 func TestDomainFromContext(t *testing.T) {

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -142,17 +142,6 @@ func (f *FormData) ParseMapData(m map[string]interface{}) error {
 	return f.checkAndValidate()
 }
 
-func (f *FormData) checkAndValidate() error {
-	f.checkProvidedFields()
-	f.validateFieldValues()
-
-	if len(f.fieldErrors) > 0 {
-		return f.fieldErrors
-	}
-
-	return nil
-}
-
 // ConstructMapForDB constructs a map for updating DB. It uses both the definition and the JSON input.
 func (f *FormData) ConstructMapForDB() map[string]interface{} {
 	result := map[string]interface{}{}
@@ -210,6 +199,17 @@ func (f *FormData) ValidatorSkippingUnchangedFields(nestedValidator validator.Fu
 		}
 		return nestedValidator(fieldInfo)
 	})
+}
+
+func (f *FormData) checkAndValidate() error {
+	f.checkProvidedFields()
+	f.validateFieldValues()
+
+	if len(f.fieldErrors) > 0 {
+		return f.fieldErrors
+	}
+
+	return nil
 }
 
 var (

--- a/app/logging/console_formatter.go
+++ b/app/logging/console_formatter.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 )
 
 type consoleFormatter struct {

--- a/app/logging/console_formatter_test.go
+++ b/app/logging/console_formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/app/logging/json_formatter.go
+++ b/app/logging/json_formatter.go
@@ -1,6 +1,6 @@
 package logging
 
-import "github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+import "github.com/sirupsen/logrus"
 
 type jsonFormatter struct {
 	logrusJSONFormatter *logrus.JSONFormatter

--- a/app/logging/json_formatter_test.go
+++ b/app/logging/json_formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -107,6 +107,18 @@ func (l *Logger) Configure(config *viper.Viper) {
 	log.SetOutput(l.logrusLogger.Writer())
 }
 
+// WithContext returns a new entry with the given context.
+func (l *Logger) WithContext(ctx context.Context) *logrus.Entry {
+	entry := l.logrusLogger.WithContext(ctx)
+
+	requestID := middleware.GetReqID(ctx)
+	if requestID != "" {
+		entry = entry.WithField("req_id", requestID)
+	}
+
+	return entry
+}
+
 func (l *Logger) setOutput(config *viper.Viper) {
 	switch config.GetString("output") {
 	case outputStdout:
@@ -131,18 +143,6 @@ func (l *Logger) setOutput(config *viper.Viper) {
 	default:
 		panic("Logging output must be either 'stdout', 'stderr' or 'file'. Got: " + config.GetString("output"))
 	}
-}
-
-// WithContext returns a new entry with the given context.
-func (l *Logger) WithContext(ctx context.Context) *logrus.Entry {
-	entry := l.logrusLogger.WithContext(ctx)
-
-	requestID := middleware.GetReqID(ctx)
-	if requestID != "" {
-		entry = entry.WithField("req_id", requestID)
-	}
-
-	return entry
 }
 
 func createLogger() *Logger {

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 
 	"github.com/go-chi/chi/middleware"
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"bou.ke/monkey"
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/app/logging/middleware.go
+++ b/app/logging/middleware.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/middleware"
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 )
 
 // StructuredLogger is a structured logrus Logger.

--- a/app/logging/middleware_test.go
+++ b/app/logging/middleware_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/middleware"
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/app/logging/mock.go
+++ b/app/logging/mock.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"context"
 
-	"github.com/sirupsen/logrus/hooks/test" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus/hooks/test"
 )
 
 // NewMockLogger creates a null/mock logger and return the logger and the hook.

--- a/app/logging/text_formatter.go
+++ b/app/logging/text_formatter.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )

--- a/app/logging/text_formatter_test.go
+++ b/app/logging/text_formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus" //nolint:depguard // using logrus in logging package is allowed in app/logging
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/app/loggingtest/loggingtest.go
+++ b/app/loggingtest/loggingtest.go
@@ -6,7 +6,7 @@ package loggingtest
 import (
 	"strings"
 
-	"github.com/sirupsen/logrus/hooks/test" //nolint
+	"github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/France-ioi/AlgoreaBackend/v2/app/logging"
 )

--- a/app/loginmodule/client.go
+++ b/app/loginmodule/client.go
@@ -39,10 +39,9 @@ func NewClient(loginModuleURL string) *Client {
 func (client *Client) GetUserProfile(ctx context.Context, accessToken string) (profile *UserProfile, err error) {
 	defer recoverPanics(&err)
 
-	request, err := http.NewRequest(http.MethodGet, client.url+"/user_api/account", http.NoBody)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.url+"/user_api/account", http.NoBody)
 	mustNotBeError(err)
 	request.Header.Set("Authorization", "Bearer "+accessToken)
-	request = request.WithContext(ctx)
 	response, err := http.DefaultClient.Do(request)
 	mustNotBeError(err)
 	body, err := io.ReadAll(io.LimitReader(response.Body, oneMegabyte))
@@ -189,9 +188,8 @@ func (client *Client) requestAccountsManagerAndDecode(ctx context.Context, urlPa
 
 	params, err := EncodeBody(requestParams, clientID, clientKey)
 
-	request, err := http.NewRequest(http.MethodPost, apiURL.String(), bytes.NewBuffer(params))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL.String(), bytes.NewBuffer(params))
 	mustNotBeError(err)
-	request = request.WithContext(ctx)
 	request.Header.Add("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(request)
 	mustNotBeError(err)

--- a/app/loginmodule/client_test.go
+++ b/app/loginmodule/client_test.go
@@ -539,6 +539,7 @@ func TestClient_AccountsManagerEndpoints(t *testing.T) {
 					responseCode: 200,
 					response:     encodeAccountsManagerResponse(`{"success":true}`, "anotherClientKey"),
 					expectedErr:  fmt.Errorf(testSuite.errorMessage+": %s", "invalid character 'Ý' in literal true (expecting 'r')"),
+					//nolint:gosmopolitan // yes, the log message does contain a rune in Han script
 					expectedLog: `level=warning .*` + regexp.QuoteMeta(`msg="Can't parse response from the login module for /platform_api/`+
 						testSuite.endpoint+
 						` (decrypted response = \"t\\xdd\\t\\xc0\\x02\\xe9M.{0\\xa5\\xba\\xff\\xcb@|\", `+
@@ -671,6 +672,7 @@ func TestClient_CreateUsers(t *testing.T) {
 			responseCode: 200,
 			response:     encodeAccountsManagerResponse(`{"success":true}`, "anotherClientKey"),
 			expectedErr:  fmt.Errorf("can't create users: %s", "invalid character 'Ý' in literal true (expecting 'r')"),
+			//nolint:gosmopolitan // yes, the log message does contain a rune in Han script
 			expectedLog: `level=warning .* ` +
 				regexp.QuoteMeta(`msg="Can't parse response from the login module for /platform_api/accounts_manager/create `+
 					`(decrypted response = \"t\\xdd\\t\\xc0\\x02\\xe9M.{0\\xa5\\xba\\xff\\xcb@|\", `+

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -13,6 +13,7 @@ import (
 // ErrorResponse is an extension of the response for returning errors.
 type ErrorResponse[T any] struct {
 	Response[T]
+
 	ErrorText string      `json:"error_text,omitempty"` // application-level error message, for debugging
 	Errors    interface{} `json:"errors,omitempty"`     // form errors
 }

--- a/app/service/errors.go
+++ b/app/service/errors.go
@@ -30,6 +30,10 @@ var _ error = &APIError{}
 // ErrAPIInsufficientAccessRights is an APIError to be returned when the has no access rights to perform an action.
 var ErrAPIInsufficientAccessRights = ErrForbidden(errors.New("insufficient access rights"))
 
+func (e *APIError) Error() string {
+	return e.EmbeddedError.Error()
+}
+
 func (e *APIError) httpResponse() render.Renderer {
 	response := Response[*struct{}]{
 		HTTPStatusCode: e.HTTPStatusCode,
@@ -52,10 +56,6 @@ func (e *APIError) httpResponse() render.Renderer {
 	}
 
 	return &result
-}
-
-func (e *APIError) Error() string {
-	return e.EmbeddedError.Error()
 }
 
 // ErrInvalidRequest is for errors caused by invalid request input

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -365,9 +365,10 @@ func constructPagingConditions(usedFields []string, configuredFields map[string]
 		columnName := configuredFields[fieldName].ColumnName
 		if subQueryNeeded {
 			condition := fmt.Sprintf("%s %s from_page.%s", columnName, fieldsSortingTypes[fieldName].conditionSign(), safeColumnName)
-			if fieldsSortingTypes[fieldName].nullPlacement == first {
+			switch fieldsSortingTypes[fieldName].nullPlacement {
+			case first:
 				condition = fmt.Sprintf("IF(from_page.%s IS NULL, %s IS NOT NULL, %s)", safeColumnName, columnName, condition)
-			} else if fieldsSortingTypes[fieldName].nullPlacement == last {
+			case last:
 				condition = fmt.Sprintf("IF(from_page.%s IS NULL, FALSE, %s IS NULL OR %s)", safeColumnName, columnName, condition)
 			}
 			conditions = append(conditions, fmt.Sprintf("(%s%s)", conditionPrefix, condition))

--- a/app/service/sorting.go
+++ b/app/service/sorting.go
@@ -168,7 +168,7 @@ func parseSortingRules(sortingRules string, configuredFields map[string]*FieldSo
 	}
 	sort.Strings(tieBreakerFieldsToAdd)
 	usedFields = append(usedFields, tieBreakerFieldsToAdd...)
-	return usedFields, fieldsSortingTypes, err
+	return usedFields, fieldsSortingTypes, nil
 }
 
 func mustHaveValidTieBreakerFieldsList(configuredFields map[string]*FieldSortingParams, tieBreakerFields map[string]FieldType) {

--- a/app/service/sorting_test.go
+++ b/app/service/sorting_test.go
@@ -462,7 +462,7 @@ func TestApplySorting(t *testing.T) {
 			defer func() {
 				if p := recover(); p != nil {
 					if tt.shouldPanic == nil {
-						assert.Fail(t, "unexpected panic() was called with value %+v", p)
+						assert.Failf(t, "unexpected panic()", "value: %+v", p)
 					} else {
 						assert.Equal(t, tt.shouldPanic, p, "panic() value mismatched")
 					}

--- a/app/servicetest/request.go
+++ b/app/servicetest/request.go
@@ -45,12 +45,17 @@ func GetResponseForRouteWithMockedDBAndUser(
 	defer ts.Close()
 
 	request, err := http.NewRequest(method, ts.URL+path, strings.NewReader(requestBody))
-	var response *http.Response
-	if err == nil {
-		response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, nil, "", err
 	}
 
-	return response, mock, (&loggingtest.Hook{Hook: logHook}).GetAllLogs(), err
+	var response *http.Response
+	response, err = http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return response, mock, (&loggingtest.Hook{Hook: logHook}).GetAllLogs(), nil
 }
 
 // WithLoggingMiddleware wraps the given handler in NullLogger with hook.

--- a/cmd/db_migrate.go
+++ b/cmd/db_migrate.go
@@ -67,8 +67,8 @@ func init() { //nolint:gochecknoinits // cobra suggests using init functions to 
 				cmd.Print(".")
 			}
 			cmd.Print("\n")
-			switch {
-			case applied == 0:
+			switch applied {
+			case 0:
 				cmd.Println("No migrations to apply!")
 			default:
 				cmd.Printf("%d migration(s) applied successfully!\n", applied)

--- a/golang/if_test.go
+++ b/golang/if_test.go
@@ -21,7 +21,7 @@ func TestIf(t *testing.T) {
 	assert.Equal(t, 1, If(true, 1))
 	assert.Equal(t, 0, If(false, 1))
 	assert.Equal(t, "a", If(true, "a"))
-	assert.Equal(t, "", If(false, "a"))
+	assert.Equal(t, "", If(false, "a")) //nolint:testifylint // we want to compare with an empty string, not any empty value
 	assert.True(t, If(true, true))
 	assert.False(t, If(false, true))
 	assert.Equal(t, (*string)(nil), If(false, strPtr))

--- a/golang/if_test.go
+++ b/golang/if_test.go
@@ -67,7 +67,7 @@ func TestLazyIf_TrueValueFuncIsCalled(t *testing.T) {
 
 func TestLazyIf_TrueValueFuncIsNotCalled(t *testing.T) {
 	var trueValueFuncCalled bool
-	assert.Equal(t, "",
+	assert.Empty(t,
 		LazyIf(false, func() string {
 			trueValueFuncCalled = true
 			return "a"

--- a/golang/zero_test.go
+++ b/golang/zero_test.go
@@ -10,7 +10,7 @@ func TestZero(t *testing.T) {
 	assert.False(t, Zero[bool]())
 	assert.Equal(t, 0, Zero[int]())
 	assert.Equal(t, int64(0), Zero[int64]())
-	assert.Equal(t, "", Zero[string]())
+	assert.Equal(t, "", Zero[string]()) //nolint:testifylint // we want to compare with an empty string, not any empty value
 	assert.Equal(t, []byte(nil), Zero[[]byte]())
 	assert.Equal(t, struct{}{}, Zero[struct{}]())
 	assert.Equal(t, (*bool)(nil), Zero[*bool]())

--- a/testhelpers/app_language_db.go
+++ b/testhelpers/app_language_db.go
@@ -10,12 +10,12 @@ func (ctx *TestContext) databaseCountRows(table string, datamap map[string]strin
 	query := ctx.application.Database.Table(table)
 	for key, value := range datamap {
 		columnName := database.QuoteName(key)
-		switch {
-		case value == nullValue:
+		switch value {
+		case nullValue:
 			query = query.Where(columnName + " IS NULL")
-		case value == tableValueFalse:
+		case tableValueFalse:
 			query = query.Where(columnName + " = 0")
-		case value == tableValueTrue:
+		case tableValueTrue:
 			query = query.Where(columnName + " = 1")
 		default:
 			var processedValue interface{} = value

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -816,9 +816,12 @@ func (ctx *TestContext) queryDBRowsMatching(tableName string, dbColumnNames, fil
 	// exec sql
 	query := fmt.Sprintf("SELECT %s FROM %s %s ORDER BY %s", selectsJoined, database.QuoteName(tableName), where, selectsJoined)
 	sqlRows, err := ctx.application.Database.GetSQLDB().QueryContext(ctx.application.Database.GetContext(), query, parameters...)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	closer := func() { _ = sqlRows.Close() }
-	return sqlRows, closer, err
+	return sqlRows, closer, nil
 }
 
 // getNbRowsMatching returns how many rows match one of values at any column.


### PR DESCRIPTION
This PR upgrades existing linters and enables some new linters:
+ funcorder (checks the order of methods and constructors)
+ embeddedstructfieldcheck (checks that embedded fields should be at the top of the field list of a struct, and there must be an empty line separating embedded fields from regular fields).

Also, here we fix some issues found by the new linters and upgraded existing linters or add explaining 'nolint' comments. Also we enable most of the linter for app/doc and specify that /app/logging* are allowed to import sirupsen/logrus right in .golangci.yml.

Fixes #1142 

