### PR TITLE
fix path-from-root to accept explicit-entry items matched on a non-rooted attempt with a started result

### DIFF
--- a/app/api/items/path_from_root.go
+++ b/app/api/items/path_from_root.go
@@ -164,8 +164,22 @@ func findItemPaths(store *database.DataStore, participantID, itemID int64, limit
 			        CAST(LPAD(IFNULL(attempts.id, '!'), 20, 0) AS CHAR(1024)), results.started_at IS NOT NULL,
 			        attempts.ended_at IS NULL AND NOW() < attempts.allows_submissions_until
 			FROM root_ancestors
-			LEFT JOIN attempts ON attempts.participant_id = ? AND
-				(NOT root_ancestors.requires_explicit_entry OR attempts.root_item_id = root_ancestors.id)
+			-- For items requiring explicit entry, the matched attempt usually must be rooted at the item itself.
+			-- We additionally allow non-rooted attempts when there is a STARTED result for the item on that attempt:
+			-- having such a started result is what proves the participant has actually entered the item, even if the
+			-- result is not on an attempt rooted at it (this can happen e.g. when "requires_explicit_entry" was flipped
+			-- on after the result was created). A non-started result is intentionally NOT enough on its own.
+			LEFT JOIN attempts ON attempts.participant_id = ? AND (
+				NOT root_ancestors.requires_explicit_entry
+				OR attempts.root_item_id = root_ancestors.id
+				OR EXISTS (
+					SELECT 1 FROM results AS started_results
+					WHERE started_results.participant_id = attempts.participant_id
+						AND started_results.attempt_id = attempts.id
+						AND started_results.item_id = root_ancestors.id
+						AND started_results.started_at IS NOT NULL
+				)
+			)
 			LEFT JOIN results ON results.participant_id = attempts.participant_id AND
 				attempts.id = results.attempt_id AND results.item_id = root_ancestors.id
 			WHERE root_ancestors.id = ? OR (
@@ -182,8 +196,20 @@ func findItemPaths(store *database.DataStore, participantID, itemID int64, limit
 			FROM paths
 			JOIN items_items ON items_items.parent_item_id = paths.final_item_id
 			JOIN item_ancestors ON item_ancestors.id = items_items.child_item_id
-			LEFT JOIN attempts ON attempts.participant_id = ? AND
-				(NOT item_ancestors.requires_explicit_entry OR attempts.root_item_id = item_ancestors.id) AND
+			-- Same relaxation as in the base case above: explicit-entry items normally require an attempt rooted
+			-- at the item, but we also accept non-rooted attempts that carry a STARTED result for the item.
+			-- A non-started result is intentionally NOT enough on its own to justify the relaxation.
+			LEFT JOIN attempts ON attempts.participant_id = ? AND (
+				NOT item_ancestors.requires_explicit_entry
+				OR attempts.root_item_id = item_ancestors.id
+				OR EXISTS (
+					SELECT 1 FROM results AS started_results
+					WHERE started_results.participant_id = attempts.participant_id
+						AND started_results.attempt_id = attempts.id
+						AND started_results.item_id = item_ancestors.id
+						AND started_results.started_at IS NOT NULL
+				)
+			) AND
 				IF(attempts.root_item_id = item_ancestors.id, attempts.parent_attempt_id, attempts.id) = paths.final_attempt_id
 			LEFT JOIN results ON results.participant_id = attempts.participant_id AND
 				attempts.id = results.attempt_id AND results.item_id = item_ancestors.id

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -621,6 +621,136 @@ func Test_findItemPaths(t *testing.T) {
 			args: args{participantID: 103, itemID: 2, limit: 1},
 		},
 		{
+			name: "supports paths starting with a root item requiring explicit entry having a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 100, itemID: 22, limit: 1},
+			want: []items.ItemPath{{Path: []string{"22"}, IsStarted: true}},
+		},
+		{
+			name: "supports paths through a non-final root item requiring explicit entry having a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: info}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 100, itemID: 30, limit: 1},
+			want: []items.ItemPath{{Path: []string{"22", "30"}, IsStarted: false}},
+		},
+		{
+			name: "supports paths through an intermediate item requiring explicit entry having a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: info}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 21, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, itemID: 30, limit: 1},
+			want: []items.ItemPath{{Path: []string{"1", "21", "30"}, IsStarted: false}},
+		},
+		{
+			name: "still ignores paths through a root item requiring explicit entry without any result for it",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: info}
+			`,
+			args: args{participantID: 100, itemID: 30, limit: 1},
+		},
+		{
+			name: "still ignores paths through an intermediate item requiring explicit entry without any result for it",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: info}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, itemID: 30, limit: 1},
+		},
+		// The two cases below verify that a NON-STARTED result on a non-rooted attempt is not enough to
+		// justify the relaxation that lets explicit-entry items be matched on attempts not rooted at them.
+		// A result row whose started_at is NULL can legitimately appear as a side effect of score propagation
+		// from descendants (or as a placeholder created during attempt setup): it does not prove that the
+		// participant ever actually started/entered the item on that attempt. Only a result with a non-NULL
+		// started_at provides that evidence, so paths based on such a not-started result must be rejected.
+		{
+			name: "still ignores paths through a root explicit-entry item with only a not-started result on a non-rooted attempt",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: info}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22}
+			`,
+			args: args{participantID: 100, itemID: 30, limit: 1},
+		},
+		{
+			name: "still ignores paths through an intermediate explicit-entry item with only a not-started result on a non-rooted attempt",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: info}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 21}
+			`,
+			args: args{participantID: 101, itemID: 30, limit: 1},
+		},
+		{
 			name: "returns all the paths when there is more than one",
 			fixture: `
 					groups:


### PR DESCRIPTION
## Context

`GET /items/{item_id}/path-from-root` was returning **403 Forbidden** for
items requiring explicit entry whose only result lived on an attempt **not
rooted at the item itself**, even when that result was started.

This typically happens when `requires_explicit_entry` is flipped from `0` to
`1` *after* the result was created: the participant's existing started
result then sits on `attempt_id = 0` rather than on an attempt rooted at
the item, and the strict `LEFT JOIN attempts` condition rejected the path.

The behavior was also inconsistent with the sibling endpoints
`GET /items/{ids}/breadcrumbs` and
`GET /items/{item_id}/breadcrumbs-from-roots`, which already accept such
results regardless of the attempt's `root_item_id`.

## Change

Relax the `LEFT JOIN attempts ... ON ...` condition in `findItemPaths` (in
both the base case and the recursive case) so that, for items requiring
explicit entry, the matched attempt may be **either**:

- rooted at the item (the original strict semantics), **or**
- any attempt for which the participant has a **started** result for the item
  (`results.started_at IS NOT NULL`).

A non-started result is intentionally **not enough**. A result row with
`started_at IS NULL` can legitimately appear as a side effect of score
propagation from descendants (or as a placeholder created during attempt
setup), and is **not** evidence that the participant has actually entered
the item on that attempt.

The doc comment on `path-from-root` was already permissive enough
("It is even possible that the final item has no linked attempt at all
while the final item requires explicit entry") and did not need updating.

## Tests

Added integration tests in `path_from_root_integration_test.go`:

**Positive cases** — paths must be returned:
- root explicit-entry item with only a started result on attempt 0
  (single-item path);
- non-final root explicit-entry item with only a started result on
  attempt 0 (the exact production scenario);
- intermediate explicit-entry item with only a started result on attempt 0.

**Negative cases** — no path must be returned:
- root explicit-entry item with no result at all;
- intermediate explicit-entry item with no result at all;
- root explicit-entry item with only a *not-started* result on a non-rooted
  attempt;
- intermediate explicit-entry item with only a *not-started* result on a
  non-rooted attempt.

The pre-existing tests `prefers the path for the last (by id) attempt
chain among all chains with started results for the same items` and
`prefers the path having an attempt for the final item` continue to pass
unchanged: the tighter "started result required" condition prevents
non-rooted attempts with only not-started results from polluting the
path-scoring sort order.

## Checklist

- [x] All existing tests still pass
- [x] New tests cover both the positive (production) scenario and the
      negative cases (no result, not-started result)
- [x] `golangci-lint run -v --timeout 2m` is clean
- [x] No schema/migration changes
- [x] No changes to API contract; pure behavior fix on a previously
      over-restrictive path