### PR TITLE
dispatch new event: user_authenticated

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -598,6 +598,7 @@ type Event struct {
 - `grade_saved`: A grade was saved for an answer
 - `item_unlocked`: Item was unlocked for a user
 - `thread_status_changed`: Help thread status changed
+- `user_authenticated`: User authenticated via login module (new login with code)
 
 ### Configuration
 

--- a/app/api/auth/create_access_token.feature
+++ b/app/api/auth/create_access_token.feature
@@ -92,6 +92,10 @@ Feature: Create an access token
       }
       """
     And the response header "Set-Cookie" should be "<expected_cookie>"
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed 🐱", "last_name": "Amrani 🐱"}}
+      """
     And the table "users" should be:
       | group_id            | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name  | last_name | student_id | country_code | birth_date | graduation_year | grade | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text              | web_site                      | sex  | email_verified | last_ip   | time_zone      | notify_news | photo_autoload | public_first_name | public_last_name |
       | 5577006791947779410 | 2019-07-16 22:02:28 | 2019-07-16 22:02:28 | 0         | 2019-07-16 22:02:28 | 2019-07-16 22:02:28    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed 🐱 | Amrani 🐱 | 123456789  | dz           | 2000-07-02 | 2020            | 0     | null    | null    | null | null             | null              | en               | I'm Mohammed Amrani 🐱 | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 | Africa/Algiers | true        | true           | true              | true             |
@@ -255,6 +259,10 @@ Feature: Create an access token
       }
       """
     And the response header "Set-Cookie" should not be set
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "11", "login_id": "100000001", "login": "jane", "user_ip": "127.0.0.1", "profile": {"first_name": {{"<first_name>" != "null" ? "\"<first_name>\"" : "null"}}, "last_name": {{"<last_name>" != "null" ? "\"<last_name>\"" : "null"}}}}
+      """
     And the table "users" should remain unchanged, regardless of the row with group_id "11"
     And the table "users" at group_id "11" should be:
       | group_id | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login | email   | first_name   | last_name   | student_id   | country_code   | birth_date   | graduation_year   | grade   | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text   | web_site   | sex   | email_verified   | last_ip   | time_zone   | notify_news   | photo_autoload   | public_first_name   | public_last_name    |
@@ -334,6 +342,10 @@ Feature: Create an access token
       """
     When I send a POST request to "/auth/token?code={{code_from_oauth}}"
     Then the response code should be 201
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "11", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
+      """
     And the table "users" should remain unchanged, regardless of the row with group_id "11"
     And the table "users" at group_id "11" should be:
       | group_id |
@@ -410,6 +422,10 @@ Feature: Create an access token
       }
       """
     And the response header "Set-Cookie" should not be set
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
+      """
     And the table "sessions" should be:
       | session_id          | user_id             |
       | 8674665223082153551 | 5577006791947779410 |
@@ -490,6 +506,10 @@ Feature: Create an access token
       }
       """
     And the response header "Set-Cookie" should be "<expected_cookie>"
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "11", "login_id": "100000001", "login": "jane", "user_ip": "127.0.0.1", "profile": {"first_name": "Jane", "last_name": "Doe"}}
+      """
     And the table "access_tokens" should be:
       | session_id          | token                       |
       | 1                   | previousaccesstoken1        |
@@ -552,6 +572,10 @@ Feature: Create an access token
       }
       """
     And the response header "Set-Cookie" should be "<expected_cookie>"
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
+      """
     And the table "sessions" should be:
       | session_id          | user_id             |
       | 8674665223082153551 | 5577006791947779410 |
@@ -620,6 +644,10 @@ Feature: Create an access token
       access_token=; Path=/api/; Domain=example.org; Expires=Tue, 16 Jul 2019 21:45:49 GMT; Max-Age=0; HttpOnly; SameSite=Strict
       access_token=2!{{access_token_from_oauth}}!127.0.0.1!/; Path=/; Domain=127.0.0.1; Expires=Thu, 16 Jul 2020 22:02:29 GMT; Max-Age=31622400; HttpOnly; Secure; SameSite=None
     """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
+      """
 
   Scenario: Create a new user with cycled badges (should refuse to create cycles)
     Given the time now is "2019-07-16T22:02:28Z"
@@ -684,6 +712,10 @@ Feature: Create an access token
           "expires_in": 31622400
         }
       }
+      """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
       """
     And logs should contain:
       """
@@ -797,6 +829,10 @@ Feature: Create an access token
         }
       }
       """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
