### PR TITLE
Allow permission grants without group reachability; add has-path endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -421,6 +421,8 @@ Uses `go-chi/render` with custom responder (`service.AppResponder`):
 - Watch permissions: `none`, `result`, `answer`, `answer_with_grant`
 - Edit/grant permissions
 - Permissions computed and cached in `permissions_generated` table
+- Managers can grant permissions on any item (subject to their own grant rights), even when the target group has no navigational path to the item
+- `GET /groups/{group_id}/permissions/{item_id}/has-path` reports whether a group can reach an item from its content tree (visible parent, visible item, or root activity/skill of an ancestor)
 
 #### Permission Checking
 ```go

--- a/app/api/groups/get_permissions_has_path.feature
+++ b/app/api/groups/get_permissions_has_path.feature
@@ -1,0 +1,116 @@
+Feature: Check if a group has a path to an item
+  Background:
+    Given the database has the following table "groups":
+      | id | name       | type  |
+      | 25 | some class | Class |
+    And the database has the following users:
+      | group_id | login | first_name  | last_name |
+      | 21       | owner | Jean-Michel | Blanquer  |
+      | 23       | user  | John        | Doe       |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_grant_group_access |
+      | 25       | 21         | 1                      |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id |
+      | 25              | 23             |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | default_language_tag |
+      | 100 | fr                   |
+      | 101 | fr                   |
+      | 102 | fr                   |
+      | 103 | fr                   |
+      | 104 | fr                   |
+    And the database has the following table "items_items":
+      | parent_item_id | child_item_id | content_view_propagation | child_order |
+      | 100            | 101           | as_info                  | 0           |
+      | 101            | 102           | as_content               | 0           |
+      | 102            | 103           | as_content               | 0           |
+    And the database has the following table "items_ancestors":
+      | ancestor_item_id | child_item_id |
+      | 100              | 101           |
+      | 100              | 102           |
+      | 100              | 103           |
+      | 101              | 102           |
+      | 101              | 103           |
+      | 102              | 103           |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated       |
+      | 23       | 100     | content_with_descendants |
+      | 23       | 101     | info                     |
+      | 23       | 103     | info                     |
+
+  Scenario: The group has a visible parent of the item
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/23/permissions/102/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": true}
+    """
+
+  Scenario: The item itself is visible to the group
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/23/permissions/100/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": true}
+    """
+
+  Scenario Outline: The item is a root activity or skill of one of the group's ancestors
+    Given I am the user with id "21"
+    And the database table "groups" also has the following rows:
+      | id | name                 | type  | root_activity_id   | root_skill_id   |
+      | 40 | Group with root item | Class | <root_activity_id> | <root_skill_id> |
+    And the database table "groups_groups" also has the following row:
+      | parent_group_id | child_group_id |
+      | 40              | 23             |
+    And the groups ancestors are computed
+    When I send a GET request to "/groups/23/permissions/104/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": true}
+    """
+  Examples:
+    | root_activity_id | root_skill_id |
+    | 104              | null          |
+    | null             | 104           |
+
+  Scenario: The group has no path to the item
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/23/permissions/104/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": false}
+    """
+
+  Scenario: A non-existent item returns has_path false
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/23/permissions/404/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": false}
+    """
+
+  Scenario: A manager of a grandparent group can call has-path for a descendant group
+    Given the database table "groups" also has the following row:
+      | id | name              | type  |
+      | 30 | grandparent class | Class |
+    And the database table "groups_groups" also has the following row:
+      | parent_group_id | child_group_id |
+      | 30              | 25             |
+    And the database table "group_managers" also has the following row:
+      | group_id | manager_id | can_grant_group_access |
+      | 30       | 21         | 1                      |
+    And the groups ancestors are computed
+    And I am the user with id "21"
+    When I send a GET request to "/groups/23/permissions/102/has-path"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    {"has_path": true}
+    """

--- a/app/api/groups/get_permissions_has_path.go
+++ b/app/api/groups/get_permissions_has_path.go
@@ -1,0 +1,127 @@
+package groups
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+)
+
+// swagger:model permissionsHasPathResponse
+type permissionsHasPathResponse struct {
+	// required: true
+	HasPath bool `json:"has_path"`
+}
+
+// swagger:operation GET /groups/{group_id}/permissions/{item_id}/has-path groups permissionsHasPath
+//
+//	---
+//	summary: Check if a group has a path to an item
+//	description: >
+//		Returns whether the given group can reach the given item from its content tree.
+//
+//		`has_path` is true when at least one of the following holds:
+//
+//		* at least one of the item's parents is visible to the group (`can_view` >= `info`),
+//		* the item itself is visible to the group (`can_view` >= `info`),
+//		* the item is a root activity/skill for an ancestor of the group.
+//
+//		The current user must be a manager (with `can_grant_group_access` permission) of a non-user
+//		ancestor of `{group_id}`, i.e. be allowed to call `updatePermissions` for `{group_id}` on
+//		`{item_id}` with some source group.
+//	parameters:
+//		- name: group_id
+//			in: path
+//			required: true
+//			type: integer
+//			format: int64
+//		- name: item_id
+//			in: path
+//			required: true
+//			type: integer
+//			format: int64
+//	responses:
+//		"200":
+//			description: OK. Whether the group has a path to the item.
+//			schema:
+//				"$ref": "#/definitions/permissionsHasPathResponse"
+//		"400":
+//			"$ref": "#/responses/badRequestResponse"
+//		"401":
+//			"$ref": "#/responses/unauthorizedResponse"
+//		"403":
+//			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
+//		"500":
+//			"$ref": "#/responses/internalErrorResponse"
+func (srv *Service) getPermissionsHasPath(responseWriter http.ResponseWriter, httpRequest *http.Request) error {
+	groupID, err := service.ResolveURLQueryPathInt64Field(httpRequest, "group_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	itemID, err := service.ResolveURLQueryPathInt64Field(httpRequest, "item_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	user := srv.GetUser(httpRequest)
+	store := srv.GetStore(httpRequest)
+
+	err = checkIfUserCanGrantPermissionsToGroup(store, user, groupID)
+	service.MustNotBeError(err)
+
+	hasPath, err := groupHasPathToItemOrItemIsRoot(store, groupID, itemID)
+	service.MustNotBeError(err)
+
+	render.Respond(responseWriter, httpRequest, permissionsHasPathResponse{HasPath: hasPath})
+	return nil
+}
+
+func checkIfUserCanGrantPermissionsToGroup(store *database.DataStore, user *database.User, groupID int64) error {
+	found, err := managerCanGrantGroupAccessScope(store, user, groupID).HasRows()
+	service.MustNotBeError(err)
+	if !found {
+		return service.ErrAPIInsufficientAccessRights
+	}
+	return nil
+}
+
+func groupHasPathToItemOrItemIsRoot(store *database.DataStore, groupID, itemID int64) (bool, error) {
+	// at least one of the item's parents should be visible to the group
+	found, err := store.Permissions().MatchingGroupAncestors(groupID).
+		WherePermissionIsAtLeast("view", info).
+		Joins("JOIN items_items ON items_items.parent_item_id = permissions.item_id").
+		Where("items_items.child_item_id = ?", itemID).
+		HasRows()
+	if err != nil {
+		return false, err
+	}
+	if found {
+		return true, nil
+	}
+
+	// if not, the item itself should be visible to the group
+	found, err = store.Permissions().MatchingGroupAncestors(groupID).WherePermissionIsAtLeast("view", info).
+		Where("item_id = ?", itemID).HasRows()
+	if err != nil {
+		return false, err
+	}
+	if found {
+		return true, nil
+	}
+
+	// if not, the item should be a root item for one of the group's ancestors
+	found, err = store.Groups().
+		Joins("JOIN groups_ancestors_active ON groups_ancestors_active.ancestor_group_id = groups.id").
+		Where("groups_ancestors_active.child_group_id = ?", groupID).
+		Where("root_activity_id = ? OR root_skill_id = ?", itemID, itemID).HasRows()
+	if err != nil {
+		return false, err
+	}
+
+	return found, nil
+}

--- a/app/api/groups/get_permissions_has_path.robustness.feature
+++ b/app/api/groups/get_permissions_has_path.robustness.feature
@@ -1,0 +1,46 @@
+Feature: Check if a group has a path to an item - robustness
+  Background:
+    Given the database has the following table "groups":
+      | id | name       | type  |
+      | 25 | some class | Class |
+      | 26 | some team  | Team  |
+    And the database has the following users:
+      | group_id | login | first_name  | last_name |
+      | 21       | owner | Jean-Michel | Blanquer  |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_grant_group_access |
+      | 25       | 21         | 0                      |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | default_language_tag |
+      | 100 | fr                   |
+
+  Scenario: Invalid group_id
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/abc/permissions/100/has-path"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for group_id (should be int64)"
+
+  Scenario: Invalid item_id
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/permissions/abc/has-path"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for item_id (should be int64)"
+
+  Scenario: The user doesn't exist
+    Given I am the user with id "404"
+    When I send a GET request to "/groups/25/permissions/100/has-path"
+    Then the response code should be 401
+    And the response error message should contain "Invalid access token"
+
+  Scenario: The user is not a manager with can_grant_group_access on an ancestor of the group
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/26/permissions/100/has-path"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: The user is a manager of the group, but doesn't have can_grant_group_access
+    Given I am the user with id "21"
+    When I send a GET request to "/groups/25/permissions/100/has-path"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"

--- a/app/api/groups/get_permissions_has_path_test.go
+++ b/app/api/groups/get_permissions_has_path_test.go
@@ -1,0 +1,52 @@
+package groups
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+)
+
+func Test_groupHasPathToItemOrItemIsRoot_HasRowsErrors(t *testing.T) {
+	db, mock := database.NewDBMock()
+	defer func() { _ = db.Close() }()
+	database.ClearAllDBEnums()
+	database.MockDBEnumQueries(mock)
+	defer database.ClearAllDBEnums()
+	store := database.NewDataStore(db)
+
+	expectedErr := errors.New("db error")
+
+	for _, test := range []struct {
+		name        string
+		failingCall int
+	}{
+		{"parent visibility query", 1},
+		{"item visibility query", 2},
+		{"root activity/skill query", 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			callCount := 0
+			patch := monkey.PatchInstanceMethod(reflect.TypeOf(&database.DB{}), "HasRows",
+				func(_ *database.DB) (bool, error) {
+					callCount++
+					if callCount == test.failingCall {
+						return false, expectedErr
+					}
+					return false, nil
+				})
+			defer patch.Unpatch()
+
+			hasPath, err := groupHasPathToItemOrItemIsRoot(store, 23, 102)
+			require.ErrorIs(t, err, expectedErr)
+			assert.False(t, hasPath)
+		})
+	}
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -37,6 +37,8 @@ func (srv *Service) SetRoutes(router chi.Router) {
 		service.AppHandler(srv.updatePermissions).ServeHTTP)
 	router.Get("/groups/{group_id}/permissions/{item_id}/explain",
 		service.AppHandler(srv.getPermissionExplanation).ServeHTTP)
+	router.Get("/groups/{group_id}/permissions/{item_id}/has-path",
+		service.AppHandler(srv.getPermissionsHasPath).ServeHTTP)
 
 	router.Post("/groups/{group_id}/code", service.AppHandler(srv.createCode).ServeHTTP)
 	router.Delete("/groups/{group_id}/code", service.AppHandler(srv.removeCode).ServeHTTP)

--- a/app/api/groups/update_permissions.feature
+++ b/app/api/groups/update_permissions.feature
@@ -386,6 +386,42 @@ Feature: Change item access rights for a group
     And the table "results_propagate" should be empty
     And the table "results_propagate_internal" should be empty
 
+  Scenario: Create a new permissions_granted row when the group has no path to the item
+    Given I am the user with id "21"
+    And the database table "items" also has the following row:
+      | id  | default_language_tag |
+      | 104 | fr                   |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | is_owner_generated |
+      | 21       | 104     | none               | solution                 | true               |
+    And the database table "permissions_granted" also has the following rows:
+      | group_id | item_id | can_view | can_grant_view | is_owner | source_group_id | origin           | latest_update_at    |
+      | 21       | 104     | none     | solution       | true     | 23              | group_membership | 2019-05-30 11:00:00 |
+    When I send a PUT request to "/groups/25/permissions/23/104" with the following body:
+    """
+    {
+      "can_view": "solution"
+    }
+    """
+    Then the response should be "updated"
+    And the table "permissions_granted" should be:
+      | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_make_session_official | can_enter_from      | can_enter_until     | TIMESTAMPDIFF(SECOND, latest_update_at, NOW()) < 3 |
+      | 21       | 104     | 23              | group_membership | none     | solution       | none      | none     | true     | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 | 0                                                  |
+      | 23       | 100     | 23              | group_membership | content  | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 | 0                                                  |
+      | 23       | 104     | 25              | group_membership | solution | none           | none      | none     | false    | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 | 1                                                  |
+    And the table "permissions_generated" should be:
+      | group_id | item_id | can_view_generated | can_grant_view_generated | is_owner_generated |
+      | 21       | 104     | solution           | solution_with_grant      | true               |
+      | 23       | 100     | content            | none                     | false              |
+      | 23       | 101     | info               | none                     | false              |
+      | 23       | 102     | none               | none                     | false              |
+      | 23       | 103     | none               | none                     | false              |
+      | 23       | 104     | solution           | none                     | false              |
+    And the table "attempts" should remain unchanged
+    And the table "results" should remain unchanged
+    And the table "results_propagate" should be empty
+    And the table "results_propagate_internal" should be empty
+
   Scenario: Drops invalid permissions from an existing permissions_granted row
     Given I am the user with id "21"
     And the database table "permissions_generated" also has the following rows:

--- a/app/api/groups/update_permissions.go
+++ b/app/api/groups/update_permissions.go
@@ -91,9 +91,6 @@ type managerGeneratedPermissions struct {
 //
 //		* The user giving the access must have `permissions_generated.can_grant_view` >= given `can_view`
 //			for the item.
-//
-//		* The group must already have access to one of the parents of the item or the item itself. If it does not,
-//			the item must be a root activity/skill for an ancestor of the group.
 //	parameters:
 //		- name: group_id
 //			in: path
@@ -150,8 +147,14 @@ func (srv *Service) updatePermissions(responseWriter http.ResponseWriter, httpRe
 	service.MustNotBeError(err)
 
 	err = srv.GetStore(httpRequest).InTransaction(func(store *database.DataStore) error {
-		err = checkIfUserIsManagerAllowedToGrantPermissionsOnItem(store, user, sourceGroupID, groupID, itemID)
+		err = checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(store, user, sourceGroupID, groupID)
 		service.MustNotBeError(err)
+
+		found, err := store.Items().ByID(itemID).HasRows()
+		service.MustNotBeError(err)
+		if !found {
+			return service.ErrAPIInsufficientAccessRights
+		}
 
 		// Even if we select a single row from permissions_granted,
 		// MAX() is used so that a row with the default values is returned even if no row exists.
@@ -518,15 +521,16 @@ const (
 	allWithGrant      = "all_with_grant"
 )
 
-func checkIfUserIsManagerAllowedToGrantPermissionsOnItem(store *database.DataStore, user *database.User,
-	sourceGroupID, groupID, itemID int64,
-) error {
-	err := checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(store, user, sourceGroupID, groupID)
-	if err != nil {
-		return err
-	}
-
-	return checkIfItemOrOneOfItsParentsIsVisibleToGroupOrItemIsRoot(store, groupID, itemID)
+// managerCanGrantGroupAccessScope matches group_managers rows where `user` manages a non-User
+// ancestor of `groupID` with `can_grant_group_access`. Callers may further constrain it (e.g. pin
+// the source group) before checking existence.
+func managerCanGrantGroupAccessScope(store *database.DataStore, user *database.User, groupID int64) *database.DB {
+	return store.ActiveGroupAncestors().ManagedByUser(user).
+		Where("groups_ancestors_active.child_group_type != 'User'").
+		Joins(`
+			JOIN groups_ancestors_active AS descendants
+				ON descendants.ancestor_group_id = groups_ancestors_active.child_group_id AND descendants.child_group_id = ?`, groupID).
+		Where("group_managers.can_grant_group_access")
 }
 
 func checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(
@@ -534,45 +538,12 @@ func checkIfUserIsManagerAllowedToGrantPermissionsToGroupID(
 ) error {
 	// the authorized user should be a manager of the sourceGroupID with `can_grant_group_access' permission and
 	// the 'sourceGroupID' should be an ancestor of 'groupID'
