### PR TITLE
new service: generate an item permission token

### DIFF
--- a/app/api/items/generate_permissions_token.feature
+++ b/app/api/items/generate_permissions_token.feature
@@ -1,0 +1,116 @@
+Feature: Generate a permissions token for an item
+  Background:
+    Given the database has the following users:
+      | group_id | login |
+      | 101      | john  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id | default_language_tag |
+      | 50 | fr                   |
+      | 60 | fr                   |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
+      | 101      | 50      | content            | content                  | result              | children           | true               |
+      | 101      | 60      | info               | none                     | none                | none               | false              |
+    And the time now is "2019-07-16T22:02:28Z"
+
+  Scenario: Successfully generate a permissions token with full permissions
+    Given I am the user with id "101"
+    And "expectedPermissionsToken" is a token signed by the app with the following payload:
+      """
+      {
+        "user_id": "101",
+        "item_id": "50",
+        "can_view": "content",
+        "can_grant_view": "content",
+        "can_watch": "result",
+        "can_edit": "children",
+        "is_owner": true,
+        "exp": 1563321748
+      }
+      """
+    When I send a POST request to "/items/50/permissions-token"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "permissions_token": "{{expectedPermissionsToken}}",
+          "expires_in": 7200
+        }
+      }
+      """
+
+  Scenario: Successfully generate a permissions token with minimal permissions
+    Given I am the user with id "101"
+    And "expectedPermissionsToken" is a token signed by the app with the following payload:
+      """
+      {
+        "user_id": "101",
+        "item_id": "60",
+        "can_view": "info",
+        "can_grant_view": "none",
+        "can_watch": "none",
+        "can_edit": "none",
+        "is_owner": false,
+        "exp": 1563321748
+      }
+      """
+    When I send a POST request to "/items/60/permissions-token"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "permissions_token": "{{expectedPermissionsToken}}",
+          "expires_in": 7200
+        }
+      }
+      """
+
+  Scenario: Permissions are aggregated across group ancestors
+    Given the database has the following table "groups":
+      | id  | type  |
+      | 102 | Class |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id |
+      | 102             | 101            |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id | default_language_tag |
+      | 70 | fr                   |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
+      | 101      | 70      | content            | none                     | none                | none               | false              |
+      | 102      | 70      | info               | content                  | answer              | all                | true               |
+    And I am the user with id "101"
+    And "expectedPermissionsToken" is a token signed by the app with the following payload:
+      """
+      {
+        "user_id": "101",
+        "item_id": "70",
+        "can_view": "content",
+        "can_grant_view": "content",
+        "can_watch": "answer",
+        "can_edit": "all",
+        "is_owner": true,
+        "exp": 1563321748
+      }
+      """
+    When I send a POST request to "/items/70/permissions-token"
+    Then the response code should be 201
+    And the response body should be, in JSON:
+      """
+      {
+        "success": true,
+        "message": "created",
+        "data": {
+          "permissions_token": "{{expectedPermissionsToken}}",
+          "expires_in": 7200
+        }
+      }
+      """