+      """
     And the table "users" should be:
       | group_id            | latest_login_at     | latest_activity_at  | temp_user | registered_at       | latest_profile_sync_at | login_id  | login    | email                | first_name | last_name | student_id | country_code | birth_date | graduation_year | grade | address | zipcode | city | land_line_number | cell_phone_number | default_language | free_text           | web_site                      | sex  | email_verified | last_ip   | time_zone      | notify_news | photo_autoload | public_first_name | public_last_name |
       | 5577006791947779410 | 2019-07-16 22:02:28 | 2019-07-16 22:02:28 | 0         | 2019-07-16 22:02:28 | 2019-07-16 22:02:28    | 100000001 | mohammed | mohammedam@gmail.com | Mohammed   | Amrani    | 123456789  | dz           | 2000-07-02 | 2020            | 0     | null    | null    | null | null             | null              | en               | I'm Mohammed Amrani | http://mohammed.freepages.com | Male | 0              | 127.0.0.1 | Africa/Algiers | true        | true           | true              | true             |
@@ -898,6 +934,10 @@ Feature: Create an access token
           "expires_in": 31622400
         }
       }
+      """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "5577006791947779410", "login_id": "100000001", "login": "mohammed", "user_ip": "127.0.0.1", "profile": {"first_name": "Mohammed", "last_name": "Amrani"}}
       """
     And logs should contain:
       """
@@ -1067,6 +1107,10 @@ Feature: Create an access token
           "expires_in": 31622420
         }
       }
+      """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "11", "login_id": "100000001", "login": "jane", "user_ip": "127.0.0.1", "profile": null}
       """
     And the column "users.profile" at group_id "11" should be, in JSON:
       """

--- a/app/api/auth/create_access_token_avoid_session_spamming.feature
+++ b/app/api/auth/create_access_token_avoid_session_spamming.feature
@@ -152,6 +152,10 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
         }
       }
       """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "@UserWith9Sessions", "login_id": "9", "login": "login", "user_ip": "127.0.0.1", "profile": null}
+      """
     And there are 10 sessions for user @UserWith9Sessions
 
   Scenario: Should add the new session and delete the oldest one when the user have 10 sessions
@@ -195,6 +199,10 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
           "expires_in": 31622420
         }
       }
+      """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "@UserWith10Sessions", "login_id": "10", "login": "login", "user_ip": "127.0.0.1", "profile": null}
       """
     And there are 10 sessions for user @UserWith10Sessions
     And there is no session @Session_UserWith10Sessions_1
@@ -241,6 +249,10 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
         }
       }
       """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "@UserWith10Sessions_2", "login_id": "102", "login": "login", "user_ip": "127.0.0.1", "profile": null}
+      """
     And there are 10 sessions for user @UserWith10Sessions_2
     And there is no session @Session_UserWith10Sessions_2_1
 
@@ -285,6 +297,10 @@ Feature: To avoid session creation spamming, we allow a maximum of 10 sessions p
           "expires_in": 31622420
         }
       }
+      """
+    And an event "user_authenticated" should have been dispatched with:
+      """
+      {"user_id": "@UserWith11Sessions", "login_id": "11", "login": "login", "user_ip": "127.0.0.1", "profile": null}
       """
     And there are 10 sessions for user @UserWith10Sessions
     And there is no session @Session_UserWith11Sessions_2

--- a/app/event/event.go
+++ b/app/event/event.go
@@ -21,5 +21,5 @@ const (
 	// EventVersion is the current event schema version.
 	// Increment minor for non-breaking changes (adding optional fields).
 	// Increment major for breaking changes (removing fields, changing semantics).
-	EventVersion = "1.1"
+	EventVersion = "1.2"
 )

--- a/app/event/types.go
+++ b/app/event/types.go
@@ -13,4 +13,7 @@ const (
 
 	// TypeThreadStatusChanged is dispatched when a thread's status changes.
 	TypeThreadStatusChanged = "thread_status_changed"
+
+	// TypeUserAuthenticated is dispatched when a user authenticates via the login module.
+	TypeUserAuthenticated = "user_authenticated"
 )


### PR DESCRIPTION
## Summary

- Dispatch a new `user_authenticated` event after a successful OAuth code exchange in `createAccessToken`, with payload containing `user_id`, `login_id`, `login`, `user_ip`, and the raw `profile` map from the login module
- Bump event schema version from 1.1 to 1.2 (non-breaking addition)

## Test plan

- [x] BDD tests added to all successful code-flow scenarios in `create_access_token.feature` (10 scenarios) and `create_access_token_avoid_session_spamming.feature` (4 scenarios)
- [x] All existing tests pass
- [x] Linter passes