### PR TITLE
Fix the DB migration 2510231857

### DIFF
--- a/db/migrations/2510231857_add_column_users_profile.sql
+++ b/db/migrations/2510231857_add_column_users_profile.sql
@@ -1,7 +1,19 @@
 -- +goose Up
-ALTER TABLE `users` ADD COLUMN `profile` JSON
-  COMMENT 'A JSON object containing user profile information returned by the login module as the "profile" field'
-  AFTER `login`;
+SET @query = IF(
+  NOT EXISTS(
+    SELECT *
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE table_name = 'users'
+      AND table_schema = DATABASE()
+      AND column_name = 'profile'
+  ),
+  "ALTER TABLE `users` ADD COLUMN `profile` JSON
+COMMENT 'A JSON object containing user profile information returned by the login module as the \"profile\" field'
+AFTER `login`",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
 
 -- +goose Down
 ALTER TABLE `users` DROP COLUMN `profile`;


### PR DESCRIPTION
Come over the error caused by a foreign key of the broken user_batches table: create users.profile in two runs (the first run creates the column and fails, the second run does nothing and passes)