### PR TITLE
allow 'Base' group to be given as input to 'path-from-root' 

### DIFF
--- a/app/api/groups/path_from_root.feature
+++ b/app/api/groups/path_from_root.feature
@@ -154,6 +154,24 @@ Feature: Find a group path
     | 23       | "26","22","23"      |
     | 38       | "38"                |
     | 41       | "26","4","41"       |
+    | 1        | "1"                 |
+    | 2        | "2"                 |
+    | 3        | "3"                 |
+    | 12       | "12"                |
+    | 27       | "26","27"           |
+
+  Scenario: Paths through Base groups are not returned
+    Given I am the user with id "41"
+    # Group 4 (Joined Class) has two parents: group 3 (Base) and group 26 (Class).
+    # The path through the Base parent (3 -> 4) is ignored; the non-Base path (26 -> 4) is returned.
+    When I send a GET request to "/groups/4/path-from-root"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "path": ["26","4"]
+    }
+    """
 
   Scenario: Ancestors of managed groups are visible
     Given I am the user with id "50"

--- a/app/api/groups/path_from_root.go
+++ b/app/api/groups/path_from_root.go
@@ -18,13 +18,15 @@ import (
 //		Finds a path from any of root groups to a given group.
 //
 //
-//		A path is an array of group ids from a visible group root
-//		(a visible non-"base" group without non-"base" parent) to the input group.
-//		Each group must be visible, so either
+//		A path is an array of group ids from a visible group root to the input group.
+//		The input group may be of any type including "Base".
+//		Each non-terminal group in the path must be a visible non-"Base" group, so either
 //		1) ancestors of groups he joined,
 //		2) ancestors of non-user groups he manages,
 //		3) descendants of groups he manages,
 //		4) groups with is_public=1.
+//		The terminal group (the input group itself) must also be visible but may be of type "Base".
+//		Base groups are never included as intermediate nodes in the path.
 //		Of all possible paths the service chooses any of shortest ones.
 //
 //
@@ -79,7 +81,7 @@ func findGroupPath(store *database.DataStore, groupID int64, user *database.User
 		store.ActiveGroupAncestors().Where("child_group_id = ?", groupID).
 			Joins("JOIN `groups` ON groups.id = ancestor_group_id"), user).
 		Select("ancestor_group_id AS id").
-		Where("groups.type != 'Base'")
+		Where("groups.type != 'Base' OR ancestor_group_id = ?", groupID)
 
 	var pathStrings []string
 	service.MustNotBeError(store.Raw(`

--- a/app/api/groups/path_from_root.robustness.feature
+++ b/app/api/groups/path_from_root.robustness.feature
@@ -144,9 +144,7 @@ Feature: Find a group path - robustness
     And the response error message should contain "Insufficient access rights"
   Examples:
     | group_id |
-    | 1        |
     | 10       |
-    | 12       |
     | 50       |
 
   Scenario: Ancestors of managed users are not visible


### PR DESCRIPTION
## Allow `GET /groups/{group_id}/path-from-root` to return a path for Base groups

### Summary

Previously, the endpoint returned `403 Insufficient access rights` whenever the requested `group_id` belonged to a group of type `Base`, because Base groups were unconditionally excluded from the set of visible ancestors used to build the path.

This change relaxes that filter: Base groups are still never included as **intermediate** nodes in a path (the path skips over them), but the **target** group itself may now be of type `Base`. The shortest visible non-Base path leading to the target is returned as before.

### Changes

**`app/api/groups/path_from_root.go`**
- Changed the `WHERE` filter in `findGroupPath` from `groups.type != 'Base'` to `groups.type != 'Base' OR ancestor_group_id = ?` (binding the target `groupID`). This allows the self-referencing ancestors row for the target to pass the filter even when the target is a Base group, while all intermediate Base ancestors remain excluded.
- Updated the swagger description to reflect that the target group may be of type `Base` and that Base groups are excluded from intermediate path nodes only.

**`app/api/groups/path_from_root.feature`**
- Added success cases for Base group targets: groups with no non-Base parent become a single-element path (e.g. `["1"]`, `["2"]`, `["3"]`, `["12"]`), and a public Base group with a non-Base parent yields the expected two-element path (`["26","27"]`).
- Added an explicit `Paths through Base groups are not returned` scenario: group 4 has both a Base parent (group 3) and a non-Base parent (group 26); the test asserts the returned path is `["26","4"]`, not `["3","4"]`.

**`app/api/groups/path_from_root.robustness.feature`**
- Removed groups 1 and 12 from the `403` examples since they are now reachable Base group targets.

### Test plan

- All existing path scenarios continue to pass unchanged.
- New Base-group target scenarios return `200` with the correct path.
- The explicit "no path through Base" scenario confirms intermediate Base nodes are skipped.
- Groups that were 403 for unrelated reasons (not visible, expired membership) remain 403.