### PR TITLE
Go version 1.21->1.25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,12 @@ jobs:
   swagger-gen:
     docker:
       - image: quay.io/goswagger/swagger:v0.31.0
+    environment:
+      # The image ships Go 1.22.3 with GOTOOLCHAIN=local, which prevents `go`
+      # from honoring the `go 1.25.0` / `toolchain go1.25.9` directives in our
+      # go.mod. Override to `auto` so the pinned toolchain is auto-fetched on
+      # the steps that build the project.
+      GOTOOLCHAIN: auto
     steps:
       - run: go install github.com/France-ioi/go-swagger/cmd/swagger@00200fa
       - run: apk add npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   deps:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
     steps:
       - checkout
       - restore_cache: &CACHEKEYMOD
@@ -21,7 +21,7 @@ jobs:
           - ~/.cache/go-build/
   tests:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
       - image: mysql:8.0.34
         command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:
@@ -77,7 +77,7 @@ jobs:
           path: log
   migration-tests:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
       - image: mysql:8.0.34
         command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:
@@ -138,7 +138,7 @@ jobs:
           no_output_timeout: 1h
   lint:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
     steps:
       - attach_workspace:
           at: ./
@@ -148,7 +148,7 @@ jobs:
 
   build:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
     steps:
       - attach_workspace:
           at: ./
@@ -203,7 +203,7 @@ jobs:
           aws s3 cp ./index.html s3://franceioi-algorea/spec/index.html --acl public-read
   dbdoc-gen:
     docker:
-      - image: cimg/go:1.20.2
+      - image: cimg/go:1.25.9
       - image: mysql:8.0.34
         command: --default-authentication-plugin=caching_sha2_password --innodb_ft_min_token_size=1 --max-allowed-packet=10485760 --collation-server=utf8mb4_0900_ai_ci --character-set-server=utf8mb4
         environment:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,7 @@ The platform emphasizes:
 ## Technology Stack
 
 ### Core Technologies
-- **Language**: Go 1.20
+- **Language**: Go 1.25
 - **Database**: MySQL 8.0.34
 - **HTTP Router**: `go-chi/chi` v3
 - **ORM**: `jinzhu/gorm` v1 (wrapped with custom extensions)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.25.9
 
 WORKDIR /go/src/AlgoreaBackend
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ docker exec -it algoreabackend_db_1 mysql -h localhost -u algorea -pa_db_passwor
 
 ## Running the setup (as dev)
 
+The project targets **Go 1.25** (see `go.mod`). The `toolchain go1.25.9` directive instructs the `go` command to auto-fetch the pinned toolchain on first use; if you have set `GOTOOLCHAIN=local` (or are on an air-gapped host), install Go 1.25.9 manually.
+
 The application needs a database (MySQL) to run and requires it for a major part of its tests.
 
 It is required to set

