### PR TITLE
add a new attribute in the services used in the menu to know whether a group has subgroups

### DIFF
--- a/app/api/groups/get_navigation.feature
+++ b/app/api/groups/get_navigation.feature
@@ -38,6 +38,8 @@ Feature: Get navigation data (groupNavigationView)
       | 34 | U2                                       | User    | false     |
       | 35 | U3                                       | User    | false     |
       | 36 | U3                                       | User    | false     |
+      | 37 | Root With Only Public Child              | Team    | false     |
+      | 38 | Public Child                             | Class   | true      |
     And the database has the following users:
       | group_id | login | first_name  | last_name |
       | 41       | owner | Jean-Michel | Blanquer  |
@@ -90,6 +92,7 @@ Feature: Get navigation data (groupNavigationView)
       | 26              | 22             | 9999-12-31 23:59:59 |
       | 26              | 25             | 2010-01-01 00:00:00 |
       | 26              | 27             | 9999-12-31 23:59:59 |
+      | 26              | 37             | 9999-12-31 23:59:59 |
       | 28              | 30             | 9999-12-31 23:59:59 |
       | 28              | 31             | 9999-12-31 23:59:59 |
       | 29              | 31             | 9999-12-31 23:59:59 |
@@ -115,6 +118,8 @@ Feature: Get navigation data (groupNavigationView)
       | 22              | 41             | 2010-01-01 00:00:00 |
       | 23              | 41             | 2010-01-01 00:00:00 |
       | 25              | 41             | 2010-01-01 00:00:00 |
+      | 37              | 38             | 9999-12-31 23:59:59 |
+      | 37              | 41             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
     And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
@@ -146,77 +151,96 @@ Feature: Get navigation data (groupNavigationView)
           "name": "Ancestor Team",
           "type": "Team",
           "current_user_membership": "direct",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": false
         },
         {
           "id": "16",
           "name": "Joined By Ancestor",
           "type": "Class",
           "current_user_membership": "descendant",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": true
         },
         {
           "id": "7",
           "name": "Joined By Ancestor Team",
           "type": "Class",
           "current_user_membership": "descendant",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": true
         },
         {
           "id": "4",
           "name": "Joined Class",
           "type": "Class",
           "current_user_membership": "direct",
-          "current_user_managership": "direct"
+          "current_user_managership": "direct",
+          "has_visible_children": false
         },
         {
           "id": "19",
           "name": "Managed By Ancestor",
           "type": "Class",
           "current_user_membership": "none",
-          "current_user_managership": "direct"
+          "current_user_managership": "direct",
+          "has_visible_children": false
         },
         {
           "id": "9",
           "name": "Managed Class",
           "type": "Class",
           "current_user_membership": "none",
-          "current_user_managership": "direct"
+          "current_user_managership": "direct",
+          "has_visible_children": false
         },
         {
           "id": "27",
           "name": "Public",
           "type": "Base",
           "current_user_managership": "none",
-          "current_user_membership": "none"
+          "current_user_membership": "none",
+          "has_visible_children": false
         },
         {
           "id": "22",
           "name": "Root With Descendant Managed By Ancestor",
           "type": "Other",
           "current_user_membership": "none",
-          "current_user_managership": "descendant"
+          "current_user_managership": "descendant",
+          "has_visible_children": true
         },
         {
           "id": "13",
           "name": "Root With Managed Ancestor",
           "type": "Friends",
           "current_user_membership": "none",
-          "current_user_managership": "ancestor"
+          "current_user_managership": "ancestor",
+          "has_visible_children": false
         },
         {
           "id": "14",
           "name": "Root With Managed Descendant",
           "type": "Other",
           "current_user_membership": "none",
-          "current_user_managership": "descendant"
+          "current_user_managership": "descendant",
+          "has_visible_children": true
+        },
+        {
+          "id": "37",
+          "name": "Root With Only Public Child",
+          "type": "Team",
+          "current_user_membership": "direct",
+          "current_user_managership": "none",
+          "has_visible_children": true
         },
         {
           "id": "5",
           "name": "School",
           "type": "Club",
           "current_user_membership": "descendant",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": true
         }
       ]
     }
