### PR TITLE
retry on session id collision (consistency)

### DIFF
--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -286,10 +286,14 @@ func (srv *Service) createAccessToken(responseWriter http.ResponseWriter, httpRe
 		logging.LogEntrySetField(httpRequest, "user_id", userID)
 		service.MustNotBeError(store.Groups().StoreBadges(userProfile.Badges, userID, true))
 
-		sessionID := rand.Int63()
-		service.MustNotBeError(store.Exec(
-			"INSERT INTO sessions (session_id, user_id, refresh_token) VALUES (?, ?, ?)",
-			sessionID, userID, token.RefreshToken).Error())
+		var sessionID int64
+		service.MustNotBeError(store.RetryOnDuplicateKeyError("sessions", "PRIMARY", "session_id",
+			func(retryStore *database.DataStore) error {
+				sessionID = rand.Int63()
+				return retryStore.Exec(
+					"INSERT INTO sessions (session_id, user_id, refresh_token) VALUES (?, ?, ?)",
+					sessionID, userID, token.RefreshToken).Error()
+			}))
 		service.MustNotBeError(store.AccessTokens().InsertNewToken(sessionID, token.AccessToken, expiresIn))
 
 		// Delete the oldest sessions of the user keeping up to maxNumberOfUserSessionsToKeep sessions.


### PR DESCRIPTION
## Summary

Wrap the `INSERT INTO sessions` in `srv.createAccessToken` (`app/api/auth/create_access_token.go`) with `store.RetryOnDuplicateKeyError("sessions", "PRIMARY", "session_id", ...)`, mirroring the canonical pattern already used by `auth.CreateNewTempSession` in `app/auth/temp_sessions.go`.

`session_id` is generated from `rand.Int63()`, and every other call site of `NewID()` / `rand.Int63()` in the codebase already retries on duplicate-key errors — `NewID()`'s own doc comment explicitly instructs callers to do so. The `/auth/token` path was the lone holdout: a duplicate would fall through `MustNotBeError(...)` and surface as a 500.

## Why

- **Consistency**: brings `/auth/token` in line with `auth.CreateNewTempSession` and every other `NewID()` call site.
- **Eliminates a latent footgun**: a `rand.Int63()` collision on `sessions.session_id` previously panicked instead of retrying. Practical impact is negligible (≈ 1/2^63 collision probability), but the asymmetry has been there since the `refresh_tokens` → `sessions` migration.
- **Behavior-preserving on the happy path**: `RetryOnDuplicateKeyError` invokes the callback once and returns immediately on success — no behavioral change unless a real collision happens.

## Scope of the change

- Only the `INSERT INTO sessions` is wrapped. `createOrUpdateUser`, `StoreBadges`, `InsertNewToken`, and `DeleteOldSessionsToKeepMaximum` stay outside the retry — they have side effects that must run exactly once with the final `sessionID`.
- `sessionID = rand.Int63()` is now generated inside the retry callback so each attempt produces a fresh ID.
- The raw `Exec(...)` is kept (not converted to `Sessions().InsertMap(...)`) to keep the diff minimal; `IsDuplicateEntryErrorForKey` parses MySQL error strings, so the call shape doesn't matter.

## Safety notes

- `db/schema/schema.sql` — `sessions` table has only `PRIMARY KEY (session_id)`; `refresh_token` is a non-unique `KEY`. The retry can only ever loop on `session_id`.
- `retryOnDuplicateKeyError` (in `app/database/db.go`) caps at 10 attempts and is safe inside an open transaction (`ER_DUP_ENTRY` is statement-level in InnoDB).

## Out of scope

- Migrating `NewID()` to `crypto/rand` (separate defense-in-depth task).
- A forced-collision test — the analogous `temp_sessions` tests don't add real coverage without monkey-patching the global RNG, and the happy path is already exercised by the existing BDD features.

## Test plan

- [x] `./bin/golangci-lint run -v --timeout 2m` — passes (`0 issues`).
- [ ] `make test-dev` — existing tests unchanged; happy path is identical, so no behavioral regression expected.
- [ ] BDD sanity check: `app/api/auth/create_access_token.feature` and `app/api/auth/create_access_token.robustness.feature` — no changes needed (no step depends on the SQL shape or the absence of a retry helper).

No `ARCHITECTURE.md` update needed — behavior-preserving fix.