### PR TITLE
items: extract frontend-only properties into a single opaque JSON column - phase 1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -931,10 +931,26 @@ Each command is defined in `cmd/<command>.go`:
 
 **Items (Educational Content)**:
 - `items`: Tasks, chapters, skills, courses
+  - `items.display_settings` (JSON, `NOT NULL`, default `{}`): opaque pass-through for frontend-only display settings; see "Display settings (frontend pass-through)" below
 - `items_strings`: Localized item content (title, description, etc.)
 - `items_items`: Parent-child item relationships
 - `items_ancestors`: Computed transitive closure of item relationships
 - `item_dependencies`: Unlock conditions between items
+
+#### Display settings (frontend pass-through)
+
+The `items.display_settings` column stores a JSON object that the backend treats as an opaque blob: it is stored verbatim and returned as-is on every `items` GET endpoint, and never inspected by backend business logic. Its purpose is to let frontends store UI-only settings against an item without requiring a backend schema change for every new setting.
+
+Currently known keys (this list is informational; the backend does not enforce it):
+
+| Key                            | Type                          | Default | Notes                                                                 |
+| ------------------------------ | ----------------------------- | ------- | --------------------------------------------------------------------- |
+| `children_layout`              | `"List" \| "Grid" \| "Hide"`  | `"List"`| How a chapter/skill renders its children list                         |
+| `prompt_to_join_group_by_code` | boolean                       | `false` | Whether the UI should display a "join group by code" form on the item |
+
+**"Omit defaults" convention**: a key is omitted from `display_settings` when its value equals the default, so `{}` is equivalent to `{"children_layout":"List","prompt_to_join_group_by_code":false}`. Frontends should follow this convention to keep payloads minimal, but the backend will faithfully store whatever object is sent (including a key explicitly set to its default value); the GET fallback logic returns the same value either way.
+
+**Phase-1 wire-compat fields**: the GET endpoints still expose `children_layout`, `prompt_to_join_group_by_code`, `title_bar_visible`, `display_details_in_parent`, `full_screen`, `show_user_infos`, and `fixed_ranks` at the top level for old clients. The first two are derived from `display_settings`; the other five always return their previous DB defaults (`true`, `false`, `"default"`, `false`, `false`). On POST/PUT, those seven legacy keys are accepted in the request body but silently ignored — frontends must move to `display_settings` to change `children_layout` / `prompt_to_join_group_by_code` and accept the hardcoded defaults for the others. These deprecated fields will be removed in a future phase.
 
 **Results & Attempts**:
 - `attempts`: User attempts on items

--- a/app/api/items/create_item.feature
+++ b/app/api/items/create_item.feature
@@ -49,8 +49,8 @@ Feature: Create item
       }
       """
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type   | url  | options | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 5577006791947779410 | Task   | null | null    | sl                   | 0                  | 0        | null    | 1                 | 0                         | 1        | 0         | default     | List            | 0             | 0           | All             | None                             | 0                   | 0                        | null     | 0                       | 0               | 0        | 0                            | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
+      | id                  | type   | url  | options | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | no_score | entering_time_min   | entering_time_max   | participants_group_id |
+      | 5577006791947779410 | Task   | null | null    | {}               | sl                   | 0                  | 0        | null    | 1        | 0         | 0             | All             | None                             | 0                   | 0                        | null     | 0                       | 0        | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
     And the table "items_strings" should be:
       | item_id             | language_tag | title       | image_url          | subtitle     | description                     |
       | 5577006791947779410 | sl           | my title 🐱 | http://bit.ly/1234 | hard task 🐱 | the goal of this task is ... 🐱 |
@@ -104,8 +104,8 @@ Feature: Create item
       }
       """
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type   | url  | options | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout  | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 5577006791947779410 | Task   | null | null    | sl                   | 0                  | 0        | null    | 1                 | 0                         | 1        | 0         | default     | List             | 0             | 0           | All             | None                             | 0                   | 0                        | null     | 0                       | 0               | 0        | 0                            | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
+      | id                  | type   | url  | options | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | no_score | entering_time_min   | entering_time_max   | participants_group_id |
+      | 5577006791947779410 | Task   | null | null    | {}               | sl                   | 0                  | 0        | null    | 1        | 0         | 0             | All             | None                             | 0                   | 0                        | null     | 0                       | 0        | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
     And the table "items_strings" should be:
       | item_id             | language_tag | title    | image_url          | subtitle  | description                  |
       | 5577006791947779410 | sl           | my title | http://bit.ly/1234 | hard task | the goal of this task is ... |
@@ -169,8 +169,8 @@ Feature: Create item
       }
       """
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type  | url  | options | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 5577006791947779410 | Skill | null | null    | sl                   | 0                  | 0        | null    | 1                 | 0                         | 1        | 0         | default     | List            | 0             | 0           | All             | None                             | 0                   | 0                        | null     | 0                       | 0               | 0        | 0                            | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
+      | id                  | type  | url  | options | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | no_score | entering_time_min   | entering_time_max   | participants_group_id |
+      | 5577006791947779410 | Skill | null | null    | {}               | sl                   | 0                  | 0        | null    | 1        | 0         | 0             | All             | None                             | 0                   | 0                        | null     | 0                       | 0        | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
     And the table "items_strings" should be:
       | item_id             | language_tag | title    | image_url          | subtitle  | description                  |
       | 5577006791947779410 | sl           | my title | http://bit.ly/1234 | hard task | the goal of this task is ... |
@@ -337,9 +337,13 @@ Feature: Create item
         "data": { "id": "5577006791947779410" }
       }
       """
+    # Phase 1 strategy A: the legacy display fields in the request body
+    # (title_bar_visible, display_details_in_parent, full_screen, children_layout,
+    # fixed_ranks, show_user_infos, prompt_to_join_group_by_code) are silently
+    # ignored on write — the resulting display_settings stays at the default `{}`.
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type    | url               | options          | default_language_tag | entry_frozen_teams | no_score | text_id     | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | entry_participant_type | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 5577006791947779410 | Chapter | http://myurl.com/ | {"opt1":"value"} | sl                   | 0                  | 1        | Tasknumber1 | 1                 | 1                         | 1        | 1         | forceYes    | Grid            | 1             | 1           | AllButOne       | All                              | 2345                | 1                        | Team                   | 01:02:03 | 1                       | 1               | 1        | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 8674665223082153551   |
+      | id                  | type    | url               | options          | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id     | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | entry_participant_type | duration | requires_explicit_entry | no_score | entering_time_min   | entering_time_max   | participants_group_id |
+      | 5577006791947779410 | Chapter | http://myurl.com/ | {"opt1":"value"} | {}               | sl                   | 0                  | 1        | Tasknumber1 | 1        | 1         | 1             | AllButOne       | All                              | 2345                | 1                        | Team                   | 01:02:03 | 1                       | 1        | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 8674665223082153551   |
     And the table "items_strings" should be:
       | item_id             | language_tag | title    | image_url          | subtitle  | description                  |
       | 5577006791947779410 | sl           | my title | http://bit.ly/1234 | hard task | the goal of this task is ... |
@@ -437,8 +441,8 @@ Feature: Create item
     }
     """
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type  | url  | options | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | participants_group_id |
-      | 5577006791947779410 | Skill | null | null    | sl                   | 0                  | 0        | null    | 1                 | 0                         | 1        | 0         | default     | List            | 0             | 0           | All             | None                             | 0                   | 0                        | null     | 0                       | 0               | 0        | 0                            | null                  |
+      | id                  | type  | url  | options | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | no_score | participants_group_id |
+      | 5577006791947779410 | Skill | null | null    | {}               | sl                   | 0                  | 0        | null    | 1        | 0         | 0             | All             | None                             | 0                   | 0                        | null     | 0                       | 0        | null                  |
     And the table "items_strings" should be:
       | item_id             | language_tag | title    | image_url | subtitle | description |
       | 5577006791947779410 | sl           | my skill | null      | null     | null        |
@@ -523,8 +527,8 @@ Feature: Create item
     }
     """
     And the table "items" at id "5577006791947779410" should be:
-      | id                  | type   | url  | options | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout  | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | no_score | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 5577006791947779410 | Task   | null | null    | sl                   | 0                  | 0        | null    | 1                 | 0                         | 1        | 0         | default     | List             |0             | 0           | All             | None                             | 0                   | 0                        | null     | 0                       | 0               | 0        | 0                            | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
+      | id                  | type   | url  | options | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | no_score | entering_time_min   | entering_time_max   | participants_group_id |
+      | 5577006791947779410 | Task   | null | null    | {}               | sl                   | 0                  | 0        | null    | 1        | 0         | 0             | All             | None                             | 0                   | 0                        | null     | 0                       | 0        | 1000-01-01 00:00:00 | 9999-12-31 23:59:59 | null                  |
     And the table "items_items" should be:
       | parent_item_id | child_item_id       | child_order |
       | 30             | 31                  | 1           |
@@ -539,7 +543,7 @@ Feature: Create item
       | 0          | 11             | 30      | 25             |
       | 0          | 11             | 31      | 50             |
 
-  Scenario: Valid (set children_layout to Hide)
+  Scenario: Valid (set display_settings.children_layout to Hide)
     Given I am the user with id "11"
     When I send a POST request to "/items" with the following body:
       """
@@ -547,7 +551,7 @@ Feature: Create item
         "type": "Chapter",
         "language_tag": "sl",
         "title": "my chapter",
-        "children_layout": "Hide",
+        "display_settings": {"children_layout": "Hide"},
         "parent": {"item_id": "21"}
       }
       """