@@ -252,14 +276,39 @@ Feature: Get navigation data (groupNavigationView)
           "name": "Ancestor Team",
           "type": "Team",
           "current_user_membership": "direct",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": false
         },
         {
           "id": "16",
           "name": "Joined By Ancestor",
           "type": "Class",
           "current_user_membership": "descendant",
-          "current_user_managership": "none"
+          "current_user_managership": "none",
+          "has_visible_children": true
+        }
+      ]
+    }
+    """
+
+  Scenario: has_visible_children is true because of a public child only
+    Given I am the user with id "41"
+    When I send a GET request to "/groups/37/navigation"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {
+      "id": "37",
+      "name": "Root With Only Public Child",
+      "type": "Team",
+      "children": [
+        {
+          "id": "38",
+          "name": "Public Child",
+          "type": "Class",
+          "current_user_membership": "none",
+          "current_user_managership": "none",
+          "has_visible_children": false
         }
       ]
     }
@@ -295,7 +344,8 @@ Feature: Get navigation data (groupNavigationView)
           "name": "Ancestor",
           "type": "Class",
           "current_user_managership": "none",
-          "current_user_membership": "descendant"
+          "current_user_membership": "descendant",
+          "has_visible_children": true
         }
       ]
     }
@@ -317,7 +367,8 @@ Feature: Get navigation data (groupNavigationView)
           "name": "Joined Team",
           "type": "Team",
           "current_user_managership": "none",
-          "current_user_membership": "direct"
+          "current_user_membership": "direct",
+          "has_visible_children": false
         }
       ]
     }
@@ -339,7 +390,8 @@ Feature: Get navigation data (groupNavigationView)
           "name": "Managed Descendant",
           "type": "Team",
           "current_user_managership": "direct",
-          "current_user_membership": "none"
+          "current_user_membership": "none",
+          "has_visible_children": false
         }
       ]
     }
@@ -375,7 +427,8 @@ Feature: Get navigation data (groupNavigationView)
           "current_user_membership": "none",
           "id": "31",
           "name": "C2",
-          "type": "Class"
+          "type": "Class",
+          "has_visible_children": false
         }
       ]
     }
@@ -397,7 +450,8 @@ Feature: Get navigation data (groupNavigationView)
           "current_user_membership": "none",
           "id": "31",
           "name": "C2",
-          "type": "Class"
+          "type": "Class",
+          "has_visible_children": false
         }
       ]
     }

--- a/app/api/groups/get_navigation.go
+++ b/app/api/groups/get_navigation.go
@@ -27,6 +27,9 @@ type groupNavigationViewResponseChild struct {
 	// required: true
 	// enum: none,direct,ancestor,descendant
 	CurrentUserManagership string `json:"current_user_managership"`
+	// whether the group has at least one direct non-user child group visible to the current user
+	// required: true
+	HasVisibleChildren bool `json:"has_visible_children"`
 }
 
 // swagger:model groupNavigationViewResponse
@@ -95,7 +98,8 @@ func (srv *Service) getNavigation(responseWriter http.ResponseWriter, httpReques
 	store := srv.GetStore(httpRequest)
 
 	var result groupNavigationViewResponse
-	err = store.Groups().PickVisibleGroups(store.Groups().ByID(groupID), user).
+	err = withVisibleGroupCTEs(store.Groups().ByID(groupID), store, user).
+		Where(visibleGroupsWhereSQL).
 		Where("groups.type != 'User'").
 		Select("id, name, type").Scan(&result).Error()
 	if gorm.IsRecordNotFoundError(err) {
@@ -103,12 +107,14 @@ func (srv *Service) getNavigation(responseWriter http.ResponseWriter, httpReques
 	}
 	service.MustNotBeError(err)
 
-	query := store.Groups().PickVisibleGroups(store.Groups().DB, user).
+	query := withVisibleGroupCTEs(store.Groups().DB, store, user).
 		With("user_ancestors", ancestorsOfUserQuery(store, user)).
+		Where(visibleGroupsWhereSQL).
 		Select(`
 			groups.id, groups.type, groups.name,
 			`+currentUserMembershipSQLColumn(user)+`,
-			`+currentUserManagershipSQLColumn).
+			`+currentUserManagershipSQLColumn+`,
+			`+hasVisibleChildrenSQLColumn).
 		Joins(`
 			JOIN groups_groups_active
 				ON groups_groups_active.child_group_id = groups.id AND groups_groups_active.parent_group_id = ?`, groupID).

--- a/app/api/groups/get_roots.feature
+++ b/app/api/groups/get_roots.feature
@@ -1,42 +1,44 @@
 Feature: Get root groups (groupRootsView)
   Background:
     Given the database has the following table "groups":
-      | id | name                                     | type    |
-      | 1  | Joined Base                              | Base    |
-      | 2  | Managed Base                             | Base    |
-      | 3  | Base                                     | Base    |
-      | 4  | Joined Class                             | Class   |
-      | 5  | School                                   | Club    |
-      | 6  | Joined Team                              | Team    |
-      | 7  | Joined By Ancestor Team                  | Class   |
-      | 8  | Ancestor Team                            | Team    |
-      | 9  | Managed Class                            | Class   |
-      | 10 | Managed By Ancestor Team                 | Class   |
-      | 11 | Ancestor Team                            | Team    |
-      | 12 | Managed Ancestor                         | Base    |
-      | 13 | Root With Managed Ancestor               | Friends |
-      | 14 | Root With Managed Descendant             | Other   |
-      | 15 | Managed Descendant                       | Team    |
-      | 16 | Joined By Ancestor                       | Class   |
-      | 17 | Intermediate Group                       | Class   |
-      | 18 | Ancestor                                 | Class   |
-      | 19 | Managed By Ancestor                      | Class   |
-      | 20 | Intermediate Group                       | Base    |
-      | 21 | Ancestor                                 | Base    |
-      | 22 | Root With Descendant Managed By Ancestor | Other   |
-      | 23 | Descendant Managed By Ancestor           | Class   |
-      | 24 | Intermediate Group                       | Base    |
-      | 25 | Ancestor                                 | Base    |
-      | 26 | S1                                       | Club    |
-      | 27 | S2                                       | Club    |
-      | 28 | C1                                       | Class   |
-      | 29 | C2                                       | Class   |
-      | 30 | C3                                       | Class   |
-      | 31 | U1                                       | User    |
-      | 32 | U2                                       | User    |
-      | 33 | U3                                       | User    |
-      | 34 | U3                                       | User    |
-      | 52 | AllUsers                                 | Base    |
+      | id | name                                     | type    | is_public |
+      | 1  | Joined Base                              | Base    | false     |
+      | 2  | Managed Base                             | Base    | false     |
+      | 3  | Base                                     | Base    | false     |
+      | 4  | Joined Class                             | Class   | false     |
+      | 5  | School                                   | Club    | false     |
+      | 6  | Joined Team                              | Team    | false     |
+      | 7  | Joined By Ancestor Team                  | Class   | false     |
+      | 8  | Ancestor Team                            | Team    | false     |
+      | 9  | Managed Class                            | Class   | false     |
+      | 10 | Managed By Ancestor Team                 | Class   | false     |
+      | 11 | Ancestor Team                            | Team    | false     |
+      | 12 | Managed Ancestor                         | Base    | false     |
+      | 13 | Root With Managed Ancestor               | Friends | false     |
+      | 14 | Root With Managed Descendant             | Other   | false     |
+      | 15 | Managed Descendant                       | Team    | false     |
+      | 16 | Joined By Ancestor                       | Class   | false     |
+      | 17 | Intermediate Group                       | Class   | false     |
+      | 18 | Ancestor                                 | Class   | false     |
+      | 19 | Managed By Ancestor                      | Class   | false     |
+      | 20 | Intermediate Group                       | Base    | false     |
+      | 21 | Ancestor                                 | Base    | false     |
+      | 22 | Root With Descendant Managed By Ancestor | Other   | false     |
+      | 23 | Descendant Managed By Ancestor           | Class   | false     |
+      | 24 | Intermediate Group                       | Base    | false     |
+      | 25 | Ancestor                                 | Base    | false     |
+      | 26 | S1                                       | Club    | false     |
+      | 27 | S2                                       | Club    | false     |
+      | 28 | C1                                       | Class   | false     |
+      | 29 | C2                                       | Class   | false     |
+      | 30 | C3                                       | Class   | false     |
+      | 31 | U1                                       | User    | false     |
+      | 32 | U2                                       | User    | false     |
+      | 33 | U3                                       | User    | false     |
+      | 34 | U3                                       | User    | false     |
+      | 37 | Root With Only Public Child              | Team    | false     |
+      | 38 | Public Child                             | Class   | true      |
+      | 52 | AllUsers                                 | Base    | false     |
     And the database has the following users:
       | group_id | login | first_name  | last_name |
       | 41       | owner | Jean-Michel | Blanquer  |
@@ -106,6 +108,8 @@ Feature: Get root groups (groupRootsView)
       | 52              | 49             | 9999-12-31 23:59:59 |
       | 52              | 50             | 9999-12-31 23:59:59 |
       | 52              | 51             | 9999-12-31 23:59:59 |
+      | 37              | 38             | 9999-12-31 23:59:59 |
+      | 37              | 41             | 9999-12-31 23:59:59 |
     And the groups ancestors are computed
     And the database has the following table "groups_ancestors":
       | ancestor_group_id | child_group_id | expires_at          |
@@ -133,70 +137,110 @@ Feature: Get root groups (groupRootsView)
         "name": "Ancestor Team",
         "type": "Team",
         "current_user_membership": "direct",
-        "current_user_managership": "none"
+        "current_user_managership": "none",
+        "has_visible_children": false
       },
       {
         "id": "16",
         "name": "Joined By Ancestor",
         "type": "Class",
         "current_user_membership": "descendant",
-        "current_user_managership": "none"
+        "current_user_managership": "none",
+        "has_visible_children": true
       },
       {
         "id": "7",
         "name": "Joined By Ancestor Team",
         "type": "Class",
         "current_user_membership": "descendant",
-        "current_user_managership": "none"
+        "current_user_managership": "none",
+        "has_visible_children": true
       },
       {
         "id": "4",
         "name": "Joined Class",
         "type": "Class",
         "current_user_membership": "direct",
-        "current_user_managership": "direct"
+        "current_user_managership": "direct",
+        "has_visible_children": false
       },
       {
         "id": "19",
         "name": "Managed By Ancestor",
         "type": "Class",
         "current_user_membership": "none",
-        "current_user_managership": "direct"
+        "current_user_managership": "direct",
+        "has_visible_children": false
       },
       {
         "id": "9",
         "name": "Managed Class",
         "type": "Class",
         "current_user_membership": "none",
-        "current_user_managership": "direct"
+        "current_user_managership": "direct",
+        "has_visible_children": false
       },
       {
         "id": "22",
         "name": "Root With Descendant Managed By Ancestor",
         "type": "Other",
         "current_user_membership": "none",
-        "current_user_managership": "descendant"
+        "current_user_managership": "descendant",
+        "has_visible_children": true
       },
       {
         "id": "13",
         "name": "Root With Managed Ancestor",
         "type": "Friends",
         "current_user_membership": "none",
-        "current_user_managership": "ancestor"
+        "current_user_managership": "ancestor",
+        "has_visible_children": false
       },
       {
         "id": "14",
         "name": "Root With Managed Descendant",
         "type": "Other",
         "current_user_membership": "none",
-        "current_user_managership": "descendant"
+        "current_user_managership": "descendant",
+        "has_visible_children": true
+      },
+      {
+        "id": "37",
+        "name": "Root With Only Public Child",
+        "type": "Team",
+        "current_user_membership": "direct",
+        "current_user_managership": "none",
+        "has_visible_children": true
       },
       {
         "id": "5",
         "name": "School",
         "type": "Club",
         "current_user_membership": "descendant",
-        "current_user_managership": "none"
+        "current_user_managership": "none",
+        "has_visible_children": true
+      }
+    ]
+    """
+
+  Scenario: has_visible_children is true because of a public child only
+    Given the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | expires_at          |
+      | 37              | 49             | 9999-12-31 23:59:59 |
+    And the groups ancestors are computed
+    And I am the user with id "49"
+    When I send a GET request to "/groups/roots"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "id": "37",
+        "name": "Root With Only Public Child",
+        "type": "Team",
+        "current_user_membership": "direct",
+        "current_user_managership": "none",
+        "has_visible_children": true
       }
     ]
     """
@@ -223,14 +267,16 @@ Feature: Get root groups (groupRootsView)
         "current_user_membership": "none",
         "id": "26",
         "name": "S1",
-        "type": "Club"
+        "type": "Club",
+        "has_visible_children": true
       },
       {
         "current_user_managership": "descendant",
         "current_user_membership": "none",
         "id": "27",
         "name": "S2",
-        "type": "Club"
+        "type": "Club",
+        "has_visible_children": true
       }
     ]
     """