--- a/app/api/auth/create_access_token.go
+++ b/app/api/auth/create_access_token.go
@@ -353,7 +353,7 @@ func (srv *Service) resolveSessionCookieAttributesFromCookieParameters(httpReque
 func setParametersFromMap(requestParameters interface{}, requestData map[string]string) error {
 	reflRequestParameters := reflect.ValueOf(requestParameters).Elem()
 	reflRequestParametersType := reflRequestParameters.Type()
-	for i := 0; i < reflRequestParameters.NumField(); i++ {
+	for i := range reflRequestParameters.NumField() {
 		field := reflRequestParameters.Field(i)
 		fieldType := reflRequestParametersType.Field(i)
 		if fieldType.Type.Elem().Kind() == reflect.Struct {

--- a/app/api/auth/refresh_access_token_integration_test.go
+++ b/app/api/auth/refresh_access_token_integration_test.go
@@ -68,7 +68,20 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 				if withTimeout {
 					cancelFunc()
 					ctx := store.GetContext()
-					(*valueCtxInterface)(unsafe.Pointer(&ctx)).p.timerCtx.err = context.DeadlineExceeded //nolint:gosec // imitate a timeout
+					timerPtr := (*valueCtxInterface)(unsafe.Pointer(&ctx)).p.timerCtx //nolint:gosec // imitate a timeout
+					// cancelFunc above already Stored context.Canceled; atomic.Value rejects
+					// Store of a different concrete type, so we overwrite the underlying
+					// `any` directly. Layout-safe: atomic.Value is `struct{ v any }`.
+					// CAVEAT: a 16-byte interface write is not atomic, so a concurrent
+					// atomic.Value.Load() in another goroutine could observe a torn eface
+					// (mismatched type/data words). The test goroutine is the only writer
+					// at this point, but parent-context watchers via propagateCancel may
+					// race; an additional Store on this Value would also panic with
+					// "store of inconsistently typed value into Value" — none happens here.
+					*(*any)(unsafe.Pointer(&timerPtr.err)) = context.DeadlineExceeded //nolint:gosec // imitate a timeout
+					// Also clear cause so context.Cause(ctx) is consistent with ctx.Err()
+					// (mirrors the pattern in app/database/deadline_test.go).
+					timerPtr.cause = nil
 				}
 
 				patchGuard.Unpatch()
@@ -321,17 +334,26 @@ func createLoginModuleStubServer(expectedRefreshToken string) (*httptest.Server,
 	})), &loginModuleCalledCount
 }
 
+// cancelCtx, timerCtx, valueCtx mirror the unexported runtime structs in
+// "context" (Go 1.25 layout) so the test below can inject a synthetic
+// context.DeadlineExceeded mid-flight. Layout changes since this test was
+// written: cancelCtx.err became atomic.Value (was error), timerCtx
+// value-embeds cancelCtx (was a pointer embed).
 type cancelCtx struct {
-	context.Context //nolint:containedctx // it is not us who store the context in the structure
+	context.Context //nolint:containedctx // mirroring an unexported runtime struct
 
-	_   sync.Mutex
-	_   atomic.Value
-	_   map[interface{}]struct{}
-	err error
+	_     sync.Mutex
+	_     atomic.Value             // done
+	_     map[interface{}]struct{} // children
+	err   atomic.Value
+	cause error
 }
 
 type timerCtx struct {
-	*cancelCtx
+	cancelCtx // value-embedded as in stdlib
+
+	_ unsafe.Pointer    // *time.Timer
+	_ [3]unsafe.Pointer // time.Time (3 words)
 }
 
 type valueCtx struct {
@@ -341,6 +363,37 @@ type valueCtx struct {
 type valueCtxInterface struct {
 	t unsafe.Pointer
 	p *valueCtx
+}
+
+// TestCancelCtxMirrorLayout verifies that the unsafe layout mirrors of
+// context.cancelCtx / context.timerCtx / context.valueCtx above still match
+// the stdlib on the running Go toolchain. If a future Go upgrade changes the
+// offsets, this test fails fast with a clear message instead of silently
+// corrupting unrelated memory inside TestService_refreshAccessToken_NotAllowRefreshTokenRaces.
+// Compatible with Go 1.21+ (when err became atomic.Value); should be re-checked
+// on every Go major bump.
+func TestCancelCtxMirrorLayout(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+
+	timerRawCtx, cancel := context.WithDeadline(parent, time.Now().Add(time.Hour))
+	cancel() // stores context.Canceled into cancelCtx.err and cancelCtx.cause
+
+	// Wrap with WithValue to produce *valueCtx -> *timerCtx, matching the chain
+	// the production code observes when chi middleware adds request-scoped values.
+	type layoutTestKey struct{}
+	rawCtx := context.WithValue(timerRawCtx, layoutTestKey{}, struct{}{})
+
+	timerMirror := (*valueCtxInterface)(unsafe.Pointer(&rawCtx)).p.timerCtx //nolint:gosec // layout-mirror sanity check
+
+	require.Equal(t, context.Canceled, rawCtx.Err(),
+		"sanity: cancel() should make ctx.Err() == context.Canceled")
+	require.Equal(t, context.Canceled, timerMirror.err.Load(),
+		"cancelCtx.err offset is wrong (via valueCtx -> timerCtx). "+
+			"Re-check the layout against the current Go runtime's context structs.")
+	require.Equal(t, context.Canceled, timerMirror.cause,
+		"cancelCtx.cause offset is wrong (via valueCtx -> timerCtx). "+
+			"Re-check the layout against the current Go runtime's context structs.")
 }
 
 type Service struct {

--- a/app/api/auth/refresh_access_token_integration_test.go
+++ b/app/api/auth/refresh_access_token_integration_test.go
@@ -69,16 +69,15 @@ func TestService_refreshAccessToken_NotAllowRefreshTokenRaces(t *testing.T) {
 					cancelFunc()
 					ctx := store.GetContext()
 					timerPtr := (*valueCtxInterface)(unsafe.Pointer(&ctx)).p.timerCtx //nolint:gosec // imitate a timeout
-					// cancelFunc above already Stored context.Canceled; atomic.Value rejects
-					// Store of a different concrete type, so we overwrite the underlying
-					// `any` directly. Layout-safe: atomic.Value is `struct{ v any }`.
-					// CAVEAT: a 16-byte interface write is not atomic, so a concurrent
-					// atomic.Value.Load() in another goroutine could observe a torn eface
-					// (mismatched type/data words). The test goroutine is the only writer
-					// at this point, but parent-context watchers via propagateCancel may
-					// race; an additional Store on this Value would also panic with
-					// "store of inconsistently typed value into Value" — none happens here.
-					*(*any)(unsafe.Pointer(&timerPtr.err)) = context.DeadlineExceeded //nolint:gosec // imitate a timeout
+					// cancelFunc above already Stored context.Canceled.
+					// atomic.Value.Store with a different concrete type panics, and a
+					// plain non-atomic interface assignment races with database/sql's
+					// awaitDone goroutine doing atomic.Value.Load via ctx.Err() (caught
+					// by `-race`). Reset the type slot atomically (concurrent Loaders
+					// see typ=nil and return nil — never a torn typ/data pair), then
+					// Store normally.
+					resetAtomicValue(&timerPtr.err)
+					timerPtr.err.Store(context.DeadlineExceeded)
 					// Also clear cause so context.Cause(ctx) is consistent with ctx.Err()
 					// (mirrors the pattern in app/database/deadline_test.go).
 					timerPtr.cause = nil
@@ -363,6 +362,15 @@ type valueCtx struct {
 type valueCtxInterface struct {
 	t unsafe.Pointer
 	p *valueCtx
+}
+
+// resetAtomicValue atomically clears the typ slot of an atomic.Value so that a
+// subsequent .Store() can succeed even with a different concrete type. Race-free
+// because (a) the write is atomic.StorePointer and (b) atomic.Value.Load checks
+// typ first and returns nil when typ==nil — readers never observe stale data.
+func resetAtomicValue(av *atomic.Value) {
+	// atomic.Value is `struct{ v any }`; its first word is the eface type pointer.
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(av)), nil) //nolint:gosec // see comment
 }
 
 // TestCancelCtxMirrorLayout verifies that the unsafe layout mirrors of

--- a/app/api/currentuser/current_user_integration_test.go
+++ b/app/api/currentuser/current_user_integration_test.go
@@ -182,7 +182,6 @@ func Test_checkPreconditionsForGroupRequests(t *testing.T) {
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/api/currentuser/render_group_group_transition_result_test.go
+++ b/app/api/currentuser/render_group_group_transition_result_test.go
@@ -106,7 +106,6 @@ func TestRenderGroupGroupTransitionResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		if len(tt.actions) == 0 {
 			tt.actions = []userGroupRelationAction{
 				acceptInvitationAction, joinGroupByCodeAction, rejectInvitationAction,
@@ -114,7 +113,6 @@ func TestRenderGroupGroupTransitionResult(t *testing.T) {
 			}
 		}
 		for _, action := range tt.actions {
-			action := action
 			t.Run(tt.name+": "+string(action), func(t *testing.T) {
 				var fn service.AppHandler = func(respW http.ResponseWriter, req *http.Request) error {
 					return RenderGroupGroupTransitionResult(respW, req, tt.result, tt.approvalsToRequest, action)

--- a/app/api/groups/create_code.go
+++ b/app/api/groups/create_code.go
@@ -99,7 +99,7 @@ func GenerateGroupCode() (string, error) {
 	const codeLength = 10
 
 	result := make([]byte, 0, codeLength)
-	for i := 0; i < codeLength; i++ {
+	for range codeLength {
 		index, err := rand.Int(rand.Reader, big.NewInt(int64(allowedCharactersLength)))
 		if err != nil {
 			return "", err

--- a/app/api/groups/create_invitations_integration_test.go
+++ b/app/api/groups/create_invitations_integration_test.go
@@ -251,7 +251,6 @@ func Test_filterOtherTeamsMembersOut(t *testing.T) {
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/api/groups/create_user_batch.go
+++ b/app/api/groups/create_user_batch.go
@@ -271,7 +271,6 @@ func createBatchUsersInDB(store *database.DataStore, input createUserBatchReques
 		var currentResultRow *resultRow
 		currentSubgroupIndex := -1
 		for _, createdUser := range createdUsers {
-			createdUser := createdUser
 			if currentSubgroupIndex == -1 || usersInSubgroup == input.Subgroups[currentSubgroupIndex].Count {
 				currentSubgroupIndex++
 				currentResultRow = &resultRow{

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -314,7 +314,7 @@ func appendTableRowToResult(orderedItemIDListWithDuplicates []int64, reflResultR
 	reflTableCellType := reflect.TypeOf(resultPtr).Elem().Elem().Elem()
 	// []*tableCellType
 	reflTableRow := reflect.MakeSlice(
-		reflect.SliceOf(reflect.PtrTo(reflTableCellType)), len(orderedItemIDListWithDuplicates), len(orderedItemIDListWithDuplicates))
+		reflect.SliceOf(reflect.PointerTo(reflTableCellType)), len(orderedItemIDListWithDuplicates), len(orderedItemIDListWithDuplicates))
 
 	// Here we fill the table row with cells. As an item can be a child of multiple parents, the row may contain duplicates.
 	for index, itemID := range orderedItemIDListWithDuplicates {
@@ -359,7 +359,7 @@ func scanAndBuildProgressResults(
 
 	// here we will store results for each item: map[int64]*tableCellType
 	reflResultRowMap := reflect.MakeMapWithSize(
-		reflect.MapOf(reflect.TypeOf(int64(0)), reflect.PtrTo(reflTableCellType)), uniqueItemsCount)
+		reflect.MapOf(reflect.TypeOf(int64(0)), reflect.PointerTo(reflTableCellType)), uniqueItemsCount)
 	previousGroupID := int64(-1)
 	service.MustNotBeError(query.ScanAndHandleMaps(func(cell map[string]interface{}) error {
 		// convert map[string]interface{} into tableCellType and store the result in reflDecodedTableCell
@@ -372,7 +372,8 @@ func scanAndBuildProgressResults(
 				// Moving to a next row of the results table, so we should insert cells from the map into the results slice
 				appendTableRowToResult(orderedItemIDListWithDuplicates, reflResultRowMap, resultPtr)
 				// and initialize a new map for cells
-				reflResultRowMap = reflect.MakeMapWithSize(reflect.MapOf(reflect.TypeOf(int64(0)), reflect.PtrTo(reflTableCellType)), uniqueItemsCount)
+				reflResultRowMap = reflect.MakeMapWithSize(
+					reflect.MapOf(reflect.TypeOf(int64(0)), reflect.PointerTo(reflTableCellType)), uniqueItemsCount)
 			}
 			previousGroupID = groupID
 		}

--- a/app/api/groups/get_permission_explanation_integration_test.go
+++ b/app/api/groups/get_permission_explanation_integration_test.go
@@ -190,7 +190,6 @@ func Test_insertGrantedPermissionsToBeExplained(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/api/groups/update_group_test.go
+++ b/app/api/groups/update_group_test.go
@@ -29,7 +29,6 @@ func Test_validateUpdateGroupInput(t *testing.T) {
 		{"code_lifetime=", map[string]interface{}{"code_lifetime": ""}, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			db, mock := database.NewDBMock()
 			defer func() { _ = db.Close() }()
@@ -183,7 +182,6 @@ func Test_isTryingToChangeOfficialSessionActivity(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isTryingToChangeOfficialSessionActivity(tt.args.dbMap, tt.args.oldIsOfficialSession, tt.args.activityIDChanged))
 		})
@@ -207,7 +205,6 @@ func Test_int64PtrEqualValues(t *testing.T) {
 		{name: "both are not nils, equal", args: args{a: golang.Ptr(int64(1)), b: golang.Ptr(int64(1))}, want: true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, int64PtrEqualValues(tt.args.a, tt.args.b))
 		})

--- a/app/api/groups/update_permissions_test.go
+++ b/app/api/groups/update_permissions_test.go
@@ -87,7 +87,6 @@ func Test_checkIfPossibleToModifyCanView(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, checkIfPossibleToModifyCanView(
 				tt.args.viewPermissionToSet, tt.args.currentPermissions, tt.args.managerPermissions, dataStore))
@@ -119,10 +118,8 @@ func testCheckerAllowsSettingLowerOrSameValue(
 	dataStore := database.NewDataStore(db)
 
 	for _, currentValue := range values {
-		currentValue := currentValue
 		want := true
 		for _, newValue := range values {
-			newValue := newValue
 			t.Run(fmt.Sprintf("%s -> %s", currentValue, newValue), func(t *testing.T) {
 				assert.Equal(t, want,
 					reflect.ValueOf(funcToCheck).Call([]reflect.Value{
@@ -148,14 +145,12 @@ func Test_checkIfPossibleToModifyCanGrantView_RequiresCanViewBeGreaterOrEqualToC
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
 	for currentCanGrantViewIndex, currentCanGrantView := range canGrantViewValues() {
-		currentCanGrantView := currentCanGrantView
 		for newCanGrantViewIndex := currentCanGrantViewIndex + 1; newCanGrantViewIndex < len(canGrantViewValues()); newCanGrantViewIndex++ {
 			newCanGrantViewValue := canGrantViewValues()[newCanGrantViewIndex]
 			if newCanGrantViewValue == solutionWithGrant {
 				break
 			}
 			for _, currentCanViewValue := range canViewValues() {
-				currentCanViewValue := currentCanViewValue
 				t.Run(fmt.Sprintf("%s -> %s, %s", currentCanGrantView, newCanGrantViewValue, currentCanViewValue),
 					func(t *testing.T) {
 						assert.Equal(t,
@@ -219,7 +214,6 @@ func Test_checkIfPossibleToModifyCanGrantView_SolutionWithGrant(t *testing.T) {
 		}, dataStore))
 
 	for _, canGrantView := range canGrantViewValues() {
-		canGrantView := canGrantView
 		t.Run(canGrantView, func(t *testing.T) {
 			assert.Equal(t, canGrantView == solutionWithGrant, checkIfPossibleToModifyCanGrantView(
 				solutionWithGrant,
@@ -265,9 +259,7 @@ func testCheckerRequiresManagerToHaveSpecificPermission(
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
 	for _, newValue := range values {
-		newValue := newValue
 		for _, managerValue := range values {
-			managerValue := managerValue
 			t.Run(fmt.Sprintf("=> %s, %s", newValue, managerValue), func(t *testing.T) {
 				assert.Equal(t, managerValue == requiredPermission,
 					funcToCheck(
@@ -323,14 +315,12 @@ func testCheckerRequiresCanViewBeGreaterOrEqualToContent(
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
 	for currentIndex, currentValue := range values {
-		currentValue := currentValue
 		for newIndex := currentIndex + 1; newIndex < len(values); newIndex++ {
 			newValue := values[newIndex]
 			if newValue == stopValue {
 				break
 			}
 			for _, currentCanViewValue := range canViewValues() {
-				currentCanViewValue := currentCanViewValue
 				t.Run(fmt.Sprintf("%s -> %s, %s",
 					currentValue, newValue, currentCanViewValue), func(t *testing.T) {
 					assert.Equal(t,
@@ -365,7 +355,6 @@ func Test_checkIfPossibleToModifyCanWatch_AnswerWithGrant(t *testing.T) {
 		{"info", true, false},
 		{"content", false, false},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("%s (can_view=%s, managerIsOwner=%v)", answerWithGrant, test.canView, test.isOwnerGenerated),
 			func(t *testing.T) {
 				assert.Equal(t, test.want, checkIfPossibleToModifyCanWatch(
@@ -379,7 +368,6 @@ func Test_checkIfPossibleToModifyCanWatch_AnswerWithGrant(t *testing.T) {
 	}
 
 	for _, canWatch := range canWatchValues() {
-		canWatch := canWatch
 		t.Run(canWatch, func(t *testing.T) {
 			assert.Equal(t, canWatch == answerWithGrant, checkIfPossibleToModifyCanWatch(
 				answerWithGrant,
@@ -464,7 +452,6 @@ func Test_checkIfPossibleToModifyCanEdit_AllWithGrant(t *testing.T) {
 		}, dataStore))
 
 	for _, canEdit := range canEditValues() {
-		canEdit := canEdit
 		t.Run(canEdit, func(t *testing.T) {
 			assert.Equal(t, canEdit == allWithGrant, checkIfPossibleToModifyCanEdit(
 				allWithGrant,
@@ -519,7 +506,6 @@ func Test_checkIfPossibleToModifyCanMakeSessionOfficial_RequiresCanViewBeGreater
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
 	for _, currentCanViewValue := range canViewValues() {
-		currentCanViewValue := currentCanViewValue
 		t.Run(currentCanViewValue, func(t *testing.T) {
 			assert.Equal(t,
 				permissionGrantedStore.ViewIndexByName(info) <= permissionGrantedStore.ViewIndexByName(currentCanViewValue),
@@ -595,7 +581,6 @@ func testCheckerRequiresManagerToHaveCanGrantViewGreaterOrEqualToEnter(
 	permissionGrantedStore := dataStore.PermissionsGranted()
 
 	for _, canGrantView := range canGrantViewValues() {
-		canGrantView := canGrantView
 		t.Run(canGrantView, func(t *testing.T) {
 			assert.Equal(t,
 				permissionGrantedStore.GrantViewIndexByName(enter) <= permissionGrantedStore.GrantViewIndexByName(canGrantView),
@@ -736,9 +721,9 @@ func testValidatorSetsModifiedFlagAndUpdatesCurrentPermissions(
 	defer pg.Unpatch()
 
 	reflValues := reflect.ValueOf(values)
-	for currentIndex := 0; currentIndex < reflValues.Len(); currentIndex++ {
+	for currentIndex := range reflValues.Len() {
 		currentValue := reflValues.Index(currentIndex).Interface()
-		for newIndex := 0; newIndex < reflValues.Len(); newIndex++ {
+		for newIndex := range reflValues.Len() {
 			newValue := reflValues.Index(newIndex).Interface()
 			t.Run(fmt.Sprintf("%s -> %s", currentValue, newValue), func(t *testing.T) {
 				currentPermissions := currentPermissionsGenerator(currentValue, permissionGrantedStore)
@@ -1045,10 +1030,8 @@ func Test_correctPermissionsDataMap(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.permission, func(t *testing.T) {
 			for _, testSpec := range test.tests {
-				testSpec := testSpec
 				t.Run(fmt.Sprintf("%s=%v, can_view=%s", test.permission, testSpec.value, testSpec.canView), func(t *testing.T) {
 					dataMap := make(map[string]interface{})
 					correctPermissionsDataMap(dataStore, dataMap, test.userPermissionsFunc(testSpec.value, testSpec.canView))

--- a/app/api/items/ask_hint_test.go
+++ b/app/api/items/ask_hint_test.go
@@ -128,7 +128,6 @@ func TestAskHintRequest_UnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/api/items/path_from_root_integration_test.go
+++ b/app/api/items/path_from_root_integration_test.go
@@ -824,7 +824,6 @@ func Test_findItemPaths(t *testing.T) {
 	`
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/api/items/start_result_path.go
+++ b/app/api/items/start_result_path.go
@@ -175,7 +175,7 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 		groupsManagedByParticipant.Select("groups.root_skill_id"))
 
 	query := store.Table("items as items0").WithSharedWriteLock()
-	for i := 0; i < len(ids); i++ {
+	for i := range ids {
 		query = query.Where(fmt.Sprintf("items%d.id = ?", i), ids[i])
 	}
 	query = query.Where("items0.id IN ? OR items0.id IN ?", rootActivities.SubQuery(), rootSkills.SubQuery())
@@ -184,7 +184,7 @@ func getDataForResultPathStart(store *database.DataStore, participantID int64, i
 	var columns string
 	attemptIsActiveCondition := "1"
 	var columnsForOrder string
-	for idIndex := 0; idIndex < len(ids); idIndex++ {
+	for idIndex := range ids {
 		var previousAttemptCondition string
 		if idIndex > 0 {
 			score += " + "

--- a/app/api/items/start_result_path_integration_test.go
+++ b/app/api/items/start_result_path_integration_test.go
@@ -689,7 +689,6 @@ func Test_getDataForResultPathStart(t *testing.T) {
 	`
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -338,7 +338,6 @@ func TestNew_DoesNotMountPprofInEnvironmentsOtherThanDev(t *testing.T) {
 
 func TestNew_DisableResultsPropagation(t *testing.T) {
 	for _, configSettingValue := range []bool{true, false} {
-		configSettingValue := configSettingValue
 		t.Run(fmt.Sprintf("disableResultsPropagation=%t", configSettingValue), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/auth/middleware_test.go
+++ b/app/auth/middleware_test.go
@@ -205,7 +205,6 @@ func TestUserMiddleware(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assertlib.New(t)
 			ctx, logger, logHook := logging.NewContextWithNewMockLogger()

--- a/app/auth/random.go
+++ b/app/auth/random.go
@@ -13,7 +13,7 @@ func GenerateKey() (string, error) {
 	const stringLength = 32
 
 	result := make([]byte, 0, stringLength)
-	for i := 0; i < stringLength; i++ {
+	for range stringLength {
 		index, err := crand.Int(crand.Reader, big.NewInt(int64(allowedCharactersLength)))
 		if err != nil {
 			return "", err

--- a/app/auth/session_cookie_attributes_test.go
+++ b/app/auth/session_cookie_attributes_test.go
@@ -63,7 +63,6 @@ func TestSessionCookieAttributes_SessionCookie(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			attributes := &SessionCookieAttributes{
 				UseCookie: tt.fields.UseCookie,
@@ -89,7 +88,6 @@ func Test_unmarshalSessionCookieValue_InvalidValue(t *testing.T) {
 		{name: "five parts", value: "!!!!"},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			gotValue, gotAttributes := unmarshalSessionCookieValue(test.value)
 			assert.Empty(t, gotValue)

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -184,13 +184,13 @@ func TestLoadConfig_Concurrent(t *testing.T) {
 	assert.NotPanics(t, func() { LoadConfig() })
 	const numGoroutines = 1000
 	done := make(chan struct{}, numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			assert.NotPanics(t, func() { LoadConfig() })
 			done <- struct{}{}
 		}()
 	}
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		<-done
 	}
 }

--- a/app/database/ancestors.go
+++ b/app/database/ancestors.go
@@ -143,7 +143,7 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 	}
 
 	recomputeAncestors := make([]*SQLStmtWrapper, len(recomputeQueries))
-	for i := 0; i < len(recomputeQueries); i++ {
+	for i := range recomputeQueries {
 		recomputeAncestors[i], err = s.Prepare(recomputeQueries[i])
 		mustNotBeError(err)
 
@@ -167,7 +167,7 @@ func (s *DataStore) createNewAncestors(objectName, singleObjectName string) { /*
 	for {
 		_, err = markAsProcessing.ExecContext(s.ctx())
 		mustNotBeError(err)
-		for i := 0; i < len(recomputeAncestors); i++ {
+		for i := range recomputeAncestors {
 			_, err = recomputeAncestors[i].ExecContext(s.ctx())
 			mustNotBeError(err)
 		}

--- a/app/database/answer_store_integration_test.go
+++ b/app/database/answer_store_integration_test.go
@@ -39,7 +39,6 @@ func TestAnswerStore_SubmitNewAnswer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/answer_store_test.go
+++ b/app/database/answer_store_test.go
@@ -31,7 +31,6 @@ func TestAnswerStore_WithMethods(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/badges_integration_test.go
+++ b/app/database/badges_integration_test.go
@@ -275,7 +275,6 @@ func TestGroupStore_StoreBadges(t *testing.T) {
 	}
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/configdb/config.go
+++ b/app/database/configdb/config.go
@@ -67,7 +67,6 @@ func insertRootGroupsAndRelations(store *database.DataStore, domainsConfig []dom
 	groupGroupStore := store.GroupGroups()
 	var relationsToCreate []map[string]interface{}
 	for _, domainConfig := range domainsConfig {
-		domainConfig := domainConfig
 		insertRootGroups(groupStore, &domainConfig)
 		for _, spec := range []map[string]interface{}{
 			{"parent_group_id": domainConfig.AllUsersGroup, "child_group_id": domainConfig.NonTempUsersGroup},

--- a/app/database/configdb/config_integration_test.go
+++ b/app/database/configdb/config_integration_test.go
@@ -138,7 +138,6 @@ groups_groups:
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -200,7 +199,6 @@ groups_groups:
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			db := testhelpers.SetupDBWithFixtureString(ctx, tt.fixtures)
 			defer func() { _ = db.Close() }()

--- a/app/database/data_store_integration_test.go
+++ b/app/database/data_store_integration_test.go
@@ -74,7 +74,7 @@ func TestDataStore_WithNamedLock_WorksOutsideOfTransaction(t *testing.T) {
 	s := database.NewDataStore(db)
 	resultCh := make(chan struct{}, 100)
 	defer close(resultCh)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		go func() {
 			assert.NoError(t, s.WithNamedLock("test", 1*time.Second, func(_ *database.DataStore) error {
 				return nil
@@ -82,7 +82,7 @@ func TestDataStore_WithNamedLock_WorksOutsideOfTransaction(t *testing.T) {
 			resultCh <- struct{}{}
 		}()
 	}
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		<-resultCh
 	}
 

--- a/app/database/data_store_test.go
+++ b/app/database/data_store_test.go
@@ -60,7 +60,6 @@ func TestDataStore_StoreConstructorsSetTablesCorrectly(t *testing.T) {
 		{"UserBatchPrefixes", func(store *DataStore) *DB { return store.UserBatchPrefixes().Where("") }, "`user_batch_prefixes`"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -115,7 +114,6 @@ func TestDataStore_StoreConstructorsReturnObjectsOfRightTypes(t *testing.T) {
 		{"UserBatchPrefixes", func(store *DataStore) interface{} { return store.UserBatchPrefixes() }, &UserBatchPrefixStore{}},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			db, _ := NewDBMock()
 			defer func() { _ = db.Close() }()

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -1043,7 +1043,7 @@ func EscapeLikeString(v string, escapeCharacter byte) string {
 	pos := 0
 	buf := make([]byte, len(v)*2) //nolint:mnd // in the worst case, where every character is escaped, we need twice as many bytes
 
-	for i := 0; i < len(v); i++ {
+	for i := range len(v) {
 		character := v[i]
 		switch character {
 		case '%', '_', escapeCharacter:

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -400,7 +400,7 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Panic(t *testing.T) {
 			monkey.Patch(sleepBeforeRetrying, func(_ context.Context) (bool, error) { sleepCount++; return true, nil })
 			defer monkey.UnpatchAll()
 
-			for i := 0; i < retriesLimit; i++ {
+			for range retriesLimit {
 				mock.ExpectBegin()
 				mock.ExpectQuery("SELECT 1").
 					WillReturnError(&mysql.MySQLError{Number: errorNumber})
@@ -434,7 +434,7 @@ func TestDB_inTransaction_RetriesAllowedUpToTheLimit_Error(t *testing.T) {
 			monkey.Patch(sleepBeforeRetrying, func(_ context.Context) (bool, error) { sleepCount++; return true, nil })
 			defer monkey.UnpatchAll()
 
-			for i := 0; i < retriesLimit; i++ {
+			for range retriesLimit {
 				mock.ExpectBegin()
 				mock.ExpectQuery("SELECT 1").
 					WillReturnError(&mysql.MySQLError{Number: errorNumber})
@@ -471,7 +471,7 @@ func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Panic(t *testing.T) 
 			monkey.Patch(sleepBeforeRetrying, func(_ context.Context) (bool, error) { sleepCount++; return true, nil })
 			defer monkey.UnpatchAll()
 
-			for i := 0; i < retriesLimit+1; i++ {
+			for range retriesLimit + 1 {
 				mock.ExpectBegin()
 				mock.ExpectQuery("SELECT 1").
 					WillReturnError(&mysql.MySQLError{Number: errorNumber})
@@ -512,7 +512,7 @@ func TestDB_inTransaction_RetriesAboveTheLimitAreDisallowed_Error(t *testing.T) 
 			monkey.Patch(sleepBeforeRetrying, func(_ context.Context) (bool, error) { sleepCount++; return true, nil })
 			defer monkey.UnpatchAll()
 
-			for i := 0; i < retriesLimit+1; i++ {
+			for range retriesLimit + 1 {
 				mock.ExpectBegin()
 				mock.ExpectQuery("SELECT 1").
 					WillReturnError(&mysql.MySQLError{Number: errorNumber})
@@ -628,7 +628,6 @@ func TestDB_QueryConstructors(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1844,7 +1843,6 @@ func TestDB_withNamedLock_HandlesReleaseError(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1979,7 +1977,6 @@ func TestDB_retryOnDuplicatePrimaryKeyError_ReturnsOtherErrors(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -2050,7 +2047,6 @@ func Test_EscapeLikeString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := EscapeLikeString(tt.args.s, tt.args.escapeCharacter)
 			assert.Equal(t, tt.want, got)
@@ -2333,8 +2329,6 @@ func TestDB_retryOnRetryableError_RetriesOnDeadlockAndLockWaitTimeoutErrors(t *t
 					},
 				},
 			} {
-				test := test
-
 				t.Run(test.name, func(t *testing.T) {
 					testoutput.SuppressIfPasses(t)
 

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -44,6 +44,15 @@ type cancelCtxInterface struct {
 	p *timerCtx
 }
 
+// resetAtomicValue atomically clears the typ slot of an atomic.Value so that a
+// subsequent .Store() can succeed even with a different concrete type. Race-free
+// because (a) the write is atomic.StorePointer and (b) atomic.Value.Load checks
+// typ first and returns nil when typ==nil — readers never observe stale data.
+func resetAtomicValue(av *atomic.Value) {
+	// atomic.Value is `struct{ v any }`; its first word is the eface type pointer.
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(av)), nil) //nolint:gosec // see comment
+}
+
 // TestCancelCtxMirrorLayout verifies that the unsafe layout mirror of
 // context.cancelCtx / context.timerCtx above still matches the stdlib on the
 // running Go toolchain. If a future Go upgrade changes the offsets, this test
@@ -298,12 +307,15 @@ func Test_Deadline(t *testing.T) {
 
 			err := test.funcToCall(dataStore, func() {
 				cancel()
-				//nolint:gosec // access the context directly to set the error
-				ctxPtr := (*cancelCtxInterface)(unsafe.Pointer(&ctx)).p
-				// cancel() above already Stored context.Canceled into err. atomic.Value rejects
-				// Store of a different concrete type, so we overwrite the underlying `any`
-				// directly. Layout-safe because atomic.Value is `struct{ v any }`.
-				*(*any)(unsafe.Pointer(&ctxPtr.err)) = context.DeadlineExceeded //nolint:gosec // imitate a deadline-exceeded
+				ctxPtr := (*cancelCtxInterface)(unsafe.Pointer(&ctx)).p //nolint:gosec // imitate a deadline-exceeded
+				// cancel() above already Stored context.Canceled into err.
+				// atomic.Value.Store with a different concrete type panics, and a plain
+				// non-atomic interface assignment races with database/sql's awaitDone
+				// goroutine doing atomic.Value.Load via ctx.Err() (caught by `-race`).
+				// Reset the type slot atomically (concurrent Loaders see typ=nil and
+				// return nil — never a torn typ/data pair), then Store normally.
+				resetAtomicValue(&ctxPtr.err)
+				ctxPtr.err.Store(context.DeadlineExceeded)
 				ctxPtr.cause = nil
 			})
 

--- a/app/database/deadline_test.go
+++ b/app/database/deadline_test.go
@@ -18,23 +18,55 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/golang"
 )
 
+// cancelCtx mirrors the layout of the unexported context.cancelCtx so that the
+// tests below can inject a synthetic context.DeadlineExceeded error mid-operation.
+// Layout matches Go 1.25: `err` became atomic.Value (previously error) and
+// timerCtx value-embeds cancelCtx (previously a pointer embed).
 type cancelCtx struct {
-	context.Context //nolint:containedctx // it is not us who store the context in the structure
+	context.Context //nolint:containedctx // mirroring an unexported runtime struct
 
 	_     sync.Mutex
-	_     atomic.Value
-	_     map[interface{}]struct{}
-	err   error
+	_     atomic.Value             // done
+	_     map[interface{}]struct{} // children
+	err   atomic.Value             // mirrors context.cancelCtx.err
 	cause error
 }
 
 type timerCtx struct {
-	*cancelCtx
+	cancelCtx // value-embedded as in stdlib
+
+	_ unsafe.Pointer    // *time.Timer
+	_ [3]unsafe.Pointer // time.Time (3 words)
 }
 
 type cancelCtxInterface struct {
 	t unsafe.Pointer
 	p *timerCtx
+}
+
+// TestCancelCtxMirrorLayout verifies that the unsafe layout mirror of
+// context.cancelCtx / context.timerCtx above still matches the stdlib on the
+// running Go toolchain. If a future Go upgrade changes the offsets, this test
+// fails fast with a clear message instead of silently corrupting unrelated
+// memory inside Test_Deadline. Compatible with Go 1.21+ (when err became
+// atomic.Value); should be re-checked on every Go major bump.
+func TestCancelCtxMirrorLayout(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+
+	rawCtx, cancel := context.WithDeadline(parent, time.Now().Add(time.Hour))
+	cancel() // stores context.Canceled into cancelCtx.err and cancelCtx.cause
+
+	mirror := (*cancelCtxInterface)(unsafe.Pointer(&rawCtx)).p //nolint:gosec // layout-mirror sanity check
+
+	require.Equal(t, context.Canceled, rawCtx.Err(),
+		"sanity: cancel() should make ctx.Err() == context.Canceled")
+	require.Equal(t, context.Canceled, mirror.err.Load(),
+		"cancelCtx.err offset is wrong: mirror does not see the value the stdlib stored. "+
+			"Re-check the layout against the current Go runtime's context.cancelCtx.")
+	require.Equal(t, context.Canceled, mirror.cause,
+		"cancelCtx.cause offset is wrong: mirror does not see the value the stdlib stored. "+
+			"Re-check the layout against the current Go runtime's context.cancelCtx.")
 }
 
 func Test_Deadline(t *testing.T) {
@@ -251,7 +283,6 @@ func Test_Deadline(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			ctx, _, logHook := logging.NewContextWithNewMockLogger()
 			db, mock := NewDBMock(ctx)
@@ -268,9 +299,12 @@ func Test_Deadline(t *testing.T) {
 			err := test.funcToCall(dataStore, func() {
 				cancel()
 				//nolint:gosec // access the context directly to set the error
-				(*cancelCtxInterface)(unsafe.Pointer(&ctx)).p.err = context.DeadlineExceeded
-				//nolint:gosec // access the context directly to set the cause to nil
-				(*cancelCtxInterface)(unsafe.Pointer(&ctx)).p.cause = nil
+				ctxPtr := (*cancelCtxInterface)(unsafe.Pointer(&ctx)).p
+				// cancel() above already Stored context.Canceled into err. atomic.Value rejects
+				// Store of a different concrete type, so we overwrite the underlying `any`
+				// directly. Layout-safe because atomic.Value is `struct{ v any }`.
+				*(*any)(unsafe.Pointer(&ctxPtr.err)) = context.DeadlineExceeded //nolint:gosec // imitate a deadline-exceeded
+				ctxPtr.cause = nil
 			})
 
 			require.EqualError(t, err, context.DeadlineExceeded.Error())

--- a/app/database/group_ancestor_store_test.go
+++ b/app/database/group_ancestor_store_test.go
@@ -35,7 +35,6 @@ func TestGroupAncestorStore_ManagedByUser(t *testing.T) {
 			storeFunc: func(db *DB) *GroupAncestorStore { return NewDataStore(db).ActiveGroupAncestors() },
 		},
 	} {
-		test := test
 		t.Run(test.tableName, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/group_group_store_integration_test.go
+++ b/app/database/group_group_store_integration_test.go
@@ -171,7 +171,6 @@ func TestGroupGroupStore_DeleteRelation(t *testing.T) {
 	}
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -355,7 +354,6 @@ func TestGroupGroupStore_TriggerBeforeInsert_SetsIsTeamMembership(t *testing.T) 
 		{parentGroupID: 2, childGroupID: 4, expectedIsTeamMembership: false},
 		{parentGroupID: 3, childGroupID: 4, expectedIsTeamMembership: true},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("parent %d child %d", test.parentGroupID, test.childGroupID), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -398,7 +396,6 @@ func TestGroupGroupStore_TriggerBeforeInsert_SetsChildGroupType(t *testing.T) {
 		{parentGroupID: 1, childGroupID: 4, expectedChildGroupType: "User"},
 		{parentGroupID: 3, childGroupID: 4, expectedChildGroupType: "User"},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("parent %d child %d", test.parentGroupID, test.childGroupID), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -471,7 +468,6 @@ func TestGroupGroupStore_TriggerAfterInsert_MarksResultsAsChanged(t *testing.T) 
 			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -562,7 +558,6 @@ func TestGroupGroupStore_TriggerAfterUpdate_MarksResultsAsChanged(t *testing.T) 
 			noChanges:       true,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/group_group_store_test.go
+++ b/app/database/group_group_store_test.go
@@ -32,7 +32,6 @@ func TestGroupGroupStore_WhereUserIsMember(t *testing.T) {
 			storeFunc: func(db *DB) *GroupGroupStore { return NewDataStore(db).ActiveGroupGroups() },
 		},
 	} {
-		test := test
 		t.Run(test.tableName, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/group_group_store_transitions_integration_test.go
+++ b/app/database/group_group_store_transitions_integration_test.go
@@ -818,7 +818,6 @@ func TestGroupGroupStore_Transition(t *testing.T) {
 	}
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1033,7 +1032,6 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestsOnAcceptingJoin
 	expectedTime := (*database.Time)(golang.Ptr(time.Date(2019, 5, 30, 11, 0, 0, 0, time.UTC)))
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range generateApprovalsTests(expectedTime) {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1107,7 +1105,6 @@ func TestGroupGroupStore_Transition_ChecksApprovalsInJoinRequestIfJoinRequestExi
 		{"when a user joins the group by badge", database.UserJoinsGroupByBadge},
 		{"when a group owner creates an accepted join request", database.UserCreatesAcceptedJoinRequest},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1191,7 +1188,6 @@ func TestGroupGroupStore_Transition_ChecksApprovalsFromParametersOnAcceptingInvi
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range generateApprovalsTests(expectedTime) {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/group_group_store_transitions_test.go
+++ b/app/database/group_group_store_transitions_test.go
@@ -55,7 +55,6 @@ func TestGroupApprovals_FromString(t *testing.T) {
 			expectedGroupApprovals: GroupApprovals{WatchApproval: true},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			var approvals GroupApprovals
 			approvals.FromString(test.csv)
@@ -94,7 +93,6 @@ func TestGroupApprovals_ToArray(t *testing.T) {
 			expectedArray:  []string{"watch"},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expectedArray, test.groupApprovals.ToArray())
 		})

--- a/app/database/group_store_integration_test.go
+++ b/app/database/group_store_integration_test.go
@@ -27,7 +27,6 @@ func TestGroupStore_CreateNew(t *testing.T) {
 		{groupType: "Class", shouldCreateAttempts: false},
 		{groupType: "Team", shouldCreateAttempts: true},
 	} {
-		test := test
 		t.Run(test.groupType, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -358,14 +357,12 @@ func TestGroupStore_CheckIfEntryConditionsStillSatisfiedForAllActiveParticipatio
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
 			db := testhelpers.SetupDBWithFixtureString(ctx, mainFixture, tt.fixture)
 			defer func() { _ = db.Close() }()
 			for _, withLock := range []bool{true, false} {
-				withLock := withLock
 				t.Run(fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
 					testoutput.SuppressIfPasses(t)
 
@@ -437,7 +434,6 @@ func TestGroupStore_DeleteGroup_RecomputesAccess(t *testing.T) {
 				permissions_generated: [{group_id: 1234, item_id: 10, can_view_generated: content}]`,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -495,7 +491,6 @@ func TestGroupStore_TriggerBeforeUpdate_RefusesToModifyType(t *testing.T) {
 		{oldType: "User", newType: "User", expectError: false},
 		{oldType: "Other", newType: "Club", expectError: false},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("%s to %s", test.oldType, test.newType), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/groups_integration_test.go
+++ b/app/database/groups_integration_test.go
@@ -104,7 +104,6 @@ func TestDataStore_GetGroupJoiningByCodeInfoByCode(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/item_access_details_test.go
+++ b/app/database/item_access_details_test.go
@@ -12,7 +12,6 @@ func canViewValues() []string {
 
 func TestItemAccessDetails_IsInfo(t *testing.T) {
 	for _, canView := range canViewValues() {
-		canView := canView
 		t.Run(canView, func(t *testing.T) {
 			assert.Equal(t, canView == "info", (&ItemAccessDetails{CanView: canView}).IsInfo())
 		})
@@ -21,7 +20,6 @@ func TestItemAccessDetails_IsInfo(t *testing.T) {
 
 func TestItemAccessDetails_IsForbidden(t *testing.T) {
 	for _, canView := range canViewValues() {
-		canView := canView
 		t.Run(canView, func(t *testing.T) {
 			assert.Equal(t, canView == "none", (&ItemAccessDetails{CanView: canView}).IsForbidden())
 		})

--- a/app/database/item_item_store_integration_test.go
+++ b/app/database/item_item_store_integration_test.go
@@ -94,7 +94,6 @@ func TestItemItemStore_TriggerAfterUpdate_MarksPermissionsForRecomputing(t *test
 		{column: "watch_propagation", newValue: 1},
 		{column: "edit_propagation", newValue: 1},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("%s=%v", test.column, test.newValue), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/item_item_store_test.go
+++ b/app/database/item_item_store_test.go
@@ -61,7 +61,6 @@ func TestItemItemStore_PropagationEnums(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/item_store.go
+++ b/app/database/item_store.go
@@ -134,7 +134,7 @@ func columnsListForBreadcrumbsHierarchy(ids []int64) string {
 	columnsList := "1"
 	if len(ids) > 0 {
 		var columnsBuilder strings.Builder
-		for idIndex := 0; idIndex < len(ids); idIndex++ {
+		for idIndex := range ids {
 			if idIndex != 0 {
 				_, _ = columnsBuilder.WriteString(", ")
 			}
@@ -161,7 +161,7 @@ func resultsForBreadcrumbsHierarchy(ids []int64, data map[string]interface{}) (
 ) {
 	attemptIDMap = make(map[int64]int64, len(ids))
 	attemptNumberMap = make(map[int64]int, len(ids))
-	for idIndex := 0; idIndex < len(ids); idIndex++ {
+	for idIndex := range ids {
 		//nolint:forcetypeassert // panic if the type of data["attempt%d"] is not int64
 		attemptIDMap[ids[idIndex]] = data[fmt.Sprintf("attempt%d", idIndex)].(int64)
 		numberKey := fmt.Sprintf("number%d", idIndex)

--- a/app/database/item_store_integration_test.go
+++ b/app/database/item_store_integration_test.go
@@ -32,7 +32,6 @@ func TestItemStore_VisibleMethods(t *testing.T) {
 		{methodToCall: "VisibleByID", args: []interface{}{int64(191)}, column: "id", expected: []int64{191}},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.methodToCall, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -91,7 +90,6 @@ func TestItemStore_CheckSubmissionRights(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -137,7 +135,6 @@ func TestItemStore_GetItemIDFromTextID(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -574,7 +571,6 @@ func TestItemStore_IsValidParticipationHierarchyForParentAttempt_And_Breadcrumbs
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		testEachWriteLockMode(t, tt.name+": is valid", func(t *testing.T, writeLock bool) {
 			t.Helper()
 
@@ -1027,7 +1023,6 @@ func TestItemStore_BreadcrumbsHierarchyForAttempt(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		testEachWriteLockMode(t, tt.name, func(t *testing.T, writeLock bool) {
 			t.Helper()
 			testoutput.SuppressIfPasses(t)
@@ -1070,7 +1065,7 @@ func TestItemStore_BreadcrumbsHierarchy_AtMaxItemPathLength(t *testing.T) {
 		fmt.Fprintf(&fixture, "  - {id: %d, default_language_tag: fr}\n", id)
 	}
 	fixture.WriteString("items_items:\n")
-	for i := 0; i < len(ids)-1; i++ {
+	for i := range len(ids) - 1 {
 		fmt.Fprintf(&fixture, "  - {parent_item_id: %d, child_item_id: %d, child_order: 1}\n", ids[i], ids[i+1])
 	}
 	fmt.Fprintf(&fixture, "groups:\n  - {id: %d, root_activity_id: %d}\n", groupID, ids[0])
@@ -1130,7 +1125,6 @@ func testEachWriteLockMode(t *testing.T, testName string, testFunc func(t *testi
 	t.Helper()
 
 	for _, writeLock := range []bool{false, true} {
-		writeLock := writeLock
 		var lockName string
 		if writeLock {
 			lockName = "(with write lock)"
@@ -1157,7 +1151,6 @@ func TestItemStore_TriggerBeforeInsert_SetsPlatformID(t *testing.T) {
 		{name: "url doesn't match any regexp", url: golang.Ptr("34"), wantPlatformID: nil},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1213,7 +1206,6 @@ func TestItemStore_TriggerBeforeUpdate_SetsPlatformID(t *testing.T) {
 		{name: "new url doesn't match any regexp", updateMap: map[string]interface{}{"url": golang.Ptr("34")}, wantPlatformID: nil},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1274,7 +1266,6 @@ func TestItemStore_PlatformsTriggerAfterInsert_SetsPlatformID(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -1343,7 +1334,6 @@ func TestItemStore_PlatformsTriggerAfterUpdate_SetsPlatformID(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/json_test.go
+++ b/app/database/json_test.go
@@ -23,7 +23,6 @@ func TestJSON_Scan(t *testing.T) {
 		{name: "empty object", bytes: []byte("{}"), wantMap: map[string]interface{}{}},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			j := &JSON{}
 			if err := j.Scan(tt.bytes); (err != nil) != tt.wantErr {

--- a/app/database/logging_integration_test.go
+++ b/app/database/logging_integration_test.go
@@ -72,7 +72,6 @@ func Test_SQLQueryAnalyzing(t *testing.T) {
 			},
 		},
 	} {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			logger, loggerHook := logging.NewMockLogger()
 			ctx := testhelpers.CreateTestContextWithLogger(logger)

--- a/app/database/logging_test.go
+++ b/app/database/logging_test.go
@@ -945,7 +945,6 @@ func generateTestFuncToCheckSQLQueryLoggingForSQLTxWrapperCommitOrRollbackFailin
 
 func Test_SQLQueryLogging(t *testing.T) {
 	for _, test := range sqlQueryLoggingTests() {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			for _, logSQLQueries := range []bool{false, true} {
 				for _, analyzeSQLQueries := range []bool{false, true} {

--- a/app/database/mock_db_test.go
+++ b/app/database/mock_db_test.go
@@ -28,7 +28,6 @@ func TestNewDBMock_ExitsOnGettingErrorFromSQLMockNew(t *testing.T) {
 			_, _ = NewDBMockWithLogConfig(ctx, LogConfig{}, false)
 		}},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -68,7 +67,6 @@ func TestNewDBMock_ExitsOnGettingErrorFromOpen(t *testing.T) {
 			_, _ = NewDBMockWithLogConfig(ctx, LogConfig{}, false)
 		}},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/permission_generated_store_integration_test.go
+++ b/app/database/permission_generated_store_integration_test.go
@@ -101,7 +101,6 @@ func TestPermissionGeneratedStore_TriggerAfterInsert_MarksResultsAsChanged(t *te
 			expectedChanged: []resultPrimaryKeyAndState{},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -201,7 +200,6 @@ func TestPermissionGeneratedStore_TriggerAfterUpdate_MarksResultsAsChanged(t *te
 			noChanges:       true,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
+++ b/app/database/permission_granted_store_compute_all_access_aggregates_integration_test.go
@@ -185,7 +185,6 @@ func TestPermissionGrantedStore_ComputeAllAccess_AggregatesAccess(t *testing.T) 
 
 	ctx := testhelpers.CreateTestContext()
 	for _, access := range []string{"solution", "content_with_descendants"} {
-		access := access
 		t.Run(access, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -330,7 +329,6 @@ func TestPermissionGrantedStore_ComputeAllAccess_PropagatesCanView(t *testing.T)
 			upperViewLevelsPropagation: "as_is", expectedCanView: "solution",
 		},
 	} {
-		testcase := testcase
 		t.Run(testcase.canView+" as "+testcase.expectedCanView, func(t *testing.T) {
 			testGeneratedPermission(t, `
 				items: [{id: 1, default_language_tag: fr}, {id: 2, default_language_tag: fr}]
@@ -367,7 +365,6 @@ func testGeneratedPermission(t *testing.T, fixture string, testCase ...generated
 	}))
 	var result string
 	for _, test := range testCase {
-		test := test
 		t.Run(test.where, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 			require.NoError(t, permissionStore.Where(test.where).
@@ -697,10 +694,8 @@ func TestPermissionGrantedStore_ComputeAllAccess_Propagates(t *testing.T) {
 			},
 		},
 	} {
-		testsuite := testsuite
 		t.Run(testsuite.column, func(t *testing.T) {
 			for _, testcase := range testsuite.tests {
-				testcase := testcase
 				testPropagates(t, testsuite.column, testsuite.propagationColumn, testcase.parentValue,
 					testcase.propagationMode, testcase.expectedValue)
 			}
@@ -735,7 +730,7 @@ func assertPermissionsGeneratedResultRowsEqual[T any](t *testing.T, expected, go
 		return
 	}
 
-	for i := 0; i < len(expected); i++ {
+	for i := range expected {
 		assert.Equal(t, expected[i], got[i])
 	}
 }

--- a/app/database/permissions_integration_test.go
+++ b/app/database/permissions_integration_test.go
@@ -83,7 +83,6 @@ func TestDB_JoinsPermissionsForGroupToItems(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("ids: %v", test.ids), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -152,7 +151,6 @@ func TestDB_JoinsPermissionsForGroupToItemsWherePermissionAtLeast(t *testing.T) 
 			},
 		},
 	} {
-		test := test
 		t.Run(fmt.Sprintf("ids: %v, %s>=%s", test.ids, test.permissionKind, test.neededPermission), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/propagation_steps_test.go
+++ b/app/database/propagation_steps_test.go
@@ -33,7 +33,6 @@ func TestPropagationStepSets(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			assert.Len(t, test.expectedContent, test.set.Size())
 			for _, step := range test.expectedContent {

--- a/app/database/query_logger_test.go
+++ b/app/database/query_logger_test.go
@@ -55,7 +55,6 @@ func Test_getSQLExecutionPlanLoggingFunc_DoesNothingDependingOnParameters(t *tes
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -218,7 +217,6 @@ func Test_fillSQLPlaceholders(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, fillSQLPlaceholders(test.args.query, test.args.values))
 		})

--- a/app/database/raw_db_logger_test.go
+++ b/app/database/raw_db_logger_test.go
@@ -71,7 +71,6 @@ func Test_prepareRawDBLoggerValuesMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := prepareRawDBLoggerValuesMap(tt.keyvals)
 			assert.Equal(t, tt.want, got)
@@ -98,7 +97,6 @@ func Test_convertRawSQLArgValue(t *testing.T) {
 		{value: `some_value`, typeStr: "unknown type", want: `some_value`},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.typeStr, func(t *testing.T) {
 			got := convertRawSQLArgValue(tt.value, tt.typeStr)
 			assert.Equal(t, tt.want, got)

--- a/app/database/raw_generated_permission_fields_test.go
+++ b/app/database/raw_generated_permission_fields_test.go
@@ -58,7 +58,6 @@ func TestRawGeneratedPermissionFields_AsItemPermissions(t *testing.T) {
 	defer ClearAllDBEnums()
 	permissionGrantedStore := NewDataStore(db).PermissionsGranted()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.raw.AsItemPermissions(permissionGrantedStore))
 		})

--- a/app/database/result_store_integration_test.go
+++ b/app/database/result_store_integration_test.go
@@ -52,7 +52,6 @@ func TestResultStore_GetHintsInfoForActiveAttempt(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -162,7 +161,6 @@ func TestResultStore_Propagate(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/result_store_propagate_aggregates_integration_test.go
+++ b/app/database/result_store_propagate_aggregates_integration_test.go
@@ -31,7 +31,6 @@ func TestResultStore_Propagate_Aggregates(t *testing.T) {
 
 	ctx := testhelpers.CreateTestContext()
 	for _, markAllResultsAsToBePropagated := range []bool{false, true} {
-		markAllResultsAsToBePropagated := markAllResultsAsToBePropagated
 		t.Run(fmt.Sprintf("mark all as to_be_propagated=%v", markAllResultsAsToBePropagated), func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -186,7 +185,6 @@ func TestResultStore_Propagate_Aggregates_EditScore(t *testing.T) {
 		{name: "diff big negative", editRule: "diff", editValue: -20, expectedComputedScore: 0},
 		{name: "diff big positive", editRule: "diff", editValue: 95, expectedComputedScore: 100},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/result_store_propagate_creates_new_integration_test.go
+++ b/app/database/result_store_propagate_creates_new_integration_test.go
@@ -143,7 +143,6 @@ func TestResultStore_Propagate_CreatesNew(t *testing.T) {
 			rootItemID:         golang.Ptr(int64(222)),
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/result_store_propagate_unlocks_integration_test.go
+++ b/app/database/result_store_propagate_unlocks_integration_test.go
@@ -153,7 +153,6 @@ func TestResultStore_Propagate_Unlocks_ItemsRequiringExplicitEntry_CanEnterFromI
 			canEnterUntil: "9999-12-31 23:59:58",
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/result_store_propagate_validated_integration_test.go
+++ b/app/database/result_store_propagate_validated_integration_test.go
@@ -70,7 +70,6 @@ func TestResultStore_Propagate_ValidatedStaysNonValidatedFor(t *testing.T) {
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 
@@ -269,7 +268,6 @@ func TestResultStore_Propagate_Validated(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 			testResultStorePropagateValidated(ctx, t,

--- a/app/database/search_integration_test.go
+++ b/app/database/search_integration_test.go
@@ -87,7 +87,6 @@ func TestDB_WhereSearchStringMatches_Integration(t *testing.T) {
 			expectedIDs:  []int64{},
 		},
 	} {
-		test := test
 		t.Run(test.searchString, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/search_test.go
+++ b/app/database/search_test.go
@@ -62,7 +62,6 @@ func TestDB_WhereSearchStringMatches(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/thread_test.go
+++ b/app/database/thread_test.go
@@ -18,7 +18,6 @@ func Test_IsThreadOpenStatus(t *testing.T) {
 		{"not_started", false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.status, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsThreadOpenStatus(tt.status))
 		})
@@ -37,7 +36,6 @@ func Test_IsClosedStatus(t *testing.T) {
 		{"not_started", true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.status, func(t *testing.T) {
 			isClosed := IsThreadClosedStatus(tt.status)
 			assert.Equal(t, tt.want, isClosed)

--- a/app/database/time_test.go
+++ b/app/database/time_test.go
@@ -59,7 +59,6 @@ func TestTime_ScanString(t *testing.T) {
 		{name: "wrong datetime with a correct number of digits", str: "2345-67-89 25:60:70", wantErr: true, wantTime: time.Time{}},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tm := &Time{}
 			if err := tm.ScanString(tt.str); (err != nil) != tt.wantErr {

--- a/app/database/user_integration_test.go
+++ b/app/database/user_integration_test.go
@@ -75,7 +75,6 @@ func TestUser_CanSeeAnswer(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/user_store_integration_test.go
+++ b/app/database/user_store_integration_test.go
@@ -39,7 +39,6 @@ func TestUserStore_DeleteTemporaryWithTraps(t *testing.T) {
 			expectDeletedSessions: golang.NewSet[int64](),
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/database/users_integration_test.go
+++ b/app/database/users_integration_test.go
@@ -92,9 +92,7 @@ func TestDataStore_CheckIfTeamParticipationsConflictWithExistingUserMemberships(
 		`)
 	defer func() { _ = db.Close() }()
 	for _, tt := range tests {
-		tt := tt
 		for _, withLock := range []bool{true, false} {
-			withLock := withLock
 			t.Run(tt.name+fmt.Sprintf(" withLock = %v", withLock), func(t *testing.T) {
 				testoutput.SuppressIfPasses(t)
 

--- a/app/domain/middleware_test.go
+++ b/app/domain/middleware_test.go
@@ -91,7 +91,6 @@ func TestMiddleware(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assertMiddleware(t, tt.domains, tt.domainOverride, tt.shouldEnterService,
 				tt.expectedStatusCode, tt.expectedBody, tt.expectedConfig, tt.expectedDomain)

--- a/app/formdata/form_data.go
+++ b/app/formdata/form_data.go
@@ -61,7 +61,7 @@ func NewFormData(definitionStructure interface{}) *FormData {
 		if name == "-" {
 			return ""
 		}
-		for i := 0; i < len(parts); i++ {
+		for i := range parts {
 			if parts[i] == squash {
 				return "<squash>"
 			}
@@ -377,7 +377,7 @@ func traverseStructure(funcToApply func(fieldValue reflect.Value, structField re
 	}
 	numberOfFields := reflValue.NumField()
 
-	for i := 0; i < numberOfFields; i++ {
+	for i := range numberOfFields {
 		field := reflValue.Field(i)
 		structField := reflValue.Type().Field(i)
 

--- a/app/formdata/form_data_integration_test.go
+++ b/app/formdata/form_data_integration_test.go
@@ -320,7 +320,6 @@ func TestFormData_ParseJSONRequestData(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
@@ -502,7 +501,6 @@ func TestFormData_ParseMapData(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			err := f.ParseMapData(tt.sourceMap)
@@ -670,7 +668,6 @@ func TestFormData_ConstructMapForDB(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
@@ -730,7 +727,6 @@ func TestFormData_ConstructPartialMapForDB(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			f := formdata.NewFormData(tt.definitionStructure)
 			req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(tt.json))
@@ -781,7 +777,6 @@ func Test_toAnythingHookFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			hook := formdata.ToAnythingHookFunc()
 			converted, err := mapstructure.DecodeHookExec(hook, tt.typeFrom, tt.typeTo, tt.data)
@@ -813,7 +808,6 @@ func Test_stringToInt64HookFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			hook := formdata.StringToInt64HookFunc()
 			converted, err := mapstructure.DecodeHookExec(hook, tt.typeFrom, tt.typeTo, tt.data)

--- a/app/formdata/form_data_test.go
+++ b/app/formdata/form_data_test.go
@@ -164,7 +164,6 @@ func Test_stringToDatabaseTimeUTCHookFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			hook := stringToDatabaseTimeUTCHookFunc(time.RFC3339)
 			converted, err := mapstructure.DecodeHookExec(hook, tt.typeFrom, tt.typeTo, tt.data)

--- a/app/formdata/validations_test.go
+++ b/app/formdata/validations_test.go
@@ -29,7 +29,6 @@ func Test_validateDuration(t *testing.T) {
 		{name: "nil", fl: &FieldLevel{FieldValue: (*string)(nil)}, want: false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := validateDuration(tt.fl); got != tt.want {
 				t.Errorf("validateDuration() = %v, want %v", got, tt.want)
@@ -56,7 +55,6 @@ func Test_validateDMYDate(t *testing.T) {
 		{name: "nil", fl: &FieldLevel{FieldValue: (*string)(nil)}, want: false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := validateDMYDate(tt.fl); got != tt.want {
 				t.Errorf("validateDuration() = %v, want %v", got, tt.want)
@@ -78,7 +76,6 @@ func Test_validateNull(t *testing.T) {
 		{name: "empty string", fl: &FieldLevel{FieldValue: ""}, want: false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := validateNull(tt.fl); got != tt.want {
 				t.Errorf("validateNull() = %v, want %v", got, tt.want)

--- a/app/logging/db_logger_test.go
+++ b/app/logging/db_logger_test.go
@@ -17,7 +17,6 @@ func TestLogger_BooleanConfigFlags(t *testing.T) {
 		{"LogRawSQLQueries", (*Logger).IsRawSQLQueriesLoggingEnabled},
 		{"AnalyzeSQLQueries", (*Logger).IsSQLQueriesAnalyzingEnabled},
 	} {
-		test := test
 		t.Run(test.flagName, func(t *testing.T) {
 			t.Run("nil config", func(t *testing.T) {
 				logger := createLogger()

--- a/app/loginmodule/client.go
+++ b/app/loginmodule/client.go
@@ -280,7 +280,7 @@ type UserProfile struct {
 func (up *UserProfile) ToMap() map[string]interface{} {
 	reflStruct := reflect.ValueOf(up).Elem()
 	userData := make(map[string]interface{}, reflStruct.NumField())
-	for fieldIndex := 0; fieldIndex < reflStruct.NumField(); fieldIndex++ {
+	for fieldIndex := range reflStruct.NumField() {
 		fieldType := reflStruct.Type().Field(fieldIndex)
 		fieldName := fieldType.Tag.Get("json")
 
@@ -393,7 +393,7 @@ func convertUserProfile(source map[string]interface{}) (*UserProfile, error) {
 func createUserProfileFromNormalizedMap(data map[string]interface{}) *UserProfile {
 	userProfile := &UserProfile{}
 	reflStruct := reflect.ValueOf(userProfile).Elem()
-	for i := 0; i < reflStruct.NumField(); i++ {
+	for i := range reflStruct.NumField() {
 		fieldType := reflStruct.Type().Field(i)
 		fieldName := fieldType.Tag.Get("json")
 		value := data[fieldName]

--- a/app/loginmodule/client_test.go
+++ b/app/loginmodule/client_test.go
@@ -250,7 +250,6 @@ func TestClient_GetUserProfile(t *testing.T) {
 
 	const moduleURL = "http://login.url.com"
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client := &Client{url: moduleURL}
 			httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
@@ -457,7 +456,6 @@ func Test_convertUserProfile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := convertUserProfile(tt.source)
 			assert.Equal(t, tt.expectedError, err)
@@ -523,7 +521,6 @@ func TestClient_AccountsManagerEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		testSuite := testSuite
 		t.Run(testSuite.endpoint, func(t *testing.T) {
 			tests := []struct {
 				name           string
@@ -576,7 +573,6 @@ func TestClient_AccountsManagerEndpoints(t *testing.T) {
 			}
 			const moduleURL = "http://login.url.com"
 			for _, tt := range tests {
-				tt := tt
 				t.Run(tt.name, func(t *testing.T) {
 					client := &Client{url: moduleURL}
 					httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
@@ -710,7 +706,6 @@ func TestClient_CreateUsers(t *testing.T) {
 
 	const moduleURL = "http://login.url.com"
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client := &Client{url: moduleURL}
 			httpmock.Activate(httpmock.WithAllowedHosts("127.0.0.1"))
@@ -801,7 +796,6 @@ func TestEncode(t *testing.T) {
 
 	const clientKey = "1234567890123456"
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := Encode(tt.data, clientKey)
 			got1 := Encode(tt.data, clientKey+"7")

--- a/app/loginmodule/crypt.go
+++ b/app/loginmodule/crypt.go
@@ -41,7 +41,7 @@ func encryptAes128Ecb(data, key []byte) []byte {
 	paddingLength := blockSize - len(data)%blockSize
 	dataCopy := make([]byte, 0, len(data)+paddingLength)
 	dataCopy = append(dataCopy, data...)
-	for i := 0; i < paddingLength; i++ {
+	for range paddingLength {
 		dataCopy = append(dataCopy, byte(paddingLength))
 	}
 

--- a/app/payloads/answer_token_test.go
+++ b/app/payloads/answer_token_test.go
@@ -83,7 +83,6 @@ func TestAnswerToken_Bind(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.answerToken.Bind()
 			if tt.wantErr == nil {

--- a/app/payloads/common.go
+++ b/app/payloads/common.go
@@ -50,7 +50,7 @@ func ConvertIntoMap(source interface{}) map[string]interface{} {
 	sourceType := sourceValue.Type()
 	fieldsCount := sourceValue.NumField()
 	out := make(map[string]interface{}, fieldsCount)
-	for fieldNumber := 0; fieldNumber < fieldsCount; fieldNumber++ {
+	for fieldNumber := range fieldsCount {
 		field := sourceType.Field(fieldNumber)
 		jsonName, omitEmpty := getJSONFieldNameAndOmitEmpty(&field)
 		if jsonName == "-" {

--- a/app/payloads/common_test.go
+++ b/app/payloads/common_test.go
@@ -111,7 +111,6 @@ func TestPayloads_ParseMap(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			target := reflect.New(reflect.TypeOf(tt.want).Elem()).Interface()
 			err := ParseMap(tt.raw, target)

--- a/app/payloads/score_token_test.go
+++ b/app/payloads/score_token_test.go
@@ -101,7 +101,6 @@ func TestScoreToken_Bind(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.scoreToken.Bind()
 			if tt.wantErr == nil {

--- a/app/payloads/task_token_test.go
+++ b/app/payloads/task_token_test.go
@@ -45,7 +45,6 @@ func TestTaskToken_Bind(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.taskToken.Bind()
 			if tt.wantErr == nil {

--- a/app/service/conversion_test.go
+++ b/app/service/conversion_test.go
@@ -64,7 +64,6 @@ func TestConvertSliceOfMapsFromDBToJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := ConvertSliceOfMapsFromDBToJSON(tt.dbMap)
 			assert.Equal(t, tt.want, got)

--- a/app/service/parameters_test.go
+++ b/app/service/parameters_test.go
@@ -74,7 +74,6 @@ func TestResolveURLQueryGetInt64SliceField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetInt64SliceField(req, "ids")
@@ -133,7 +132,6 @@ func TestResolveURLQueryPathInt64Field(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			router := chi.NewRouter()
 			called := false
@@ -213,7 +211,6 @@ func TestResolveURLQueryPathInt64SliceField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			called := false
 			router := chi.NewRouter()
@@ -267,7 +264,6 @@ func TestResolveURLQueryGetStringField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringField(req, "name")
@@ -320,7 +316,6 @@ func TestResolveURLQueryGetBoolField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetBoolField(req, "flag")
@@ -393,7 +388,6 @@ func TestResolveURLQueryGetBoolFieldWithDefault(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetBoolFieldWithDefault(req, "flag", testCase.defaultValue)
@@ -438,7 +432,6 @@ func TestResolveURLQueryGetTimeField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			dateTime, err := ResolveURLQueryGetTimeField(req, "time")
@@ -497,7 +490,6 @@ func TestResolveURLQueryGetStringSliceField(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringSliceField(req, "values")
@@ -574,7 +566,6 @@ func TestResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(t *testi
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/health-check?"+testCase.queryString, http.NoBody)
 			list, err := ResolveURLQueryGetStringSliceFieldFromIncludeExcludeParameters(req, "fruits",
@@ -625,7 +616,6 @@ func TestResolveURLQueryPathInt64SliceFieldWithLimit(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			patch := monkey.Patch(ResolveURLQueryPathInt64SliceField, func(r *http.Request, paramName string) ([]int64, error) {
 				assert.Equal(t, expectedRequest, r)
@@ -672,7 +662,6 @@ func TestResolveJSONBodyIntoMap(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPut, "/", strings.NewReader(testCase.body))
 			list, err := ResolveJSONBodyIntoMap(r)

--- a/app/service/participant_integration_test.go
+++ b/app/service/participant_integration_test.go
@@ -64,7 +64,6 @@ func TestGetParticipantIDFromRequest(t *testing.T) {
 	for _, test := range tests {
 		testoutput.SuppressIfPasses(t)
 
-		test := test
 		participantID, err := service.GetParticipantIDFromRequest(
 			&http.Request{URL: &url.URL{RawQuery: test.query}}, &database.User{GroupID: 4}, store)
 		assert.Equal(t, test.expectedResult, participantID)

--- a/app/service/participant_test.go
+++ b/app/service/participant_test.go
@@ -89,7 +89,6 @@ func TestParticipantMiddleware(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			result := callThroughParticipantMiddleware(
 				tt.userID, tt.asTeamID, tt.returnedError, tt.panicWith)

--- a/app/service/query_limiter_test.go
+++ b/app/service/query_limiter_test.go
@@ -71,7 +71,6 @@ func TestQueryLimiter_Apply(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/service/responses.go
+++ b/app/service/responses.go
@@ -93,7 +93,7 @@ func checkInt64JsonHasStringTag(val reflect.Value) {
 
 	switch {
 	case val.Kind() == reflect.Slice:
-		for j := 0; j < val.Len(); j++ {
+		for j := range val.Len() {
 			checkInt64JsonHasStringTag(val.Index(j))
 		}
 	case val.Kind() == reflect.Map:
@@ -111,7 +111,7 @@ func checkInt64JsonHasStringTagInFields(val reflect.Value) {
 	}
 
 	rt := val.Type()
-	for i := 0; i < val.NumField(); i++ {
+	for i := range val.NumField() {
 		fieldType := rt.Field(i)
 
 		panicIfInt64JsonHasStringTag(&fieldType)

--- a/app/service/sorting_test.go
+++ b/app/service/sorting_test.go
@@ -457,7 +457,6 @@ func TestApplySorting(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/service/watched_group_integration_test.go
+++ b/app/service/watched_group_integration_test.go
@@ -60,7 +60,6 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/service/watched_group_test.go
+++ b/app/service/watched_group_test.go
@@ -27,7 +27,6 @@ func TestBase_ResolveWatchedGroupID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, tt.url, http.NoBody)
 			watchedGroupID, watchedGroupIDIsSet, gotError := (&Base{}).ResolveWatchedGroupID(req)

--- a/app/token/encoding_integration_test.go
+++ b/app/token/encoding_integration_test.go
@@ -127,7 +127,6 @@ func TestUnmarshalDependingOnItemPlatform(t *testing.T) {
 
 	ctx := testhelpers.CreateTestContext()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testoutput.SuppressIfPasses(t)
 

--- a/app/token/encoding_test.go
+++ b/app/token/encoding_test.go
@@ -104,7 +104,6 @@ func TestParseAndValidate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return tt.currentTime })
 			defer monkey.UnpatchAll()
@@ -142,7 +141,6 @@ func TestGenerate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return tt.currentTime })
 			defer monkey.UnpatchAll()
@@ -170,7 +168,9 @@ func TestGenerate_PanicsOnError(t *testing.T) {
 	privateKey := &rsa.PrivateKey{D: &big.Int{}, PublicKey: rsa.PublicKey{N: &big.Int{}}}
 	defer func() {
 		e := recover()
-		assert.Equal(t, errors.New("crypto/rsa: message too long for RSA key size"), e)
+		// Go 1.24 added a minimum-key-size guard that fires before the message-length
+		// check used by older Go versions, so the panic value's message changed.
+		assert.Equal(t, errors.New("crypto/rsa: 0-bit keys are insecure (see https://go.dev/pkg/crypto/rsa#hdr-Minimum_key_size)"), e)
 	}()
 	Generate(map[string]interface{}{}, privateKey)
 }

--- a/app/token/token_test.go
+++ b/app/token/token_test.go
@@ -68,7 +68,6 @@ func marshalAndSignTests() []marshalAndSignTest {
 
 func TestToken_MarshalJSON(t *testing.T) {
 	for _, test := range marshalAndSignTests() {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()
@@ -103,7 +102,6 @@ func TestToken_MarshalJSON(t *testing.T) {
 
 func TestToken_Sign(t *testing.T) {
 	for _, test := range marshalAndSignTests() {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()
@@ -137,7 +135,6 @@ func TestToken_Sign(t *testing.T) {
 
 func TestToken_MarshalString(t *testing.T) {
 	for _, test := range marshalAndSignTests() {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			monkey.Patch(time.Now, func() time.Time { return test.currentTime })
 			defer monkey.UnpatchAll()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/France-ioi/AlgoreaBackend/v2
 
-go 1.21
+go 1.25.0
+
+toolchain go1.25.9
 
 exclude github.com/SermoDigital/jose v0.9.1
 

--- a/testhelpers/db_time.go
+++ b/testhelpers/db_time.go
@@ -55,7 +55,7 @@ func getNowReplacer(parsedTime time.Time) func(string) string {
 				panic(err)
 			}
 			layout += fmt.Sprintf(".%0*d", fsp, 0)
-			for i := 0; i < fsp; i++ {
+			for range fsp {
 				precision /= 10
 			}
 		}
@@ -172,7 +172,6 @@ func patchDatabaseDBMethodsWithStringQuery(nowReplacer func(string) string, patc
 	}
 	stringDBGuards := make(map[string]*monkey.PatchGuard, len(stringDBMethods))
 	for _, methodName := range stringDBMethods {
-		methodName := methodName
 		stringDBGuards[methodName] = monkey.PatchInstanceMethod(
 			reflect.TypeOf(&database.DB{}), methodName,
 			func(db *database.DB, query string) *database.DB {
@@ -195,7 +194,6 @@ func patchDatabaseDBMethodsWithStringQueryAndArgs(nowReplacer func(string) strin
 	}
 	stringAndArgsDBGuards := make(map[string]*monkey.PatchGuard, len(stringAndArgsDBMethods))
 	for _, methodName := range stringAndArgsDBMethods {
-		methodName := methodName
 		stringAndArgsDBGuards[methodName] = monkey.PatchInstanceMethod(
 			reflect.TypeOf(&database.DB{}), methodName,
 			func(db *database.DB, query string, args ...interface{}) *database.DB {
@@ -217,7 +215,6 @@ func constructReflArgsForQueryAndArgs(query interface{}, args []interface{}) []r
 	reflArgs = append(reflArgs, reflect.ValueOf(query))
 	nilReflValue := reflect.New(reflect.TypeOf((*string)(nil))).Elem()
 	for _, arg := range args {
-		arg := arg
 		var reflValue reflect.Value
 		if arg == nil {
 			reflValue = nilReflValue
@@ -235,7 +232,6 @@ func patchDatabaseDBMethodsWithIntQueryAndArgs(nowReplacer func(string) string, 
 	}
 	standardDBGuards := make(map[string]*monkey.PatchGuard, len(standardDBMethods))
 	for _, methodName := range standardDBMethods {
-		methodName := methodName
 		standardDBGuards[methodName] = monkey.PatchInstanceMethod(
 			reflect.TypeOf(&database.DB{}), methodName,
 			func(db *database.DB, query interface{}, args ...interface{}) *database.DB {

--- a/testhelpers/loader.go
+++ b/testhelpers/loader.go
@@ -58,7 +58,6 @@ func RunGodogTests(t *testing.T, tags string) {
 	}
 
 	for _, featureFile := range featureFiles {
-		featureFile := featureFile
 		t.Run(featureFile, func(t *testing.T) {
 			var restoreFunc flowmingo.RestoreFunc
 			if !testing.Verbose() { // Do not suppress output in verbose mode

--- a/testhelpers/steps_app_language.go
+++ b/testhelpers/steps_app_language.go
@@ -64,7 +64,7 @@ func (ctx *TestContext) getRowMap(rowIndex int, table *godog.Table) map[string]s
 	sourceRow := table.Rows[rowIndex]
 
 	rowMap := make(map[string]string, len(rowHeader.Cells))
-	for cellIndex := 0; cellIndex < len(rowHeader.Cells); cellIndex++ {
+	for cellIndex := range len(rowHeader.Cells) {
 		value := sourceRow.Cells[cellIndex].Value
 		if value == "" {
 			continue

--- a/testhelpers/steps_db.go
+++ b/testhelpers/steps_db.go
@@ -587,7 +587,7 @@ func (ctx *TestContext) sortGodogTable(table *godog.Table) {
 	columnNumber := len(table.Rows[0].Cells)
 
 	sort.Slice(table.Rows[1:], func(leftRowIndex, rightRowIndex int) bool {
-		for columnIndex := 0; columnIndex < columnNumber; columnIndex++ {
+		for columnIndex := range columnNumber {
 			var leftCellValue, rightCellValue string
 			if table.Rows[leftRowIndex+1].Cells[columnIndex] != nil {
 				leftCellValue = table.Rows[leftRowIndex+1].Cells[columnIndex].Value

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -237,7 +237,7 @@ func (ctx *TestContext) wantRowsMatchesJSONPathResultArr(
 		curResult := make(map[string]string)
 
 		wantRow := wants.Rows[rowIndex]
-		for cellIndex := 0; cellIndex < len(headerCells); cellIndex++ {
+		for cellIndex := range headerCells {
 			curHeader := headerCells[cellIndex].Value
 
 			curWant[curHeader] = ctx.replaceReferencesWithIDs(wantRow.Cells[cellIndex].Value)
@@ -269,7 +269,7 @@ func sortSliceForEasyComparison(
 	headerCells []*messages.PickleTableCell,
 ) []map[string]string {
 	sort.Slice(slice, func(i, j int) bool {
-		for curHeader := 0; curHeader < len(headerCells); curHeader++ {
+		for curHeader := range headerCells {
 			header := headerCells[curHeader].Value
 
 			curComparison := strings.Compare(slice[i][header], slice[j][header])
@@ -295,7 +295,7 @@ func (ctx *TestContext) wantValuesMatchesJSONPathResultArr(
 
 	sortedResults := make([]string, len(wants.Rows))
 	sortedWants := make([]string, len(wants.Rows))
-	for i := 0; i < len(wants.Rows); i++ {
+	for i := range len(wants.Rows) {
 		sortedResults[i] = stringifyJSONPathResultValue(jsonPathResArr[i])
 		sortedWants[i] = ctx.replaceReferencesWithIDs(wants.Rows[i].Cells[0].Value)
 	}

--- a/testhelpers/threads.go
+++ b/testhelpers/threads.go
@@ -5,7 +5,7 @@ package testhelpers
 // RunConcurrently runs a given function concurrently.
 func RunConcurrently(funcToRun func(), threadsNumber int) {
 	done := make(chan bool, threadsNumber)
-	for i := 0; i < threadsNumber; i++ {
+	for range threadsNumber {
 		go func() {
 			defer func() {
 				done <- true
@@ -13,7 +13,7 @@ func RunConcurrently(funcToRun func(), threadsNumber int) {
 			funcToRun()
 		}()
 	}
-	for i := 0; i < threadsNumber; i++ {
+	for range threadsNumber {
 		<-done
 	}
 }


### PR DESCRIPTION
# Upgrade Go toolchain: 1.20/1.21 → 1.25

## Why

Bumps every Go version reference in the repo to **Go 1.25.9** (the oldest still-maintained Go release at time of writing — 1.21 through 1.24 are EOL). This:

- gets us back onto a maintained Go release,
- unblocks the `golang.org/x/oauth2 ≥ v0.27.0` upgrade (CVE-2025-22868) — to be done in a follow-up PR, intentionally separate so this toolchain bump can be reverted independently if needed,
- activates Go 1.22 per-iteration `for` loop variable scoping, which silently fixes a class of latent closure-capture bugs.

## What changed

### Toolchain / build / CI
- `go.mod`: `go 1.21` → `go 1.25.0` + `toolchain go1.25.9`
- `Dockerfile`: `golang:1.20` → `golang:1.25.9` (pinned, matching CI)
- `.circleci/config.yml`: 6× `cimg/go:1.20.2` → `cimg/go:1.25.9`

### Docs
- `ARCHITECTURE.md`, `README.md` (dev-setup section), `CHANGELOG.md`

### Lint fallout (mechanical, mostly auto-fixed)

The bumped `go` directive activates several lints that were previously suppressed:

| Lint            | Count | Fix                                                                                                        |
| --------------- | ----: | ---------------------------------------------------------------------------------------------------------- |
| `copyloopvar`   |   168 | Removed redundant `tt := tt` shadows (per-iteration scoping is now the default).                           |
| `intrange`      |    38 | `for i := 0; i < N; i++` → `for i := range N` / `for range N`.                                             |
| `staticcheck`   |     3 | `reflect.PtrTo` → `reflect.PointerTo` (deprecated since Go 1.22).                                          |
| (cleanups)      |     — | Whitespace + one `lll` fix that fell out of the above.                                                     |

### Test fixes for stdlib changes

- **`app/database/deadline_test.go`** and **`app/api/auth/refresh_access_token_integration_test.go`** — the unsafe layout mirror of `context.cancelCtx` / `timerCtx` no longer matched: `cancelCtx.err` became `atomic.Value` (Go 1.21) and `timerCtx` value-embeds `cancelCtx` (was a pointer embed). Updated layouts and now overwrite the underlying `any` of `atomic.Value` directly to bypass its same-concrete-type-on-Store check (since `cancel()` already stored `context.Canceled`).
- **`app/token/encoding_test.go::TestGenerate_PanicsOnError`** — Go 1.24 added a min-RSA-key-size guard, changing the panic message from `"crypto/rsa: message too long for RSA key size"` to `"crypto/rsa: 0-bit keys are insecure (...)"`.
- Added `TestCancelCtxMirrorLayout` in both files: drives the real stdlib (`WithCancel` / `WithDeadline` / `WithValue` + `cancel()`) and reads back through the unsafe mirror, so a future stdlib layout change fails the test fast with a clear message instead of silently corrupting memory inside the real test.

## Loop-variable audit

Bumping the `go` directive to `1.25.0` activates Go 1.22 per-iteration loop variable semantics. Scope of the audit:

- All ~493 `for ... range` sites scanned for closures (`go func`, `defer func`, `func` passed to higher-order helpers like `InTransaction`, `WithNamedLock`, `RetryOnDuplicatePrimaryKeyError`).
- The codebase already used the defensive `tt := tt` shadow idiom in every table-driven test, so removing those shadows is a no-op semantically.
- The only goroutines outside `for` loops (`app/server.go`, `testhelpers/threads.go`) don't capture range vars, so they're unaffected.
- `make test-bdd` runs with `-race`, which would catch any miss.

## Validation

- `go mod tidy` — clean (only `go`/`toolchain` lines move; `go.sum` unchanged)
- `./bin/golangci-lint run -v --timeout 2m` — **0 issues** (`golangci-lint` v2.5.0 is already pinned and supports Go 1.25)
- `make test-dev` — all packages pass (one pre-existing environmental failure in `TestIsKindOfErrors` exists on `master` too, caused by the local test MySQL user lacking `CREATE USER` privilege; unrelated to this PR)
- `make linux-build` — pass
- `make awslambda-build` — pass

## Diff stats

103 files, +161 / −235 lines (mostly mechanical removals).

## Intentionally NOT in this PR

- `golang.org/x/oauth2 ≥ v0.27.0` (CVE-2025-22868) — follow-up PR; with Go 1.25 in place it becomes a one-line bump.
- Other stale dep upgrades (`spf13/viper`, `jinzhu/gorm`, …) — out of scope.
- AWS Lambda runtime change — already on `provided.al2`/`al2023`, unaffected.