### PR TITLE
item-children service: add display settings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -939,7 +939,16 @@ Each command is defined in `cmd/<command>.go`:
 
 #### Display settings (frontend pass-through)
 
-The `items.display_settings` column stores a JSON object that the backend treats as an opaque blob: it is stored verbatim and returned as-is on every `items` GET endpoint, and never inspected by backend business logic. Its purpose is to let frontends store UI-only settings against an item without requiring a backend schema change for every new setting.
+The `items.display_settings` column stores a JSON object that the backend treats as an opaque blob: it is stored verbatim and returned as-is on the GET endpoints listed below, and never inspected by backend business logic. Its purpose is to let frontends store UI-only settings against an item without requiring a backend schema change for every new setting.
+
+Endpoints that currently expose `display_settings`:
+
+| Endpoint                                    | Where the field appears               |
+| ------------------------------------------- | ------------------------------------- |
+| `GET /items/{item_id}` (`itemView`)         | top-level field on the item           |
+| `GET /items/{item_id}/children` (`itemChildrenView`) | per visible child            |
+
+Endpoints that **do not** expose `display_settings` (yet): `itemParentsView`, `itemPrerequisitesView`, `itemDependenciesView`, and `itemNavigationView`. They return items but omit this field; frontends that need display settings for the items returned by these endpoints must re-fetch via `itemView`. Rolling the field out to those endpoints would only require adding it to the shared `RawCommonItemFields` plumbing, but has been deliberately deferred until there is a concrete frontend need (the contract on the existing endpoints is unaffected).
 
 Currently known keys (this list is informational; the backend does not enforce it):
 

--- a/app/api/items/get_children.feature
+++ b/app/api/items/get_children.feature
@@ -12,14 +12,14 @@ Feature: Get item children
       | 17       | fr         | fr               |
       | 22       | info       |                  |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url                    | uses_api | hints_allowed |
-      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl         | true     | true          |
-      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null                   | true     | true          |
-      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          |
-      | 230 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          |
-      | 300 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/300 | true     | true          |
-      | 301 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/301 | true     | true          |
-      | 302 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/302 | true     | true          |
+      | id  | type    | default_language_tag | no_score | validation_type | requires_explicit_entry | allows_multiple_attempts | entry_participant_type | duration | read_only | url                    | uses_api | hints_allowed | display_settings                                               |
+      | 200 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://someurl         | true     | true          | {}                                                             |
+      | 210 | Chapter | en                   | true     | All             | false                   | true                     | User                   | 10:20:31 | true      | null                   | true     | true          | {"children_layout":"Grid"}                                     |
+      | 220 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          | {"prompt_to_join_group_by_code":true}                          |
+      | 230 | Chapter | en                   | true     | All             | false                   | true                     | Team                   | 10:20:32 | true      | null                   | true     | true          | {"children_layout":"Hide","prompt_to_join_group_by_code":true} |
+      | 300 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/300 | true     | true          | {}                                                             |
+      | 301 | Skill   | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/301 | true     | true          | {}                                                             |
+      | 302 | Task    | en                   | true     | All             | true                    | true                     | Team                   | 10:20:30 | true      | http://example.com/302 | true     | true          | {}                                                             |
     And the database has the following table "items_strings":
       | item_id | language_tag | title        | image_url                  | subtitle     | description     | edu_comment    |
       | 200     | en           | Category 1   | http://example.com/my0.jpg | Subtitle 0   | Description 0   | Some comment   |