@@ -247,7 +293,8 @@ Feature: Get root groups (groupRootsView)
         "current_user_membership": "none",
         "id": "26",
         "name": "S1",
-        "type": "Club"
+        "type": "Club",
+        "has_visible_children": true
       }
     ]
     """

--- a/app/api/groups/get_roots.go
+++ b/app/api/groups/get_roots.go
@@ -28,6 +28,9 @@ type groupRootsViewResponseRow struct {
 	// required: true
 	// enum: none,direct,ancestor,descendant
 	CurrentUserManagership string `json:"current_user_managership"`
+	// whether the group has at least one direct non-user child group visible to the current user
+	// required: true
+	HasVisibleChildren bool `json:"has_visible_children"`
 }
 
 // swagger:operation GET /groups/roots group-memberships groupRootsView
@@ -78,6 +81,8 @@ func (srv *Service) getRoots(responseWriter http.ResponseWriter, httpRequest *ht
 			SubQuery())
 
 	query := store.Raw(`
+		WITH visible_joined_ancestors AS (?),
+		     visible_managed_groups AS (?)
 		SELECT groups.id, groups.type, groups.name,
 		       IF(
 			       is_ancestor_of_joined,
@@ -92,7 +97,8 @@ func (srv *Service) getRoots(responseWriter http.ResponseWriter, httpRequest *ht
 		           'direct',
 		           IF(is_managed_via_ancestor, 'ancestor', 'descendant')
 		         )
-		       ) AS 'current_user_managership'
+		       ) AS 'current_user_managership',
+		       `+hasVisibleChildrenSQLColumn+`
 		FROM ? AS `+"`groups`"+`
 		WHERE
 			type != 'Base' AND
@@ -103,7 +109,10 @@ func (srv *Service) getRoots(responseWriter http.ResponseWriter, httpRequest *ht
 					   groups_groups_active.child_group_id = groups.id
 				WHERE parent_group.type != 'Base'
 			)
-		ORDER BY groups.name`, matchingGroupsQuery.SubQuery())
+		ORDER BY groups.name`,
+		visibleJoinedAncestorsQuery(store, user).SubQuery(),
+		visibleManagedGroupsQuery(store, user).SubQuery(),
+		matchingGroupsQuery.SubQuery())
 
 	var result []groupRootsViewResponseRow
 	service.MustNotBeError(query.Scan(&result).Error())

--- a/app/api/groups/visible_groups.go
+++ b/app/api/groups/visible_groups.go
@@ -1,0 +1,39 @@
+package groups
+
+import (
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+)
+
+const (
+	visibleJoinedAncestorsCTEName = "visible_joined_ancestors"
+	visibleManagedGroupsCTEName   = "visible_managed_groups"
+
+	visibleGroupsWhereSQL = "groups.is_public OR groups.id IN (SELECT ancestor_group_id FROM visible_joined_ancestors) " +
+		"OR groups.id IN (SELECT ancestor_group_id FROM visible_managed_groups)"
+
+	hasVisibleChildrenSQLColumn = `
+		EXISTS(
+			SELECT 1
+			FROM groups_groups_active AS child_links
+			JOIN ` + "`groups`" + ` AS visible_child
+				ON visible_child.id = child_links.child_group_id
+			WHERE child_links.parent_group_id = groups.id
+				AND visible_child.type != 'User'
+				AND (visible_child.is_public OR visible_child.id IN (SELECT ancestor_group_id FROM visible_joined_ancestors)
+					OR visible_child.id IN (SELECT ancestor_group_id FROM visible_managed_groups))
+		) AS has_visible_children`
+)
+
+func visibleJoinedAncestorsQuery(store *database.DataStore, user *database.User) *database.DB {
+	return store.Groups().AncestorsOfJoinedGroups(store, user)
+}
+
+func visibleManagedGroupsQuery(store *database.DataStore, user *database.User) *database.DB {
+	return store.Groups().ManagedUsersAndAncestorsOfManagedGroupsForGroup(store, user.GroupID)
+}
+
+func withVisibleGroupCTEs(db *database.DB, store *database.DataStore, user *database.User) *database.DB {
+	return db.
+		With(visibleJoinedAncestorsCTEName, visibleJoinedAncestorsQuery(store, user)).
+		With(visibleManagedGroupsCTEName, visibleManagedGroupsQuery(store, user))
+}


### PR DESCRIPTION
## Summary

Adds a `has_visible_children` boolean to group navigation and roots responses, so the frontend can tell whether a group is expandable without fetching its children first.

- **`GET /groups/roots`**: each root row includes `has_visible_children`
- **`GET /groups/{group_id}/navigation`**: each child row includes `has_visible_children`

The flag is `true` when the group has at least one **direct** child with `type != 'User'` that is **visible to the current user**, using the same three-branch rule as `PickVisibleGroups` (`is_public`, ancestors of joined groups, managed users/ancestors of managed groups). It is a plain `EXISTS`, not a count.

Shared SQL lives in [`app/api/groups/visible_groups.go`](app/api/groups/visible_groups.go). Visibility sets are hoisted into CTEs so they are computed once per request and reused for both filtering and the `has_visible_children` check.

## Test plan

- [x] BDD: `get_navigation.feature` (including a scenario where `has_visible_children` is true solely because of a public child)
- [x] BDD: `get_roots.feature` (same public-child scenario)
- [x] `./bin/golangci-lint run ./app/api/groups/...`