### PR TITLE
Item children layout add hide option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,14 @@ Note: There may be a flaky timeout test in `app/database` that occasionally hang
 
 If you get DB connection errors, ensure docker-compose services are running with `docker-compose ps`.
 
+## Database Migrations
+
+Migrations live in `db/migrations/` and use [goose](https://github.com/pressly/goose). They can be SQL (`.sql`) or Go (`.go`) files.
+
+**Naming convention**: `YYMMDDHHMM_description.sql` (10-digit timestamp, e.g., `2602270000_add_hide_to_items_children_layout.sql`).
+
+**Important**: `db/schema/schema.sql` is the base schema snapshot loaded by `db-restore`. Migrations are applied on top of it by `db-migrate`. Do **not** manually edit `schema.sql` to reflect migration changes -- the migration file is the sole source of truth for schema evolution.
+
 ## Event System
 
 The project has an event dispatch system that sends domain events to external systems (e.g., AWS SQS).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1080,10 +1080,11 @@ go tool pprof http://127.0.0.1:8080/debug/pprof/profile?seconds=10
 
 ### Migrations
 
-- Named: `YYMMDDHHMMSS_description.sql` or `.go`
+- Named: `YYMMDDHHMM_description.sql` or `.go` (10-digit timestamp)
 - Up and down in same file (for SQL)
 - Use `goose` for migration management
 - Never modify old migrations (create new ones)
+- **`db/schema/schema.sql`** is the base schema snapshot loaded by `db-restore`. Migrations are applied on top of it by `db-migrate`. Do **not** manually edit `schema.sql` to reflect migration changes.
 
 ---
 

--- a/app/api/items/create_item.feature
+++ b/app/api/items/create_item.feature
@@ -538,3 +538,28 @@ Feature: Create item
       | 0          | 11             | 21      | 0              |
       | 0          | 11             | 30      | 25             |
       | 0          | 11             | 31      | 50             |
+
+  Scenario: Valid (set children_layout to Hide)
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Chapter",
+        "language_tag": "sl",
+        "title": "my chapter",
+        "children_layout": "Hide",
+        "parent": {"item_id": "21"}
+      }
+      """
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": { "id": "5577006791947779410" }
+      }
+      """
+    And the table "items" at id "5577006791947779410" should be:
+      | id                  | type    | children_layout |
+      | 5577006791947779410 | Chapter | Hide            |

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -29,7 +29,7 @@ type Item struct {
 	TextID                 *string `json:"text_id"`
 	DisplayDetailsInParent bool    `json:"display_details_in_parent"`
 	ReadOnly               bool    `json:"read_only"`
-	// enum: List,Grid
+	// enum: List,Grid,Hide
 	ChildrenLayout string `json:"children_layout"`
 	// enum: forceYes,forceNo,default
 	FullScreen   string `json:"full_screen"   validate:"oneof=forceYes forceNo default"`

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -712,3 +712,18 @@ Feature: Get item view information
     | none                | enter                    | none                              | false                  | true                            | {{watched_group_permissions}}                   |
     | none                | none                     | content                           | false                  | true                            | {{watched_group_permissions}}                   |
     | result              | none                     | none                              | false                  | false                           | {{watched_group_average_score_and_permissions}} |
+
+  Scenario: Chapter with children_layout set to Hide
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id  | type    | default_language_tag | children_layout |
+      | 230 | Chapter | en                   | Hide            |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title     |
+      | 230     | en           | Chapter C |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
+      | 11       | 230     | solution           | none                     | none               | none                | false              |
+    When I send a GET request to "/items/230"
+    Then the response code should be 200
+    And the response at $.children_layout should be "Hide"

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -135,7 +135,7 @@ type itemResponse struct {
 	// enum: forceYes,forceNo,default
 	FullScreen string `json:"full_screen"`
 	// required: true
-	// enum: List,Grid
+	// enum: List,Grid,Hide
 	ChildrenLayout string `json:"children_layout"`
 	// required: true
 	ShowUserInfos bool `json:"show_user_infos"`

--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -783,3 +783,17 @@ Background:
     And the table "items_items" at parent_item_id "21" should be:
       | parent_item_id | child_item_id | child_order | category  | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation |
       | 21             | 112           | 1           | Challenge | 2            | as_content               | as_is                         | true                   | true              | true             |
+
+  Scenario: Valid (set children_layout to Hide)
+    Given I am the user with id "11"
+    When I send a PUT request to "/items/60" with the following body:
+      """
+      {
+        "children_layout": "Hide"
+      }
+      """
+    Then the response should be "updated"
+    And the table "items" should remain unchanged, regardless of the row with id "60"
+    And the table "items" at id "60" should be:
+      | id | type    | children_layout |
+      | 60 | Chapter | Hide            |

--- a/db/migrations/2602271700_add_hide_to_items_children_layout.sql
+++ b/db/migrations/2602271700_add_hide_to_items_children_layout.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+ALTER TABLE `items`
+  MODIFY COLUMN `children_layout` enum('List','Grid','Hide') DEFAULT 'List'
+    COMMENT 'How the children list are displayed (for chapters and skills)';
+
+-- +goose Down
+UPDATE `items` SET `children_layout` = 'List' WHERE `children_layout` = 'Hide';
+ALTER TABLE `items`
+  MODIFY COLUMN `children_layout` enum('List','Grid') DEFAULT 'List'
+    COMMENT 'How the children list are displayed (for chapters and skills)';


### PR DESCRIPTION
## Add `Hide` option for `children_layout` item property

### Summary

Extends the `children_layout` property on `items` from two options (`List`, `Grid`) to three, adding `Hide` as a valid value. This allows the UI to fully hide the children list for a chapter or skill.

### Changes

**Database**
- New migration (`2602271700_add_hide_to_items_children_layout.sql`) alters the `children_layout` ENUM from `('List','Grid')` to `('List','Grid','Hide')`.
- The Down migration safely converts any `'Hide'` values back to `'List'` before reverting the ENUM, preventing data loss on rollback.

**API**
- Updated the `// enum:` swagger comment on the `ChildrenLayout` field in `create_item.go` and `get_item.go` to include `Hide`.
- No Go validation tag change needed — the MySQL ENUM constraint already enforces valid values.

**Tests**
- `get_item.feature`: new scenario asserting that a chapter with `children_layout = 'Hide'` in the DB is returned correctly by the GET endpoint.
- `update_item.feature`: new scenario asserting that PUTting `"children_layout": "Hide"` persists correctly.
- `create_item.feature`: new scenario asserting that POSTing a new item with `"children_layout": "Hide"` stores the value correctly.

**Documentation**
- `AGENTS.md` / `ARCHITECTURE.md`: added a note that `db/schema/schema.sql` is a base snapshot used by `db-restore` and must not be manually edited — migrations are the sole source of schema evolution. Also corrected the migration timestamp format (`YYMMDDHHMM`, 10 digits).

### Test plan

- [ ] Run `ALGOREA_ENV=test ./bin/AlgoreaBackend db-migrate` and confirm migration `2602271700` applies cleanly
- [ ] Run `ALGOREA_ENV=test go test ./app/api/items/... -run TestBDD/get_item.feature` — all pass
- [ ] Run `ALGOREA_ENV=test go test ./app/api/items/... -run TestBDD/update_item.feature` — all pass
- [ ] Run `ALGOREA_ENV=test go test ./app/api/items/... -run TestBDD/create_item.feature` — all pass
- [ ] Run `./bin/golangci-lint run -v --timeout 2m` — 0 issues