### PR TITLE
Allow using attemptsList with can_view=info on the item

### DIFF
--- a/app/api/items/list_attempts.feature
+++ b/app/api/items/list_attempts.feature
@@ -32,8 +32,8 @@ Feature: List attempts for current user and item_id
       | 210 | 1                        | fr                   |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       |
-      | 13       | 200     | content                  |
-      | 13       | 210     | info                     |
+      | 13       | 200     | info                     |
+      | 13       | 210     | none                     |
       | 23       | 210     | content_with_descendants |
     And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | root_item_id | ended_at            |

--- a/app/api/items/list_attempts.go
+++ b/app/api/items/list_attempts.go
@@ -60,7 +60,7 @@ type attemptsListResponseRow struct {
 //
 //	 Restrictions:
 //		 * `{as_team_id}` (if given) should be the current user's team,
-//		 * the participant should have at least 'content' access on the item,
+//		 * the participant should have at least 'info' access on the item,
 //		 * if `{attempt_id}` is given, it should exist for the participant in order to determine `{parent_attempt_id}`
 //			 (we assume that the 'zero attempt' always exists and it is its own parent attempt),
 //
@@ -207,7 +207,7 @@ func (srv *Service) resolveParametersForListAttempts(httpRequest *http.Request) 
 	}
 
 	found, err := store.Permissions().MatchingGroupAncestors(participantID).
-		WherePermissionIsAtLeast("view", "content").
+		WherePermissionIsAtLeast("view", "info").
 		Where("item_id = ?", itemID).HasRows()
 
 	service.MustNotBeError(err)

--- a/app/api/items/list_attempts.robustness.feature
+++ b/app/api/items/list_attempts.robustness.feature
@@ -21,7 +21,7 @@ Feature: List attempts for current user and item_id - robustness
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated |
       | 11       | 210     | content            |
-      | 13       | 210     | info               |
+      | 13       | 210     | none               |
       | 15       | 210     | solution           |
     And the database has the following table "attempts":
       | id | participant_id | created_at          | creator_id | parent_attempt_id | ended_at |


### PR DESCRIPTION
Allow listing attempts for an item when the user only has can_view=info permission on the item

Fixes #1367 