### PR TITLE
Restore old behaviour of app actions logging in Cucumber tests 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -126,6 +126,7 @@ func (app *Application) Reset(config *viper.Viper, loggerOptional ...*logging.Lo
 func resolveOrCreateLogger(loggingConfig *viper.Viper, loggerOptional []*logging.Logger) (logger *logging.Logger) {
 	if len(loggerOptional) > 0 && loggerOptional[0] != nil {
 		logger = loggerOptional[0]
+		logger.Configure(loggingConfig)
 	} else {
 		logger = logging.NewLoggerFromConfig(loggingConfig)
 	}

--- a/app/logging/mock.go
+++ b/app/logging/mock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 )
 
-// NewMockLogger creates a null/mock logger and return the logger and the hook.
+// NewMockLogger creates a null/mock logger and returns the logger and the hook.
 func NewMockLogger() (*Logger, *test.Hook) {
 	l, h := test.NewNullLogger()
 	return &Logger{l, nil}, h

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -4,7 +4,6 @@ package testhelpers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/cucumber/godog"
@@ -162,8 +161,6 @@ func InitializeScenario(scenarioContext *godog.ScenarioContext) {
 				(*parentOutputRestorerFunc)(true)
 				*parentOutputRestorerFunc = nil
 			}
-
-			fmt.Printf("\nLogs: \n%s\n", ctx.logsHook.GetAllStructuredLogs()) //nolint:forbidigo // Print the app logs of the failed test
 		}
 		return contextCtx, tearDownErr //nolint:nilnil // It looks like we really want to return the context even if there is an error.
 	})


### PR DESCRIPTION
Here we restore the behaviour of app actions logging in Cucumber tests that we had had before #1308: print the app logs during test runs (not after), configure the logger to respect output format and options related to SQL query logging.

1. Configure the provided logger in app.(*Application).Reset();
2. Do not print collected logs in Gherkin handler called after each scenario as the configured logger prints them by itself;
3. Fix a misprint in a function comment