--- a/app/api/items/generate_permissions_token.go
+++ b/app/api/items/generate_permissions_token.go
@@ -1,0 +1,93 @@
+package items
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/jinzhu/gorm"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/payloads"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/token"
+)
+
+const permissionsTokenLifetime = 2 * time.Hour
+
+// swagger:operation POST /items/{item_id}/permissions-token items itemPermissionsTokenGenerate
+//
+//	---
+//	summary: Generate a permissions token
+//	description: >
+//		Generates a signed JWS token that asserts the current user's permissions on an item.
+//		The token contains the user's ID, item ID, and all permission fields
+//		(can_view, can_grant_view, can_watch, can_edit, is_owner).
+//
+//
+//		Restrictions:
+//
+//		* the user must have at least `can_view` >= 'info' on the item,
+//
+//		otherwise the 'forbidden' error is returned.
+//	parameters:
+//		- name: item_id
+//			in: path
+//			type: integer
+//			format: int64
+//			required: true
+//	responses:
+//		"201":
+//			"$ref": "#/responses/permissionsTokenResponse"
+//		"400":
+//			"$ref": "#/responses/badRequestResponse"
+//		"401":
+//			"$ref": "#/responses/unauthorizedResponse"
+//		"403":
+//			"$ref": "#/responses/forbiddenResponse"
+//		"500":
+//			"$ref": "#/responses/internalErrorResponse"
+func (srv *Service) generatePermissionsToken(responseWriter http.ResponseWriter, httpRequest *http.Request) error {
+	itemID, err := service.ResolveURLQueryPathInt64Field(httpRequest, "item_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	user := srv.GetUser(httpRequest)
+	store := srv.GetStore(httpRequest)
+
+	var rawPermissions database.RawGeneratedPermissionFields
+	err = store.Permissions().
+		AggregatedPermissionsForItemsOnWhichGroupHasPermission(user.GroupID, "view", "info").
+		Where("permissions.item_id = ?", itemID).
+		Take(&rawPermissions).Error()
+	if gorm.IsRecordNotFoundError(err) {
+		return service.ErrAPIInsufficientAccessRights
+	}
+	service.MustNotBeError(err)
+
+	itemPermissions := rawPermissions.AsItemPermissions(store.PermissionsGranted())
+
+	expiresIn := int32(permissionsTokenLifetime / time.Second)
+	expirationTime := time.Now().Add(permissionsTokenLifetime)
+
+	permissionsToken, err := (&token.Token[payloads.PermissionsToken]{Payload: payloads.PermissionsToken{
+		UserID:       strconv.FormatInt(user.GroupID, 10),
+		ItemID:       strconv.FormatInt(itemID, 10),
+		CanView:      itemPermissions.CanView,
+		CanGrantView: itemPermissions.CanGrantView,
+		CanWatch:     itemPermissions.CanWatch,
+		CanEdit:      itemPermissions.CanEdit,
+		IsOwner:      itemPermissions.IsOwner,
+		Exp:          expirationTime.Unix(),
+	}}).Sign(srv.TokenConfig.PrivateKey)
+	service.MustNotBeError(err)
+
+	service.MustNotBeError(render.Render(responseWriter, httpRequest, service.CreationSuccess(map[string]interface{}{
+		"permissions_token": permissionsToken,
+		"expires_in":        expiresIn,
+	})))
+
+	return nil
+}

--- a/app/api/items/generate_permissions_token.robustness.feature
+++ b/app/api/items/generate_permissions_token.robustness.feature
@@ -1,0 +1,45 @@
+Feature: Generate a permissions token for an item - robustness
+  Background:
+    Given the database has the following user:
+      | group_id | login |
+      | 101      | john  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id | default_language_tag |
+      | 50 | fr                   |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated |
+      | 101      | 50      | none               |
+
+  Scenario: Invalid item_id
+    Given I am the user with id "101"
+    When I send a POST request to "/items/abc/permissions-token"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for item_id (should be int64)"
+
+  Scenario: User not found
+    Given I am the user with id "404"
+    When I send a POST request to "/items/50/permissions-token"
+    Then the response code should be 401
+    And the response error message should contain "Invalid access token"
+
+  Scenario: No access to the item (can_view is none)
+    Given I am the user with id "101"
+    When I send a POST request to "/items/50/permissions-token"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: No permissions row for the item
+    Given the database has the following table "items":
+      | id  | default_language_tag |
+      | 100 | fr                   |
+    And I am the user with id "101"
+    When I send a POST request to "/items/100/permissions-token"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Item does not exist
+    Given I am the user with id "101"
+    When I send a POST request to "/items/999/permissions-token"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"

--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -53,6 +53,7 @@ func (srv *Service) SetRoutes(router chi.Router) {
 		service.AppHandler(srv.applyDependency).ServeHTTP)
 	routerWithAuthAndParticipant.Get("/items/{item_id}/dependencies", service.AppHandler(srv.getItemDependencies).ServeHTTP)
 	routerWithAuth.Get("/items/search", service.AppHandler(srv.searchForItems).ServeHTTP)
+	routerWithAuth.Post("/items/{item_id}/permissions-token", service.AppHandler(srv.generatePermissionsToken).ServeHTTP)
 
 	routerWithAuthAndParticipant.Post("/items/{item_id}/attempts/{attempt_id}/generate-task-token",
 		service.AppHandler(srv.generateTaskToken).ServeHTTP)

--- a/app/doc/responses.go
+++ b/app/doc/responses.go
@@ -264,3 +264,26 @@ type identityTokenResponse struct {
 		} `json:"data"`
 	}
 }
