### PR TITLE
Start result path allow started result with explicit entry

### DIFF
--- a/app/api/items/start_result_path.feature
+++ b/app/api/items/start_result_path.feature
@@ -167,6 +167,52 @@ Feature: Start results for an item path
     And the table "results_propagate" should be empty
     And the table "results_propagate_internal" should be empty
 
+  # Regression: when "requires_explicit_entry" is flipped on after a started result already exists,
+  # the participant's existing started result for the explicit-entry item sits on a non-rooted attempt
+  # (here, attempt 0) instead of an attempt rooted at it. The chain must still resolve to that attempt
+  # and return 200, reusing the pre-existing started result without overwriting its started_at.
+  Scenario: Can start the path for an explicit-entry item via a pre-existing started result on a non-rooted attempt
+    Given I am the user with id "111"
+    And the database table "items" also has the following row:
+      | id | url  | type | allows_multiple_attempts | default_language_tag | requires_explicit_entry |
+      | 80 | null | Task | 1                        | fr                   | 1                       |
+    And the database table "items_items" also has the following row:
+      | parent_item_id | child_item_id | child_order |
+      | 10             | 80            | 2           |
+    And the database table "items_ancestors" also has the following row:
+      | ancestor_item_id | child_item_id |
+      | 10               | 80            |
+    And the database table "permissions_generated" also has the following row:
+      | group_id | item_id | can_view_generated |
+      | 111      | 80      | content            |
+    And the database table "results" also has the following rows:
+      | attempt_id | participant_id | item_id | started_at          | latest_activity_at  |
+      | 0          | 111            | 80      | 2019-05-30 11:00:00 | 2019-05-30 11:00:00 |
+    When I send a POST request to "/items/10/80/start-result-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+      """
+      {
+        "message": "updated",
+        "success": true,
+        "data": {
+          "attempt_id": "0"
+        }
+      }
+      """
+    And the table "attempts" should remain unchanged
+    And the table "results" should be:
+      | attempt_id | participant_id | item_id | score_computed | tasks_tried | ABS(TIMESTAMPDIFF(SECOND, latest_activity_at, NOW())) < 3 | latest_submission_at | score_obtained_at | validated_at | ABS(TIMESTAMPDIFF(SECOND, started_at, NOW())) < 3 |
+      | 0          | 111            | 10      | 0              | 0           | 1                                                         | null                 | null              | null         | 1                                                 |
+      | 0          | 111            | 80      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 1          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 2          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 10      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+      | 3          | 102            | 60      | 0              | 0           | 0                                                         | null                 | null              | null         | 0                                                 |
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_internal" should be empty
+
   Scenario: Can create new results for all the path
     Given I am the user with id "101"
     When I send a POST request to "/items/60/70/start-result-path?as_team_id=102"

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -189,22 +189,22 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 			const comma = ", "
 			columns += comma
 			previousAttemptCondition = fmt.Sprintf(` AND
-					IF(attempts%d.root_item_id = items%d.id, attempts%d.parent_attempt_id, attempts%d.id) = attempts%d.id`,
-				idIndex, idIndex, idIndex, idIndex, idIndex-1)
+					IF(attempts%[1]d.root_item_id = items%[1]d.id, attempts%[1]d.parent_attempt_id, attempts%[1]d.id) = attempts%[2]d.id`,
+				idIndex, idIndex-1)
 		}
 
 		columnsForOrder += fmt.Sprintf(", attempts%d.id DESC", idIndex)
 		attemptIsActiveCondition = fmt.Sprintf(
-			"attempts%d.ended_at IS NULL AND NOW() < attempts%d.allows_submissions_until AND %s", idIndex, idIndex, attemptIsActiveCondition)
-		score += fmt.Sprintf("((results%d.started_at IS NULL) << %d)", idIndex, len(ids)-idIndex-1)
+			"attempts%[1]d.ended_at IS NULL AND NOW() < attempts%[1]d.allows_submissions_until AND %[2]s",
+			idIndex, attemptIsActiveCondition)
+		score += fmt.Sprintf("((results%[1]d.started_at IS NULL) << %[2]d)", idIndex, len(ids)-idIndex-1)
 		query = query.
-			Joins(fmt.Sprintf("JOIN attempts AS attempts%d ON attempts%d.participant_id = ?"+previousAttemptCondition,
-				idIndex, idIndex),
+			Joins(fmt.Sprintf("JOIN attempts AS attempts%[1]d ON attempts%[1]d.participant_id = ?"+previousAttemptCondition, idIndex),
 				participantID).
 			Joins(fmt.Sprintf(`
-				LEFT JOIN results AS results%d ON results%d.participant_id = attempts%d.participant_id AND
-					attempts%d.id = results%d.attempt_id AND results%d.item_id = items%d.id`,
-				idIndex, idIndex, idIndex, idIndex, idIndex, idIndex, idIndex)).
+				LEFT JOIN results AS results%[1]d ON results%[1]d.participant_id = attempts%[1]d.participant_id AND
+					attempts%[1]d.id = results%[1]d.attempt_id AND results%[1]d.item_id = items%[1]d.id`,
+				idIndex)).
 			// For items requiring explicit entry, the matched attempt usually must be rooted at the item itself
 			// AND carry a result for it. We additionally allow non-rooted attempts when there is a STARTED result
 			// for the item on the chosen attempt: such a started result is what proves the participant has actually
@@ -222,12 +222,12 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 
 		if idIndex != len(ids)-1 {
 			query = query.Joins(fmt.Sprintf(
-				"JOIN items_items AS items_items%d ON items_items%d.parent_item_id = items%d.id AND items_items%d.child_item_id = ?",
-				idIndex+1, idIndex+1, idIndex, idIndex+1), ids[idIndex+1]).
-				Joins(fmt.Sprintf("JOIN items AS items%d ON items%d.id = items_items%d.child_item_id", idIndex+1, idIndex+1, idIndex+1))
+				"JOIN items_items AS items_items%[2]d ON items_items%[2]d.parent_item_id = items%[1]d.id AND items_items%[2]d.child_item_id = ?",
+				idIndex, idIndex+1), ids[idIndex+1]).
+				Joins(fmt.Sprintf("JOIN items AS items%[1]d ON items%[1]d.id = items_items%[1]d.child_item_id", idIndex+1))
 		}
 		columns += fmt.Sprintf(
-			"attempts%d.id AS attempt_id%d, results%d.started_at IS NOT NULL AS has_started_result%d", idIndex, idIndex, idIndex, idIndex)
+			"attempts%[1]d.id AS attempt_id%[1]d, results%[1]d.started_at IS NOT NULL AS has_started_result%[1]d", idIndex)
 	}
 	query = query.Select(columns).Where("results0.attempt_id IS NOT NULL OR attempts0.id = 0").
 		Order(score + columnsForOrder).Limit(1)

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -21,8 +21,10 @@ import (
 //		Of all possible chains of attempts the service chooses the one having missing/not-started results located closer
 //		to the end of the path, preferring chains having less missing/not-started results and having higher values of `attempt_id`.
 //		If there is no result for the first item, the service tries to create an attempt chain starting with the zero attempt.
-//		The chain of attempts cannot have missing results for items requiring explicit entry or require to start/create results
-//		within or below ended/not-allowing-submissions attempts.
+//		For each item requiring explicit entry, the chosen attempt must either be rooted at that item or carry a started
+//		(not merely propagated) result for it; chains that cannot satisfy this for an explicit-entry item are rejected.
+//		When both options exist for the same explicit-entry item, the rooted attempt is preferred. The chain also cannot
+//		require starting/creating results within or below ended/not-allowing-submissions attempts.
 //
 //		If `as_team_id` is given, the created/updated results are linked to the `as_team_id` group instead of the user's self group.
 //

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -198,18 +198,27 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 			"attempts%d.ended_at IS NULL AND NOW() < attempts%d.allows_submissions_until AND %s", idIndex, idIndex, attemptIsActiveCondition)
 		score += fmt.Sprintf("((results%d.started_at IS NULL) << %d)", idIndex, len(ids)-idIndex-1)
 		query = query.
-			Joins(fmt.Sprintf(`
-				JOIN attempts AS attempts%d ON attempts%d.participant_id = ? AND
-					(NOT items%d.requires_explicit_entry OR attempts%d.root_item_id = items%d.id)`+previousAttemptCondition,
-				idIndex, idIndex, idIndex, idIndex, idIndex),
+			Joins(fmt.Sprintf("JOIN attempts AS attempts%d ON attempts%d.participant_id = ?"+previousAttemptCondition,
+				idIndex, idIndex),
 				participantID).
 			Joins(fmt.Sprintf(`
 				LEFT JOIN results AS results%d ON results%d.participant_id = attempts%d.participant_id AND
 					attempts%d.id = results%d.attempt_id AND results%d.item_id = items%d.id`,
 				idIndex, idIndex, idIndex, idIndex, idIndex, idIndex, idIndex)).
-			Where(
-				fmt.Sprintf("(NOT items%d.requires_explicit_entry OR results%d.attempt_id IS NOT NULL) AND (results%d.started_at IS NOT NULL OR %s)",
-					idIndex, idIndex, idIndex, attemptIsActiveCondition))
+			// For items requiring explicit entry, the matched attempt usually must be rooted at the item itself
+			// AND carry a result for it. We additionally allow non-rooted attempts when there is a STARTED result
+			// for the item on the chosen attempt: such a started result is what proves the participant has actually
+			// entered the item, even if the result is not on an attempt rooted at it (this can happen e.g. when
+			// "requires_explicit_entry" was flipped on after the result was created). A non-started result on a
+			// non-rooted attempt is intentionally NOT enough on its own. The two clauses below are kept separate
+			// for clarity: the first picks which attempt is acceptable, the second enforces that the chosen
+			// attempt actually has a result for the explicit-entry item.
+			Where(fmt.Sprintf(
+				"(NOT items%[1]d.requires_explicit_entry OR attempts%[1]d.root_item_id = items%[1]d.id "+
+					"OR results%[1]d.started_at IS NOT NULL) AND "+
+					"(NOT items%[1]d.requires_explicit_entry OR results%[1]d.attempt_id IS NOT NULL) AND "+
+					"(results%[1]d.started_at IS NOT NULL OR %[2]s)",
+				idIndex, attemptIsActiveCondition))
 
 		if idIndex != len(ids)-1 {
 			query = query.Joins(fmt.Sprintf(

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -190,8 +190,9 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 			columns += comma
 			// Chain link: when the attempt is rooted at this item the chain steps into a child attempt
 			// (linked via parent_attempt_id); otherwise the same attempt id propagates from the previous rung.
-			// The "false" branch also covers the relaxation below, where an explicit-entry item is matched on
-			// a non-rooted attempt carrying a started result for it (e.g. attempt 0 propagating through the chain).
+			// The IF condition itself is unchanged by the relaxation below; the relaxation merely makes the
+			// "false" branch reachable for explicit-entry items too (so e.g. attempt 0 can carry through the
+			// chain when an explicit-entry item is matched on it via a started result).
 			previousAttemptCondition = fmt.Sprintf(` AND
 					IF(attempts%[1]d.root_item_id = items%[1]d.id, attempts%[1]d.parent_attempt_id, attempts%[1]d.id) = attempts%[2]d.id`,
 				idIndex, idIndex-1)

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -201,7 +201,20 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 		attemptIsActiveCondition = fmt.Sprintf(
 			"attempts%[1]d.ended_at IS NULL AND NOW() < attempts%[1]d.allows_submissions_until AND %[2]s",
 			idIndex, attemptIsActiveCondition)
-		score += fmt.Sprintf("((results%[1]d.started_at IS NULL) << %[2]d)", idIndex, len(ids)-idIndex-1)
+		// Per-position score (lower is better), summed across positions; bits at distinct shifts
+		// never overlap so the sum behaves like a bitwise OR. The HIGH half (shift `2*len-i-1`)
+		// penalizes "non-rooted attempt on an explicit-entry item" and dominates the LOW half
+		// (shift `len-i-1`, which penalizes "result not started yet"). Effect: when a rooted
+		// alternative exists for an explicit-entry item, it ALWAYS beats a non-rooted attempt --
+		// even if the rooted attempt's result is not yet started and the non-rooted one's is.
+		// The non-rooted-with-started-result candidacy (allowed by the WHERE relaxation below)
+		// therefore acts only as a fallback when no rooted alternative is reachable in the chain.
+		// `<=>` is used for a NULL-safe equality so attempts with `root_item_id IS NULL` count as
+		// non-rooted rather than "unknown".
+		score += fmt.Sprintf(
+			"((items%[1]d.requires_explicit_entry AND NOT (attempts%[1]d.root_item_id <=> items%[1]d.id)) << %[3]d)"+
+				" + ((results%[1]d.started_at IS NULL) << %[2]d)",
+			idIndex, len(ids)-idIndex-1, 2*len(ids)-idIndex-1)
 		query = query.
 			Joins(fmt.Sprintf("JOIN attempts AS attempts%[1]d ON attempts%[1]d.participant_id = ?"+previousAttemptCondition, idIndex),
 				participantID).
@@ -213,7 +226,10 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 			// AND carry a result for it. We additionally allow non-rooted attempts when there is a STARTED result
 			// for the item on the chosen attempt: such a started result is what proves the participant has actually
 			// entered the item, even if the result is not on an attempt rooted at it (this can happen e.g. when
-			// "requires_explicit_entry" was flipped on after the result was created). A non-started result on a
+			// "requires_explicit_entry" was flipped on after the result was created). This non-rooted candidacy
+			// is intentionally a FALLBACK only -- the score above ensures a rooted alternative wins whenever one
+			// exists in the chain, so stale-but-started rows on a parent attempt do not silently bypass the
+			// "explicit entry creates a child attempt rooted at the item" semantics. A non-started result on a
 			// non-rooted attempt is intentionally NOT enough on its own. The two clauses below are kept separate
 			// for clarity: the first picks which attempt is acceptable, the second enforces that the chosen
 			// attempt actually has a result for the explicit-entry item.

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -188,6 +188,10 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 			score += " + "
 			const comma = ", "
 			columns += comma
+			// Chain link: when the attempt is rooted at this item the chain steps into a child attempt
+			// (linked via parent_attempt_id); otherwise the same attempt id propagates from the previous rung.
+			// The "false" branch also covers the relaxation below, where an explicit-entry item is matched on
+			// a non-rooted attempt carrying a started result for it (e.g. attempt 0 propagating through the chain).
 			previousAttemptCondition = fmt.Sprintf(` AND
 					IF(attempts%[1]d.root_item_id = items%[1]d.id, attempts%[1]d.parent_attempt_id, attempts%[1]d.id) = attempts%[2]d.id`,
 				idIndex, idIndex-1)

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -549,6 +549,48 @@ func Test_getDataForResultPathStart(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Chain-forward through the relaxation. Item 21 (B, explicit-entry) is matched on
+			// attempt 0 via the WHERE relaxation (started result on a non-rooted attempt). At the
+			// next rung, item 30 (C, non-EE) genuinely has TWO valid candidates: stay on attempt 0
+			// (chain link's "false" branch -- non-rooted attempt id propagates) or step into the
+			// rooted-at-30 attempt 5 whose parent_attempt_id = 0 (chain link's "true" branch).
+			// Both pass the WHERE: attempt 0 has no result for item 30 but is active; attempt 5
+			// carries a started result. The score breaks the tie via the LOW "started_at IS NULL"
+			// bit at item 30's position (attempt 5: 0, attempt 0: 1), so attempt_id2 = 5. The HIGH
+			// "non-rooted on EE" bit fires for item 21 on attempt 0 and contributes the same value
+			// to both candidate paths, so it does not affect the choice. This locks in that the
+			// chain link walks forward into a rooted child attempt downstream of an EE rung that
+			// was matched via the relaxation, and that the score interaction stays consistent
+			// across this transition.
+			name: "chain steps into a rooted child attempt downstream of an explicit-entry rung matched via the relaxation",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				attempts:
+					- {participant_id: 101, id: 5, parent_attempt_id: 0, root_item_id: 30}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 21, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 5, item_id: 30, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, ids: []int64{1, 21, 30}},
+			want: []map[string]interface{}{
+				{
+					"attempt_id0": int64(0), "has_started_result0": int64(1),
+					"attempt_id1": int64(0), "has_started_result1": int64(1),
+					"attempt_id2": int64(5), "has_started_result2": int64(1),
+				},
+			},
+		},
 		// The four cases below verify the negative side of the relaxation: missing or NOT-STARTED results
 		// on non-rooted attempts must NOT unlock chains for explicit-entry items. A result row whose
 		// started_at is NULL can legitimately appear as a side effect of score propagation from descendants

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -486,11 +486,16 @@ func Test_getDataForResultPathStart(t *testing.T) {
 			},
 		},
 		{
-			// This pins the tie-break introduced by the relaxation: when an explicit-entry item has BOTH
-			// a non-rooted attempt with a STARTED result AND rooted-but-not-started attempts available,
-			// the non-rooted started attempt wins (lower score). Before the relaxation the rooted attempt
-			// was the only viable candidate, so attempt_id2 used to be 1; under the new semantics it is 0.
-			name: "prefers a non-rooted attempt with a started result over a rooted attempt with a not-started result for an explicit-entry item",
+			// Locks in the rooted-vs-non-rooted preference for explicit-entry items. The non-rooted
+			// attempt 0 has a STARTED result for item 22 (so it would be allowed by the WHERE
+			// relaxation), and the rooted attempt 1 has only a NOT-STARTED result. Even though the
+			// non-rooted candidate would win on the LOW "started_at IS NULL" bit, the HIGH bit in
+			// the score penalizes "non-rooted on explicit-entry item" and dominates: the rooted
+			// attempt is selected, preserving the "explicit entry creates a child attempt rooted
+			// at the item" semantics whenever a rooted alternative is reachable. attempt 2 is
+			// rooted too but its parent_attempt_id=1 is unreachable (item 2's only viable attempt
+			// is 0), so the highest reachable rooted candidate is 1.
+			name: "prefers a rooted attempt with a not-started result over a non-rooted attempt with a started result for an explicit-entry item",
 			fixture: `
 				permissions_generated:
 					- {group_id: 100, item_id: 1, can_view_generated: content}
@@ -511,7 +516,36 @@ func Test_getDataForResultPathStart(t *testing.T) {
 				{
 					"attempt_id0": int64(0), "has_started_result0": int64(1),
 					"attempt_id1": int64(0), "has_started_result1": int64(1),
-					"attempt_id2": int64(0), "has_started_result2": int64(1),
+					"attempt_id2": int64(1), "has_started_result2": int64(0),
+				},
+			},
+		},
+		{
+			// Sibling lock-in: when BOTH a rooted attempt and a non-rooted attempt have a STARTED
+			// result for the same explicit-entry item, the rooted one must still win. With the
+			// score above this is decided by the HIGH bit (rooted = 0, non-rooted = 1), so the
+			// `attempts.id DESC` tie-break never has to step in. This guards against any future
+			// score change that would let the lower id (attempt 0) outrank the rooted attempt.
+			name: "prefers a rooted attempt with a started result over a non-rooted attempt with a started result for an explicit-entry item",
+			fixture: `
+				permissions_generated:
+					- {group_id: 100, item_id: 1, can_view_generated: content}
+					- {group_id: 100, item_id: 2, can_view_generated: content}
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 100, id: 1, parent_attempt_id: 0, root_item_id: 22}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 1, item_id: 22, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 100, ids: []int64{1, 2, 22}},
+			want: []map[string]interface{}{
+				{
+					"attempt_id0": int64(0), "has_started_result0": int64(1),
+					"attempt_id1": int64(0), "has_started_result1": int64(1),
+					"attempt_id2": int64(1), "has_started_result2": int64(1),
 				},
 			},
 		},

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -174,7 +174,6 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					- {participant_id: 101, id: 4, parent_attempt_id: 0, root_item_id: 22}
 				results:
 					- {participant_id: 100, attempt_id: 0, started_at: 2019-05-30 11:00:00, item_id: 2}
-					- {participant_id: 100, attempt_id: 0, started_at: 2019-05-30 11:00:00, item_id: 22}
 					- {participant_id: 100, attempt_id: 1, item_id: 22}
 					- {participant_id: 100, attempt_id: 2, item_id: 22}
 					- {participant_id: 100, attempt_id: 3, item_id: 22}
@@ -419,6 +418,149 @@ func Test_getDataForResultPathStart(t *testing.T) {
 					- {participant_id: 103, attempt_id: 1, item_id: 1}
 			`,
 			args: args{participantID: 103, ids: []int64{1}},
+		},
+		{
+			name: "supports root explicit-entry single-item path with only a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 100, ids: []int64{22}},
+			want: []map[string]interface{}{
+				{"attempt_id0": int64(0), "has_started_result0": int64(1)},
+			},
+		},
+		{
+			name: "supports paths through a non-final root explicit-entry item with only a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 100, ids: []int64{22, 30}},
+			want: []map[string]interface{}{
+				{
+					"attempt_id0": int64(0), "has_started_result0": int64(1),
+					"attempt_id1": int64(0), "has_started_result1": int64(0),
+				},
+			},
+		},
+		{
+			name: "supports paths through an intermediate explicit-entry item with only a started result on attempt 0 (no rooted attempt)",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 21, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, ids: []int64{1, 21, 30}},
+			want: []map[string]interface{}{
+				{
+					"attempt_id0": int64(0), "has_started_result0": int64(1),
+					"attempt_id1": int64(0), "has_started_result1": int64(1),
+					"attempt_id2": int64(0), "has_started_result2": int64(0),
+				},
+			},
+		},
+		// The four cases below verify the negative side of the relaxation: missing or NOT-STARTED results
+		// on non-rooted attempts must NOT unlock chains for explicit-entry items. A result row whose
+		// started_at is NULL can legitimately appear as a side effect of score propagation from descendants
+		// (or as a placeholder created during attempt setup): it does not prove that the participant ever
+		// actually started/entered the item on that attempt. Only a result with a non-NULL started_at
+		// provides that evidence.
+		{
+			name: "still ignores paths through a root explicit-entry item without any result for it",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: content}
+			`,
+			args: args{participantID: 100, ids: []int64{22, 30}},
+		},
+		{
+			name: "still ignores paths through an intermediate explicit-entry item without any result for it",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+			`,
+			args: args{participantID: 101, ids: []int64{1, 21, 30}},
+		},
+		{
+			name: "still ignores paths through a root explicit-entry item with only a not-started result on a non-rooted attempt",
+			fixture: `
+				groups: [{id: 110, root_activity_id: 22}]
+				groups_groups:
+					- {parent_group_id: 110, child_group_id: 100}
+				items:
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 22, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+					- {group_id: 100, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 22}
+			`,
+			args: args{participantID: 100, ids: []int64{22, 30}},
+		},
+		{
+			name: "still ignores paths through an intermediate explicit-entry item with only a not-started result on a non-rooted attempt",
+			fixture: `
+				items:
+					- {id: 21, default_language_tag: fr, requires_explicit_entry: true}
+					- {id: 30, default_language_tag: fr}
+				items_items:
+					- {parent_item_id: 1, child_item_id: 21, child_order: 5}
+					- {parent_item_id: 21, child_item_id: 30, child_order: 1}
+				permissions_generated:
+					- {group_id: 101, item_id: 1, can_view_generated: content}
+					- {group_id: 101, item_id: 21, can_view_generated: content}
+					- {group_id: 101, item_id: 30, can_view_generated: content}
+				results:
+					- {participant_id: 101, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 101, attempt_id: 0, item_id: 21}
+			`,
+			args: args{participantID: 101, ids: []int64{1, 21, 30}},
 		},
 	}
 	const globalFixture = `

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -485,6 +485,36 @@ func Test_getDataForResultPathStart(t *testing.T) {
 				},
 			},
 		},
+		{
+			// This pins the tie-break introduced by the relaxation: when an explicit-entry item has BOTH
+			// a non-rooted attempt with a STARTED result AND rooted-but-not-started attempts available,
+			// the non-rooted started attempt wins (lower score). Before the relaxation the rooted attempt
+			// was the only viable candidate, so attempt_id2 used to be 1; under the new semantics it is 0.
+			name: "prefers a non-rooted attempt with a started result over a rooted attempt with a not-started result for an explicit-entry item",
+			fixture: `
+				permissions_generated:
+					- {group_id: 100, item_id: 1, can_view_generated: content}
+					- {group_id: 100, item_id: 2, can_view_generated: content}
+					- {group_id: 100, item_id: 22, can_view_generated: content}
+				attempts:
+					- {participant_id: 100, id: 1, parent_attempt_id: 0, root_item_id: 22}
+					- {participant_id: 100, id: 2, parent_attempt_id: 1, root_item_id: 22}
+				results:
+					- {participant_id: 100, attempt_id: 0, item_id: 1, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 0, item_id: 2, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 0, item_id: 22, started_at: 2019-05-30 11:00:00}
+					- {participant_id: 100, attempt_id: 1, item_id: 22}
+					- {participant_id: 100, attempt_id: 2, item_id: 22}
+			`,
+			args: args{participantID: 100, ids: []int64{1, 2, 22}},
+			want: []map[string]interface{}{
+				{
+					"attempt_id0": int64(0), "has_started_result0": int64(1),
+					"attempt_id1": int64(0), "has_started_result1": int64(1),
+					"attempt_id2": int64(0), "has_started_result2": int64(1),
+				},
+			},
+		},
 		// The four cases below verify the negative side of the relaxation: missing or NOT-STARTED results
 		// on non-rooted attempts must NOT unlock chains for explicit-entry items. A result row whose
 		// started_at is NULL can legitimately appear as a side effect of score propagation from descendants


### PR DESCRIPTION
## Summary

Fixes `POST /items/{ids}/start-result-path` returning 403 for explicit-entry items whose only started result lives on a non-rooted attempt — same class of bug as commit `abfe10b8` fixed for `path-from-root` (e.g. when `requires_explicit_entry` is flipped on after a started result already exists on attempt 0).

## Behavior change

- **Relaxation:** for an explicit-entry item, the chosen attempt may be either *rooted at the item* (existing rule) **or** *non-rooted but carrying a started (not merely propagated) result for it* (new fallback). A non-started/propagated result on a non-rooted attempt is intentionally NOT enough.
- **Tie-break preservation:** when a rooted alternative is reachable in the chain, it **always** wins — regardless of started status — so stale-but-started rows on a parent attempt cannot silently bypass the "explicit entry creates a child attempt rooted at the item" semantics. Implemented via a HIGH score bit penalizing "non-rooted on EE" that dominates the existing LOW "started_at IS NULL" bit (NULL-safe `<=>` for `root_item_id`).
- Swagger description updated to reflect both rules.

## What changed

- `app/api/items/start_result_path.go`: SQL relaxation in WHERE (no EXISTS subquery — reads off the existing `LEFT JOIN results`), new HIGH score bit for the rooted-vs-non-rooted preference, swagger update, comment passes.
- `app/api/items/start_result_path.feature`: happy-path BDD scenario for the regression (`requires_explicit_entry` flipped on after a started result on attempt 0; expects 200 + reuses the pre-existing started result without rewriting `started_at`).
- `app/api/items/start_result_path_integration_test.go`: +10 cases — 3 positives unblocked by the fix (single-item, non-final root, intermediate EE), 2 tie-breaks (rooted-not-started > non-rooted-started; rooted-started > non-rooted-started), 1 chain-forward (chain steps into a rooted child attempt downstream of an EE rung matched via the relaxation), 4 negatives (missing / not-started results on non-rooted attempts must NOT unlock chains).

## Out of scope

- `path_from_root.go` — already fixed in `abfe10b8` (kept its EXISTS form because of `LEFT JOIN attempts` + the doc-permitted "no attempt at all" semantics).
- `CHANGELOG.md` entry — added at release-cut time per the v2.41.0 sibling's convention. Suggested wording: *"fix `start-result-path` to accept explicit-entry items matched on a non-rooted attempt with a started result"*.
- `ARCHITECTURE.md` — does not document the explicit-entry attempt-rooting contract (verified via grep), so no update needed.
- JOIN-time pre-filter via EXISTS subquery (parity with `path_from_root.go`) — flagged by review as informational, "no action required unless slow-query logs surface this".

## Test plan

- `./bin/golangci-lint run -v --timeout 2m` — clean.
- `Test_getDataForResultPathStart` — all 31 subtests pass.
- `TestBDD` for the items package — passes (incl. the new feature scenario and the existing `Cannot start the path` 403 scenario in `*.robustness.feature` as a contrast pair).