-	found, err := store.ActiveGroupAncestors().ManagedByUser(user).
+	found, err := managerCanGrantGroupAccessScope(store, user, groupID).
 		Where("groups_ancestors_active.child_group_id = ?", sourceGroupID).
-		Where("groups_ancestors_active.child_group_type != 'User'").
-		Joins(`
-				JOIN groups_ancestors_active AS descendants
-					ON descendants.ancestor_group_id = groups_ancestors_active.child_group_id AND descendants.child_group_id = ?`, groupID).
-		Where("group_managers.can_grant_group_access").
 		HasRows()
 	service.MustNotBeError(err)
 	if !found {
 		return service.ErrAPIInsufficientAccessRights
-	}
-	return nil
-}
-
-func checkIfItemOrOneOfItsParentsIsVisibleToGroupOrItemIsRoot(store *database.DataStore, groupID, itemID int64) error {
-	// at least one of the item's parents should be visible to the group
-	found, err := store.Permissions().MatchingGroupAncestors(groupID).
-		WherePermissionIsAtLeast("view", info).
-		Joins("JOIN items_items ON items_items.parent_item_id = permissions.item_id").
-		Where("items_items.child_item_id = ?", itemID).
-		HasRows()
-	service.MustNotBeError(err)
-	if !found {
-		// if not, the item itself should be visible to the group
-		found, err = store.Permissions().MatchingGroupAncestors(groupID).WherePermissionIsAtLeast("view", info).
-			Where("item_id = ?", itemID).HasRows()
-		service.MustNotBeError(err)
-		if !found {
-			// if not, the item should be a root item for one of the group's ancestors
-			found, err = store.Groups().
-				Joins("JOIN groups_ancestors_active ON groups_ancestors_active.ancestor_group_id = groups.id").
-				Where("groups_ancestors_active.child_group_id = ?", groupID).
-				Where("root_activity_id = ? OR root_skill_id = ?", itemID, itemID).HasRows()
-			service.MustNotBeError(err)
-			if !found {
-				return service.ErrAPIInsufficientAccessRights
-			}
-		}
 	}
 	return nil
 }

