### PR TITLE
add item display settings into the item nav/root services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -948,6 +948,8 @@ Endpoints that currently expose `display_settings`:
 | `GET /items/{item_id}` (`itemView`)         | top-level field on the item           |
 | `GET /items/{item_id}/children` (`itemChildrenView`) | per visible child            |
 | `GET /items/{item_id}/navigation` (`itemNavigationView`) | root item + per child |
+| `GET /current-user/group-memberships/activities` (`activitiesView`) | per root activity |
+| `GET /current-user/group-memberships/skills` (`skillsView`) | per root skill |
 
 Endpoints that **do not** expose `display_settings` (yet): `itemParentsView`, `itemPrerequisitesView`, and `itemDependenciesView`. They return items but omit this field; frontends that need display settings for the items returned by these endpoints must re-fetch via `itemView`. Rolling the field out to those endpoints would only require adding it to the shared `RawCommonItemFields` plumbing, but has been deliberately deferred until there is a concrete frontend need (the contract on the existing endpoints is unaffected).
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -947,8 +947,9 @@ Endpoints that currently expose `display_settings`:
 | ------------------------------------------- | ------------------------------------- |
 | `GET /items/{item_id}` (`itemView`)         | top-level field on the item           |
 | `GET /items/{item_id}/children` (`itemChildrenView`) | per visible child            |
+| `GET /items/{item_id}/navigation` (`itemNavigationView`) | root item + per child |
 
-Endpoints that **do not** expose `display_settings` (yet): `itemParentsView`, `itemPrerequisitesView`, `itemDependenciesView`, and `itemNavigationView`. They return items but omit this field; frontends that need display settings for the items returned by these endpoints must re-fetch via `itemView`. Rolling the field out to those endpoints would only require adding it to the shared `RawCommonItemFields` plumbing, but has been deliberately deferred until there is a concrete frontend need (the contract on the existing endpoints is unaffected).
+Endpoints that **do not** expose `display_settings` (yet): `itemParentsView`, `itemPrerequisitesView`, and `itemDependenciesView`. They return items but omit this field; frontends that need display settings for the items returned by these endpoints must re-fetch via `itemView`. Rolling the field out to those endpoints would only require adding it to the shared `RawCommonItemFields` plumbing, but has been deliberately deferred until there is a concrete frontend need (the contract on the existing endpoints is unaffected).
 
 Currently known keys (this list is informational; the backend does not enforce it):
 

--- a/app/api/currentuser/get_group_activities.feature
+++ b/app/api/currentuser/get_group_activities.feature
@@ -52,21 +52,21 @@ Feature: Get root activities for a participant group
       | 29         | 22       | true              |
       | 30         | 24       | true              |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
-      | 200 | Task    | en                   | false    | false                   | User                   |
-      | 210 | Chapter | en                   | false    | false                   | User                   |
-      | 220 | Chapter | en                   | false    | false                   | User                   |
-      | 230 | Chapter | en                   | true     | true                    | Team                   |
-      | 211 | Task    | en                   | false    | false                   | User                   |
-      | 231 | Task    | en                   | false    | false                   | User                   |
-      | 232 | Task    | en                   | false    | false                   | User                   |
-      | 240 | Task    | en                   | false    | false                   | User                   |
-      | 250 | Task    | en                   | false    | false                   | User                   |
-      | 260 | Task    | en                   | false    | false                   | User                   |
-      | 270 | Task    | en                   | false    | false                   | User                   |
-      | 280 | Task    | en                   | false    | false                   | User                   |
-      | 290 | Task    | en                   | false    | false                   | User                   |
-      | 300 | Task    | en                   | false    | false                   | User                   |
+      | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type | display_settings           |
+      | 200 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 210 | Chapter | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 220 | Chapter | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 230 | Chapter | en                   | true     | true                    | Team                   | {"children_layout":"Grid"} |
+      | 211 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 231 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 232 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 240 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 250 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 260 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 270 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 280 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 290 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 300 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
@@ -196,6 +196,7 @@ Feature: Get root activities for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "answer_with_grant", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -225,6 +226,7 @@ Feature: Get root activities for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -248,6 +250,7 @@ Feature: Get root activities for a participant group
           "permissions": {
             "can_view": "solution", "can_grant_view": "solution_with_grant", "can_watch": "none", "can_edit": "none", "is_owner": true
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "entry_participant_type": "User",
           "no_score": false,
@@ -291,6 +294,7 @@ Feature: Get root activities for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "answer_with_grant", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "fr", "title": "Chapitre A"},
@@ -310,6 +314,7 @@ Feature: Get root activities for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "en", "title": "Chapter B"},
@@ -331,6 +336,7 @@ Feature: Get root activities for a participant group
           "entry_participant_type": "User",
           "has_visible_children": true,
           "no_score": false,
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -365,6 +371,7 @@ Feature: Get root activities for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -394,6 +401,7 @@ Feature: Get root activities for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "en", "title": "Chapter B"},
@@ -413,6 +421,7 @@ Feature: Get root activities for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "en", "title": "Chapter B"},
@@ -442,6 +451,7 @@ Feature: Get root activities for a participant group
           },
           "best_score": 10,
           "entry_participant_type": "User",
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "has_visible_children": true,
           "no_score": false,
