### PR TITLE
item breadcrumb: use straight join so the planner stops doing an exhaustive join-order search on long item paths

### DIFF
--- a/app/api/items/get_breadcrumbs.go
+++ b/app/api/items/get_breadcrumbs.go
@@ -196,9 +196,13 @@ func attemptIDOrParentAttemptID(httpRequest *http.Request) (
 }
 
 // maxNumberOfIDsInItemPath caps the depth of any item path passed in URLs (breadcrumbs, start-result(-path),
-// enter, attempts). It cannot grow much larger because BreadcrumbsHierarchy* SQL builds ~4·N joined tables
-// per path of length N (visible_items + results + attempts + items_items per step, plus a tail results+attempts),
-// and MySQL has a hard limit of 61 joined tables per query (~4·15 − 1 = 59, safely under the limit).
+// enter, attempts). It cannot grow much larger because BreadcrumbsHierarchy* / IsValidParticipationHierarchy*
+// SQL builds ~4·N joined tables per path of length N (visible_items + results + attempts + items_items per
+// step, plus a tail results+attempts):
+//   - MySQL has a hard limit of 61 joined tables per query (~4·15 − 1 = 59, safely under the limit).
+//   - The optimizer's join-order search would also be exponential at this depth (default
+//     optimizer_search_depth=62), so itemAttemptChainWithoutAttemptForTail uses STRAIGHT_JOIN to keep
+//     planning linear in N. Bumping this constant requires both checks to keep passing.
 const maxNumberOfIDsInItemPath = 15
 
 func idsFromRequest(r *http.Request) ([]int64, error) {

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -277,6 +277,14 @@ func (s *ItemStore) participationHierarchyForParentAttempt(
 		With("visible_items", s.visibleItemsFromListForGroupQuery(ids, groupID))
 }
 
+// itemAttemptChainWithoutAttemptForTail builds the long chain query used by the breadcrumbs and
+// participation-hierarchy services. It produces ~4*N joined tables for a path of length N, which
+// would push MySQL's optimizer into an exhaustive join-order search (default optimizer_search_depth=62)
+// and take many minutes on small DB hosts at our maxNumberOfIDsInItemPath. We use STRAIGHT_JOIN so
+// the planner keeps the natural left-deep order, which is also the only sensible execution order:
+// each step's join key (results.item_id, attempts.id, items_items.parent_item_id, child_item_id)
+// is fully determined by tables already on its left, and all keys are indexed. Planning then becomes
+// linear in N rather than exponential.
 func (s *ItemStore) itemAttemptChainWithoutAttemptForTail(ids []int64, groupID int64,
 	requireAttemptsToBeActive, requireContentAccessToTheFinalItem, withWriteLock bool,
 ) *DB {
@@ -301,16 +309,16 @@ func (s *ItemStore) itemAttemptChainWithoutAttemptForTail(ids []int64, groupID i
 
 	for idIndex := 1; idIndex < len(ids); idIndex++ {
 		subQuery = subQuery.Joins(fmt.Sprintf(`
-				JOIN results AS results%d ON results%d.participant_id = ? AND
+				STRAIGHT_JOIN results AS results%d ON results%d.participant_id = ? AND
 					results%d.item_id = items%d.id AND results%d.started_at IS NOT NULL`, idIndex-1, idIndex-1, idIndex-1, idIndex-1, idIndex-1), groupID).
 			Joins(fmt.Sprintf(`
-				JOIN attempts AS attempts%d ON attempts%d.participant_id = results%d.participant_id AND
+				STRAIGHT_JOIN attempts AS attempts%d ON attempts%d.participant_id = results%d.participant_id AND
 					attempts%d.id = results%d.attempt_id`, idIndex-1, idIndex-1, idIndex-1, idIndex-1, idIndex-1)).
 			Joins(
 				fmt.Sprintf(
-					"JOIN items_items AS items_items%d ON items_items%d.parent_item_id = items%d.id AND items_items%d.child_item_id = ?",
+					"STRAIGHT_JOIN items_items AS items_items%d ON items_items%d.parent_item_id = items%d.id AND items_items%d.child_item_id = ?",
 					idIndex, idIndex, idIndex-1, idIndex), ids[idIndex]).
-			Joins(fmt.Sprintf("JOIN visible_items AS items%d ON items%d.id = items_items%d.child_item_id", idIndex, idIndex, idIndex)).
+			Joins(fmt.Sprintf("STRAIGHT_JOIN visible_items AS items%d ON items%d.id = items_items%d.child_item_id", idIndex, idIndex, idIndex)).
 			Where(fmt.Sprintf("items%d.can_view_generated_value >= ?", idIndex-1),
 				s.PermissionsGranted().ViewIndexByName("content"))
 
@@ -344,11 +352,11 @@ func (s *ItemStore) breadcrumbsHierarchyForAttempt(
 		Where(fmt.Sprintf("attempts%d.id = ?", finalItemIndex), attemptID)
 	subQuery = subQuery.
 		Joins(fmt.Sprintf(`
-				JOIN results AS results%d ON results%d.participant_id = ? AND
+				STRAIGHT_JOIN results AS results%d ON results%d.participant_id = ? AND
 					results%d.item_id = items%d.id AND results%d.started_at IS NOT NULL`,
 			finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex), groupID).
 		Joins(fmt.Sprintf(`
-				JOIN attempts AS attempts%d ON attempts%d.participant_id = results%d.participant_id AND
+				STRAIGHT_JOIN attempts AS attempts%d ON attempts%d.participant_id = results%d.participant_id AND
 					attempts%d.id = results%d.attempt_id`, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex, finalItemIndex))
 	if len(ids) > 1 {
 		subQuery = subQuery.Where(fmt.Sprintf(

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -1042,12 +1042,16 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 	}
 }
 
-// TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength guards against MySQL's hard limit
-// of 61 joined tables per query. The breadcrumbs SQL builds ~4·N table references for a path
-// of length N, so we exercise the full chain at the maximum depth allowed by URL routing
-// (maxNumberOfIDsInItemPath in app/api/items/get_breadcrumbs.go) to make sure the query
-// still executes. If maxNumberOfIDsInItemPath is bumped, this constant must be bumped too
-// (and the SQL must be checked for fitting under the MySQL limit).
+// TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength guards two limits at once for the full
+// breadcrumbs chain (~4·N joined tables for a path of length N):
+//   - MySQL's hard 61-tables-per-join cap (~4·15 − 1 = 59, just under).
+//   - the optimizer's planning cost: without STRAIGHT_JOIN in itemAttemptChainWithoutAttemptForTail,
+//     MySQL would do an exhaustive join-order search and the query would hang for many minutes on
+//     constrained DB hosts (we observed ~9-10 min on CircleCI before adding STRAIGHT_JOIN). This test
+//     therefore also catches any future change that re-introduces ordinary JOINs in the chain.
+//
+// If maxNumberOfIDsInItemPath is bumped, this constant must be bumped too (and both checks above
+// re-verified).
 func TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 


### PR DESCRIPTION
## Summary

Switch the long breadcrumbs / participation-hierarchy chain to use MySQL `STRAIGHT_JOIN` so the planner stops doing an exhaustive join-order search on long item paths. Fixes the master-branch CI failure of `TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength` and the underlying production slowness it surfaced.

## Why

After bumping `maxNumberOfIDsInItemPath` from 10 to 15 in #1388, the new integration test guarding the maximum path length started timing out on master CI. Two consecutive master runs of the same commit hung for **~9m30s** on the same query before tripping the 10-min Go test timeout. The PR-branch run "passed" only because it finished a few seconds inside that timeout (the test job took ~15 min wall time even when "green").

Root cause: at `N=15` the breadcrumbs SQL builds **~59 joined tables** (`1` anchor + `4·14` per-step + `2` tail). MySQL's default `optimizer_search_depth` is 62, so when `tables ≤ depth` the planner does an exhaustive join-order search whose cost is exponential. On small CircleCI containers that search lives right around the 10-min test timeout. Real users on small DB hosts would hit the same wall, so the fix belongs in production code, not just the test.

## Insight that makes the fix safe

The chain produced by `itemAttemptChainWithoutAttemptForTail` is a strict left-deep walk along the item path. Every joined table's join key is fully determined by tables already joined to its left and is fully indexed:

- `results%d.item_id = items%d.id`
- `attempts%d.id = results%d.attempt_id`
- `items_items%d.parent_item_id = items%d-1.id`
- `visible_items items%d.id = items_items%d.child_item_id`

So the written order is also the optimal execution order. `STRAIGHT_JOIN` just tells MySQL "use this order" → planning becomes O(N) instead of exponential. Same rows out, same correctness, fast plan.

## Changes

- `app/database/item_store.go`
  - `itemAttemptChainWithoutAttemptForTail`: the 4 per-step joins (`results`, `attempts`, `items_items`, `visible_items`) now use `STRAIGHT_JOIN`. Added a doc comment explaining the rationale.
  - `breadcrumbsHierarchyForAttempt`: the 2 tail joins (`results`, `attempts` for the final item) now use `STRAIGHT_JOIN`.
- `app/api/items/get_breadcrumbs.go`: refresh the comment on `maxNumberOfIDsInItemPath` to list both bounds (61-table hard limit *and* exhaustive-planning cost) and note the dependency on `STRAIGHT_JOIN`.
- `app/database/item_store_integration_test.go`: tighten the doc comment on `TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength` so it explicitly says the test also catches any future regression that drops `STRAIGHT_JOIN`, with the observed ~9-10 min CI symptom for context.

Out of scope (intentionally left as plain `JOIN`):
- The 2-table `JOIN attempts ON ...` inside the window-function subquery built by `columnsListForBreadcrumbsHierarchy` — only 2 tables, planner is trivially fast.
- The `IN (subquery)` predicates on `items0.id` for root activities/skills — not part of the chain join order.

## Test plan

- [x] `go test -gcflags=all=-l -race -count=1 -run 'TestItemStore_BreadcrumbsHierarchy|TestItemStore_IsValidParticipationHierarchy' ./app/database/ -p 1 -parallel 1 -timeout 180s` — passes in 8.1s; the max-path-length test alone runs in **0.385s** (down from ~9m30s on CI).
- [x] `go test -gcflags=all=-l -race -count=1 -run 'TestBDD/(get_breadcrumbs|start_result|enter|create_attempt)' ./app/api/items/ -p 1 -parallel 1 -timeout 600s` — all BDD scenarios for the four endpoints that consume the chain pass.
- [x] `./bin/golangci-lint run -v --timeout 2m ./app/database/... ./app/api/items/...` — 0 issues.
- [x] Inspected the generated SQL: every chain join is a `STRAIGHT_JOIN` (15 `results` + 15 `attempts` + 14 `items_items` + 14 `visible_items` aliases at N=15); subquery and CTE-internal joins remain plain `JOIN`.
- [x] Master CI green and the breadcrumbs test runs in seconds rather than ~9 minutes.

## Rollback plan

Single-commit, easily revertable. If `STRAIGHT_JOIN` ever causes a regression on a query whose optimal join order is not the written one (none in this chain by construction), the fallback is to drop `maxNumberOfIDsInItemPath` back to ~11.