@@ -560,6 +564,70 @@ Feature: Create item
         "data": { "id": "5577006791947779410" }
       }
       """
-    And the table "items" at id "5577006791947779410" should be:
-      | id                  | type    | children_layout |
-      | 5577006791947779410 | Chapter | Hide            |
+    And the column "items.display_settings" at id "5577006791947779410" should be, in JSON:
+      """
+      {"children_layout": "Hide"}
+      """
+
+  Scenario: Valid (legacy children_layout in POST body is silently ignored in phase 1)
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Chapter",
+        "language_tag": "sl",
+        "title": "my chapter",
+        "children_layout": "Hide",
+        "prompt_to_join_group_by_code": true,
+        "parent": {"item_id": "21"}
+      }
+      """
+    Then the response code should be 201
+    And the column "items.display_settings" at id "5577006791947779410" should be, in JSON:
+      """
+      {}
+      """
+
+  Scenario: Valid (set display_settings to an arbitrary object, including unknown keys)
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Chapter",
+        "language_tag": "sl",
+        "title": "my chapter",
+        "display_settings": {
+          "children_layout": "Grid",
+          "prompt_to_join_group_by_code": true,
+          "frontend_only_key": "anything"
+        },
+        "parent": {"item_id": "21"}
+      }
+      """
+    Then the response code should be 201
+    And the column "items.display_settings" at id "5577006791947779410" should be, in JSON:
+      """
+      {
+        "children_layout": "Grid",
+        "prompt_to_join_group_by_code": true,
+        "frontend_only_key": "anything"
+      }
+      """
+
+  Scenario: Valid (set display_settings to an empty object)
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Chapter",
+        "language_tag": "sl",
+        "title": "my chapter",
+        "display_settings": {},
+        "parent": {"item_id": "21"}
+      }
+      """
+    Then the response code should be 201
+    And the column "items.display_settings" at id "5577006791947779410" should be, in JSON:
+      """
+      {}
+      """

--- a/app/api/items/create_item.go
+++ b/app/api/items/create_item.go
@@ -17,6 +17,14 @@ import (
 )
 
 // Item represents input fields that are common to itemCreate & itemUpdate.