+
+// Created. The permissions token was generated successfully.
+// swagger:response permissionsTokenResponse
+type permissionsTokenResponse struct {
+	// in:body
+	Body struct {
+		// enum: created
+		// required: true
+		Message string `json:"message"`
+		// true
+		// required: true
+		Success bool `json:"success"`
+		// required: true
+		Data struct {
+			// The signed JWS permissions token
+			// required: true
+			PermissionsToken string `json:"permissions_token"`
+			// Token lifetime in seconds
+			// required: true
+			ExpiresIn int32 `json:"expires_in"`
+		} `json:"data"`
+	}
+}

--- a/app/payloads/permissions_token.go
+++ b/app/payloads/permissions_token.go
@@ -1,0 +1,33 @@
+package payloads
+
+// PermissionsToken represents data inside a permissions JWS token.
+// This token allows external services to verify a user's permissions on an item.
+// swagger:model PermissionsToken
+type PermissionsToken struct {
+	// Format dd-mm-yyyy (auto-added by token.Generate)
+	// required:true
+	Date string `json:"date" validate:"dmy-date"`
+	// The authenticated user's ID
+	// required:true
+	UserID string `json:"user_id"`
+	// The item ID
+	// required:true
+	ItemID string `json:"item_id"`
+	// required:true
+	// enum: none,info,content,content_with_descendants,solution
+	CanView string `json:"can_view"`
+	// required:true
+	// enum: none,enter,content,content_with_descendants,solution,solution_with_grant
+	CanGrantView string `json:"can_grant_view"`
+	// required:true
+	// enum: none,result,answer,answer_with_grant
+	CanWatch string `json:"can_watch"`
+	// required:true
+	// enum: none,children,all,all_with_grant
+	CanEdit string `json:"can_edit"`
+	// required:true
+	IsOwner bool `json:"is_owner"`
+	// Expiry date in the number of seconds since 01/01/1970 UTC.
+	// required:true
+	Exp int64 `json:"exp"`
+}


### PR DESCRIPTION
## Add `POST /items/{item_id}/permissions-token` endpoint

### Summary

- Add a new endpoint that generates a signed JWS token asserting the current user's aggregated permissions on an item (`can_view`, `can_grant_view`, `can_watch`, `can_edit`, `is_owner`), along with the user ID, item ID, and a 2-hour expiration.
- The token is designed to be passed to external services (e.g., task platforms) so they can verify what the user is allowed to do on a given item without calling back to the backend.
- The endpoint requires authentication (temp users included) and at least `can_view >= "info"` on the item; no `as_team_id` support.

### New files

- `app/payloads/permissions_token.go` -- `PermissionsToken` payload struct
- `app/api/items/generate_permissions_token.go` -- endpoint handler
- `app/api/items/generate_permissions_token.feature` -- BDD happy path tests (3 scenarios)
- `app/api/items/generate_permissions_token.robustness.feature` -- BDD error case tests (5 scenarios)

### Modified files

- `app/api/items/items.go` -- route registration
- `app/doc/responses.go` -- swagger response definition

### Test plan

- [x] 3 happy path scenarios: full permissions, minimal permissions, aggregation across group ancestors
- [x] 5 robustness scenarios: invalid item_id, user not found, can_view is none, no permissions row, item does not exist
- [x] Linter passes with 0 issues