--- a/app/api/groups/update_permissions.robustness.feature
+++ b/app/api/groups/update_permissions.robustness.feature
@@ -175,7 +175,7 @@ Feature: Change item access rights for a group - robustness
 
   Scenario: The item doesn't exist
     Given I am the user with id "21"
-    When I send a PUT request to "/groups/25/permissions/23/404" with the following body:
+    When I send a PUT request to "/groups/26/permissions/23/404" with the following body:
     """
     {
       "can_view": "solution"

--- a/app/api/groups/update_permissions.robustness.feature
+++ b/app/api/groups/update_permissions.robustness.feature
@@ -263,16 +263,3 @@ Feature: Change item access rights for a group - robustness
     And the response error message should contain "Insufficient access rights"
     And the table "permissions_granted" should remain unchanged
     And the table "permissions_generated" should remain unchanged
-
-  Scenario: There are no item's parents visible to the group
-    Given I am the user with id "31"
-    When I send a PUT request to "/groups/25/permissions/23/103" with the following body:
-    """
-    {
-      "can_view": "solution"
-    }
-    """
-    Then the response code should be 403
-    And the response error message should contain "Insufficient access rights"
-    And the table "permissions_granted" should remain unchanged
-    And the table "permissions_generated" should remain unchanged


### PR DESCRIPTION
## Summary

- **Relax `updatePermissions`**: managers can grant permissions on any existing item, subject only to their own `can_grant_*` rights and manager authorization. The old "group must have a navigational path to the item" gate is removed.
- **Add `GET /groups/{group_id}/permissions/{item_id}/has-path`**: read-only endpoint that reports whether a group can reach an item (`has_path: true/false`), so the frontend can warn before granting on unreachable content.
- **Refactor shared auth**: extract `managerCanGrantGroupAccessScope`, used by both `updatePermissions` and the new endpoint.

## Motivation

The reachability check on `updatePermissions` blocked valid use cases:

- Granting watch permissions on **public / AllUsers** content to a class group (the check only looked at the target group's ancestors, not AllUsers).
- Letting managers **pre-seed permissions** on items a group will reach later, without requiring an existing tree path.

Removing the grant-time check does **not** weaken runtime access: starting or entering items still requires a valid participation hierarchy. The new `has-path` endpoint preserves the old reachability logic for UI warnings.

## API changes

### `PUT /groups/{source_group_id}/permissions/{group_id}/{item_id}` (behavior change)

**Before:** 403 if the target group had no path to the item (no visible parent/item, and item not a root activity/skill of an ancestor).

**After:** allowed when the manager is authorized and holds sufficient grant rights on the item. Only checks:

1. Manager has `can_grant_group_access` on `{source_group_id}`, which must be an ancestor of `{group_id}`.
2. Item exists (still returns **403** for missing items, to avoid leaking existence).

Per-field validators (`checkIfPossibleToModifyCanView`, etc.) are unchanged.

### `GET /groups/{group_id}/permissions/{item_id}/has-path` (new)

Returns `{"has_path": bool}` with **200**. `has_path` is `true` when any of:

1. A parent of the item is visible to the group (`can_view >= info`),
2. The item itself is visible to the group,
3. The item is a `root_activity_id` or `root_skill_id` of a group ancestor.

**Auth:** caller must manage a non-User ancestor of `{group_id}` with `can_grant_group_access` (equivalent to being able to call `updatePermissions` for that group with some source group).

Non-existent items return `{"has_path": false}` (200).

## Implementation notes

- Reachability logic moved from deleted `checkIfItemOrOneOfItsParentsIsVisibleToGroupOrItemIsRoot` into `groupHasPathToItemOrItemIsRoot`.
- `managerCanGrantGroupAccessScope` deduplicates the ancestor/`can_grant_group_access` query; `updatePermissions` pins `source_group_id`, `has-path` does not.

## Test plan

- [x] `get_permissions_has_path.feature` — visible parent, visible item, root activity/skill, no path, non-existent item, grandparent manager
- [x] `get_permissions_has_path.robustness.feature` — invalid IDs, 401/403 auth cases
- [x] `update_permissions.feature` — new positive scenario: grant on item 104 when group 23 has no path to it
- [x] `update_permissions.robustness.feature` — removed obsolete "no visible parents → 403" scenario
- [x] `./bin/golangci-lint run -v --timeout 2m ./app/api/groups/...`
- [ ] Manual: frontend calls `has-path` before grant and shows a warning when `has_path` is false
- [ ] Manual: confirm granting watch on AllUsers/public content to a class group now succeeds

## Docs

- `ARCHITECTURE.md` updated with the relaxed grant rule and the new endpoint.