+//
+// The fields tagged `sql:"-"` (DisplayDetailsInParent, ChildrenLayout, FullScreen,
+// FixedRanks, TitleBarVisible, ShowUserInfos, PromptToJoinGroupByCode) are kept on
+// the struct only to remain accept-and-ignore-compatible with old frontends during
+// phase 1: their backing DB columns were dropped, so `sql:"-"` makes the form-data
+// builder skip them when constructing the UPDATE/INSERT map. The values that the
+// frontend cares about (children_layout, prompt_to_join_group_by_code) must now be
+// sent through the `display_settings` JSON field instead.
 type Item struct {
 	URL     *string `json:"url"`
 	Options *string `json:"options" validate:"null|options"`
@@ -26,15 +34,23 @@ type Item struct {
 	NoScore bool `json:"no_score"`
 	// Identifier to reference the task.
 	// Unique
-	TextID                 *string `json:"text_id"`
-	DisplayDetailsInParent bool    `json:"display_details_in_parent"`
-	ReadOnly               bool    `json:"read_only"`
+	TextID *string `json:"text_id"`
+	// Deprecated: silently ignored. Will be removed in phase 2.
+	DisplayDetailsInParent bool `json:"display_details_in_parent" sql:"-"`
+	ReadOnly               bool `json:"read_only"`
+	// Deprecated: send through `display_settings.children_layout` instead.
+	// Silently ignored on write in phase 1. Will be removed in phase 2.
 	// enum: List,Grid,Hide
-	ChildrenLayout string `json:"children_layout"`
+	ChildrenLayout string `json:"children_layout" sql:"-"`
+	// Deprecated: silently ignored on write. Will be removed in phase 2.
+	// No `oneof=` validator: like the other six legacy fields, garbage values are
+	// accepted-and-dropped (never written), keeping the deprecation behavior
+	// uniform across all of them.
 	// enum: forceYes,forceNo,default
-	FullScreen   string `json:"full_screen"   validate:"oneof=forceYes forceNo default"`
+	FullScreen   string `json:"full_screen"   sql:"-"`
 	HintsAllowed bool   `json:"hints_allowed"`
-	FixedRanks   bool   `json:"fixed_ranks"`
+	// Deprecated: silently ignored. Will be removed in phase 2.
+	FixedRanks bool `json:"fixed_ranks" sql:"-"`
 
 	// enum: None,All,AllButOne,Categories,One,Manual
 	// default: All
@@ -46,8 +62,9 @@ type Item struct {
 	EnteringTimeMin              time.Time `json:"entering_time_min"`
 	EnteringTimeMax              time.Time `json:"entering_time_max"`
 	EntryMaxTeamSize             int32     `json:"entry_max_team_size"`
-	TitleBarVisible              bool      `json:"title_bar_visible"`
-	AllowsMultipleAttempts       bool      `json:"allows_multiple_attempts"`
+	// Deprecated: silently ignored. Will be removed in phase 2.
+	TitleBarVisible        bool `json:"title_bar_visible"        sql:"-"`
+	AllowsMultipleAttempts bool `json:"allows_multiple_attempts"`
 	// enum: User,Team
 	EntryParticipantType string `json:"entry_participant_type" validate:"oneof=User Team"`
 	// MySQL time (max value is 838:59:59), cannot be set for skills
@@ -55,10 +72,24 @@ type Item struct {
 	// example: 838:59:59
 	Duration *string `json:"duration" validate:"omitempty,duration,cannot_be_set_for_skills,duration_requires_explicit_entry"`
 	// should be true when the duration is not null, cannot be set for skill items
-	RequiresExplicitEntry   bool `json:"requires_explicit_entry"      validate:"cannot_be_set_for_skills,duration_requires_explicit_entry"`
-	ShowUserInfos           bool `json:"show_user_infos"`
-	UsesAPI                 bool `json:"uses_api"`
-	PromptToJoinGroupByCode bool `json:"prompt_to_join_group_by_code"`
+	RequiresExplicitEntry bool `json:"requires_explicit_entry" validate:"cannot_be_set_for_skills,duration_requires_explicit_entry"`
+	// Deprecated: silently ignored. Will be removed in phase 2.
+	ShowUserInfos bool `json:"show_user_infos" sql:"-"`
+	UsesAPI       bool `json:"uses_api"`
+	// Deprecated: send through `display_settings.prompt_to_join_group_by_code`.
+	// Silently ignored on write in phase 1. Will be removed in phase 2.
+	PromptToJoinGroupByCode bool `json:"prompt_to_join_group_by_code" sql:"-"`
+
+	// JSON object with display/UI settings interpreted by the frontend.
+	// See `ARCHITECTURE.md` §"Display settings (frontend pass-through)" for the
+	// storage convention and the list of keys currently used by the frontend.
+	//
+	// Behavior on PUT/POST:
+	//   - omitted: the column is left untouched (or defaults to `{}` for new rows);
+	//   - sent as a JSON object (possibly `{}`): replaces the column entirely
+	//     (no merge with the previous value);
+	//   - sent as `null`: rejected as a 400 (column is NOT NULL).
+	DisplaySettings *database.JSON `json:"display_settings" validate:"display_settings"`
 }
 
 // ItemWithRequiredType represents common item fields plus the required type field.
@@ -519,6 +550,7 @@ func registerAddItemValidators(formData *formdata.FormData, store *database.Data
 	formData.RegisterTranslation("child_type_non_skill", "a skill cannot be a child of a non-skill item")
 	formData.RegisterValidation("options", constructItemOptionsValidator())
 	formData.RegisterTranslation("null|options", "options should be a valid JSON or null")
+	registerDisplaySettingsValidator(formData)
 }
 
 func registerLanguageTagValidator(formData *formdata.FormData, store *database.DataStore) {

--- a/app/api/items/create_item.robustness.feature
+++ b/app/api/items/create_item.robustness.feature
@@ -376,8 +376,6 @@ Feature: Create item - robustness
     And the table "permissions_generated" should remain unchanged
     Examples:
       | field                            | value       | error                                                                     |
-      | full_screen                      | wrong value | full_screen must be one of [forceYes forceNo default]                     |
-      | full_screen                      |             | full_screen must be one of [forceYes forceNo default]                     |
       | type                             | Wrong       | type must be one of [Chapter Task Skill]                           |
       | type                             | Skill       | type can be equal to 'Skill' only if the parent item is a skill           |
       | validation_type                  | Wrong       | validation_type must be one of [None All AllButOne Categories One Manual] |
@@ -392,6 +390,45 @@ Feature: Create item - robustness
       | duration                         | 99:59:60    | invalid duration                                                          |
       | entry_participant_type           | Class       | entry_participant_type must be one of [User Team]                         |
       | options                          |             | options should be a valid JSON or null                                    |
+
+  Scenario Outline: Wrong optional field value (raw JSON value)
+    # Sibling of "Wrong optional field value" but without quoting `<value>`, so
+    # the table can carry non-string JSON literals (null, arrays, scalars).
+    Given I am the user with id "11"
+    When I send a POST request to "/items" with the following body:
+      """
+      {
+        "type": "Task",
+        "language_tag": "sl",
+        "title": "my title",
+        "parent": {"item_id": "21"},
+        "<field>": <value>
+      }
+      """
+    Then the response code should be 400
+    And the response body should be, in JSON:
+      """
+      {
+        "success": false,
+        "message": "Bad Request",
+        "error_text": "Invalid input data",
+        "errors":{
+          "<field>": ["<error>"]
+        }
+      }
+      """
+    And the table "items" should remain unchanged
+    And the table "items_items" should remain unchanged
+    And the table "items_ancestors" should remain unchanged
+    And the table "items_strings" should remain unchanged
+    And the table "permissions_granted" should remain unchanged
+    And the table "permissions_generated" should remain unchanged
+    Examples:
+      | field            | value   | error                                                       |
+      | display_settings | null    | display_settings should be a JSON object and cannot be null |
+      | display_settings | []      | expected a map, got 'slice'                                 |
+      | display_settings | "hello" | expected a map, got 'string'                                |
+      | display_settings | 42      | expected a map, got 'float64'                               |
 
   Scenario Outline: Wrong optional parent field value
     Given I am the user with id "11"

--- a/app/api/items/display_settings.go
+++ b/app/api/items/display_settings.go
@@ -1,0 +1,72 @@
+package items
+
+import (
+	"reflect"
+
+	"github.com/France-ioi/validator"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/formdata"
+)
+
+// stringFromDisplaySettings reads a string-typed key from the `display_settings`
+// map and falls back to `def` when the key is absent or holds a non-string value.
+//
+// This is used to resolve legacy GET fields (e.g. `children_layout`) that the
+// backend kept exposing for wire-compat after their dedicated DB columns were
+// dropped: the value now lives opaquely inside `items.display_settings`, with
+// the convention that defaults are *omitted* from the JSON.
+func stringFromDisplaySettings(ds database.JSON, key, def string) string {
+	if v, ok := ds[key].(string); ok {
+		return v
+	}
+	return def
+}
+
+// boolFromDisplaySettings reads a bool-typed key from the `display_settings`
+// map and falls back to `def` when the key is absent or holds a non-bool value.
+//
+// We accept JSON booleans (the canonical encoding new clients write) AND JSON
+// numbers (the encoding any legacy/manually-inserted row might still hold for a
+// boolean key — `encoding/json` decodes those into `float64`). This keeps the
+// helper resilient to off-spec values without making the storage convention any
+// less strict on the write side.
+func boolFromDisplaySettings(ds database.JSON, key string, def bool) bool {
+	switch v := ds[key].(type) {
+	case bool:
+		return v
+	case float64:
+		return v != 0
+	}
+	return def
+}
+
+// constructDisplaySettingsValidator rejects `null` for the `display_settings`
+// field. The DB column is `NOT NULL`, so writing nil through gorm would fail.
+//
+// The framework only surfaces a validation error for fields that the client
+// explicitly sent (see `FormData.processValidatorErrors`), so omitted requests
+// pass even though the underlying field is also nil in that case.
+func constructDisplaySettingsValidator() validator.Func {
+	return func(fl validator.FieldLevel) bool {
+		field := fl.Field()
+		// `DisplaySettings` is `*database.JSON` (pointer to a map). The validator
+		// library extracts pointer kinds without diving when the pointer is nil,
+		// and dives into the map otherwise — handle both.
+		switch field.Kind() {
+		case reflect.Ptr, reflect.Map:
+			return !field.IsNil()
+		default:
+			return false
+		}
+	}
+}
+
+// registerDisplaySettingsValidator wires `constructDisplaySettingsValidator` and
+// its translation onto a FormData. Callers in itemCreate and itemUpdate share
+// the exact same validator + message, so this lives next to the helpers to keep
+// every `display_settings`-related concern in one file.
+func registerDisplaySettingsValidator(formData *formdata.FormData) {
+	formData.RegisterValidation("display_settings", constructDisplaySettingsValidator())
+	formData.RegisterTranslation("display_settings", "display_settings should be a JSON object and cannot be null")
+}

--- a/app/api/items/display_settings_test.go
+++ b/app/api/items/display_settings_test.go
@@ -1,0 +1,126 @@
+package items
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/formdata"
+)
+
+func TestStringFromDisplaySettings(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   database.JSON
+		key  string
+		def  string
+		want string
+	}{
+		{name: "nil map returns default", ds: nil, key: "any", def: "fallback", want: "fallback"},
+		{name: "absent key returns default", ds: database.JSON{}, key: "missing", def: "fallback", want: "fallback"},
+		{name: "string value returned as-is", ds: database.JSON{"k": "value"}, key: "k", def: "fallback", want: "value"},
+		{name: "non-string value falls back", ds: database.JSON{"k": 42.0}, key: "k", def: "fallback", want: "fallback"},
+		{name: "nil JSON value falls back", ds: database.JSON{"k": nil}, key: "k", def: "fallback", want: "fallback"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stringFromDisplaySettings(tt.ds, tt.key, tt.def))
+		})
+	}
+}
+
+func TestBoolFromDisplaySettings(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   database.JSON
+		key  string
+		def  bool
+		want bool
+	}{
+		{name: "nil map returns default true", ds: nil, key: "any", def: true, want: true},
+		{name: "nil map returns default false", ds: nil, key: "any", def: false, want: false},
+		{name: "absent key returns default", ds: database.JSON{}, key: "missing", def: true, want: true},
+		{name: "bool true returned as-is", ds: database.JSON{"k": true}, key: "k", def: false, want: true},
+		{name: "bool false returned as-is", ds: database.JSON{"k": false}, key: "k", def: true, want: false},
+		// `encoding/json` decodes JSON numbers as float64; the helper has to treat
+		// non-zero numbers as `true` for legacy rows that store booleans numerically.
+		{name: "float64 non-zero treated as true", ds: database.JSON{"k": 1.0}, key: "k", def: false, want: true},
+		{name: "float64 zero treated as false", ds: database.JSON{"k": 0.0}, key: "k", def: true, want: false},
+		{name: "string value falls back", ds: database.JSON{"k": "true"}, key: "k", def: false, want: false},
+		{name: "nil JSON value falls back to default", ds: database.JSON{"k": nil}, key: "k", def: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, boolFromDisplaySettings(tt.ds, tt.key, tt.def))
+		})
+	}
+}
+
+// displaySettingsTestForm is a minimal struct that mirrors the field type used
+// by the production Item struct so we can exercise the validator end-to-end
+// through the actual FormData parse path (the path that fires on every
+// itemCreate/itemUpdate request).
+type displaySettingsTestForm struct {
+	DisplaySettings *database.JSON `json:"display_settings" validate:"display_settings"`
+}
+
+func TestRegisterDisplaySettingsValidator(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		wantErrs formdata.FieldErrorsError
+	}{
+		{
+			name:  "field omitted passes (validator only runs on set fields with non-nil pointer)",
+			input: map[string]interface{}{},
+		},
+		{
+			name:  "empty object passes",
+			input: map[string]interface{}{"display_settings": map[string]interface{}{}},
+		},
+		{
+			name:  "populated object passes",
+			input: map[string]interface{}{"display_settings": map[string]interface{}{"children_layout": "Grid"}},
+		},
+		{
+			name:     "explicit null is rejected",
+			input:    map[string]interface{}{"display_settings": nil},
+			wantErrs: formdata.FieldErrorsError{"display_settings": []string{"display_settings should be a JSON object and cannot be null"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := &displaySettingsTestForm{}
+			fd := formdata.NewFormData(form)
+			registerDisplaySettingsValidator(fd)
+
+			err := fd.ParseMapData(tt.input)
+			if tt.wantErrs == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.wantErrs, err)
+			}
+		})
+	}
+}
+
+// nonPtrNonMapDisplaySettingsForm uses the `display_settings` validator on a
+// field whose kind is neither pointer nor map, to cover the validator's
+// `default: return false` fallback. The production struct never exposes the
+// validator on such a field, but the fallback exists as a defensive guard and
+// must remain reachable behavior.
+type nonPtrNonMapDisplaySettingsForm struct {
+	DisplaySettings string `json:"display_settings" validate:"display_settings"`
+}
+
+func TestConstructDisplaySettingsValidator_RejectsNonPtrNonMapField(t *testing.T) {
+	form := &nonPtrNonMapDisplaySettingsForm{}
+	fd := formdata.NewFormData(form)
+	registerDisplaySettingsValidator(fd)
+
+	err := fd.ParseMapData(map[string]interface{}{"display_settings": "not-a-map"})
+	assert.Equal(t, formdata.FieldErrorsError{
+		"display_settings": []string{"display_settings should be a JSON object and cannot be null"},
+	}, err)
+}

--- a/app/api/items/get_children.feature
+++ b/app/api/items/get_children.feature
@@ -12,14 +12,14 @@ Feature: Get item children
       | 17       | fr         | fr               |
       | 22       | info       |                  |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url                    | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl         | true     | true          |
-      | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null                   | true     | true          |
-      | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null                   | true     | true          |
-      | 230 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null                   | true     | true          |
-      | 300 | Skill   | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/300 | true     | true          |
-      | 301 | Skill   | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/301 | true     | true          |
-      | 302 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://example.com/302 | true     | true          |
+      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url                    | uses_api | hints_allowed |
+      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl         | true     | true          |
+      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null                   | true     | true          |
+      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          |
+      | 230 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          |
+      | 300 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/300 | true     | true          |
+      | 301 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/301 | true     | true          |
+      | 302 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/302 | true     | true          |
     And the database has the following table "items_strings":
       | item_id | language_tag | title        | image_url                  | subtitle     | description     | edu_comment    |
       | 200     | en           | Category 1   | http://example.com/my0.jpg | Subtitle 0   | Description 0   | Some comment   |
