### PR TITLE
allow longer (10->20) item breadcrumbs

### DIFF
--- a/app/api/items/create_attempt.go
+++ b/app/api/items/create_attempt.go
@@ -43,7 +43,7 @@ import (
 //		- name: ids
 //			in: path
 //			type: string
-//			description: slash-separated list of item IDs (no more than 10 IDs)
+//			description: slash-separated list of item IDs (no more than 15 IDs)
 //			required: true
 //		- name: parent_attempt_id
 //			in: query

--- a/app/api/items/enter.go
+++ b/app/api/items/enter.go
@@ -38,7 +38,7 @@ import (
 //		- name: ids
 //			in: path
 //			type: string
-//			description: slash-separated list of item IDs (no more than 10 IDs)
+//			description: slash-separated list of item IDs (no more than 15 IDs)
 //			required: true
 //		- name: parent_attempt_id
 //			description: "`id` of an attempt which will be used as a parent attempt for the participation"

--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -36,7 +36,7 @@ import (
 //		- name: ids
 //			in: path
 //			type: string
-//			description: slash-separated list of IDs (no more than 10 IDs)
+//			description: slash-separated list of IDs (no more than 15 IDs)
 //			required: true
 //		- name: parent_attempt_id
 //			description: "`id` of an attempt for the second to the final item in the path.
@@ -195,7 +195,11 @@ func attemptIDOrParentAttemptID(httpRequest *http.Request) (
 	return attemptID, parentAttemptID, attemptIDSet, nil
 }
 
-const maxNumberOfIDsInItemPath = 10
+// maxNumberOfIDsInItemPath caps the depth of any item path passed in URLs (breadcrumbs, start-result(-path),
+// enter, attempts). It cannot grow much larger because BreadcrumbsHierarchy* SQL builds ~4·N joined tables
+// per path of length N (visible_items + results + attempts + items_items per step, plus a tail results+attempts),
+// and MySQL has a hard limit of 61 joined tables per query (~4·15 − 1 = 59, safely under the limit).
+const maxNumberOfIDsInItemPath = 15
 
 func idsFromRequest(r *http.Request) ([]int64, error) {
 	return service.ResolveURLQueryPathInt64SliceFieldWithLimit(r, "ids", maxNumberOfIDsInItemPath)

--- a/app/api/items/get_breadcrumbs.robustness.feature
+++ b/app/api/items/get_breadcrumbs.robustness.feature
@@ -160,11 +160,11 @@ Feature: Get item breadcrumbs - robustness
     Then the response code should be 400
     And the response error message should contain "Unable to parse one of the integers given as query args (value: '11111111111111111111111111111', param: 'ids')"
 
-  Scenario: More than 10 ids
+  Scenario: More than 15 ids
     And I am the user with id "11"
-    When I send a GET request to "/items/1/2/3/4/5/6/7/8/9/10/11/breadcrumbs"
+    When I send a GET request to "/items/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/breadcrumbs"
     Then the response code should be 400
-    And the response error message should contain "No more than 10 ids expected"
+    And the response error message should contain "No more than 15 ids expected"
 
   Scenario: Invalid attempt_id
     And I am the user with id "11"

--- a/app/api/items/start_result.go
+++ b/app/api/items/start_result.go
@@ -55,7 +55,7 @@ type updatedStartResultResponse struct { //nolint:unused // used in swagger docu
 //			- name: ids
 //				in: path
 //				type: string
-//				description: slash-separated list of item IDs (no more than 10 IDs)
+//				description: slash-separated list of item IDs (no more than 15 IDs)
 //				required: true
 //			- name: attempt_id
 //				in: query

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -40,7 +40,7 @@ import (
 //		- name: ids
 //			in: path
 //			type: string
-//			description: slash-separated list of item IDs (no more than 10 IDs)
+//			description: slash-separated list of item IDs (no more than 15 IDs)
 //			required: true
 //		- name: as_team_id
 //			in: query

--- a/app/api/items/start_result_path.robustness.feature
+++ b/app/api/items/start_result_path.robustness.feature
@@ -39,9 +39,9 @@ Feature: Start results for an item path - robustness
 
   Scenario: The path is too long
     Given I am the user with id "101"
-    When I send a POST request to "/items/1/2/3/4/5/6/7/8/9/10/11/start-result-path"
+    When I send a POST request to "/items/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/start-result-path"
     Then the response code should be 400
-    And the response error message should contain "No more than 10 ids expected"
+    And the response error message should contain "No more than 15 ids expected"
     And the table "results" should remain unchanged
 
   Scenario: Invalid as_team_id

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -4,7 +4,9 @@ package database_test
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1038,6 +1040,86 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 			}))
 		})
 	}