@@ -140,6 +140,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 13.3,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "string": {
           "language_tag": "en",
           "title": "Chapter B",
@@ -186,6 +187,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 22.2,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "string": {
           "language_tag": "en",
           "title": "Chapter A",
@@ -242,6 +244,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 0,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "permissions": {
           "can_edit": "none",
           "can_grant_view": "none",
@@ -278,6 +281,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 20,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "permissions": {
           "can_edit": "none",
           "can_grant_view": "none",
@@ -333,6 +337,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -368,6 +373,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -414,6 +420,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 15.5,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "string": {
           "language_tag": "en",
           "title": "Chapter B",
@@ -460,6 +467,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 24.4,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "string": {
           "language_tag": "en",
           "title": "Chapter A",
@@ -516,6 +524,7 @@ Feature: Get item children
         "requires_explicit_entry": false,
         "best_score": 0,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "string": {
           "language_tag": "en",
           "title": "Chapter B",
@@ -550,6 +559,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "string": {
           "language_tag": "en",
           "title": "Chapter A",
@@ -595,6 +605,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -633,6 +644,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -683,6 +695,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": false,
+        "display_settings": {"prompt_to_join_group_by_code": true},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -721,6 +734,7 @@ Feature: Get item children
         "default_language_tag": "en",
         "best_score": 0,
         "grants_access_to_items": true,
+        "display_settings": {"children_layout": "Grid"},
         "requires_explicit_entry": false,
         "results": [],
         "string": {
@@ -815,4 +829,61 @@ Feature: Get item children
     And the response at $[*].results in JSON should be:
     """
     [[]]
+    """
+
+  Scenario: display_settings is returned verbatim as a pass-through (including unknown keys)
+    Given I am the user with id "11"
+    # 400 has an empty object, 401 carries an unknown key alongside a known one
+    # (to prove the backend never whitelists or rewrites the payload), and 402
+    # exercises the multi-key shape with BOTH known keys set — the exact shape
+    # the phase-1 migration produces from rows that previously had
+    # `children_layout = 'Hide'` and `prompt_to_join_group_by_code = true`.
+    And the database table "items" also has the following rows:
+      | id  | type    | default_language_tag | display_settings                                               |
+      | 400 | Chapter | en                   | {}                                                             |
+      | 401 | Chapter | en                   | {"children_layout":"Grid","foo":"bar"}                         |
+      | 402 | Chapter | en                   | {"children_layout":"Hide","prompt_to_join_group_by_code":true} |
+    And the database table "items_strings" also has the following rows:
+      | item_id | language_tag | title        |
+      | 400     | en           | Empty        |
+      | 401     | en           | Pass-through |
+      | 402     | en           | Multi-key    |
+    And the database table "items_items" also has the following rows:
+      | parent_item_id | child_item_id | child_order |
+      | 200            | 400           | 4           |
+      | 200            | 401           | 5           |
+      | 200            | 402           | 6           |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated |
+      | 11       | 400     | solution           |
+      | 11       | 401     | solution           |
+      | 11       | 402     | solution           |
+    When I send a GET request to "/items/200/children?attempt_id=1"
+    Then the response code should be 200
+    # Response is ordered by items_items.child_order: 220 (1), 210 (2), 400 (4),
+    # 401 (5), 402 (6); item 230 (3) is filtered out because user 11 has no
+    # permission on it.
+    And the response at $[2].id in JSON should be:
+    """
+    "400"
+    """
+    And the response at $[2].display_settings in JSON should be:
+    """
+    {}
+    """
+    And the response at $[3].id in JSON should be:
+    """
+    "401"
+    """
+    And the response at $[3].display_settings in JSON should be:
+    """
+    {"children_layout": "Grid", "foo": "bar"}
+    """
+    And the response at $[4].id in JSON should be:
+    """
+    "402"
+    """
+    And the response at $[4].display_settings in JSON should be:
+    """
+    {"children_layout": "Hide", "prompt_to_join_group_by_code": true}
     """

--- a/app/api/items/get_children.go
+++ b/app/api/items/get_children.go
@@ -64,6 +64,12 @@ type visibleChildItemFields struct {
 	// whether solving this item grants access to some items (visible or not)
 	// (only for visible items)
 	GrantsAccessToItems bool `json:"grants_access_to_items"`
+
+	// JSON object with display/UI settings interpreted by the frontend.
+	// Absent for invisible children (like every other field on this struct);
+	// when present, it is always an object (possibly `{}`), never `null`.
+	// only for visible items
+	DisplaySettings database.JSON `json:"display_settings"`
 }
 
 // swagger:model childItem
@@ -144,6 +150,11 @@ type rawListChildItem struct {
 	WatchPropagation           bool
 	EditPropagation            bool
 	RequestHelpPropagation     bool
+
+	// items
+	// `items.display_settings` is `NOT NULL` (defaults to `{}`), so we can read it
+	// into a non-pointer `database.JSON`; downstream code never needs a nil check.
+	DisplaySettings database.JSON
 
 	// item_dependencies
 	GrantsAccessToItems bool
@@ -258,6 +269,7 @@ func (srv *Service) getItemChildren(responseWriter http.ResponseWriter, httpRequ
 				upper_view_levels_propagation, grant_view_propagation, watch_propagation, edit_propagation, request_help_propagation,
 				items.id, items.type, items.default_language_tag,
 				items.validation_type, items.duration, items.entry_participant_type, items.no_score,
+				items.display_settings,
 				IFNULL(can_view_generated_value, 1) AS can_view_generated_value,
 				IFNULL(can_grant_view_generated_value, 1) AS can_grant_view_generated_value,
 				IFNULL(can_watch_generated_value, 1) AS can_watch_generated_value,
@@ -357,6 +369,10 @@ func childItemsFromRawData(
 					Duration:               rawData[index].Duration,
 					NoScore:                rawData[index].NoScore,
 					GrantsAccessToItems:    rawData[index].GrantsAccessToItems,
+					// OrEmpty() defends the documented "never null" contract against a
+					// stray DB NULL (the column is NOT NULL, but `JSON.Scan` decodes
+					// any NULL it sees into a nil map, which would marshal to `null`).
+					DisplaySettings: rawData[index].DisplaySettings.OrEmpty(),
 				}
 			}
 			if rawData[index].CanViewGeneratedValue >= permissionGrantedStore.ViewIndexByName("content") {

--- a/app/api/items/get_item.go
+++ b/app/api/items/get_item.go
@@ -482,9 +482,12 @@ func constructItemResponseFromDBData(
 		ReadOnly:                     rawData.ReadOnly,
 		EnteringTimeMin:              time.Time(rawData.EnteringTimeMin),
 		EnteringTimeMax:              time.Time(rawData.EnteringTimeMax),
-		DisplaySettings:              rawData.DisplaySettings,
-		BestScore:                    rawData.BestScore,
-		SupportedLanguageTags:        strings.Split(rawData.SupportedLanguageTags, ","),
+		// OrEmpty() defends the documented "never null" contract against a stray
+		// DB NULL (the column is NOT NULL, but `JSON.Scan` decodes any NULL it
+		// sees into a nil map, which would marshal to `null`).
+		DisplaySettings:       rawData.DisplaySettings.OrEmpty(),
+		BestScore:             rawData.BestScore,
+		SupportedLanguageTags: strings.Split(rawData.SupportedLanguageTags, ","),
 	}
 
 	if rawData.CanViewGeneratedValue == permissionGrantedStore.ViewIndexByName("solution") {

--- a/app/database/json.go
+++ b/app/database/json.go
@@ -35,6 +35,26 @@ func (j *JSON) Value() (driver.Value, error) {
 	return json.Marshal(*j)
 }
 
+// OrEmpty returns a non-nil JSON map: the underlying map when the receiver
+// holds one, and an empty (allocated) JSON map otherwise (including when the
+// receiver pointer itself is nil). Use it on the response-construction path
+// for columns documented as "always a JSON object, never NULL" (e.g.
+// `items.display_settings`): the DB schema enforces NOT NULL, but `Scan`
+// defensively decodes a stray NULL into a nil map, which `encoding/json`
+// would then emit as `null` — silently violating the documented contract.
+// OrEmpty closes that gap at the call site without changing `Scan`'s
+// semantics (which other, legitimately nullable JSON columns like
+// `users.profile` rely on for `null` round-tripping).
+//
+// Pointer receiver keeps method-set parity with `Scan`/`Value` (the
+// `recvcheck` linter rejects a mixed receiver style on the same type).
+func (j *JSON) OrEmpty() JSON {
+	if j == nil || *j == nil {
+		return JSON{}
+	}
+	return *j
+}
+
 var (
 	_ = sql.Scanner(&JSON{})
 	_ = driver.Valuer(&JSON{})

--- a/app/database/json_test.go
+++ b/app/database/json_test.go
@@ -61,3 +61,32 @@ func TestJSON_Value_Nil(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, value)
 }
+
+func TestJSON_OrEmpty(t *testing.T) {
+	populated := JSON{"children_layout": "Grid", "foo": "bar"}
+	nilMap := JSON(nil)
+	emptyMap := JSON{}
+	tests := []struct {
+		name string
+		in   *JSON
+		want JSON
+	}{
+		{name: "nil pointer receiver returns empty allocated map", in: nil, want: JSON{}},
+		{name: "non-nil pointer to nil map returns empty allocated map", in: &nilMap, want: JSON{}},
+		{name: "already-empty map is preserved", in: &emptyMap, want: JSON{}},
+		{
+			name: "populated map is preserved (same keys, same values)",
+			in:   &populated,
+			want: JSON{"children_layout": "Grid", "foo": "bar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.OrEmpty()
+			assert.Equal(t, tt.want, got)
+			// Result must always be a non-nil map so encoding/json emits `{}`
+			// rather than `null` for the "never null" response contract.
+			assert.NotNil(t, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `display_settings` JSON object to every visible child returned by `GET /items/{item_id}/children`, as an opaque pass-through (same shape as `GET /items/{item_id}` already exposes). Also lands a small defensive helper (`database.JSON.OrEmpty`) that locks in the documented "never `null`" contract at both call sites, and tightens the docs to enumerate which list endpoints expose the field and which don't.

No DB migration, no event-system change, no breaking change. Purely additive on the GET side.

## Why

Phase 1 (v2.44.0) introduced `items.display_settings` and added the field to `GET /items/{item_id}` + POST/PUT. Phase 2 (v2.45.0) removed the seven legacy display fields. The v2.44.0 CHANGELOG advertised `display_settings` on `itemChildrenView`/`itemParentsView`/`itemPrerequisitesView`/`itemDependenciesView` too, but **none** of those endpoints actually carried it. This PR closes the gap for `itemChildrenView` (by far the most-used of the four) and corrects the documentation to be precise about which endpoints still don't expose the field.

## What changed

### Feature — `display_settings` on `itemChildrenView`

- `app/api/items/get_children.go`
  - SELECT `items.display_settings` in `constructItemChildrenQuery`.
  - Scan into a new `DisplaySettings database.JSON` field on `rawListChildItem`.
  - Expose as `DisplaySettings database.JSON \`json:"display_settings"\`` on `visibleChildItemFields` (i.e. **only for visible children** — invisible rows surfaced via `show_invisible_items=1` still emit only the stripped id/type/items_items/permissions fields, matching the existing convention).
  - Populate via `rawData[index].DisplaySettings.OrEmpty()` in `childItemsFromRawData`.

### Defensive fix — never silently emit `"display_settings": null`

- `app/database/json.go` adds `(*JSON).OrEmpty()`. Returns a non-nil JSON map: the underlying map when the receiver holds one, an empty allocated map otherwise (covers both the nil-pointer-receiver and pointer-to-nil-map cases).
- `Scan` itself is intentionally left alone — `users.profile` is a legitimately nullable `*database.JSON` column that relies on `null` round-tripping. `OrEmpty` closes the gap at the call site only.
- Wired up in:
  - `childItemsFromRawData` (new code in this PR).
  - `constructItemResponseFromDBData` in `app/api/items/get_item.go` (pre-existing latent hole — same fix).

### Docs

- `ARCHITECTURE.md` §"Display settings (frontend pass-through)" — replaces the prose with a table enumerating endpoints that **do** expose `display_settings` (`itemView`, `itemChildrenView`) and an explicit list of those that **don't** (`itemParentsView`, `itemPrerequisitesView`, `itemDependenciesView`, `itemNavigationView`), with the rationale (deferred until concrete frontend need; trivial to roll out via `RawCommonItemFields` later).
- `CHANGELOG.md` (Unreleased)
  1. The new field on `itemChildrenView`, with the explicit note that the sibling list endpoints still don't carry it.
  2. A `docs:` line back-correcting the v2.44.0 entry, which inaccurately listed four list endpoints as having received `display_settings` in that release.

### Tests

- `app/api/items/get_children.feature`
  - `display_settings` column added to the items fixture, with values exercising empty/single-key/multi-key shapes and the omit-defaults convention.
  - Every existing visible-child assertion (7 scenarios × 2 children = 14 places) extended with `"display_settings": <object>`.
  - The `show_invisible_items=1` scenario verifies the invisible row (id 230) still does **not** carry the key.
  - New "pass-through" scenario covers three shapes on three new items (400/401/402): `{}`, `{"children_layout":"Grid","foo":"bar"}` (unknown key proves no whitelisting), and `{"children_layout":"Hide","prompt_to_join_group_by_code":true}` (the exact multi-key shape the phase-1 migration produces).
- `app/database/json_test.go` — table-driven `TestJSON_OrEmpty` covering nil pointer, pointer-to-nil-map, already-empty map, populated map.

## Verification

```bash
./bin/golangci-lint run -v --timeout 2m       # 0 issues
go test ./app/database/ -run TestJSON -count=1   # all pass (including 4 new OrEmpty sub-tests)
make test-bdd DIRECTORY=./app/api/items       # all scenarios pass, ~6 min