### PR TITLE
Fix the DB migrations 2510231857, 2510232356, 2510240012 on dev

### DIFF
--- a/db/migrations/2510231857_add_column_users_profile.sql
+++ b/db/migrations/2510231857_add_column_users_profile.sql
@@ -16,4 +16,16 @@ PREPARE stmt FROM @query;
 EXECUTE stmt;
 
 -- +goose Down
-ALTER TABLE `users` DROP COLUMN `profile`;
+SET @query = IF(
+  EXISTS(
+    SELECT *
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE table_name = 'users'
+      AND table_schema = DATABASE()
+      AND column_name = 'profile'
+  ),
+  "ALTER TABLE `users` DROP COLUMN `profile`",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;

--- a/db/migrations/2510232356_add_index_on_users_profile.sql
+++ b/db/migrations/2510232356_add_index_on_users_profile.sql
@@ -1,5 +1,27 @@
 -- +goose Up
-ALTER TABLE `users` ADD INDEX `profile_is_null` ((NOT temp_user AND `profile` IS NULL));
+SET @query = IF(
+  NOT EXISTS(
+    SELECT * FROM INFORMATION_SCHEMA.INNODB_INDEXES
+    JOIN INFORMATION_SCHEMA.INNODB_TABLES USING(TABLE_ID)
+    WHERE INFORMATION_SCHEMA.INNODB_TABLES.NAME = CONCAT(DATABASE(), '/users') AND
+          INFORMATION_SCHEMA.INNODB_INDEXES.NAME = 'profile_is_null'
+  ),
+  "ALTER TABLE `users` ADD INDEX `profile_is_null` ((NOT temp_user AND `profile` IS NULL))",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
 
 -- +goose Down
-ALTER TABLE `users` DROP INDEX `profile_is_null`;
+SET @query = IF(
+  EXISTS(
+    SELECT * FROM INFORMATION_SCHEMA.INNODB_INDEXES
+    JOIN INFORMATION_SCHEMA.INNODB_TABLES USING(TABLE_ID)
+    WHERE INFORMATION_SCHEMA.INNODB_TABLES.NAME = CONCAT(DATABASE(), '/users') AND
+      INFORMATION_SCHEMA.INNODB_INDEXES.NAME = 'profile_is_null'
+  ),
+  "ALTER TABLE `users` DROP INDEX `profile_is_null`",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;

--- a/db/migrations/2510240012_remove_index_on_users_profile.sql
+++ b/db/migrations/2510240012_remove_index_on_users_profile.sql
@@ -1,5 +1,27 @@
 -- +goose Up
-ALTER TABLE `users` DROP INDEX `profile_is_null`;
+SET @query = IF(
+  EXISTS(
+    SELECT * FROM INFORMATION_SCHEMA.INNODB_INDEXES
+    JOIN INFORMATION_SCHEMA.INNODB_TABLES USING(TABLE_ID)
+    WHERE INFORMATION_SCHEMA.INNODB_TABLES.NAME = CONCAT(DATABASE(), '/users') AND
+      INFORMATION_SCHEMA.INNODB_INDEXES.NAME = 'profile_is_null'
+  ),
+  "ALTER TABLE `users` DROP INDEX `profile_is_null`",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;
 
 -- +goose Down
-ALTER TABLE `users` ADD INDEX `profile_is_null` ((NOT temp_user AND `profile` IS NULL));
+SET @query = IF(
+  NOT EXISTS(
+    SELECT * FROM INFORMATION_SCHEMA.INNODB_INDEXES
+    JOIN INFORMATION_SCHEMA.INNODB_TABLES USING(TABLE_ID)
+    WHERE INFORMATION_SCHEMA.INNODB_TABLES.NAME = CONCAT(DATABASE(), '/users') AND
+      INFORMATION_SCHEMA.INNODB_INDEXES.NAME = 'profile_is_null'
+  ),
+  "ALTER TABLE `users` ADD INDEX `profile_is_null` ((NOT temp_user AND `profile` IS NULL))",
+  'DO TRUE'
+);
+PREPARE stmt FROM @query;
+EXECUTE stmt;


### PR DESCRIPTION
Come over errors caused by a foreign key of the broken user_batches table: create/remove users.profile and the profile_is_null index in two runs (the first run creates/removes the column/index and fails, the second run does nothing and passes)