@@ -478,6 +488,7 @@ Feature: Get root activities for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -504,6 +515,7 @@ Feature: Get root activities for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -530,6 +542,7 @@ Feature: Get root activities for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -556,6 +569,7 @@ Feature: Get root activities for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {

--- a/app/api/currentuser/get_group_activities.go
+++ b/app/api/currentuser/get_group_activities.go
@@ -28,6 +28,10 @@ type rawRootItem struct {
 	EntryParticipantType  string
 	NoScore               bool
 
+	// `items.display_settings` is `NOT NULL` (defaults to `{}`), so we can read it
+	// into a non-pointer `database.JSON`; downstream code never needs a nil check.
+	DisplaySettings database.JSON
+
 	// title (from items_strings) in the user’s default language or (if not available) default language of the item
 	Title       *string
 	LanguageTag string
@@ -84,6 +88,12 @@ type rootItem struct {
 	BestScore float32 `json:"best_score"`
 	// required:true
 	Results []structures.ItemResult `json:"results"`
+
+	// JSON object with display/UI settings interpreted by the frontend. Always
+	// present, never `null`; an item with no non-default settings has the value
+	// `{}`.
+	// required: true
+	DisplaySettings database.JSON `json:"display_settings"`
 }
 
 // swagger:operation GET /current-user/group-memberships/activities group-memberships activitiesView
@@ -228,6 +238,10 @@ func generateRootItemInfoFromRawData(store *database.DataStore, rawData *rawRoot
 		HasVisibleChildren:    rawData.HasVisibleChildren,
 		BestScore:             rawData.BestScore,
 		Results:               make([]structures.ItemResult, 0, 1),
+		// OrEmpty() defends the documented "never null" contract against a stray
+		// DB NULL (the column is NOT NULL, but `JSON.Scan` decodes any NULL it
+		// sees into a nil map, which would marshal to `null`).
+		DisplaySettings: rawData.DisplaySettings.OrEmpty(),
 	}
 }
 
@@ -291,6 +305,7 @@ func getRootItemsFromDB(
 			groups.id AS group_id, groups.name AS group_name, groups.type AS group_type, groups.created_at,
 			items.id, items.type AS item_type,
 			items.requires_explicit_entry, items.entry_participant_type, items.no_score, items.default_language_tag,
+			items.display_settings,
 			IFNULL(
 				(SELECT MAX(results.score_computed) AS best_score
 				 FROM results

--- a/app/api/currentuser/get_group_skills.feature
+++ b/app/api/currentuser/get_group_skills.feature
@@ -53,21 +53,21 @@ Feature: Get root skills for a participant group
       | 29         | 22       | true              |
       | 30         | 24       | true              |
     And the database has the following table "items":
-      | id  | type  | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
-      | 200 | Skill | en                   | false    | false                   | User                   |
-      | 210 | Skill | en                   | false    | false                   | User                   |
-      | 211 | Task  | en                   | false    | false                   | User                   |
-      | 220 | Skill | en                   | false    | false                   | User                   |
-      | 230 | Skill | en                   | true     | true                    | Team                   |
-      | 231 | Task  | en                   | false    | false                   | User                   |
-      | 232 | Task  | en                   | false    | false                   | User                   |
-      | 240 | Skill | en                   | false    | false                   | User                   |
-      | 250 | Skill | en                   | false    | false                   | User                   |
-      | 260 | Skill | en                   | false    | false                   | User                   |
-      | 270 | Skill | en                   | false    | false                   | User                   |
-      | 280 | Skill | en                   | false    | false                   | User                   |
-      | 290 | Skill | en                   | false    | false                   | User                   |
-      | 300 | Skill | en                   | false    | false                   | User                   |
+      | id  | type  | default_language_tag | no_score | requires_explicit_entry | entry_participant_type | display_settings           |
+      | 200 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 210 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 211 | Task  | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 220 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 230 | Skill | en                   | true     | true                    | Team                   | {"children_layout":"Grid"} |
+      | 231 | Task  | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 232 | Task  | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 240 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 250 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 260 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 270 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 280 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 290 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
+      | 300 | Skill | en                   | false    | false                   | User                   | {"children_layout":"Grid"} |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
@@ -197,6 +197,7 @@ Feature: Get root skills for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "answer_with_grant", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -226,6 +227,7 @@ Feature: Get root skills for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -249,6 +251,7 @@ Feature: Get root skills for a participant group
           "permissions": {
             "can_view": "solution", "can_grant_view": "solution_with_grant", "can_watch": "none", "can_edit": "none", "is_owner": true
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "entry_participant_type": "User",
           "no_score": false,
@@ -292,6 +295,7 @@ Feature: Get root skills for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "answer_with_grant", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "fr", "title": "Compétence 2"},
@@ -311,6 +315,7 @@ Feature: Get root skills for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "en", "title": "Skill 3"},
@@ -332,6 +337,7 @@ Feature: Get root skills for a participant group
           "entry_participant_type": "User",
           "has_visible_children": true,
           "no_score": false,
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -366,6 +372,7 @@ Feature: Get root skills for a participant group
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants",
             "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [
             {
@@ -394,6 +401,7 @@ Feature: Get root skills for a participant group
             "can_view": "content_with_descendants", "can_grant_view": "none", "can_watch": "result", "can_edit": "none", "is_owner": false
           },
           "best_score": 78,
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": true,
           "entry_participant_type": "Team",
           "has_visible_children": true,
@@ -420,6 +428,7 @@ Feature: Get root skills for a participant group
           "permissions": {
             "can_edit": "none", "can_grant_view": "none", "can_view": "content_with_descendants", "can_watch": "none", "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {"language_tag": "en", "title": "Skill 3"},
@@ -449,6 +458,7 @@ Feature: Get root skills for a participant group
           },
           "best_score": 10,
           "entry_participant_type": "User",
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "has_visible_children": true,
           "no_score": false,
@@ -486,6 +496,7 @@ Feature: Get root skills for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -512,6 +523,7 @@ Feature: Get root skills for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -538,6 +550,7 @@ Feature: Get root skills for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {
@@ -564,6 +577,7 @@ Feature: Get root skills for a participant group
             "can_watch": "none",
             "is_owner": false
           },
+          "display_settings": {"children_layout": "Grid"},
           "requires_explicit_entry": false,
           "results": [],
           "string": {

--- a/app/api/items/get_navigation.feature
+++ b/app/api/items/get_navigation.feature
@@ -32,15 +32,15 @@ Feature: Get navigation for an item
       | 12         | 1        | true              |
       | 12         | 19       | true              |
     And the database has the following table "items":
-      | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type |
-      | 200 | Task    | en                   | false    | false                   | User                   |
-      | 210 | Chapter | en                   | false    | false                   | User                   |
-      | 220 | Chapter | en                   | false    | false                   | User                   |
-      | 230 | Chapter | en                   | true     | true                    | Team                   |
-      | 211 | Task    | en                   | false    | false                   | User                   |
-      | 231 | Task    | en                   | false    | false                   | User                   |
-      | 232 | Task    | en                   | false    | false                   | User                   |
-      | 250 | Task    | en                   | false    | false                   | User                   |
+      | id  | type    | default_language_tag | no_score | requires_explicit_entry | entry_participant_type | display_settings                                               |
+      | 200 | Task    | en                   | false    | false                   | User                   | {"children_layout":"Grid","prompt_to_join_group_by_code":true} |
+      | 210 | Chapter | en                   | false    | false                   | User                   | {"prompt_to_join_group_by_code":true}                          |
+      | 220 | Chapter | en                   | false    | false                   | User                   | {}                                                             |
+      | 230 | Chapter | en                   | true     | true                    | Team                   | {"children_layout":"Grid"}                                     |
+      | 211 | Task    | en                   | false    | false                   | User                   | {}                                                             |
+      | 231 | Task    | en                   | false    | false                   | User                   | {}                                                             |
+      | 232 | Task    | en                   | false    | false                   | User                   | {}                                                             |
+      | 250 | Task    | en                   | false    | false                   | User                   | {}                                                             |
     And the database has the following table "permissions_generated":
       | group_id | item_id | can_view_generated       | can_grant_view_generated | can_watch_generated | can_edit_generated | is_owner_generated |
       | 1        | 230     | none                     | none                     | result              | none               | false              |
@@ -142,6 +142,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "permissions": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_watch": "none", "can_edit": "none", "is_owner": true
@@ -151,6 +152,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -176,6 +178,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -196,6 +199,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -299,6 +303,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "attempt_id": "0",
         "permissions": {
@@ -308,6 +313,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -333,6 +339,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -353,6 +360,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -387,6 +395,7 @@ Feature: Get navigation for an item
       {
         "id": "232",
         "type": "Task",
+        "display_settings": {},
         "string": {"title": "Task 3", "language_tag": "en"},
         "attempt_id": "0",
         "permissions": {
@@ -405,6 +414,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "attempt_id": "0",
         "permissions": {
@@ -423,6 +433,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Catégorie 1", "language_tag": "fr"},
         "attempt_id": "0",
         "permissions": {
@@ -432,6 +443,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -446,6 +458,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -464,6 +477,7 @@ Feature: Get navigation for an item
             "no_score": false,
             "has_visible_children": false,
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "string": {"title": "Chapitre A", "language_tag": "fr"},
             "best_score": 0,
             "permissions": {
@@ -484,6 +498,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "attempt_id": "0",
         "permissions": {
@@ -493,6 +508,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -513,6 +529,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -527,6 +544,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -557,6 +575,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "attempt_id": "0",
         "permissions": {
@@ -566,6 +585,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -596,6 +616,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "permissions": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_watch": "none", "can_edit": "none", "is_owner": true
@@ -605,6 +626,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -631,6 +653,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -652,6 +675,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -683,6 +707,7 @@ Feature: Get navigation for an item
       {
         "id": "200",
         "type": "Task",
+        "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
         "string": {"title": "Category 1", "language_tag": "en"},
         "permissions": {
           "can_view": "solution", "can_grant_view": "solution_with_grant", "can_watch": "none", "can_edit": "none", "is_owner": true
@@ -692,6 +717,7 @@ Feature: Get navigation for an item
           {
             "id": "230",
             "type": "Chapter",
+            "display_settings": {"children_layout": "Grid"},
             "requires_explicit_entry": true,
             "entry_participant_type": "Team",
             "no_score": true,
@@ -718,6 +744,7 @@ Feature: Get navigation for an item
           {
             "id": "220",
             "type": "Chapter",
+            "display_settings": {},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,
@@ -739,6 +766,7 @@ Feature: Get navigation for an item
           {
             "id": "210",
             "type": "Chapter",
+            "display_settings": {"prompt_to_join_group_by_code": true},
             "requires_explicit_entry": false,
             "entry_participant_type": "User",
             "no_score": false,

--- a/app/api/items/get_navigation.go
+++ b/app/api/items/get_navigation.go
@@ -16,6 +16,12 @@ import (
 type itemNavigationResponse struct {
 	*structures.ItemCommonFields
 
+	// JSON object with display/UI settings interpreted by the frontend. Always
+	// present, never `null`; an item with no non-default settings has the value
+	// `{}`.
+	// required: true
+	DisplaySettings database.JSON `json:"display_settings"`
+
 	// required: true
 	AttemptID int64 `json:"attempt_id,string"`
 	// required: true
@@ -41,6 +47,12 @@ type navigationItemChild struct {
 	BestScore float32 `json:"best_score"`
 	// required:true
 	Results []structures.ItemResult `json:"results"`
+
+	// JSON object with display/UI settings interpreted by the frontend. Always
+	// present, never `null`; an item with no non-default settings has the value
+	// `{}`.
+	// required: true
+	DisplaySettings database.JSON `json:"display_settings"`
 
 	WatchedGroup *itemWatchedGroupStat `json:"watched_group,omitempty"`
 }
@@ -155,7 +167,11 @@ func (srv *Service) getItemNavigation(responseWriter http.ResponseWriter, httpRe
 
 	response := itemNavigationResponse{
 		ItemCommonFields: fillItemCommonFieldsWithDBData(store, &rawData[0]),
-		AttemptID:        *rawData[0].AttemptID,
+		// OrEmpty() defends the documented "never null" contract against a stray
+		// DB NULL (the column is NOT NULL, but `JSON.Scan` decodes any NULL it
+		// sees into a nil map, which would marshal to `null`).
+		DisplaySettings: rawData[0].DisplaySettings.OrEmpty(),
+		AttemptID:       *rawData[0].AttemptID,
 	}
 	idMap := map[int64]*rawNavigationItem{}
 	for index := range rawData {
@@ -232,6 +248,10 @@ func fillNavigationWithChildren(
 				HasVisibleChildren:    rawData[index].HasVisibleChildren,
 				BestScore:             rawData[index].BestScore,
 				Results:               make([]structures.ItemResult, 0, 1),
+				// OrEmpty() defends the documented "never null" contract against a
+				// stray DB NULL (the column is NOT NULL, but `JSON.Scan` decodes
+				// any NULL it sees into a nil map, which would marshal to `null`).
+				DisplaySettings: rawData[index].DisplaySettings.OrEmpty(),
 			}
 			if rawData[index].CanViewGeneratedValue < store.PermissionsGranted().ViewIndexByName("content") {
 				child.HasVisibleChildren = false

--- a/app/api/items/navigation_data_mapper.go
+++ b/app/api/items/navigation_data_mapper.go
@@ -20,6 +20,10 @@ type rawNavigationItem struct {
 	EntryParticipantType  string
 	NoScore               bool
 
+	// `items.display_settings` is `NOT NULL` (defaults to `{}`), so we can read it
+	// into a non-pointer `database.JSON`; downstream code never needs a nil check.
+	DisplaySettings database.JSON
+
 	// title (from items_strings) in the user’s default language or (if not available) default language of the item.
 	Title       *string
 	LanguageTag string
@@ -47,7 +51,7 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 	itemsQuery := items.ByID(rootID).JoinsPermissionsForGroupToItemsWherePermissionAtLeast(groupID, "view", "info").
 		Select(
 			commonAttributes+`, 0 AS requires_explicit_entry, NULL AS parent_item_id, NULL AS entry_participant_type,
-				0 AS no_score, 0 AS has_visible_children, NULL AS child_order,
+				0 AS no_score, 0 AS has_visible_children, NULL AS child_order, items.display_settings,
 				NULL AS watched_group_can_view, 0 AS can_watch_for_group_results, 0 AS watched_group_avg_score, 0 AS watched_group_all_validated,
 				results.attempt_id, 1 AS has_attempt,
 				NULL AS score_computed, NULL AS validated, NULL AS started_at, NULL AS latest_activity_at,
@@ -85,7 +89,7 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 		watchedGroupID,
 		commonAttributes+
 			`, items.requires_explicit_entry, parent_item_id, items.entry_participant_type, items.no_score,
-			 IFNULL(?, 0) AS has_visible_children, child_order`,
+			 IFNULL(?, 0) AS has_visible_children, child_order, items.display_settings`,
 		[]interface{}{hasVisibleChildrenQuery},
 		"",
 		func(db *database.DB) *database.DB {
@@ -112,6 +116,7 @@ func getRawNavigationData(dataStore *database.DataStore, rootID, groupID, attemp
 			items.can_watch_generated_value, items.can_edit_generated_value, items.is_owner_generated,
 			items.parent_item_id AS parent_item_id,
 			items.can_view_generated_value,
+			items.display_settings,
 			items.attempt_id,
 			items.has_attempt,
 			items.score_computed, items.validated, items.started_at, items.latest_activity_at,


### PR DESCRIPTION
## Summary

- Expose `display_settings` on `GET /items/{item_id}/navigation` (`itemNavigationView`) for the **root item** and each **child**, matching the contract already used by `itemView` and `itemChildrenView`.
- Expose `display_settings` on `GET /current-user/group-memberships/activities` (`activitiesView`) and `GET /current-user/group-memberships/skills` (`skillsView`) for each root activity/skill (both share the `rootItem` struct in `get_group_activities.go`).
- Read `items.display_settings` in the relevant DB queries and map it through `database.JSON.OrEmpty()` so responses always return a JSON object (never `null`; defaults to `{}`).
- Update BDD expectations and document the new endpoint coverage in `ARCHITECTURE.md`.

This lets frontends render navigation and group-membership UI (e.g. `children_layout`, `prompt_to_join_group_by_code`) without extra `itemView` round-trips. No DB migration — the column already exists from the `display_settings` rollout.

## API changes

All changes are **additive** (non-breaking): existing clients that ignore unknown fields are unaffected.

### `GET /items/{item_id}/navigation`

```json
{
  "id": "200",
  "type": "Task",
  "display_settings": {"children_layout": "Grid", "prompt_to_join_group_by_code": true},
  "attempt_id": "0",
  "children": [
    {
      "id": "230",
      "type": "Chapter",
      "display_settings": {"children_layout": "Grid"},
      ...
    }
  ]
}