+}
+
+// TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength guards against MySQL's hard limit
+// of 61 joined tables per query. The breadcrumbs SQL builds ~4·N table references for a path
+// of length N, so we exercise the full chain at the maximum depth allowed by URL routing
+// (maxNumberOfIDsInItemPath in app/api/items/get_breadcrumbs.go) to make sure the query
+// still executes. If maxNumberOfIDsInItemPath is bumped, this constant must be bumped too
+// (and the SQL must be checked for fitting under the MySQL limit).
+func TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	const maxItemPathLength = 15
+	const groupID = int64(101)
+	const attemptID = int64(0)
+
+	ids := make([]int64, maxItemPathLength)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	var fixture strings.Builder
+	fixture.WriteString("items:\n")
+	for _, id := range ids {
+		fmt.Fprintf(&fixture, "  - {id: %d, default_language_tag: fr}\n", id)
+	}
+	fixture.WriteString("items_items:\n")
+	for i := 0; i < len(ids)-1; i++ {
+		fmt.Fprintf(&fixture, "  - {parent_item_id: %d, child_item_id: %d, child_order: 1}\n", ids[i], ids[i+1])
+	}
+	fmt.Fprintf(&fixture, "groups:\n  - {id: %d, root_activity_id: %d}\n", groupID, ids[0])
+	fixture.WriteString("permissions_generated:\n")
+	for _, id := range ids {
+		fmt.Fprintf(&fixture, "  - {group_id: %d, item_id: %d, can_view_generated: content}\n", groupID, id)
+	}
+	fmt.Fprintf(&fixture, "attempts:\n  - {participant_id: %d, id: %d}\n", groupID, attemptID)
+	fixture.WriteString("results:\n")
+	for _, id := range ids {
+		fmt.Fprintf(&fixture, "  - {participant_id: %d, attempt_id: %d, item_id: %d, started_at: 2019-05-30 11:00:00}\n",
+			groupID, attemptID, id)
+	}
+
+	db := testhelpers.SetupDBWithFixtureString(testhelpers.CreateTestContext(), fixture.String())
+	defer func() { _ = db.Close() }()
+
+	wantAttemptIDMapForAttempt := make(map[int64]int64, len(ids))
+	for _, id := range ids {
+		wantAttemptIDMapForAttempt[id] = attemptID
+	}
+	wantAttemptIDMapForParentAttempt := make(map[int64]int64, len(ids)-1)
+	for _, id := range ids[:len(ids)-1] {
+		wantAttemptIDMapForParentAttempt[id] = attemptID
+	}
+	wantAttemptNumberMap := map[int64]int{}
+
+	testEachWriteLockMode(t, "BreadcrumbsHierarchyForAttempt", func(t *testing.T, writeLock bool) {
+		t.Helper()
+		testoutput.SuppressIfPasses(t)
+
+		assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+			gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForAttempt(ids, groupID, attemptID, writeLock)
+			require.NoError(t, err,
+				"BreadcrumbsHierarchyForAttempt failed at the max path length; "+
+					"the MySQL 61-tables-per-join limit may have been exceeded")
+			assertBreadcrumbsHierarchy(t, wantAttemptIDMapForAttempt, gotIDs, wantAttemptNumberMap, gotNumbers, err)
+			return nil
+		}))
+	})
+	testEachWriteLockMode(t, "BreadcrumbsHierarchyForParentAttempt", func(t *testing.T, writeLock bool) {
+		t.Helper()
+		testoutput.SuppressIfPasses(t)
+
+		assert.NoError(t, database.NewDataStore(db).InTransaction(func(store *database.DataStore) error {
+			gotIDs, gotNumbers, err := store.Items().BreadcrumbsHierarchyForParentAttempt(ids, groupID, attemptID, writeLock)
+			require.NoError(t, err,
+				"BreadcrumbsHierarchyForParentAttempt failed at the max path length; "+
+					"the MySQL 61-tables-per-join limit may have been exceeded")
+			assertBreadcrumbsHierarchy(t, wantAttemptIDMapForParentAttempt, gotIDs, wantAttemptNumberMap, gotNumbers, err)
+			return nil
+		}))
+	})
 }
 
 func testEachWriteLockMode(t *testing.T, testName string, testFunc func(t *testing.T, writeLock bool)) {


### PR DESCRIPTION
## Summary

Raise the cap on the number of item IDs accepted in the slash-separated `{ids}` URL segment of the item-path endpoints from **10 to 15** (`itemBreadcrumbsGet`, `itemStartResultPath`, `itemStartResult`, `itemEnter`, `itemAttemptCreate`).

## Why 15 and not more?

The breadcrumbs SQL (`BreadcrumbsHierarchyForAttempt` / `…ForParentAttempt`) builds roughly **`4·N − 1`** joined-table references for a path of length `N` (one `visible_items`, `results`, `attempts`, `items_items` per step, plus a tail `results`+`attempts`). MySQL has a hard limit of **61 joined tables per query**, so:

| Path length `N` | Joined tables | Safe under MySQL? |
| --- | --- | --- |
| 10 (previous) | 39 | ✅ |
| 15 (this PR) | 59 | ✅ (close to the limit) |
| 20 | 79 | ❌ would hit `ER_TOO_MANY_TABLES` |

15 is the largest value that fits comfortably; bumping further would require refactoring the per-step joins.

## Changes

- `maxNumberOfIDsInItemPath`: `10` → `15` (with a comment documenting the MySQL constraint).
- Swagger `description` of the `ids` path parameter updated in the 5 endpoints sharing `idsFromRequest`.
- BDD robustness scenarios `More than 15 ids` and `The path is too long` updated to send 16 IDs and assert the new "No more than 15 ids expected" message.
- New integration test `TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength` that programmatically builds a 15-item chain, calls both breadcrumb hierarchy queries (with and without write lock) against the real DB, and fails loudly with a hint about the MySQL join limit if the SQL stops executing — so any future bump of `maxNumberOfIDsInItemPath` must keep this test green.

## Test plan

- [x] `./bin/golangci-lint run -v --timeout 2m ./app/api/items/... ./app/database/...` — clean
- [x] `go test -gcflags=all=-l -tags='!unit' -run 'TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength' ./app/database/` — 4/4 sub-tests pass (with/without write lock × `ForAttempt`/`ForParentAttempt`)
- [x] `go test -gcflags=all=-l -tags='!unit' -run 'TestBDD/get_breadcrumbs.robustness.feature|TestBDD/start_result_path.robustness.feature' ./app/api/items/` — all scenarios pass, including the updated `More_than_15_ids` and `The_path_is_too_long`

## Notes

- All 5 item-path endpoints share `idsFromRequest`, so they all get the new cap consistently.
- `maxNumberOfIDsInGroupPath` (groups breadcrumbs) is a separate constant and is left at 10 — unaffected.
- No DB schema change, no migration.