### PR TITLE
add a new atteribute score_improved to TypeGradeSaved event

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -595,7 +595,7 @@ type Event struct {
 ### Event Types
 
 - `submission_created`: User submitted an answer
-- `grade_saved`: A grade was saved for an answer
+- `grade_saved`: A grade was saved for an answer. Payload includes `score_improved` (bool) indicating whether the result's computed score was updated (i.e., the new grade set a new best score).
 - `item_unlocked`: Item was unlocked for a user
 - `thread_status_changed`: Help thread status changed
 - `user_authenticated`: User authenticated via login module (new login with code)

--- a/app/api/items/save_grade.feature
+++ b/app/api/items/save_grade.feature
@@ -103,7 +103,7 @@ Feature: Save grading result
     And the table "results_propagate_internal" should be empty
     And an event "grade_saved" should have been dispatched with:
       """
-      {"answer_id": "123", "participant_id": "101", "attempt_id": "0", "item_id": "50", "validated": true, "caller_id": "101", "score": 100}
+      {"answer_id": "123", "participant_id": "101", "attempt_id": "0", "item_id": "50", "validated": true, "caller_id": "101", "score": 100, "score_improved": true}
       """
 
   Scenario: User is able to save the grading result for a team (participant_id is the first integer in idAttempt in the score token)
@@ -215,6 +215,10 @@ Feature: Save grading result
     And the table "results_propagate" should be empty
     And the table "results_propagate_sync" should be empty
     And the table "results_propagate_internal" should be empty
+    And an event "grade_saved" should have been dispatched with:
+      """
+      {"answer_id": "123", "participant_id": "101", "attempt_id": "0", "item_id": "50", "validated": false, "caller_id": "101", "score": <score>, "score_improved": true}
+      """
   Examples:
     | score | score_edit_rule | score_edit_value | score_computed | parent_score |
     | 99    | null            | null             | 99             | 49.5         |
@@ -283,6 +287,10 @@ Feature: Save grading result
     And the table "results_propagate" should be empty
     And the table "results_propagate_sync" should be empty
     And the table "results_propagate_internal" should be empty
+    And an event "grade_saved" should have been dispatched with:
+      """
+      {"answer_id": "124", "participant_id": "101", "attempt_id": "1", "item_id": "60", "validated": false, "caller_id": "101", "score": 99, "score_improved": true}
+      """
 
   Scenario Outline: Should keep previous score if it is greater
     Given the database has the following table "answers":
@@ -298,10 +306,10 @@ Feature: Save grading result
       | id | participant_id |
       | 0  | 101            |
     And the database has the following table "results":
-      | participant_id | attempt_id | item_id | score_computed | score_obtained_at   | score_edit_rule   | score_edit_value   |
-      | 101            | 0          | 10      | 20             | 2018-05-29 06:38:38 | null              | null               |
-      | 101            | 0          | 50      | 20             | 2018-05-29 06:38:38 | <score_edit_rule> | <score_edit_value> |
-      | 101            | 0          | 60      | 20             | 2018-05-29 06:38:38 | null              | null               |
+      | participant_id | attempt_id | item_id | score_computed | score_obtained_at   | tasks_tried | score_edit_rule   | score_edit_value   |
+      | 101            | 0          | 10      | 20             | 2018-05-29 06:38:38 | 1           | null              | null               |
+      | 101            | 0          | 50      | 20             | 2018-05-29 06:38:38 | 1           | <score_edit_rule> | <score_edit_value> |
+      | 101            | 0          | 60      | 20             | 2018-05-29 06:38:38 | 1           | null              | null               |
     And "scoreToken" is a token signed by the task platform with the following payload:
       """
       {
@@ -337,6 +345,10 @@ Feature: Save grading result
       | 124       | <score> | 1                                                |
       | 125       | 20      | 0                                                |
     And the table "results" should remain unchanged
+    And an event "grade_saved" should have been dispatched with:
+      """
+      {"answer_id": "124", "participant_id": "101", "attempt_id": "0", "item_id": "60", "validated": false, "caller_id": "101", "score": <score>, "score_improved": false}
+      """
     Examples:
       | score | score_edit_rule | score_edit_value |
       | 19    | null            | null             |
@@ -640,3 +652,7 @@ Feature: Save grading result
     And the table "results_propagate" should be empty
     And the table "results_propagate_sync" should be empty
     And the table "results_propagate_internal" should be empty
+    And an event "grade_saved" should have been dispatched with:
+      """
+      {"answer_id": "123", "participant_id": "101", "attempt_id": "0", "item_id": "50", "validated": true, "caller_id": "101", "score": 100, "score_improved": false}
+      """

--- a/app/api/items/save_grade.go
+++ b/app/api/items/save_grade.go
@@ -114,12 +114,12 @@ func (srv *Service) saveGrade(responseWriter http.ResponseWriter, httpRequest *h
 
 	logging.LogEntrySetField(httpRequest, "user_id", requestData.ScoreToken.Payload.Converted.UserID)
 
-	var validated, newGradingSaved bool
+	var validated, newGradingSaved, scoreImproved bool
 	unlockedItems := make([]map[string]interface{}, 0)
 	err = store.InTransaction(func(store *database.DataStore) error {
 		service.MustNotBeError(store.SetPropagationsModeToSync())
 		var unlockedItemIDs *golang.Set[int64]
-		validated, newGradingSaved, unlockedItemIDs = saveGradingResultsIntoDB(store, &requestData)
+		validated, newGradingSaved, scoreImproved, unlockedItemIDs = saveGradingResultsIntoDB(store, &requestData)
 
 		if !newGradingSaved || unlockedItemIDs.Size() == 0 {
 			return nil
@@ -157,6 +157,7 @@ func (srv *Service) saveGrade(responseWriter http.ResponseWriter, httpRequest *h
 		"validated":      validated,
 		"caller_id":      strconv.FormatInt(requestData.ScoreToken.Payload.Converted.UserID, 10),
 		"score":          requestData.ScoreToken.Payload.Converted.Score,
+		"score_improved": scoreImproved,
 	})
 
 	service.MustNotBeError(render.Render(responseWriter, httpRequest, service.CreationSuccess(map[string]interface{}{
@@ -167,7 +168,7 @@ func (srv *Service) saveGrade(responseWriter http.ResponseWriter, httpRequest *h
 }
 
 func saveGradingResultsIntoDB(store *database.DataStore, requestData *saveGradeRequestParsed) (
-	validated, ok bool, unlockedItemIDs *golang.Set[int64],
+	validated, ok, scoreImproved bool, unlockedItemIDs *golang.Set[int64],
 ) {
 	score := requestData.ScoreToken.Payload.Converted.Score
 
@@ -175,7 +176,7 @@ func saveGradingResultsIntoDB(store *database.DataStore, requestData *saveGradeR
 	gotFullScore := score == maxScore
 	validated = gotFullScore // currently a validated task is only a task with a full score (score == 100)
 	if !saveNewScoreIntoGradings(store, requestData, score) {
-		return validated, false, golang.NewSet[int64]()
+		return validated, false, false, golang.NewSet[int64]()
 	}
 
 	// Build query to update results
@@ -222,8 +223,11 @@ func saveGradingResultsIntoDB(store *database.DataStore, requestData *saveGradeR
 	updateResult := store.Exec("UPDATE results JOIN answers ON answers.id = ? "+
 		updateExpr+" WHERE results.participant_id = ? AND results.attempt_id = ? AND results.item_id = ?", values...)
 	service.MustNotBeError(updateResult.Error())
-	if updateResult.RowsAffected() == 0 { // nothing to propagate
-		return validated, true, golang.NewSet[int64]()
+	// RowsAffected() == 0 means the result row didn't change, i.e., the score was not improved.
+	// When there is no prior grading, tasks_tried is 0 and will change to 1, making the row change
+	// even if the computed score stays at 0 — going from "no grading" to "score 0" is treated as an improvement.
+	if updateResult.RowsAffected() == 0 {
+		return validated, true, false, golang.NewSet[int64]()
 	}
 
 	resultStore := store.Results()
@@ -234,7 +238,7 @@ func saveGradingResultsIntoDB(store *database.DataStore, requestData *saveGradeR
 	unlockedItemIDs, err := resultStore.PropagateAndCollectUnlockedItemsForParticipant(requestData.ScoreToken.Payload.Converted.ParticipantID)
 	service.MustNotBeError(err)
 
-	return validated, true, unlockedItemIDs
+	return validated, true, true, unlockedItemIDs
 }
 
 func saveNewScoreIntoGradings(store *database.DataStore, requestData *saveGradeRequestParsed, score float64) bool {

--- a/app/event/event.go
+++ b/app/event/event.go
@@ -21,5 +21,5 @@ const (
 	// EventVersion is the current event schema version.
 	// Increment minor for non-breaking changes (adding optional fields).
 	// Increment major for breaking changes (removing fields, changing semantics).
-	EventVersion = "1.2"
+	EventVersion = "1.3"
 )


### PR DESCRIPTION
# Add `score_improved` field to `grade_saved` event

## Summary

- Adds a `score_improved` boolean field to the `grade_saved` event payload, indicating whether this grading resulted in an improvement of the participant's computed score for the item.
- Bumps the event schema version from `1.2` to `1.3` (non-breaking addition).

## Details

`score_improved` is `true` when `RowsAffected() > 0` on the result UPDATE, which covers two cases:
- The new computed score strictly beats the previous best (any relevant column changed).
- The first grading ever on this result (`tasks_tried` goes from 0 to 1), even if the computed score ends up at 0 due to score edit rules.

It is `false` when the row is unchanged — i.e., the new score did not beat the existing best and `tasks_tried` was already ≥ 1.

## Test fixes

The "Should keep previous score if it is greater" BDD scenario fixture was missing `tasks_tried = 1` on its result rows, which was inconsistent (a result with an existing score must have been graded before). This has been corrected, which also makes the `RowsAffected()` signal reliable for the `score_improved` logic.