@@ -131,7 +131,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -178,7 +178,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -235,7 +235,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -272,7 +272,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -329,7 +329,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -365,7 +365,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -411,7 +411,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -458,7 +458,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -515,7 +515,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -551,7 +551,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -597,7 +597,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -636,7 +636,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -687,7 +687,7 @@ Feature: Get item children
         "edit_propagation": false,
         "request_help_propagation": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -726,7 +726,7 @@ Feature: Get item children
         "edit_propagation": true,
         "request_help_propagation": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -259,7 +259,7 @@ func (srv *Service) getItemChildren(responseWriter http.ResponseWriter, httpRequ
 			`items.allows_multiple_attempts, category, score_weight, content_view_propagation,
 				upper_view_levels_propagation, grant_view_propagation, watch_propagation, edit_propagation, request_help_propagation,
 				items.id, items.type, items.default_language_tag,
-				items.validation_type, items.display_details_in_parent, items.duration, items.entry_participant_type, items.no_score,
+				items.validation_type, items.duration, items.entry_participant_type, items.no_score,
 				IFNULL(can_view_generated_value, 1) AS can_view_generated_value,
 				IFNULL(can_grant_view_generated_value, 1) AS can_grant_view_generated_value,
 				IFNULL(can_watch_generated_value, 1) AS can_watch_generated_value,
@@ -349,10 +349,13 @@ func childItemsFromRawData(
 						Title:       rawData[index].StringTitle,
 						ImageURL:    rawData[index].StringImageURL,
 					}},
-					DefaultLanguageTag:     rawData[index].DefaultLanguageTag,
-					BestScore:              rawData[index].BestScore,
-					Results:                make([]structures.ItemResult, 0, 1),
-					DisplayDetailsInParent: rawData[index].DisplayDetailsInParent,
+					DefaultLanguageTag: rawData[index].DefaultLanguageTag,
+					BestScore:          rawData[index].BestScore,
+					Results:            make([]structures.ItemResult, 0, 1),
+					// Hardcoded default during phase 1: the legacy `display_details_in_parent`
+					// column was dropped; the value is opaquely stored in `items.display_settings`
+					// (read by the frontend) but the backend keeps emitting `false` for wire compat.
+					DisplayDetailsInParent: false,
 					ValidationType:         rawData[index].ValidationType,
 					RequiresExplicitEntry:  rawData[index].RequiresExplicitEntry,
 					AllowsMultipleAttempts: rawData[index].AllowsMultipleAttempts,

--- a/app/api/items/get_dependencies.feature
+++ b/app/api/items/get_dependencies.feature
@@ -14,10 +14,10 @@ Feature: Get item dependencies
       | 22       | info       |                  |
       | 23       | jane       |                  |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
-      | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
-      | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
+      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url            | uses_api | hints_allowed |
+      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl | true     | true          |
+      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null           | true     | true          |
+      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null           | true     | true          |
     And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
@@ -105,7 +105,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -133,7 +133,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -171,7 +171,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -199,7 +199,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -237,7 +237,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -264,7 +264,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -301,7 +301,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -329,7 +329,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -367,7 +367,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -394,7 +394,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -431,7 +431,7 @@ Feature: Get item dependencies
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -461,7 +461,7 @@ Feature: Get item dependencies
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",

--- a/app/api/items/get_item.feature
+++ b/app/api/items/get_item.feature
@@ -13,11 +13,16 @@ Feature: Get item view information
       | 14       | nosolution |                  |
       | 17       | fr         | fr               |
       | 22       | info       |                  |
+    # display_settings carries the legacy children_layout & prompt_to_join_group_by_code
+    # values (and may carry frontend-only keys). Per the "omit defaults" convention,
+    # children_layout=List would normally be omitted; we keep it here explicitly so
+    # the assertions below (which expect "List") exercise the JSON-extract path
+    # rather than the hardcoded default fallback.
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | text_id  | display_details_in_parent | validation_type | requires_explicit_entry | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | entry_participant_type | duration | prompt_to_join_group_by_code | title_bar_visible | read_only | full_screen | children_layout | show_user_infos | url            | options | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | Task_30c | true                      | All             | true                    | All                              | false              | 10                  | true                     | Team                   | 10:20:30 | true                         | true              | true      | forceYes    | List            | true            | http://someurl | {}      | true     | true          |
-      | 210 | Chapter | en                   | true     | null     | true                      | All             | false                   | All                              | false              | 10                  | true                     | User                   | 10:20:31 | true                         | true              | true      | forceYes    | List            | true            | null           | null    | true     | true          |
-      | 220 | Chapter | en                   | true     | Task_30e | true                      | All             | false                   | All                              | false              | 10                  | true                     | Team                   | 10:20:32 | true                         | true              | true      | forceYes    | List            | true            | null           | null    | true     | true          |
+      | id  | type    | default_language_tag | no_score | text_id  | validation_type | requires_explicit_entry | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | entry_participant_type | duration | read_only | url            | options | uses_api | hints_allowed | display_settings                                                  |
+      | 200 | Task    | en                   | true     | Task_30c | All             | true                    | All                              | false              | 10                  | true                     | Team                   | 10:20:30 | true      | http://someurl | {}      | true     | true          | {"children_layout":"List","prompt_to_join_group_by_code":true}    |
+      | 210 | Chapter | en                   | true     | null     | All             | false                   | All                              | false              | 10                  | true                     | User                   | 10:20:31 | true      | null           | null    | true     | true          | {"children_layout":"List","prompt_to_join_group_by_code":true}    |
+      | 220 | Chapter | en                   | true     | Task_30e | All             | false                   | All                              | false              | 10                  | true                     | Team                   | 10:20:32 | true      | null           | null    | true     | true          | {"children_layout":"List","prompt_to_join_group_by_code":true}    |
     And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
@@ -109,7 +114,7 @@ Feature: Get item view information
     {
       "id": "200",
       "type": "Task",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": true,
       "entry_min_admitted_members_ratio": "All",
@@ -125,12 +130,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
       "url": "http://someurl",
       "options": "{}",
       "uses_api": true,
@@ -172,7 +178,7 @@ Feature: Get item view information
     {
       "id": "210",
       "type": "Chapter",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": false,
       "entry_min_admitted_members_ratio": "All",
@@ -188,12 +194,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
 
       "best_score": 10,
 
@@ -227,7 +234,7 @@ Feature: Get item view information
     {
       "id": "210",
       "type": "Chapter",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "entry_min_admitted_members_ratio": "All",
       "requires_explicit_entry": false,
@@ -243,12 +250,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
 
       "best_score": 0,
 
@@ -281,7 +289,7 @@ Feature: Get item view information
     {
       "id": "200",
       "type": "Task",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": true,
       "entry_min_admitted_members_ratio": "All",
@@ -297,12 +305,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
       "url": "http://someurl",
       "options": "{}",
       "uses_api": true,
@@ -340,7 +349,7 @@ Feature: Get item view information
     {
       "id": "200",
       "type": "Task",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": true,
       "entry_min_admitted_members_ratio": "All",
@@ -356,12 +365,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
       "url": "http://someurl",
       "options": "{}",
       "uses_api": true,
@@ -401,7 +411,7 @@ Feature: Get item view information
     {
       "id": "210",
       "type": "Chapter",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": false,
       "entry_min_admitted_members_ratio": "All",
@@ -417,12 +427,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
 
       "best_score": 0,
 
@@ -455,7 +466,7 @@ Feature: Get item view information
     {
       "id": "200",
       "type": "Task",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": true,
       "entry_min_admitted_members_ratio": "All",
@@ -471,12 +482,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
       "url": "http://someurl",
       "options": "{}",
       "uses_api": true,
@@ -553,7 +565,7 @@ Feature: Get item view information
     {
       "id": "220",
       "type": "Chapter",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": false,
       "entry_min_admitted_members_ratio": "All",
@@ -569,12 +581,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
 
       "best_score": 0,
 
@@ -658,7 +671,7 @@ Feature: Get item view information
     {
       "id": "220",
       "type": "Chapter",
-      "display_details_in_parent": true,
+      "display_details_in_parent": false,
       "validation_type": "All",
       "requires_explicit_entry": false,
       "entry_min_admitted_members_ratio": "All",
@@ -674,12 +687,13 @@ Feature: Get item view information
       "default_language_tag": "en",
       "supported_language_tags": ["en", "fr"],
       "prompt_to_join_group_by_code": true,
+      "display_settings": {"children_layout": "List", "prompt_to_join_group_by_code": true},
 
       "title_bar_visible": true,
       "read_only": true,
-      "full_screen": "forceYes",
+      "full_screen": "default",
       "children_layout": "List",
-      "show_user_infos": true,
+      "show_user_infos": false,
 
       "best_score": 0,
 
@@ -713,11 +727,11 @@ Feature: Get item view information
     | none                | none                     | content                           | false                  | true                            | {{watched_group_permissions}}                   |
     | result              | none                     | none                              | false                  | false                           | {{watched_group_average_score_and_permissions}} |
 
-  Scenario: Chapter with children_layout set to Hide
+  Scenario: Chapter with display_settings.children_layout set to Hide (legacy children_layout field is derived from display_settings)
     Given I am the user with id "11"
     And the database table "items" also has the following rows:
-      | id  | type    | default_language_tag | children_layout |
-      | 230 | Chapter | en                   | Hide            |
+      | id  | type    | default_language_tag | display_settings              |
+      | 230 | Chapter | en                   | {"children_layout":"Hide"}    |
     And the database table "items_strings" also has the following rows:
       | item_id | language_tag | title     |
       | 230     | en           | Chapter C |
@@ -727,3 +741,71 @@ Feature: Get item view information
     When I send a GET request to "/items/230"
     Then the response code should be 200
     And the response at $.children_layout should be "Hide"
+    And the response at $.display_settings in JSON should be:
+      """
+      {"children_layout": "Hide"}
+      """
+
+  Scenario: Empty display_settings returns default values for derived legacy fields
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id  | type    | default_language_tag | display_settings |
+      | 231 | Chapter | en                   | {}               |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title      |
+      | 231     | en           | Chapter D  |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
+      | 11       | 231     | solution           | none                     | none               | none                | false              |
+    When I send a GET request to "/items/231"
+    Then the response code should be 200
+    And the response at $.children_layout should be "List"
+    And the response at $.prompt_to_join_group_by_code should be "false"
+    And the response at $.display_settings in JSON should be:
+      """
+      {}
+      """
+
+  Scenario: display_settings can carry frontend-only keys that the backend returns unchanged
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id  | type    | default_language_tag | display_settings                                                |
+      | 232 | Chapter | en                   | {"children_layout":"Grid","frontend_only_key":42,"flag":false}  |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title      |
+      | 232     | en           | Chapter E  |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
+      | 11       | 232     | solution           | none                     | none               | none                | false              |
+    When I send a GET request to "/items/232"
+    Then the response code should be 200
+    And the response at $.children_layout should be "Grid"
+    And the response at $.display_settings in JSON should be:
+      """
+      {"children_layout": "Grid", "frontend_only_key": 42, "flag": false}
+      """
+
+  # Defense-in-depth: even if a row ends up with `prompt_to_join_group_by_code`
+  # stored as a JSON integer (e.g. produced by a buggy hand-written backfill or
+  # an off-spec frontend), the legacy `prompt_to_join_group_by_code` GET field
+  # must still resolve to the right boolean.
+  Scenario Outline: Legacy prompt_to_join_group_by_code is derived correctly even when stored as a JSON integer
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id  | type    | default_language_tag | display_settings                              |
+      | 233 | Chapter | en                   | <display_settings>                            |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title      |
+      | 233     | en           | Chapter F  |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | can_edit_generated | can_watch_generated | is_owner_generated |
+      | 11       | 233     | solution           | none                     | none               | none                | false              |
+    When I send a GET request to "/items/233"
+    Then the response code should be 200
+    And the response at $.prompt_to_join_group_by_code should be "<expected>"
+    Examples:
+      | display_settings                          | expected |
+      | {"prompt_to_join_group_by_code": 1}       | true     |
+      | {"prompt_to_join_group_by_code": 0}       | false    |
+      | {"prompt_to_join_group_by_code": true}    | true     |
+      | {"prompt_to_join_group_by_code": false}   | false    |

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -123,26 +123,40 @@ type itemResponse struct {
 	EntryFrozenTeams bool `json:"entry_frozen_teams"`
 	// required: true
 	EntryMaxTeamSize int32 `json:"entry_max_team_size"`
+	// Deprecated: use `display_settings.prompt_to_join_group_by_code` instead.
+	// Resolved from `display_settings` with default `false`. Will be removed in phase 2.
 	// required: true
 	PromptToJoinGroupByCode bool `json:"prompt_to_join_group_by_code"`
+	// Deprecated: not stored anymore; always `true`. Will be removed in phase 2.
 	// required: true
 	TitleBarVisible bool `json:"title_bar_visible"`
 	// required: true
 	TextID *string `json:"text_id"`
 	// required: true
 	ReadOnly bool `json:"read_only"`
+	// Deprecated: not stored anymore; always `"default"`. Will be removed in phase 2.
 	// required: true
 	// enum: forceYes,forceNo,default
 	FullScreen string `json:"full_screen"`
+	// Deprecated: use `display_settings.children_layout` instead.
+	// Resolved from `display_settings` with default `"List"`. Will be removed in phase 2.
 	// required: true
 	// enum: List,Grid,Hide
 	ChildrenLayout string `json:"children_layout"`
+	// Deprecated: not stored anymore; always `false`. Will be removed in phase 2.
 	// required: true
 	ShowUserInfos bool `json:"show_user_infos"`
 	// required: true
 	EnteringTimeMin time.Time `json:"entering_time_min"`
 	// required: true
 	EnteringTimeMax time.Time `json:"entering_time_max"`
+
+	// JSON object with display/UI settings interpreted by the frontend. Always
+	// present, never `null`; an item with no non-default settings has the value
+	// `{}`. See `ARCHITECTURE.md` §"Display settings (frontend pass-through)" for
+	// the storage convention and the list of keys.
+	// required: true
+	DisplaySettings database.JSON `json:"display_settings"`
 
 	// required: true
 	SupportedLanguageTags []string `json:"supported_language_tags"`
@@ -293,21 +307,19 @@ type rawItem struct {
 	*RawCommonItemFields
 
 	// items
-	TitleBarVisible              bool
 	ReadOnly                     bool
-	FullScreen                   string
-	ChildrenLayout               string
-	ShowUserInfos                bool
 	EntryMinAdmittedMembersRatio string
 	EntryFrozenTeams             bool
 	EntryMaxTeamSize             int32
-	PromptToJoinGroupByCode      bool
-	TextID                       *string
-	URL                          *string // only if not a chapter
-	Options                      *string // only if not a chapter
-	UsesAPI                      bool    // only if not a chapter
-	HintsAllowed                 bool    // only if not a chapter
-	BestScore                    float32
+	// `items.display_settings` is `NOT NULL` (defaults to `{}`), so we can read it
+	// into a non-pointer `database.JSON`; downstream code never needs a nil check.
+	DisplaySettings database.JSON
+	TextID          *string
+	URL             *string // only if not a chapter
+	Options         *string // only if not a chapter
+	UsesAPI         bool    // only if not a chapter
+	HintsAllowed    bool    // only if not a chapter
+	BestScore       float32
 
 	// items_strings
 	SupportedLanguageTags string
@@ -335,7 +347,6 @@ func getRawItemData(store *database.ItemStore, rootID, groupID int64, languageTa
 	columnsBuffer := bytes.NewBufferString(`
 		items.id AS id,
 		items.type,
-		items.display_details_in_parent,
 		items.validation_type,
 		items.entry_min_admitted_members_ratio,
 		items.entry_frozen_teams,
@@ -350,12 +361,8 @@ func getRawItemData(store *database.ItemStore, rootID, groupID int64, languageTa
 		items.default_language_tag,
 		IFNULL((SELECT GROUP_CONCAT(language_tag ORDER BY language_tag)
 		        FROM items_strings WHERE item_id = items.id), '') AS supported_language_tags,
-		items.prompt_to_join_group_by_code,
-		items.title_bar_visible,
+		items.display_settings,
 		items.read_only,
-		items.full_screen,
-		items.children_layout,
-		items.show_user_infos,
 		items.url,
 		items.options,
 		items.requires_explicit_entry,
@@ -492,17 +499,23 @@ func constructItemResponseFromDBData(
 		EntryMinAdmittedMembersRatio: rawData.EntryMinAdmittedMembersRatio,
 		EntryFrozenTeams:             rawData.EntryFrozenTeams,
 		EntryMaxTeamSize:             rawData.EntryMaxTeamSize,
-		PromptToJoinGroupByCode:      rawData.PromptToJoinGroupByCode,
-		TitleBarVisible:              rawData.TitleBarVisible,
-		TextID:                       rawData.TextID,
-		ReadOnly:                     rawData.ReadOnly,
-		FullScreen:                   rawData.FullScreen,
-		ChildrenLayout:               rawData.ChildrenLayout,
-		ShowUserInfos:                rawData.ShowUserInfos,
-		EnteringTimeMin:              time.Time(rawData.EnteringTimeMin),
-		EnteringTimeMax:              time.Time(rawData.EnteringTimeMax),
-		BestScore:                    rawData.BestScore,
-		SupportedLanguageTags:        strings.Split(rawData.SupportedLanguageTags, ","),
+		// The five hardcoded constants below are wire-compat defaults for clients
+		// that still expect the legacy fields; their backing columns were dropped
+		// in phase 1. The two display_settings-backed fields (children_layout,
+		// prompt_to_join_group_by_code) keep returning the real value so existing
+		// frontends keep working until phase 2.
+		PromptToJoinGroupByCode: boolFromDisplaySettings(rawData.DisplaySettings, "prompt_to_join_group_by_code", false),
+		TitleBarVisible:         true,
+		TextID:                  rawData.TextID,
+		ReadOnly:                rawData.ReadOnly,
+		FullScreen:              "default",
+		ChildrenLayout:          stringFromDisplaySettings(rawData.DisplaySettings, "children_layout", "List"),
+		ShowUserInfos:           false,
+		EnteringTimeMin:         time.Time(rawData.EnteringTimeMin),
+		EnteringTimeMax:         time.Time(rawData.EnteringTimeMax),
+		DisplaySettings:         rawData.DisplaySettings,
+		BestScore:               rawData.BestScore,
+		SupportedLanguageTags:   strings.Split(rawData.SupportedLanguageTags, ","),
 	}
 
 	if rawData.CanViewGeneratedValue == permissionGrantedStore.ViewIndexByName("solution") {

--- a/app/api/items/get_parents.feature
+++ b/app/api/items/get_parents.feature
@@ -13,10 +13,10 @@ Feature: Get item parents
       | 17       | fr         | fr               |
       | 22       | info       |                  |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
-      | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
-      | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
+      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url            | uses_api | hints_allowed |
+      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl | true     | true          |
+      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null           | true     | true          |
+      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null           | true     | true          |
     And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
@@ -103,7 +103,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -140,7 +140,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -187,7 +187,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -216,7 +216,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -263,7 +263,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -291,7 +291,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -329,7 +329,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -366,7 +366,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -413,7 +413,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -441,7 +441,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -479,7 +479,7 @@ Feature: Get item parents
         "order": 1,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -510,7 +510,7 @@ Feature: Get item parents
         "order": 2,
         "category": "Discovery",
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",

--- a/app/api/items/get_parents.go
+++ b/app/api/items/get_parents.go
@@ -156,7 +156,7 @@ func constructItemParentsQuery(dataStore *database.DataStore, childItemID, group
 ) *database.DB {
 	itemsWithoutResultsQuery := constructItemListWithoutResultsQuery(dataStore, groupID, "info",
 		watchedGroupIDIsSet, watchedGroupID, `items.allows_multiple_attempts, category, items.id, items.type, items.default_language_tag,
-			validation_type, display_details_in_parent, duration, entry_participant_type, no_score,
+			validation_type, duration, entry_participant_type, no_score,
 			can_view_generated_value, can_grant_view_generated_value, can_watch_generated_value, can_edit_generated_value, is_owner_generated,
 			IFNULL(
 				(SELECT MAX(results.score_computed) AS best_score

--- a/app/api/items/get_prerequisites.feature
+++ b/app/api/items/get_prerequisites.feature
@@ -14,10 +14,10 @@ Feature: Get item prerequisites
       | 22       | info       |                  |
       | 23       | jane       |                  |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | display_details_in_parent | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | title_bar_visible | read_only | full_screen | show_user_infos | url            | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | true                      | All             | true                    | true                     | Team                   | 10:20:30 | true              | true      | forceYes    | true            | http://someurl | true     | true          |
-      | 210 | Chapter | en                   | true     | true                      | All             | false                   | true                     | User                   | 10:20:31 | true              | true      | forceYes    | true            | null           | true     | true          |
-      | 220 | Chapter | en                   | true     | true                      | All             | false                   | true                     | Team                   | 10:20:32 | true              | true      | forceYes    | true            | null           | true     | true          |
+      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url            | uses_api | hints_allowed |
+      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl | true     | true          |
+      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null           | true     | true          |
+      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null           | true     | true          |
     And the database has the following table "items_strings":
       | item_id | language_tag | title       | image_url                  | subtitle     | description   | edu_comment    |
       | 200     | en           | Category 1  | http://example.com/my0.jpg | Subtitle 0   | Description 0 | Some comment   |
@@ -105,7 +105,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -133,7 +133,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -171,7 +171,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -199,7 +199,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -237,7 +237,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -264,7 +264,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -301,7 +301,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -329,7 +329,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -367,7 +367,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -394,7 +394,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",
@@ -431,7 +431,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 30,
         "dependency_grant_content_view": false,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "Team",
@@ -461,7 +461,7 @@ Feature: Get item prerequisites
         "dependency_required_score": 20,
         "dependency_grant_content_view": true,
         "type": "Chapter",
-        "display_details_in_parent": true,
+        "display_details_in_parent": false,
         "validation_type": "All",
         "allows_multiple_attempts": true,
         "entry_participant_type": "User",

--- a/app/api/items/get_prerequisites.go
+++ b/app/api/items/get_prerequisites.go
@@ -133,7 +133,7 @@ func (srv *Service) getItemPrerequisitesOrDependencies(
 		constructItemListWithoutResultsQuery(
 			store, participantID, "info", watchedGroupIDIsSet, watchedGroupID,
 			`items.allows_multiple_attempts, items.id, items.type, items.default_language_tag,
-				validation_type, display_details_in_parent, duration, entry_participant_type, no_score,
+				validation_type, duration, entry_participant_type, no_score,
 				can_view_generated_value, can_grant_view_generated_value, can_watch_generated_value, can_edit_generated_value, is_owner_generated,
 				score AS dependency_required_score, grant_content_view AS dependency_grant_content_view,
 				IFNULL(

--- a/app/api/items/raw_common_item_fields.go
+++ b/app/api/items/raw_common_item_fields.go
@@ -11,7 +11,6 @@ type RawCommonItemFields struct {
 	// items
 	ID                     int64
 	Type                   string
-	DisplayDetailsInParent bool
 	ValidationType         string
 	EntryParticipantType   string
 	EnteringTimeMin        database.Time
@@ -25,9 +24,12 @@ type RawCommonItemFields struct {
 
 func (raw *RawCommonItemFields) asItemCommonFields(permissionGrantedStore *database.PermissionGrantedStore) *commonItemFields {
 	return &commonItemFields{
-		ID:                     raw.ID,
-		Type:                   raw.Type,
-		DisplayDetailsInParent: raw.DisplayDetailsInParent,
+		ID:   raw.ID,
+		Type: raw.Type,
+		// Hardcoded default during phase 1: the legacy `items.display_details_in_parent`
+		// column was dropped; the value is now opaquely stored in `items.display_settings`
+		// for the frontend, but the backend keeps emitting `false` here for wire compat.
+		DisplayDetailsInParent: false,
 		ValidationType:         raw.ValidationType,
 		RequiresExplicitEntry:  raw.RequiresExplicitEntry,
 		AllowsMultipleAttempts: raw.AllowsMultipleAttempts,

--- a/app/api/items/update_item.feature
+++ b/app/api/items/update_item.feature
@@ -7,11 +7,11 @@ Background:
     | group_id | login |
     | 11       | jdoe  |
   And the database has the following table "items":
-    | id | type    | url                  | options   | default_language_tag | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-    | 21 | Chapter | http://someurl1.com/ | {"opt":1} | en                   | 1        | Task1   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
-    | 50 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task2   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
-    | 60 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task3   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
-    | 70 | Skill   | http://someurl3.com/ | {"opt":3} | en                   | 0        | null    | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
+    | id | type    | url                  | options   | default_language_tag | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | entering_time_min   | entering_time_max   | participants_group_id |
+    | 21 | Chapter | http://someurl1.com/ | {"opt":1} | en                   | 1        | Task1   | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
+    | 50 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task2   | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
+    | 60 | Chapter | http://someurl2.com/ | {"opt":2} | en                   | 1        | Task3   | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
+    | 70 | Skill   | http://someurl3.com/ | {"opt":3} | en                   | 0        | null    | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1                       | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | 1234                  |
   And the database has the following table "items_items":
     | parent_item_id | child_item_id | child_order |
     | 21             | 60            | 0           |
@@ -64,8 +64,8 @@ Background:
     Then the response should be "updated"
     And the table "items" should remain unchanged, regardless of the row with id "50"
     And the table "items" at id "50" should be:
-      | id | type    | url                  | options   | default_language_tag | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | show_user_infos | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 50 | Chapter | http://someurl3.com/ | {"opt":3} | en                   | 1        | Task2   | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
+      | id | type    | url                  | options   | display_settings | default_language_tag | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | entering_time_min   | entering_time_max   | participants_group_id |
+      | 50 | Chapter | http://someurl3.com/ | {"opt":3} | {}               | en                   | 1        | Task2   | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
     And the table "items_strings" should remain unchanged
     And the table "items_items" should remain unchanged
     And the table "items_ancestors" should remain unchanged
@@ -84,8 +84,8 @@ Background:
     Then the response should be "updated"
     And the table "items" should remain unchanged, regardless of the row with id "50"
     And the table "items" at id "50" should be:
-      | id | type    | url  | options | default_language_tag | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | show_user_infos | prompt_to_join_group_by_code | entering_time_min   | entering_time_max   | participants_group_id |
-      | 50 | Chapter | null | null    | en                   | 1        | null    | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | null     | 1               | 1                            | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
+      | id | type    | url  | options | display_settings | default_language_tag | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | entering_time_min   | entering_time_max   | participants_group_id |
+      | 50 | Chapter | null | null    | {}               | en                   | 1        | null    | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | null     | 2007-01-01 01:02:03 | 3007-01-01 01:02:03 | null                  |
     And the table "items_strings" should remain unchanged
     And the table "items_items" should remain unchanged
     And the table "items_ancestors" should remain unchanged
@@ -147,9 +147,12 @@ Background:
       """
     Then the response should be "updated"
     And the table "items" should remain unchanged, regardless of the row with id "50"
+    # Phase 1 strategy A: the legacy display fields in the request body are
+    # silently ignored on write — the display_settings column keeps its previous
+    # value ({} for this row in the Background fixture).
     And the table "items" at id "50" should be:
-      | id | type    | url               | options      | default_language_tag | entry_frozen_teams | no_score | text_id     | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | show_user_infos | prompt_to_join_group_by_code | participants_group_id |
-      | 50 | Chapter | http://myurl.com/ | {"opt":true} | sl                   | 1                  | 0        | Tasknumber1 | 1                 | 0                         | 1        | 0         | forceYes    | Grid            | 0             | 0           | AllButOne       | All                              | 1                  | 2345                | 0                        | 01:02:03 | 1                       | 0               | 0                            | 5577006791947779410   |
+      | id | type    | url               | options      | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id     | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | requires_explicit_entry | participants_group_id |
+      | 50 | Chapter | http://myurl.com/ | {"opt":true} | {}               | sl                   | 1                  | 0        | Tasknumber1 | 1        | 0         | 0             | AllButOne       | All                              | 1                  | 2345                | 0                        | 01:02:03 | 1                       | 5577006791947779410   |
     And the table "items_strings" should remain unchanged
     And the table "items_items" should be:
       | parent_item_id | child_item_id | category    | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation |
@@ -233,8 +236,8 @@ Background:
     Then the response should be "updated"
     And the table "items" should remain unchanged, regardless of the row with id "70"
     And the table "items" at id "70" should be:
-      | id | type  | url                  | options   | default_language_tag | entry_frozen_teams | no_score | text_id | title_bar_visible | display_details_in_parent | uses_api | read_only | full_screen | children_layout | hints_allowed | fixed_ranks | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | show_user_infos | prompt_to_join_group_by_code | participants_group_id |
-      | 70 | Skill | http://someurl3.com/ | {"opt":3} | en                   | 0                  | 0        | null    | 0                 | 1                         | 0        | 1         | forceNo     | List            | 1             | 1           | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1               | 1                            | 1234                  |
+      | id | type  | url                  | options   | display_settings | default_language_tag | entry_frozen_teams | no_score | text_id | uses_api | read_only | hints_allowed | validation_type | entry_min_admitted_members_ratio | entry_frozen_teams | entry_max_team_size | allows_multiple_attempts | duration | participants_group_id |
+      | 70 | Skill | http://someurl3.com/ | {"opt":3} | {}               | en                   | 0                  | 0        | null    | 0        | 1         | 1             | One             | Half                             | 0                  | 10                  | 1                        | 01:20:30 | 1234                  |
     And the table "items_strings" should remain unchanged
     And the table "items_items" should be:
       | parent_item_id | child_item_id | category    | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation |
@@ -784,16 +787,72 @@ Background:
       | parent_item_id | child_item_id | child_order | category  | score_weight | content_view_propagation | upper_view_levels_propagation | grant_view_propagation | watch_propagation | edit_propagation |
       | 21             | 112           | 1           | Challenge | 2            | as_content               | as_is                         | true                   | true              | true             |
 
-  Scenario: Valid (set children_layout to Hide)
+  Scenario: Valid (set display_settings.children_layout to Hide via the new JSON field)
     Given I am the user with id "11"
     When I send a PUT request to "/items/60" with the following body:
       """
       {
-        "children_layout": "Hide"
+        "display_settings": {"children_layout": "Hide"}
       }
       """
     Then the response should be "updated"
     And the table "items" should remain unchanged, regardless of the row with id "60"
-    And the table "items" at id "60" should be:
-      | id | type    | children_layout |
-      | 60 | Chapter | Hide            |
+    And the column "items.display_settings" at id "60" should be, in JSON:
+      """
+      {"children_layout": "Hide"}
+      """
+
+  Scenario: Valid (legacy children_layout in PUT body is silently ignored in phase 1; display_settings unchanged)
+    Given I am the user with id "11"
+    When I send a PUT request to "/items/60" with the following body:
+      """
+      {
+        "children_layout": "Hide",
+        "prompt_to_join_group_by_code": true
+      }
+      """
+    Then the response should be "updated"
+    And the table "items" should remain unchanged
+
+  Scenario: Valid (set display_settings to a richer object; full replacement, no merge)
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id | type    | default_language_tag | display_settings              |
+      | 80 | Chapter | en                   | {"children_layout": "Grid"}   |
+    And the database table "permissions_generated" also has the following row:
+      | group_id | item_id | can_view_generated | can_edit_generated |
+      | 11       | 80      | solution           | all_with_grant     |
+    When I send a PUT request to "/items/80" with the following body:
+      """
+      {
+        "display_settings": {
+          "prompt_to_join_group_by_code": true,
+          "frontend_only_key": 42
+        }
+      }
+      """
+    Then the response should be "updated"
+    And the column "items.display_settings" at id "80" should be, in JSON:
+      """
+      {"prompt_to_join_group_by_code": true, "frontend_only_key": 42}
+      """
+
+  Scenario: Valid (set display_settings to {} clears the column to an empty object)
+    Given I am the user with id "11"
+    And the database table "items" also has the following rows:
+      | id | type    | default_language_tag | display_settings              |
+      | 80 | Chapter | en                   | {"children_layout": "Grid"}   |
+    And the database table "permissions_generated" also has the following row:
+      | group_id | item_id | can_view_generated | can_edit_generated |
+      | 11       | 80      | solution           | all_with_grant     |
+    When I send a PUT request to "/items/80" with the following body:
+      """
+      {
+        "display_settings": {}
+      }
+      """
+    Then the response should be "updated"
+    And the column "items.display_settings" at id "80" should be, in JSON:
+      """
+      {}
+      """

--- a/app/api/items/update_item.go
+++ b/app/api/items/update_item.go
@@ -168,6 +168,7 @@ func (srv *Service) updateItem(responseWriter http.ResponseWriter, httpRequest *
 		formData.RegisterTranslation("duration_requires_explicit_entry", "requires_explicit_entry should be true when the duration is not null")
 		formData.RegisterValidation("options", constructItemOptionsValidator())
 		formData.RegisterTranslation("null|options", "options should be a valid JSON or null")
+		registerDisplaySettingsValidator(formData)
 
 		err = formData.ParseMapData(rawRequestData)
 		if err != nil {

--- a/app/api/items/update_item.robustness.feature
+++ b/app/api/items/update_item.robustness.feature
@@ -84,8 +84,6 @@ Feature: Update item - robustness
     | default_language_tag             | ""            | default_language_tag must be at least 1 character in length                        |
     | default_language_tag             | "unknow"      | default language should exist and there should be item's strings in this language  |
     | default_language_tag             | "sl"          | default language should exist and there should be item's strings in this language  | # no strings for the tag
-    | full_screen                      | "wrong value" | full_screen must be one of [forceYes forceNo default]                              |
-    | full_screen                      | ""            | full_screen must be one of [forceYes forceNo default]                              |
     | validation_type                  | "Wrong"       | validation_type must be one of [None All AllButOne Categories One Manual]          |
     | entry_min_admitted_members_ratio | "Wrong"       | entry_min_admitted_members_ratio must be one of [All Half One None]                |
     | duration                         | ""            | invalid duration                                                                   |
@@ -98,6 +96,10 @@ Feature: Update item - robustness
     | duration                         | "99:59:60"    | invalid duration                                                                   |
     | duration                         | "00:00:01"    | requires_explicit_entry should be true when the duration is not null               |
     | options                          | ""            | options should be a valid JSON or null                                             |
+    | display_settings                 | null          | display_settings should be a JSON object and cannot be null                        |
+    | display_settings                 | []            | expected a map, got 'slice'                                                        |
+    | display_settings                 | "hello"       | expected a map, got 'string'                                                       |
+    | display_settings                 | 42            | expected a map, got 'float64'                                                      |
 
   Scenario: Invalid item_id
     And I am the user with id "11"

--- a/app/database/json.go
+++ b/app/database/json.go
@@ -14,7 +14,15 @@ import (
 type JSON map[string]interface{}
 
 // Scan assigns a value from a database driver value (unmarshalls given bytes).
+// A NULL DB value (which the driver passes as `src == nil`) is decoded as a nil
+// map. Without this short-circuit the unconditional `src.([]byte)` assertion
+// would panic on NULL — defensive against e.g. a manual `UPDATE ... SET col = NULL`
+// on a column whose schema is non-NULL.
 func (j *JSON) Scan(src interface{}) (err error) {
+	if src == nil {
+		*j = nil
+		return nil
+	}
 	//nolint:forcetypeassert // panic if src is not []byte (this means that the database returned a value of unexpected type)
 	return json.Unmarshal(src.([]byte), j)
 }

--- a/app/database/json_test.go
+++ b/app/database/json_test.go
@@ -12,20 +12,23 @@ import (
 func TestJSON_Scan(t *testing.T) {
 	tests := []struct {
 		name    string
-		bytes   []byte
+		src     interface{}
 		wantErr bool
 		wantMap map[string]interface{}
 	}{
 		{
-			name: "normal JSON", bytes: []byte(`{"key":"value","num":123}`),
+			name: "normal JSON", src: []byte(`{"key":"value","num":123}`),
 			wantMap: map[string]interface{}{"key": "value", "num": float64(123)},
 		},
-		{name: "empty object", bytes: []byte("{}"), wantMap: map[string]interface{}{}},
+		{name: "empty object", src: []byte("{}"), wantMap: map[string]interface{}{}},
+		// `src == nil` is the path the driver hits when the DB column holds NULL.
+		// It must decode to a nil map without touching the type assertion below.
+		{name: "nil src decodes to nil map", src: nil, wantMap: nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := &JSON{}
-			if err := j.Scan(tt.bytes); (err != nil) != tt.wantErr {
+			if err := j.Scan(tt.src); (err != nil) != tt.wantErr {
 				t.Errorf("Scan() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantMap, map[string]interface{}(*j))

--- a/db/migrations/2605211000_extract_items_frontend_properties.sql
+++ b/db/migrations/2605211000_extract_items_frontend_properties.sql
@@ -1,0 +1,72 @@
+-- +goose Up
+ALTER TABLE `items`
+  ADD COLUMN `display_settings` JSON NOT NULL DEFAULT (JSON_OBJECT())
+    COMMENT 'JSON object containing display/UI-only settings consumed by the frontend (e.g. children_layout, prompt_to_join_group_by_code). The backend does not interpret these settings; it stores and returns them as-is.'
+    AFTER `options`;
+
+-- Backfill `display_settings` from the legacy columns. We follow the
+-- "omit defaults" convention: a key is only present when its value differs from
+-- the column default (`children_layout = 'List'`, `prompt_to_join_group_by_code = 0`).
+-- `IFNULL(children_layout, 'List')` treats a NULL legacy value as the default.
+--
+-- `prompt_to_join_group_by_code` is a TINYINT(1), and CAST(<tinyint> AS JSON)
+-- yields a JSON *number* (e.g. 1) — but we want the JSON *boolean* `true`, since
+-- that's what new clients write through the API and what the response builder
+-- type-asserts on. CAST(IF(col, 'true', 'false') AS JSON) is the documented way
+-- to produce a JSON boolean from a numeric source in MySQL 8.
+UPDATE `items`
+SET `display_settings` = JSON_REMOVE(
+  JSON_OBJECT(
+    'children_layout',              IFNULL(`children_layout`, 'List'),
+    'prompt_to_join_group_by_code', CAST(IF(`prompt_to_join_group_by_code`, 'true', 'false') AS JSON)
+  ),
+  -- `'$.__none__'` is a no-op path: JSON_REMOVE silently skips nonexistent paths.
+  CASE WHEN IFNULL(`children_layout`, 'List') = 'List'
+       THEN '$.children_layout' ELSE '$.__none__' END,
+  CASE WHEN `prompt_to_join_group_by_code` = 0
+       THEN '$.prompt_to_join_group_by_code' ELSE '$.__none__' END
+);
+
+ALTER TABLE `items`
+  DROP COLUMN `repository_path`,
+  DROP COLUMN `title_bar_visible`,
+  DROP COLUMN `display_details_in_parent`,
+  DROP COLUMN `full_screen`,
+  DROP COLUMN `fixed_ranks`,
+  DROP COLUMN `show_user_infos`,
+  DROP COLUMN `children_layout`,
+  DROP COLUMN `prompt_to_join_group_by_code`;
+
+-- +goose Down
+ALTER TABLE `items`
+  ADD COLUMN `repository_path` text,
+  ADD COLUMN `title_bar_visible` tinyint unsigned NOT NULL DEFAULT '1'
+    COMMENT 'Whether the title bar should be visible initially when this item is loaded',
+  ADD COLUMN `display_details_in_parent` tinyint unsigned NOT NULL DEFAULT '0'
+    COMMENT 'If true, display a large icon, the subtitle, and more within the parent chapter',
+  ADD COLUMN `full_screen` enum('forceYes','forceNo','default') NOT NULL DEFAULT 'default'
+    COMMENT 'Whether the item should be loaded in full screen mode (without the navigation panel and most of the top header). By default, tasks are displayed in full screen, but not chapters.',
+  ADD COLUMN `fixed_ranks` tinyint(1) NOT NULL DEFAULT '0'
+    COMMENT 'If true, prevents users from changing the order of the children by drag&drop and auto-calculation of the order of children. Allows for manual setting of the order, for instance in cases where we want to have multiple items with the same order (check items_items.child_order).',
+  ADD COLUMN `show_user_infos` tinyint(1) NOT NULL DEFAULT '0'
+    COMMENT 'Always show user infos in title bar of all descendants. Allows the teacher to see who is working on what (e.g., during an exam).',
+  ADD COLUMN `children_layout` enum('List','Grid','Hide') DEFAULT 'List'
+    COMMENT 'How the children list are displayed (for chapters and skills)',
+  ADD COLUMN `prompt_to_join_group_by_code` tinyint(1) NOT NULL DEFAULT '0'
+    COMMENT 'Whether the UI should display a form for joining a group by code on the item page';
+
+-- Re-derive the two columns that we know how to extract from `display_settings`.
+-- `->>` returns the string "null" when the key is absent (the JSON_EXTRACT'd
+-- value is JSON null), hence the NULLIF guard before COALESCE.
+UPDATE `items`
+SET
+  `children_layout` = COALESCE(
+    NULLIF(`display_settings`->>'$.children_layout', 'null'),
+    'List'
+  ),
+  `prompt_to_join_group_by_code` = COALESCE(
+    JSON_EXTRACT(`display_settings`, '$.prompt_to_join_group_by_code') = TRUE,
+    0
+  );
+
+ALTER TABLE `items` DROP COLUMN `display_settings`;


### PR DESCRIPTION
## Summary

Phase 1 of a two-phase rework of the `items` table to extract frontend-only properties into a single opaque JSON column. The backend stops storing UI-only fields it never interprets, while the public API stays wire-compatible for old clients.

- **Drop 8 unused columns**: `items.repository_path`, `items.title_bar_visible`, `items.display_details_in_parent`, `items.full_screen`, `items.fixed_ranks`, `items.show_user_infos`, `items.children_layout`, `items.prompt_to_join_group_by_code`.
- **Add `items.display_settings`** (`JSON NOT NULL DEFAULT (JSON_OBJECT())`): an opaque pass-through blob for frontend-controlled display settings. The backend stores and returns it verbatim; it is never inspected by business logic. Currently used keys are `children_layout` and `prompt_to_join_group_by_code`, but the frontend can add arbitrary keys.
- **GET endpoints** (`itemView`, `itemChildrenView`, `itemParentsView`, `itemPrerequisitesView`, `itemDependenciesView`) now return `display_settings` alongside the legacy fields, which are kept for wire-compatibility:
  - `children_layout` and `prompt_to_join_group_by_code` are derived from `display_settings` (defaults: `"List"`, `false`).
  - `title_bar_visible`, `display_details_in_parent`, `full_screen`, `show_user_infos`, `fixed_ranks` always return their previous DB defaults (`true`, `false`, `"default"`, `false`, `false`).
- **POST/PUT endpoints** (`itemCreate`, `itemUpdate`) accept `display_settings` (object, never `null`; full replacement on PUT). The seven deprecated legacy request-side fields are still accepted but silently ignored on write — frontends must migrate to `display_settings` to keep changing those settings.
- Migration backfills `display_settings` from the legacy columns, applying the **omit-defaults convention**: a key is present only when its value differs from the default (`children_layout = 'List'`, `prompt_to_join_group_by_code = false`), so the typical row materializes as `{}`.
- Phase 2 (separate, future PR) will remove the deprecated fields from the request/response shapes entirely.

## Migration

`db/migrations/2605211000_extract_items_frontend_properties.sql`:
- Adds `display_settings` (JSON, NOT NULL, default `{}`).
- Backfills it from `children_layout` / `prompt_to_join_group_by_code`, omitting any key equal to its default.
- The boolean is materialized via `CAST(IF(prompt_to_join_group_by_code, 'true', 'false') AS JSON)` to produce a JSON `true`/`false` (a naive `CAST(<tinyint> AS JSON)` would yield a JSON integer `1`/`0`, which the GET response builder would silently fall back to `false` on).
- Drops the eight deprecated columns.
- Down migration restores all eight columns and re-derives `children_layout` / `prompt_to_join_group_by_code` from `display_settings`.

## Notable design decisions

- **`display_settings` is `NOT NULL` with default `{}`**, so the GET response builder never has to deal with a nil map and the column is always a well-formed object on the wire.
- **Pointer (`*database.JSON`) on the request side** to distinguish "field omitted" (leave column untouched) from "field set to `{}`" (replace with empty object). Sending `null` is rejected with HTTP 400.
- **Full replacement on PUT, no merge**: simpler semantics, easier for the frontend to reason about.
- **Deprecation behavior is uniform across all seven legacy request fields**: any value (including off-spec ones for `full_screen`) is accepted-and-dropped. No `oneof=` validators on the deprecated fields.
- **`boolFromDisplaySettings` is permissive** (accepts `bool` and `float64`) as defense-in-depth against any legacy/manually-inserted row that happens to store a boolean key as a JSON integer.
- **`database.JSON.Scan` short-circuits on `src == nil`**, so a NULL DB value (e.g. from a manual `UPDATE … SET col = NULL` on a debug instance) decodes to a nil map instead of panicking on the type assertion. Affects all callers of this type, not just `items` — `users.profile` benefits too.

## Documentation

- `ARCHITECTURE.md`: new "Display settings (frontend pass-through)" subsection covering the storage convention, the known keys, the omit-defaults rule, and the phase-1 wire-compat behavior.
- `CHANGELOG.md`: Unreleased entry listing the schema break, the new column, the GET/POST/PUT changes, and the deprecation.
- `plans/items-display-settings-phase-1.md`: full rollout plan for this PR.
- `plans/items-display-settings-phase-2.md`: follow-up plan for the eventual cleanup.
- `plans/items-display-settings-frontend-migration.md`: migration guide for frontend teams (what to change, worked examples, glossary).
- `reviews/items-display-settings-phase-1.md`: code review notes (incl. the resolution of each remark).

## Test plan

- [x] `./bin/golangci-lint run -v --timeout 2m`: 0 issues.
- [x] All BDD scenarios under `app/api/items/...` pass, including:
  - `display_settings` happy paths on create / update / get (set to object, set to `{}`, omitted, with arbitrary frontend-only keys).
  - `display_settings` derived legacy-field readback (`children_layout`, `prompt_to_join_group_by_code` correctly resolved from the JSON).
  - **Robustness**: `display_settings: null | [] | "hello" | 42` rejected with HTTP 400 on both create and update.
  - **Regression** for the migration's JSON-shape correctness: a `Scenario Outline` in `get_item.feature` exercises rows where `prompt_to_join_group_by_code` is stored as `1`, `0`, `true`, `false`, asserting the legacy GET field resolves to the right boolean in every case.
- [x] Migration backfill expression manually probed against MySQL 8.0.34 with seven `(children_layout, prompt_to_join_group_by_code)` input combinations; output matches the omit-defaults convention and produces JSON booleans (not integers).
- [ ] Frontend(s) consuming this API need to start writing `children_layout` / `prompt_to_join_group_by_code` through `display_settings` (see `plans/items-display-settings-frontend-migration.md`). The legacy fields will keep working through phase 1 and be removed in phase 2.

## Out of scope

- Removing the deprecated request/response fields from the API (planned as phase 2 once frontends have migrated).
- Validating the contents of `display_settings` (the column is intentionally an opaque pass-through).
- Per-key migration of arbitrary additional frontend-only settings — the column is a free-form blob and frontends can add new keys without backend changes.
