### PR TITLE
first version of the service to export group progress as a zip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,28 @@ Note: There may be a flaky timeout test in `app/database` that occasionally hang
 
 If you get DB connection errors, ensure docker-compose services are running with `docker-compose ps`.
 
+#### Test coverage (required)
+
+At the end of any task that adds or changes code, you MUST compute test coverage and ensure the code you touched is 100% covered.
+
+1. Run the suite with a coverage profile (the `test` target writes `test-results/coverage.txt`; `test-dev` does not produce coverage). To scope to the package you changed and keep it fast:
+```
+go test -gcflags=all=-l \
+  -coverpkg=<package-under-test> \
+  -coverprofile=/tmp/cov.txt -covermode=atomic \
+  ./path/to/package/ -p 1 -parallel 1
+```
+2. Inspect per-function coverage for the files you touched:
+```
+go tool cover -func=/tmp/cov.txt | grep <changed-file>.go
+```
+3. For a line-by-line view of what is still uncovered:
+```
+go tool cover -html=/tmp/cov.txt -o /tmp/cov.html
+```
+
+Every function and branch in code you added or modified must reach 100%. If a line is genuinely unreachable in tests, add the test that exercises it; only leave it uncovered if it is truly impossible to trigger, and document why.
+
 ## Comments
 - Do NOT add obvious, narrating comments (e.g., `// increment counter`, `// return result`).
 - DO add comments when a non-trivial choice has been made and the reasoning is not self-evident from the code. Examples:

--- a/app/api/groups/get_group_progress.go
+++ b/app/api/groups/get_group_progress.go
@@ -141,7 +141,7 @@ func (srv *Service) getGroupProgress(responseWriter http.ResponseWriter, httpReq
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	if len(itemParentIDs) == 0 {
@@ -396,7 +396,9 @@ func scanAndBuildProgressResults(
 	appendTableRowToResult(orderedItemIDListWithDuplicates, reflResultRowMap, resultPtr)
 }
 
-func resolveAndCheckParentIDs(store *database.DataStore, r *http.Request, user *database.User) ([]int64, error) {
+func resolveAndCheckParentIDs(
+	store *database.DataStore, r *http.Request, user *database.User, canWatchPermission string,
+) ([]int64, error) {
 	itemParentIDs, err := service.ResolveURLQueryGetInt64SliceField(r, "parent_item_ids")
 	if err != nil {
 		return nil, service.ErrInvalidRequest(err)
@@ -405,7 +407,7 @@ func resolveAndCheckParentIDs(store *database.DataStore, r *http.Request, user *
 	if len(itemParentIDs) > 0 {
 		var cnt int
 		service.MustNotBeError(store.Permissions().MatchingUserAncestors(user).
-			WherePermissionIsAtLeast("watch", "result").Where("item_id IN(?)", itemParentIDs).
+			WherePermissionIsAtLeast("watch", canWatchPermission).Where("item_id IN(?)", itemParentIDs).
 			PluckFirst("COUNT(DISTINCT item_id)", &cnt).Error())
 		if cnt != len(itemParentIDs) {
 			return nil, service.ErrAPIInsufficientAccessRights

--- a/app/api/groups/get_group_progress_csv.go
+++ b/app/api/groups/get_group_progress_csv.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
 	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
 )
 
@@ -88,7 +89,7 @@ func (srv *Service) getGroupProgressCSV(responseWriter http.ResponseWriter, http
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	responseWriter.Header().Set("Content-Type", "text/csv")
@@ -105,12 +106,19 @@ func (srv *Service) getGroupProgressCSV(responseWriter http.ResponseWriter, http
 		return nil
 	}
 
-	// Preselect item IDs since we need them to build the results table (there shouldn't be many)
-	orderedItemIDListWithDuplicates, uniqueItemIDs, itemOrder, itemsSubQuery := preselectIDsOfVisibleItems(store, itemParentIDs, user)
-
 	csvWriter := csv.NewWriter(responseWriter)
 	defer csvWriter.Flush()
 	csvWriter.Comma = ';'
+
+	writeGroupProgressCSV(csvWriter, store, user, itemParentIDs, groupID)
+	return nil
+}
+
+func writeGroupProgressCSV(
+	csvWriter *csv.Writer, store *database.DataStore, user *database.User, itemParentIDs []int64, groupID int64,
+) {
+	// Preselect item IDs since we need them to build the results table (there shouldn't be many)
+	orderedItemIDListWithDuplicates, uniqueItemIDs, itemOrder, itemsSubQuery := preselectIDsOfVisibleItems(store, itemParentIDs, user)
 
 	printTableHeader(store, user, uniqueItemIDs, orderedItemIDListWithDuplicates, itemOrder, csvWriter,
 		[]string{"Group name"})
@@ -127,7 +135,7 @@ func (srv *Service) getGroupProgressCSV(responseWriter http.ResponseWriter, http
 		Scan(&groups).Error())
 
 	if len(groups) == 0 {
-		return nil
+		return
 	}
 
 	ancestorGroupIDs := make([]string, len(groups))
@@ -179,8 +187,6 @@ func (srv *Service) getGroupProgressCSV(responseWriter http.ResponseWriter, http
 				csvWriter)).Error())
 		writeEmptyRowsForSkippedGroupsAtTheEnd(groupNumber, batchBoundary, groups, len(orderedItemIDListWithDuplicates), csvWriter)
 	}
-
-	return nil
 }
 
 func generateGroupNameAndWriteEmptyRowsForSkippedGroups(

--- a/app/api/groups/get_group_progress_with_answers_zip.feature
+++ b/app/api/groups/get_group_progress_with_answers_zip.feature
@@ -1,0 +1,122 @@
+Feature: Export the current progress of a group with answers on a subset of items as a ZIP file (groupGroupProgressWithAnswersZIP)
+  Scenario: Should include empty group_progress.csv when no parent item ids are given
+    Given I am @Teacher
+    And there is a group @Classroom
+    And I am a manager of the group @Classroom and can watch for submissions from the group and its descendants
+    When I send a GET request to "/groups/@Classroom/group-progress-with-answers-zip?parent_item_ids="
+    Then the response code should be 200
+    And the response header "Content-Type" should be "application/zip"
+    And the response header "Content-Disposition" should be "attachment; filename=groups_progress_with_answers_for_group-@Classroom-and_child_items_of-.zip"
+    And the response should be a ZIP file containing the following files:
+      """
+        [
+          {
+            "filename": "group_progress.csv",
+            "content": "Group name\n"
+          }
+        ]
+      """
+
+  Scenario: Should export nested progress, submissions and CSV content
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id | type  | name       |
+      | 1  | Base  | Root 1     |
+      | 11 | Class | Our Class  |
+      | 15 | Team  | Our Team   |
+    And the database has the following users:
+      | group_id | login | default_language |
+      | 21       | owner | en               |
+      | 57       | johnd | fr               |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_watch_members |
+      | 1        | 21         | true              |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | is_team_membership |
+      | 1               | 11             | 0                  |
+      | 11              | 15             | 0                  |
+      | 15              | 57             | 1                  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | type    | default_language_tag |
+      | 210 | Chapter | fr                   |
+      | 211 | Task    | fr                   |
+      | 212 | Task    | fr                   |
+      | 213 | Task    | fr                   |
+      | 220 | Chapter | fr                   |
+    And the database has the following table "items_strings":
+      | item_id | language_tag | title        |
+      | 210     | fr           | Chapitre 210 |
+      | 211     | fr           | Item 211     |
+      | 212     | fr           | Item 212     |
+      | 213     | fr           | SubTask 213  |
+      | 220     | fr           | Chapitre 220 |
+      | 220     | en           | Chapter 220  |
+    And the database has the following table "items_items":
+      | parent_item_id | child_item_id | child_order |
+      | 210            | 211           | 1           |
+      | 210            | 212           | 1           |
+      | 211            | 213           | 2           |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_watch_generated |
+      | 21       | 210     | info               | answer              |
+      | 21       | 211     | info               | none                |
+      | 21       | 212     | info               | none                |
+      | 21       | 213     | info               | none                |
+      | 21       | 220     | info               | answer              |
+    And the database has the following table "attempts":
+      | id | participant_id | created_at          |
+      | 3  | 57             | 2019-01-01 00:00:00 |
+    And the database has the following table "results":
+      | attempt_id | participant_id | item_id | started_at          | score_computed | score_obtained_at   | hints_cached | submissions | validated_at        | latest_activity_at  |
+      | 3          | 57             | 213     | 2019-01-01 00:00:00 | 15             | 2019-01-02 00:00:00 | 2            | 3           | 2019-01-03 00:00:00 | 2019-01-04 00:00:00 |
+    And the results are computed
+    And the database has the following table "answers":
+      | id   | author_id | participant_id | attempt_id | item_id | type       | answer      | created_at          |
+      | 9001 | 57        | 57             | 3          | 213     | Submission | first try   | 2019-01-01 01:00:00 |
+      | 9002 | 57        | 57             | 3          | 213     | Submission | second try  | 2019-01-01 02:00:00 |
+    And the database has the following table "gradings":
+      | answer_id | score | graded_at           |
+      | 9001      | 5     | 2019-01-01 01:30:00 |
+      | 9002      | 15    | 2019-01-01 02:30:00 |
+    When I send a GET request to "/groups/11/group-progress-with-answers-zip?parent_item_ids=210,220"
+    Then the response code should be 200
+    And the response header "Content-Type" should be "application/zip"
+    And the response header "Content-Disposition" should be "attachment; filename=groups_progress_with_answers_for_group-11-and_child_items_of-210-220.zip"
+    And the response should be a ZIP file containing the following files:
+      """
+        [
+          {
+            "filename": "group_progress.csv",
+            "content": "Group name;Chapitre 210;1. Item 211;2. Item 212\n"
+          },
+          {
+            "filename": "0-Chapitre 210-210/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          },
+          {
+            "filename": "0-Chapitre 210-210/1-Item 211-211/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          },
+          {
+            "filename": "0-Chapitre 210-210/1-Item 211-211/2-SubTask 213-213/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":2,\"latest_activity_at\":\"2019-01-04T00:00:00Z\",\"score\":15,\"submissions\":3,\"time_spent\":172800,\"validated\":true}"
+          },
+          {
+            "filename": "0-Chapitre 210-210/1-Item 211-211/2-SubTask 213-213/submissions/johnd/0-3-5-9001.txt",
+            "content": "first try"
+          },
+          {
+            "filename": "0-Chapitre 210-210/1-Item 211-211/2-SubTask 213-213/submissions/johnd/1-3-15-9002.txt",
+            "content": "second try"
+          },
+          {
+            "filename": "0-Chapitre 210-210/1-Item 212-212/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          },
+          {
+            "filename": "0-Chapter 220-220/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          }
+        ]
+      """

--- a/app/api/groups/get_group_progress_with_answers_zip.feature
+++ b/app/api/groups/get_group_progress_with_answers_zip.feature
@@ -120,3 +120,101 @@ Feature: Export the current progress of a group with answers on a subset of item
           }
         ]
       """
+
+  Scenario: Should export only the CSV when the group has no users
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id | type  | name      |
+      | 1  | Base  | Root 1    |
+      | 11 | Class | Our Class |
+    And the database has the following users:
+      | group_id | login | default_language |
+      | 21       | owner | en               |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_watch_members |
+      | 1        | 21         | true              |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | is_team_membership |
+      | 1               | 11             | 0                  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | type    | default_language_tag |
+      | 210 | Chapter | fr                   |
+    And the database has the following table "items_strings":
+      | item_id | language_tag | title        |
+      | 210     | fr           | Chapitre 210 |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_watch_generated |
+      | 21       | 210     | info               | answer              |
+    When I send a GET request to "/groups/11/group-progress-with-answers-zip?parent_item_ids=210"
+    Then the response code should be 200
+    And the response should be a ZIP file containing the following files:
+      """
+        [
+          {
+            "filename": "group_progress.csv",
+            "content": "Group name;Chapitre 210\n"
+          }
+        ]
+      """
+
+  Scenario: Should deduplicate items reachable from several parents and sanitize path separators
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id | type  | name      |
+      | 1  | Base  | Root 1    |
+      | 11 | Class | Our Class |
+    And the database has the following users:
+      | group_id | login | default_language |
+      | 21       | owner | en               |
+      | 57       | johnd | fr               |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_watch_members |
+      | 1        | 21         | true              |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | is_team_membership |
+      | 1               | 11             | 0                  |
+      | 11              | 57             | 0                  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | type    | default_language_tag |
+      | 210 | Chapter | fr                   |
+      | 220 | Chapter | fr                   |
+      | 230 | Task    | fr                   |
+    And the database has the following table "items_strings":
+      | item_id | language_tag | title    |
+      | 210     | fr           | Chap 210 |
+      | 220     | fr           | Chap 220 |
+      | 230     | fr           | a/b..c   |
+    And the database has the following table "items_items":
+      | parent_item_id | child_item_id | child_order |
+      | 210            | 230           | 1           |
+      | 220            | 230           | 1           |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_watch_generated |
+      | 21       | 210     | info               | answer              |
+      | 21       | 220     | info               | answer              |
+      | 21       | 230     | info               | none                |
+    When I send a GET request to "/groups/11/group-progress-with-answers-zip?parent_item_ids=210,220"
+    Then the response code should be 200
+    And the response should be a ZIP file containing the following files:
+      """
+        [
+          {
+            "filename": "group_progress.csv",
+            "content": "Group name;Chap 210;1. a/b..c;Chap 220;1. a/b..c\n"
+          },
+          {
+            "filename": "0-Chap 210-210/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          },
+          {
+            "filename": "0-Chap 210-210/1-a-b-c-230/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          },
+          {
+            "filename": "0-Chap 220-220/submissions/johnd/data.json",
+            "content": "{\"hints_requested\":0,\"latest_activity_at\":null,\"score\":0,\"submissions\":0,\"time_spent\":0,\"validated\":false}"
+          }
+        ]
+      """

--- a/app/api/groups/get_group_progress_with_answers_zip.go
+++ b/app/api/groups/get_group_progress_with_answers_zip.go
@@ -115,10 +115,6 @@ type progressZIPItemChild struct {
 //						type: string
 //						format: binary
 //		"400":
-//			description: >
-//				Invalid request. This includes exceeding export limits:
-//				"The number of items exceeds the limit (100)" or
-//				"The number of users exceeds the limit (100)".
 //			"$ref": "#/responses/badRequestResponse"
 //		"401":
 //			"$ref": "#/responses/unauthorizedResponse"

--- a/app/api/groups/get_group_progress_with_answers_zip.go
+++ b/app/api/groups/get_group_progress_with_answers_zip.go
@@ -170,13 +170,12 @@ func (srv *Service) getGroupProgressWithAnswersZIP(responseWriter http.ResponseW
 			groupID, strings.Join(itemParentIDsString, "-")),
 	)
 
-	// Buffer the ZIP in memory so a mid-generation failure returns an error response
+	// Buffer the ZIP in memory so a mid-generation failure (raised as a panic via
+	// service.MustNotBeError and recovered by AppHandler) yields a clean error response
 	// instead of a 200 with a truncated archive.
 	zipBuffer := &bytes.Buffer{}
 	zipWriter := zip.NewWriter(zipBuffer)
-	if err := writeProgressZIPArchive(zipWriter, store, user, itemParentIDs, groupID, subtreeItems, zipUsers); err != nil {
-		return err
-	}
+	writeProgressZIPArchive(zipWriter, store, user, itemParentIDs, groupID, subtreeItems, zipUsers)
 	service.MustNotBeError(zipWriter.Close())
 
 	_, err = io.Copy(responseWriter, zipBuffer)
@@ -187,40 +186,38 @@ func (srv *Service) getGroupProgressWithAnswersZIP(responseWriter http.ResponseW
 func writeProgressZIPArchive(
 	zipWriter *zip.Writer, store *database.DataStore, user *database.User,
 	itemParentIDs []int64, groupID int64, subtreeItems []progressZIPSubtreeItem, zipUsers []progressZIPUser,
-) error {
+) {
 	csvBuffer := &bytes.Buffer{}
 	csvWriter := csv.NewWriter(csvBuffer)
 	csvWriter.Comma = ';'
 	if len(itemParentIDs) == 0 {
-		if _, err := csvBuffer.WriteString("Group name\n"); err != nil {
-			return err
-		}
+		// No error check needed: WriteString on a bytes.Buffer never fails.
+		_, _ = csvBuffer.WriteString("Group name\n")
 	} else {
 		writeGroupProgressCSV(csvWriter, store, user, itemParentIDs, groupID)
 		csvWriter.Flush()
 	}
 
+	// The ZIP is written to an in-memory buffer, so these writes cannot fail in practice;
+	// MustNotBeError turns any unexpected failure into a recovered 500 rather than a partial 200.
 	groupProgressFile, err := zipWriter.Create("group_progress.csv")
-	if err != nil {
-		return err
-	}
-	if _, err = io.Copy(groupProgressFile, csvBuffer); err != nil {
-		return err
-	}
+	service.MustNotBeError(err)
+	_, err = io.Copy(groupProgressFile, csvBuffer)
+	service.MustNotBeError(err)
 
 	if len(itemParentIDs) == 0 {
-		return nil
+		return
 	}
 
-	return writeProgressZIPContent(zipWriter, store, subtreeItems, zipUsers)
+	writeProgressZIPContent(zipWriter, store, subtreeItems, zipUsers)
 }
 
 func writeProgressZIPContent(
 	zipWriter *zip.Writer, store *database.DataStore,
 	subtreeItems []progressZIPSubtreeItem, zipUsers []progressZIPUser,
-) error {
-	if len(subtreeItems) == 0 || len(zipUsers) == 0 {
-		return nil
+) {
+	if len(zipUsers) == 0 {
+		return
 	}
 
 	subtreeItemIDs := make([]int64, len(subtreeItems))
@@ -233,36 +230,29 @@ func writeProgressZIPContent(
 
 	for _, subtreeItem := range subtreeItems {
 		for _, zipUser := range zipUsers {
-			if err := writeProgressZIPUserItemFiles(
+			writeProgressZIPUserItemFiles(
 				zipWriter, subtreeItem, zipUser, userProgressByGroupAndItem, submissionsByParticipantAndItem,
-			); err != nil {
-				return err
-			}
+			)
 		}
 	}
-
-	return nil
 }
 
 func writeProgressZIPUserItemFiles(
 	zipWriter *zip.Writer, subtreeItem progressZIPSubtreeItem, zipUser progressZIPUser,
 	userProgressByGroupAndItem map[int64]map[int64]progressZIPUserItemData,
 	submissionsByParticipantAndItem map[int64]map[int64][]progressZIPSubmission,
-) error {
+) {
+	// The ZIP is written to an in-memory buffer, so these Create/Write/Marshal calls cannot
+	// fail in practice; MustNotBeError guards against unexpected failures without dead branches.
 	dataPath := subtreeItem.DirPath + "submissions/" + zipUser.SanitizedLogin + "/data.json"
 	dataFile, err := zipWriter.Create(dataPath)
-	if err != nil {
-		return err
-	}
+	service.MustNotBeError(err)
 
 	progressData := userProgressByGroupAndItem[zipUser.GroupID][subtreeItem.ItemID]
 	encodedData, err := json.Marshal(progressData)
-	if err != nil {
-		return err
-	}
-	if _, err = dataFile.Write(encodedData); err != nil {
-		return err
-	}
+	service.MustNotBeError(err)
+	_, err = dataFile.Write(encodedData)
+	service.MustNotBeError(err)
 
 	for _, submission := range submissionsByParticipantAndItem[zipUser.GroupID][subtreeItem.ItemID] {
 		scoreString := ""
@@ -273,14 +263,10 @@ func writeProgressZIPUserItemFiles(
 			subtreeItem.DirPath, zipUser.SanitizedLogin,
 			submission.Number, submission.AttemptID, scoreString, submission.AnswerID)
 		answerFile, err := zipWriter.Create(filePath)
-		if err != nil {
-			return err
-		}
-		if _, err = answerFile.Write([]byte(submission.Answer)); err != nil {
-			return err
-		}
+		service.MustNotBeError(err)
+		_, err = answerFile.Write([]byte(submission.Answer))
+		service.MustNotBeError(err)
 	}
-	return nil
 }
 
 func buildProgressZIPVisibleSubtree(
@@ -463,10 +449,6 @@ func getProgressZIPUserItemData(
 		}
 	}
 
-	if len(zipUsers) == 0 || len(subtreeItemIDs) == 0 {
-		return result
-	}
-
 	userIDs := make([]string, len(zipUsers))
 	for i := range zipUsers {
 		userIDs[i] = strconv.FormatInt(zipUsers[i].GroupID, 10)
@@ -571,10 +553,6 @@ func getProgressZIPSubmissions(
 	store *database.DataStore, zipUsers []progressZIPUser, subtreeItemIDs []int64,
 ) map[int64]map[int64][]progressZIPSubmission {
 	result := make(map[int64]map[int64][]progressZIPSubmission, len(zipUsers))
-	if len(zipUsers) == 0 || len(subtreeItemIDs) == 0 {
-		return result
-	}
-
 	participantIDs := make([]int64, len(zipUsers))
 	for i := range zipUsers {
 		participantIDs[i] = zipUsers[i].GroupID

--- a/app/api/groups/get_group_progress_with_answers_zip.go
+++ b/app/api/groups/get_group_progress_with_answers_zip.go
@@ -1,0 +1,623 @@
+package groups
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/database"
+	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+)
+
+const (
+	maxUsersInProgressZIP = 100
+	maxItemsInProgressZIP = 100
+)
+
+type progressZIPSubtreeItem struct {
+	ItemID  int64
+	DirPath string
+}
+
+type progressZIPUser struct {
+	GroupID        int64
+	Login          string
+	SanitizedLogin string
+}
+
+type progressZIPSubmission struct {
+	ParticipantID int64
+	ItemID        int64
+	Number        int
+	AttemptID     int64
+	Answer        string
+	Score         *float32
+	AnswerID      int64
+}
+
+type progressZIPUserItemData struct {
+	HintsRequested   int32          `json:"hints_requested"`
+	LatestActivityAt *database.Time `json:"latest_activity_at"`
+	Score            float32        `json:"score"`
+	Submissions      int32          `json:"submissions"`
+	TimeSpent        int32          `json:"time_spent"`
+	Validated        bool           `json:"validated"`
+}
+
+type progressZIPItemChild struct {
+	ChildItemID int64
+	ChildOrder  int32
+}
+
+// swagger:operation GET /groups/{group_id}/group-progress-with-answers-zip groups groupGroupProgressWithAnswersZIP
+//
+//	---
+//	summary: Get group progress with answers as a ZIP file
+//	description: >
+//		Returns the current progress of users on a subset of items with their submission answers.
+//
+//		Content of the ZIP file:
+//
+//		* `group_progress.csv` at the root, with the same content as `groupGroupProgressCSV`
+//
+//		* directories reflecting the visible items subtree, with directory names in the format
+//		  `{child_order}-{title}-{id}/` where `title` is sanitized and root parent items use `child_order` 0.
+//		  Descendants are nested at arbitrary depth under their parent directory.
+//
+//		* each item directory contains a `submissions/` subdirectory with one directory per user login.
+//		  Each user directory contains:
+//
+//		  - `data.json` with `hints_requested`, `latest_activity_at`, `score`, `submissions`, `time_spent`, `validated`
+//
+//		  - for each Submission answer of the user on the item, a file named
+//		    `{number}-{attempt_id}-{score}-{answers.id}.txt` where `number` is the 0-based order by `created_at`
+//		    and the file content is the `answer` field
+//
+//		Restrictions:
+//
+//		* The current user should be a manager of the group (or of one of its ancestors)
+//		  with `can_watch_members` set to true,
+//
+//		* The current user should have `can_watch` >= 'answer' on each of `{parent_item_ids}` items,
+//
+//		* The export is limited to 100 users and 100 items in the visible descendant subtree.
+//		  If either limit is exceeded, a distinct 400 error is returned.
+//
+//		Otherwise the 'forbidden' error is returned.
+//	parameters:
+//		- name: group_id
+//			in: path
+//			type: integer
+//			format: int64
+//			required: true
+//		- name: parent_item_ids
+//			in: query
+//			type: array
+//			required: true
+//			items:
+//				type: integer
+//				format: int64
+//	responses:
+//		"200":
+//			description: OK. Success response with users progress and answers on items
+//			content:
+//				application/zip:
+//					schema:
+//						type: string
+//						format: binary
+//		"400":
+//			description: >
+//				Invalid request. This includes exceeding export limits:
+//				"The number of items exceeds the limit (100)" or
+//				"The number of users exceeds the limit (100)".
+//			"$ref": "#/responses/badRequestResponse"
+//		"401":
+//			"$ref": "#/responses/unauthorizedResponse"
+//		"403":
+//			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
+//		"500":
+//			"$ref": "#/responses/internalErrorResponse"
+func (srv *Service) getGroupProgressWithAnswersZIP(responseWriter http.ResponseWriter, httpRequest *http.Request) error {
+	user := srv.GetUser(httpRequest)
+	store := srv.GetStore(httpRequest)
+
+	groupID, err := service.ResolveURLQueryPathInt64Field(httpRequest, "group_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	if !user.CanWatchGroupMembers(store, groupID) {
+		return service.ErrAPIInsufficientAccessRights
+	}
+
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "answer")
+	service.MustNotBeError(err)
+
+	var subtreeItems []progressZIPSubtreeItem
+	var zipUsers []progressZIPUser
+	if len(itemParentIDs) > 0 {
+		var itemCount int
+		subtreeItems, itemCount = buildProgressZIPVisibleSubtree(store, user, itemParentIDs)
+		if itemCount > maxItemsInProgressZIP {
+			return service.ErrInvalidRequest(errors.New("The number of items exceeds the limit (100)")) //nolint:staticcheck // API-specified message
+		}
+
+		zipUsers = getProgressZIPUsers(store, groupID)
+		if len(zipUsers) > maxUsersInProgressZIP {
+			return service.ErrInvalidRequest(errors.New("The number of users exceeds the limit (100)")) //nolint:staticcheck // API-specified message
+		}
+	}
+
+	responseWriter.Header().Set("Content-Type", "application/zip")
+	itemParentIDsString := make([]string, len(itemParentIDs))
+	for i, id := range itemParentIDs {
+		itemParentIDsString[i] = strconv.FormatInt(id, 10)
+	}
+	responseWriter.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf("attachment; filename=groups_progress_with_answers_for_group-%d-and_child_items_of-%s.zip",
+			groupID, strings.Join(itemParentIDsString, "-")),
+	)
+
+	// Buffer the ZIP in memory so a mid-generation failure returns an error response
+	// instead of a 200 with a truncated archive.
+	zipBuffer := &bytes.Buffer{}
+	zipWriter := zip.NewWriter(zipBuffer)
+	if err := writeProgressZIPArchive(zipWriter, store, user, itemParentIDs, groupID, subtreeItems, zipUsers); err != nil {
+		return err
+	}
+	service.MustNotBeError(zipWriter.Close())
+
+	_, err = io.Copy(responseWriter, zipBuffer)
+	service.MustNotBeError(err)
+	return nil
+}
+
+func writeProgressZIPArchive(
+	zipWriter *zip.Writer, store *database.DataStore, user *database.User,
+	itemParentIDs []int64, groupID int64, subtreeItems []progressZIPSubtreeItem, zipUsers []progressZIPUser,
+) error {
+	csvBuffer := &bytes.Buffer{}
+	csvWriter := csv.NewWriter(csvBuffer)
+	csvWriter.Comma = ';'
+	if len(itemParentIDs) == 0 {
+		if _, err := csvBuffer.WriteString("Group name\n"); err != nil {
+			return err
+		}
+	} else {
+		writeGroupProgressCSV(csvWriter, store, user, itemParentIDs, groupID)
+		csvWriter.Flush()
+	}
+
+	groupProgressFile, err := zipWriter.Create("group_progress.csv")
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(groupProgressFile, csvBuffer); err != nil {
+		return err
+	}
+
+	if len(itemParentIDs) == 0 {
+		return nil
+	}
+
+	return writeProgressZIPContent(zipWriter, store, subtreeItems, zipUsers)
+}
+
+func writeProgressZIPContent(
+	zipWriter *zip.Writer, store *database.DataStore,
+	subtreeItems []progressZIPSubtreeItem, zipUsers []progressZIPUser,
+) error {
+	if len(subtreeItems) == 0 || len(zipUsers) == 0 {
+		return nil
+	}
+
+	subtreeItemIDs := make([]int64, len(subtreeItems))
+	for itemIndex := range subtreeItems {
+		subtreeItemIDs[itemIndex] = subtreeItems[itemIndex].ItemID
+	}
+
+	userProgressByGroupAndItem := getProgressZIPUserItemData(store, zipUsers, subtreeItemIDs)
+	submissionsByParticipantAndItem := getProgressZIPSubmissions(store, zipUsers, subtreeItemIDs)
+
+	for _, subtreeItem := range subtreeItems {
+		for _, zipUser := range zipUsers {
+			if err := writeProgressZIPUserItemFiles(
+				zipWriter, subtreeItem, zipUser, userProgressByGroupAndItem, submissionsByParticipantAndItem,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeProgressZIPUserItemFiles(
+	zipWriter *zip.Writer, subtreeItem progressZIPSubtreeItem, zipUser progressZIPUser,
+	userProgressByGroupAndItem map[int64]map[int64]progressZIPUserItemData,
+	submissionsByParticipantAndItem map[int64]map[int64][]progressZIPSubmission,
+) error {
+	dataPath := subtreeItem.DirPath + "submissions/" + zipUser.SanitizedLogin + "/data.json"
+	dataFile, err := zipWriter.Create(dataPath)
+	if err != nil {
+		return err
+	}
+
+	progressData := userProgressByGroupAndItem[zipUser.GroupID][subtreeItem.ItemID]
+	encodedData, err := json.Marshal(progressData)
+	if err != nil {
+		return err
+	}
+	if _, err = dataFile.Write(encodedData); err != nil {
+		return err
+	}
+
+	for _, submission := range submissionsByParticipantAndItem[zipUser.GroupID][subtreeItem.ItemID] {
+		scoreString := ""
+		if submission.Score != nil {
+			scoreString = fmt.Sprintf("%v", *submission.Score)
+		}
+		filePath := fmt.Sprintf("%ssubmissions/%s/%d-%d-%s-%d.txt",
+			subtreeItem.DirPath, zipUser.SanitizedLogin,
+			submission.Number, submission.AttemptID, scoreString, submission.AnswerID)
+		answerFile, err := zipWriter.Create(filePath)
+		if err != nil {
+			return err
+		}
+		if _, err = answerFile.Write([]byte(submission.Answer)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildProgressZIPVisibleSubtree(
+	store *database.DataStore, user *database.User, itemParentIDs []int64,
+) (subtreeItems []progressZIPSubtreeItem, itemCount int) {
+	permissionsSubQuery := store.Permissions().MatchingUserAncestors(user).
+		Select("item_id").
+		WherePermissionIsAtLeast("view", "info").SubQuery()
+
+	var childrenByParent map[int64][]progressZIPItemChild
+	childrenByParent, itemCount = loadProgressZIPChildrenByParent(store, itemParentIDs, permissionsSubQuery)
+	if itemCount > maxItemsInProgressZIP {
+		return nil, itemCount
+	}
+
+	itemTitles := getProgressZIPItemTitles(store, user, itemParentIDs, childrenByParent)
+
+	visited := make(map[int64]bool)
+	subtreeItems = make([]progressZIPSubtreeItem, 0, itemCount)
+	for _, parentItemID := range itemParentIDs {
+		appendProgressZIPSubtreeItem(
+			parentItemID, 0, "", itemTitles, childrenByParent, visited, &subtreeItems,
+		)
+	}
+
+	return subtreeItems, itemCount
+}
+
+func loadProgressZIPChildrenByParent(
+	store *database.DataStore, itemParentIDs []int64, permissionsSubQuery interface{},
+) (childrenByParent map[int64][]progressZIPItemChild, itemCount int) {
+	childrenByParent = make(map[int64][]progressZIPItemChild)
+	parentFrontier := append([]int64(nil), itemParentIDs...)
+	knownParents := make(map[int64]bool, len(itemParentIDs))
+	for _, parentID := range itemParentIDs {
+		knownParents[parentID] = true
+	}
+
+	for len(parentFrontier) > 0 {
+		var childRelations []struct {
+			ParentItemID int64
+			ChildItemID  int64
+			ChildOrder   int32
+		}
+		service.MustNotBeError(store.ItemItems().
+			Select("items_items.parent_item_id, items_items.child_item_id, items_items.child_order").
+			Where("items_items.parent_item_id IN (?)", parentFrontier).
+			Joins("JOIN ? AS permissions ON permissions.item_id = items_items.child_item_id", permissionsSubQuery).
+			Order("items_items.parent_item_id, items_items.child_order, items_items.child_item_id").
+			Scan(&childRelations).Error())
+
+		nextFrontier := make([]int64, 0, len(childRelations))
+		for i := range childRelations {
+			parentID := childRelations[i].ParentItemID
+			childID := childRelations[i].ChildItemID
+			childrenByParent[parentID] = append(childrenByParent[parentID], progressZIPItemChild{
+				ChildItemID: childID,
+				ChildOrder:  childRelations[i].ChildOrder,
+			})
+			if !knownParents[childID] {
+				knownParents[childID] = true
+				itemCount = len(knownParents)
+				if itemCount > maxItemsInProgressZIP {
+					return childrenByParent, itemCount
+				}
+				nextFrontier = append(nextFrontier, childID)
+			}
+		}
+		parentFrontier = nextFrontier
+	}
+
+	return childrenByParent, len(knownParents)
+}
+
+func getProgressZIPItemTitles(
+	store *database.DataStore, user *database.User, itemParentIDs []int64, childrenByParent map[int64][]progressZIPItemChild,
+) map[int64]string {
+	itemIDSet := make(map[int64]bool, len(itemParentIDs))
+	for _, parentItemID := range itemParentIDs {
+		itemIDSet[parentItemID] = true
+	}
+	for parentID := range childrenByParent {
+		for _, child := range childrenByParent[parentID] {
+			itemIDSet[child.ChildItemID] = true
+		}
+	}
+
+	itemIDs := make([]int64, 0, len(itemIDSet))
+	for itemID := range itemIDSet {
+		itemIDs = append(itemIDs, itemID)
+	}
+
+	var items []struct {
+		ID    int64
+		Title string
+	}
+	service.MustNotBeError(store.Items().
+		JoinsUserAndDefaultItemStrings(user).
+		Where("items.id IN (?)", itemIDs).
+		Select("items.id, COALESCE(user_strings.title, default_strings.title) AS title").
+		Scan(&items).Error())
+
+	itemTitles := make(map[int64]string, len(items))
+	for i := range items {
+		itemTitles[items[i].ID] = items[i].Title
+	}
+	return itemTitles
+}
+
+func appendProgressZIPSubtreeItem(
+	itemID int64, childOrder int32, parentPath string, itemTitles map[int64]string,
+	childrenByParent map[int64][]progressZIPItemChild, visited map[int64]bool, subtreeItems *[]progressZIPSubtreeItem,
+) {
+	if visited[itemID] {
+		return
+	}
+	visited[itemID] = true
+
+	dirPath := parentPath + fmt.Sprintf("%d-%s-%d/", childOrder, sanitizeZIPPathSegment(itemTitles[itemID], "untitled"), itemID)
+	*subtreeItems = append(*subtreeItems, progressZIPSubtreeItem{
+		ItemID:  itemID,
+		DirPath: dirPath,
+	})
+
+	for _, child := range childrenByParent[itemID] {
+		appendProgressZIPSubtreeItem(
+			child.ChildItemID, child.ChildOrder, dirPath, itemTitles, childrenByParent, visited, subtreeItems,
+		)
+	}
+}
+
+func sanitizeZIPPathSegment(segment, emptyFallback string) string {
+	segment = strings.ReplaceAll(segment, "/", "-")
+	segment = strings.ReplaceAll(segment, "\\", "-")
+	for strings.Contains(segment, "..") {
+		segment = strings.ReplaceAll(segment, "..", "-")
+	}
+	segment = strings.Trim(segment, ". ")
+	if segment == "" {
+		return emptyFallback
+	}
+	return segment
+}
+
+func getProgressZIPUsers(store *database.DataStore, groupID int64) []progressZIPUser {
+	var users []progressZIPUser
+	service.MustNotBeError(store.Groups().
+		Select("groups.id AS group_id, users.login").
+		Joins("JOIN groups_groups_active ON groups_groups_active.child_group_id = groups.id").
+		Joins(`
+			JOIN groups_ancestors_active ON groups_ancestors_active.child_group_id = groups_groups_active.parent_group_id AND
+				groups_ancestors_active.ancestor_group_id = ?`, groupID).
+		Joins("JOIN users ON users.group_id = groups.id").
+		Where("groups.type = 'User'").
+		Group("groups.id").
+		Order("groups.name, groups.id").
+		Scan(&users).Error())
+	for i := range users {
+		users[i].SanitizedLogin = sanitizeZIPPathSegment(users[i].Login, "user")
+	}
+	return users
+}
+
+func getProgressZIPUserItemData(
+	store *database.DataStore, zipUsers []progressZIPUser, subtreeItemIDs []int64,
+) map[int64]map[int64]progressZIPUserItemData {
+	defaultData := progressZIPUserItemData{
+		HintsRequested: 0,
+		Score:          0,
+		Submissions:    0,
+		TimeSpent:      0,
+		Validated:      false,
+	}
+
+	result := make(map[int64]map[int64]progressZIPUserItemData, len(zipUsers))
+	for _, zipUser := range zipUsers {
+		result[zipUser.GroupID] = make(map[int64]progressZIPUserItemData, len(subtreeItemIDs))
+		for _, itemID := range subtreeItemIDs {
+			result[zipUser.GroupID][itemID] = defaultData
+		}
+	}
+
+	if len(zipUsers) == 0 || len(subtreeItemIDs) == 0 {
+		return result
+	}
+
+	userIDs := make([]string, len(zipUsers))
+	for i := range zipUsers {
+		userIDs[i] = strconv.FormatInt(zipUsers[i].GroupID, 10)
+	}
+	itemIDs := make([]string, len(subtreeItemIDs))
+	for i, itemID := range subtreeItemIDs {
+		itemIDs[i] = strconv.FormatInt(itemID, 10)
+	}
+	userIDsList := strings.Join(userIDs, ", ")
+	itemsSubQuery := gorm.Expr(`JSON_TABLE('[` + strings.Join(itemIDs, ", ") + `]', "$[*]" COLUMNS(id BIGINT PATH "$"))`)
+
+	var progressRows []struct {
+		GroupID          int64
+		ItemID           int64
+		Score            float32
+		Validated        bool
+		LatestActivityAt *database.Time
+		HintsRequested   int32
+		Submissions      int32
+		TimeSpent        int32
+	}
+	service.MustNotBeError(
+		joinUserOnlyProgressResults(
+			store.Raw(`
+				SELECT STRAIGHT_JOIN
+					items.id AS item_id,
+					users.group_id AS group_id, `+userProgressFields+`
+				FROM JSON_TABLE('[`+userIDsList+`]', "$[*]" COLUMNS(group_id BIGINT PATH "$")) AS users`).
+				Joins("JOIN ? AS items", itemsSubQuery),
+			gorm.Expr("users.group_id"),
+		).
+			Group("users.group_id, items.id").
+			Scan(&progressRows).Error())
+
+	for rowIndex := range progressRows {
+		result[progressRows[rowIndex].GroupID][progressRows[rowIndex].ItemID] = progressZIPUserItemData{
+			HintsRequested:   progressRows[rowIndex].HintsRequested,
+			LatestActivityAt: progressRows[rowIndex].LatestActivityAt,
+			Score:            progressRows[rowIndex].Score,
+			Submissions:      progressRows[rowIndex].Submissions,
+			TimeSpent:        progressRows[rowIndex].TimeSpent,
+			Validated:        progressRows[rowIndex].Validated,
+		}
+	}
+
+	return result
+}
+
+func joinUserOnlyProgressResults(db *database.DB, userID interface{}) *database.DB {
+	// Deliberately omits team-result merging from joinUserProgressResults: this export
+	// scopes participants to user self-groups only (no teams), per product decision.
+	return db.
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT participant_id, attempt_id, score_computed, score_obtained_at
+				FROM results AS result_with_best_score_for_user
+				WHERE participant_id = ? AND item_id = items.id
+				ORDER BY participant_id, item_id, score_computed DESC, score_obtained_at
+				LIMIT 1
+			) AS result_with_best_score_for_user ON 1`, userID).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT participant_id, attempt_id, latest_activity_at
+				FROM results AS last_result_of_user USE INDEX (participant_id_item_id_latest_activity_at_desc)
+				WHERE participant_id = ? AND item_id = items.id AND latest_activity_at IS NOT NULL
+				ORDER BY participant_id, item_id, latest_activity_at DESC LIMIT 1
+			) AS last_result_of_user ON 1`, userID).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT last_result_of_user.latest_activity_at AS latest_activity_at
+			) AS last_result ON 1`).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT participant_id, attempt_id, started_at
+				FROM results AS first_result_of_user USE INDEX (participant_id_item_id_started_started_at)
+				WHERE participant_id = ? AND item_id = items.id AND started = 1
+				ORDER BY participant_id, item_id, started, started_at LIMIT 1
+			) AS first_result_of_user ON 1`, userID).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT first_result_of_user.started_at AS started_at
+			) AS first_result ON 1`).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT participant_id, attempt_id, validated_at
+				FROM results AS first_validated_result_of_user USE INDEX (participant_id_item_id_validated_validated_at)
+				WHERE participant_id = ? AND item_id = items.id AND validated = 1
+				ORDER BY participant_id, item_id, validated, validated_at LIMIT 1
+			) AS first_validated_result_of_user ON 1`, userID).
+		Joins(`
+			LEFT JOIN LATERAL (
+				SELECT first_validated_result_of_user.validated_at AS validated_at
+			) AS first_validated_result ON 1`).
+		Joins(`
+			LEFT JOIN results AS result_with_best_score
+			ON result_with_best_score.participant_id = result_with_best_score_for_user.participant_id
+			AND result_with_best_score.attempt_id = result_with_best_score_for_user.attempt_id
+			AND result_with_best_score.item_id = items.id`)
+}
+
+func getProgressZIPSubmissions(
+	store *database.DataStore, zipUsers []progressZIPUser, subtreeItemIDs []int64,
+) map[int64]map[int64][]progressZIPSubmission {
+	result := make(map[int64]map[int64][]progressZIPSubmission, len(zipUsers))
+	if len(zipUsers) == 0 || len(subtreeItemIDs) == 0 {
+		return result
+	}
+
+	participantIDs := make([]int64, len(zipUsers))
+	for i := range zipUsers {
+		participantIDs[i] = zipUsers[i].GroupID
+		result[zipUsers[i].GroupID] = make(map[int64][]progressZIPSubmission, len(subtreeItemIDs))
+	}
+
+	var answers []struct {
+		ParticipantID int64
+		ItemID        int64
+		ID            int64
+		AttemptID     int64
+		Answer        string
+		Score         *float32
+	}
+	service.MustNotBeError(store.Answers().
+		WithGradings().
+		Where("answers.type = 'Submission'").
+		Where("answers.participant_id IN (?)", participantIDs).
+		Where("answers.item_id IN (?)", subtreeItemIDs).
+		Order("answers.participant_id, answers.item_id, answers.created_at").
+		Select("answers.participant_id, answers.item_id, answers.id, answers.attempt_id, answers.answer, gradings.score").
+		Scan(&answers).Error())
+
+	answerNumbers := make(map[int64]map[int64]int, len(zipUsers))
+	for answerIndex := range answers {
+		participantID := answers[answerIndex].ParticipantID
+		itemID := answers[answerIndex].ItemID
+		if answerNumbers[participantID] == nil {
+			answerNumbers[participantID] = make(map[int64]int)
+		}
+		submissionNumber := answerNumbers[participantID][itemID]
+		answerNumbers[participantID][itemID]++
+
+		result[participantID][itemID] = append(result[participantID][itemID], progressZIPSubmission{
+			ParticipantID: participantID,
+			ItemID:        itemID,
+			Number:        submissionNumber,
+			AttemptID:     answers[answerIndex].AttemptID,
+			Answer:        answers[answerIndex].Answer,
+			Score:         answers[answerIndex].Score,
+			AnswerID:      answers[answerIndex].ID,
+		})
+	}
+
+	return result
+}

--- a/app/api/groups/get_group_progress_with_answers_zip.robustness.feature
+++ b/app/api/groups/get_group_progress_with_answers_zip.robustness.feature
@@ -1,0 +1,717 @@
+Feature: Export the current progress of a group with answers on a subset of items as a ZIP file (groupGroupProgressWithAnswersZIP) - robustness
+  Scenario: User is not able to watch group members
+    Given I am @John
+    And there is a group @Classroom
+    And there are the following items:
+      | item  | type |
+      | @Item | Task |
+    And I am a manager of the group @Classroom
+    When I send a GET request to "/groups/@Classroom/group-progress-with-answers-zip?parent_item_ids=@Item"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Group id is incorrect
+    Given I am @John
+    And there are the following items:
+      | item  | type |
+      | @Item | Task |
+    When I send a GET request to "/groups/abc/group-progress-with-answers-zip?parent_item_ids=@Item"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for group_id (should be int64)"
+
+  Scenario: parent_item_ids is incorrect
+    Given I am @John
+    And there is a group @Classroom
+    And I am a manager of the group @Classroom and can watch for submissions from the group and its descendants
+    And there are the following items:
+      | item  | type |
+      | @Item | Task |
+    When I send a GET request to "/groups/@Classroom/group-progress-with-answers-zip?parent_item_ids=abc,@Item"
+    Then the response code should be 400
+    And the response error message should contain "Unable to parse one of the integers given as query args (value: 'abc', param: 'parent_item_ids')"
+
+  Scenario: Not enough permissions to watch answers on parent_item_ids
+    Given I am @John
+    And there is a group @Classroom
+    And I am a manager of the group @Classroom and can watch for submissions from the group and its descendants
+    And there are the following items:
+      | item                | type |
+      | @ItemCanWatchAnswer | Task |
+      | @ItemCanWatchResult | Task |
+    And there are the following item permissions:
+      | item                | group | can_watch |
+      | @ItemCanWatchAnswer | @John | answer    |
+      | @ItemCanWatchResult | @John | result    |
+    When I send a GET request to "/groups/@Classroom/group-progress-with-answers-zip?parent_item_ids=@ItemCanWatchAnswer,@ItemCanWatchResult"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: User not found
+    Given I am the user with id "404"
+    And there is a group @Classroom
+    And there are the following items:
+      | item  | type |
+      | @Item | Task |
+    When I send a GET request to "/groups/@Classroom/group-progress-with-answers-zip?parent_item_ids=@Item"
+    Then the response code should be 401
+    And the response error message should contain "Invalid access token"
+
+
+  Scenario: The number of items exceeds the limit
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id | type  | name      |
+      | 1  | Base  | Root 1    |
+      | 11 | Class | Our Class |
+    And the database has the following users:
+      | group_id | login | default_language |
+      | 21       | owner | en               |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_watch_members |
+      | 1        | 21         | true              |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | is_team_membership |
+      | 1               | 11             | 0                  |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id | type | default_language_tag |
+      | 6000 | Chapter | fr |
+      | 6001 | Task | fr |
+      | 6002 | Task | fr |
+      | 6003 | Task | fr |
+      | 6004 | Task | fr |
+      | 6005 | Task | fr |
+      | 6006 | Task | fr |
+      | 6007 | Task | fr |
+      | 6008 | Task | fr |
+      | 6009 | Task | fr |
+      | 6010 | Task | fr |
+      | 6011 | Task | fr |
+      | 6012 | Task | fr |
+      | 6013 | Task | fr |
+      | 6014 | Task | fr |
+      | 6015 | Task | fr |
+      | 6016 | Task | fr |
+      | 6017 | Task | fr |
+      | 6018 | Task | fr |
+      | 6019 | Task | fr |
+      | 6020 | Task | fr |
+      | 6021 | Task | fr |
+      | 6022 | Task | fr |
+      | 6023 | Task | fr |
+      | 6024 | Task | fr |
+      | 6025 | Task | fr |
+      | 6026 | Task | fr |
+      | 6027 | Task | fr |
+      | 6028 | Task | fr |
+      | 6029 | Task | fr |
+      | 6030 | Task | fr |
+      | 6031 | Task | fr |
+      | 6032 | Task | fr |
+      | 6033 | Task | fr |
+      | 6034 | Task | fr |
+      | 6035 | Task | fr |
+      | 6036 | Task | fr |
+      | 6037 | Task | fr |
+      | 6038 | Task | fr |
+      | 6039 | Task | fr |
+      | 6040 | Task | fr |
+      | 6041 | Task | fr |
+      | 6042 | Task | fr |
+      | 6043 | Task | fr |
+      | 6044 | Task | fr |
+      | 6045 | Task | fr |
+      | 6046 | Task | fr |
+      | 6047 | Task | fr |
+      | 6048 | Task | fr |
+      | 6049 | Task | fr |
+      | 6050 | Task | fr |
+      | 6051 | Task | fr |
+      | 6052 | Task | fr |
+      | 6053 | Task | fr |
+      | 6054 | Task | fr |
+      | 6055 | Task | fr |
+      | 6056 | Task | fr |
+      | 6057 | Task | fr |
+      | 6058 | Task | fr |
+      | 6059 | Task | fr |
+      | 6060 | Task | fr |
+      | 6061 | Task | fr |
+      | 6062 | Task | fr |
+      | 6063 | Task | fr |
+      | 6064 | Task | fr |
+      | 6065 | Task | fr |
+      | 6066 | Task | fr |
+      | 6067 | Task | fr |
+      | 6068 | Task | fr |
+      | 6069 | Task | fr |
+      | 6070 | Task | fr |
+      | 6071 | Task | fr |
+      | 6072 | Task | fr |
+      | 6073 | Task | fr |
+      | 6074 | Task | fr |
+      | 6075 | Task | fr |
+      | 6076 | Task | fr |
+      | 6077 | Task | fr |
+      | 6078 | Task | fr |
+      | 6079 | Task | fr |
+      | 6080 | Task | fr |
+      | 6081 | Task | fr |
+      | 6082 | Task | fr |
+      | 6083 | Task | fr |
+      | 6084 | Task | fr |
+      | 6085 | Task | fr |
+      | 6086 | Task | fr |
+      | 6087 | Task | fr |
+      | 6088 | Task | fr |
+      | 6089 | Task | fr |
+      | 6090 | Task | fr |
+      | 6091 | Task | fr |
+      | 6092 | Task | fr |
+      | 6093 | Task | fr |
+      | 6094 | Task | fr |
+      | 6095 | Task | fr |
+      | 6096 | Task | fr |
+      | 6097 | Task | fr |
+      | 6098 | Task | fr |
+      | 6099 | Task | fr |
+      | 6100 | Task | fr |
+    And the database has the following table "items_items":
+      | parent_item_id | child_item_id | child_order |
+      | 6000 | 6001 | 0 |
+      | 6000 | 6002 | 1 |
+      | 6000 | 6003 | 2 |
+      | 6000 | 6004 | 3 |
+      | 6000 | 6005 | 4 |
+      | 6000 | 6006 | 5 |
+      | 6000 | 6007 | 6 |
+      | 6000 | 6008 | 7 |
+      | 6000 | 6009 | 8 |
+      | 6000 | 6010 | 9 |
+      | 6000 | 6011 | 10 |
+      | 6000 | 6012 | 11 |
+      | 6000 | 6013 | 12 |
+      | 6000 | 6014 | 13 |
+      | 6000 | 6015 | 14 |
+      | 6000 | 6016 | 15 |
+      | 6000 | 6017 | 16 |
+      | 6000 | 6018 | 17 |
+      | 6000 | 6019 | 18 |
+      | 6000 | 6020 | 19 |
+      | 6000 | 6021 | 20 |
+      | 6000 | 6022 | 21 |
+      | 6000 | 6023 | 22 |
+      | 6000 | 6024 | 23 |
+      | 6000 | 6025 | 24 |
+      | 6000 | 6026 | 25 |
+      | 6000 | 6027 | 26 |
+      | 6000 | 6028 | 27 |
+      | 6000 | 6029 | 28 |
+      | 6000 | 6030 | 29 |
+      | 6000 | 6031 | 30 |
+      | 6000 | 6032 | 31 |
+      | 6000 | 6033 | 32 |
+      | 6000 | 6034 | 33 |
+      | 6000 | 6035 | 34 |
+      | 6000 | 6036 | 35 |
+      | 6000 | 6037 | 36 |
+      | 6000 | 6038 | 37 |
+      | 6000 | 6039 | 38 |
+      | 6000 | 6040 | 39 |
+      | 6000 | 6041 | 40 |
+      | 6000 | 6042 | 41 |
+      | 6000 | 6043 | 42 |
+      | 6000 | 6044 | 43 |
+      | 6000 | 6045 | 44 |
+      | 6000 | 6046 | 45 |
+      | 6000 | 6047 | 46 |
+      | 6000 | 6048 | 47 |
+      | 6000 | 6049 | 48 |
+      | 6000 | 6050 | 49 |
+      | 6000 | 6051 | 50 |
+      | 6000 | 6052 | 51 |
+      | 6000 | 6053 | 52 |
+      | 6000 | 6054 | 53 |
+      | 6000 | 6055 | 54 |
+      | 6000 | 6056 | 55 |
+      | 6000 | 6057 | 56 |
+      | 6000 | 6058 | 57 |
+      | 6000 | 6059 | 58 |
+      | 6000 | 6060 | 59 |
+      | 6000 | 6061 | 60 |
+      | 6000 | 6062 | 61 |
+      | 6000 | 6063 | 62 |
+      | 6000 | 6064 | 63 |
+      | 6000 | 6065 | 64 |
+      | 6000 | 6066 | 65 |
+      | 6000 | 6067 | 66 |
+      | 6000 | 6068 | 67 |
+      | 6000 | 6069 | 68 |
+      | 6000 | 6070 | 69 |
+      | 6000 | 6071 | 70 |
+      | 6000 | 6072 | 71 |
+      | 6000 | 6073 | 72 |
+      | 6000 | 6074 | 73 |
+      | 6000 | 6075 | 74 |
+      | 6000 | 6076 | 75 |
+      | 6000 | 6077 | 76 |
+      | 6000 | 6078 | 77 |
+      | 6000 | 6079 | 78 |
+      | 6000 | 6080 | 79 |
+      | 6000 | 6081 | 80 |
+      | 6000 | 6082 | 81 |
+      | 6000 | 6083 | 82 |
+      | 6000 | 6084 | 83 |
+      | 6000 | 6085 | 84 |
+      | 6000 | 6086 | 85 |
+      | 6000 | 6087 | 86 |
+      | 6000 | 6088 | 87 |
+      | 6000 | 6089 | 88 |
+      | 6000 | 6090 | 89 |
+      | 6000 | 6091 | 90 |
+      | 6000 | 6092 | 91 |
+      | 6000 | 6093 | 92 |
+      | 6000 | 6094 | 93 |
+      | 6000 | 6095 | 94 |
+      | 6000 | 6096 | 95 |
+      | 6000 | 6097 | 96 |
+      | 6000 | 6098 | 97 |
+      | 6000 | 6099 | 98 |
+      | 6000 | 6100 | 99 |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_watch_generated |
+      | 21 | 6000 | info | answer |
+      | 21 | 6001 | info | none |
+      | 21 | 6002 | info | none |
+      | 21 | 6003 | info | none |
+      | 21 | 6004 | info | none |
+      | 21 | 6005 | info | none |
+      | 21 | 6006 | info | none |
+      | 21 | 6007 | info | none |
+      | 21 | 6008 | info | none |
+      | 21 | 6009 | info | none |
+      | 21 | 6010 | info | none |
+      | 21 | 6011 | info | none |
+      | 21 | 6012 | info | none |
+      | 21 | 6013 | info | none |
+      | 21 | 6014 | info | none |
+      | 21 | 6015 | info | none |
+      | 21 | 6016 | info | none |
+      | 21 | 6017 | info | none |
+      | 21 | 6018 | info | none |
+      | 21 | 6019 | info | none |
+      | 21 | 6020 | info | none |
+      | 21 | 6021 | info | none |
+      | 21 | 6022 | info | none |
+      | 21 | 6023 | info | none |
+      | 21 | 6024 | info | none |
+      | 21 | 6025 | info | none |
+      | 21 | 6026 | info | none |
+      | 21 | 6027 | info | none |
+      | 21 | 6028 | info | none |
+      | 21 | 6029 | info | none |
+      | 21 | 6030 | info | none |
+      | 21 | 6031 | info | none |
+      | 21 | 6032 | info | none |
+      | 21 | 6033 | info | none |
+      | 21 | 6034 | info | none |
+      | 21 | 6035 | info | none |
+      | 21 | 6036 | info | none |
+      | 21 | 6037 | info | none |
+      | 21 | 6038 | info | none |
+      | 21 | 6039 | info | none |
+      | 21 | 6040 | info | none |
+      | 21 | 6041 | info | none |
+      | 21 | 6042 | info | none |
+      | 21 | 6043 | info | none |
+      | 21 | 6044 | info | none |
+      | 21 | 6045 | info | none |
+      | 21 | 6046 | info | none |
+      | 21 | 6047 | info | none |
+      | 21 | 6048 | info | none |
+      | 21 | 6049 | info | none |
+      | 21 | 6050 | info | none |
+      | 21 | 6051 | info | none |
+      | 21 | 6052 | info | none |
+      | 21 | 6053 | info | none |
+      | 21 | 6054 | info | none |
+      | 21 | 6055 | info | none |
+      | 21 | 6056 | info | none |
+      | 21 | 6057 | info | none |
+      | 21 | 6058 | info | none |
+      | 21 | 6059 | info | none |
+      | 21 | 6060 | info | none |
+      | 21 | 6061 | info | none |
+      | 21 | 6062 | info | none |
+      | 21 | 6063 | info | none |
+      | 21 | 6064 | info | none |
+      | 21 | 6065 | info | none |
+      | 21 | 6066 | info | none |
+      | 21 | 6067 | info | none |
+      | 21 | 6068 | info | none |
+      | 21 | 6069 | info | none |
+      | 21 | 6070 | info | none |
+      | 21 | 6071 | info | none |
+      | 21 | 6072 | info | none |
+      | 21 | 6073 | info | none |
+      | 21 | 6074 | info | none |
+      | 21 | 6075 | info | none |
+      | 21 | 6076 | info | none |
+      | 21 | 6077 | info | none |
+      | 21 | 6078 | info | none |
+      | 21 | 6079 | info | none |
+      | 21 | 6080 | info | none |
+      | 21 | 6081 | info | none |
+      | 21 | 6082 | info | none |
+      | 21 | 6083 | info | none |
+      | 21 | 6084 | info | none |
+      | 21 | 6085 | info | none |
+      | 21 | 6086 | info | none |
+      | 21 | 6087 | info | none |
+      | 21 | 6088 | info | none |
+      | 21 | 6089 | info | none |
+      | 21 | 6090 | info | none |
+      | 21 | 6091 | info | none |
+      | 21 | 6092 | info | none |
+      | 21 | 6093 | info | none |
+      | 21 | 6094 | info | none |
+      | 21 | 6095 | info | none |
+      | 21 | 6096 | info | none |
+      | 21 | 6097 | info | none |
+      | 21 | 6098 | info | none |
+      | 21 | 6099 | info | none |
+      | 21 | 6100 | info | none |
+    When I send a GET request to "/groups/11/group-progress-with-answers-zip?parent_item_ids=6000"
+    Then the response code should be 400
+    And the response error message should contain "The number of items exceeds the limit (100)"
+
+
+  Scenario: The number of users exceeds the limit
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id | type  | name      |
+      | 1  | Base  | Root 1    |
+      | 11 | Class | Our Class |
+      | 21 | User  | owner     |
+      | 7000 | User | user000 |
+      | 7001 | User | user001 |
+      | 7002 | User | user002 |
+      | 7003 | User | user003 |
+      | 7004 | User | user004 |
+      | 7005 | User | user005 |
+      | 7006 | User | user006 |
+      | 7007 | User | user007 |
+      | 7008 | User | user008 |
+      | 7009 | User | user009 |
+      | 7010 | User | user010 |
+      | 7011 | User | user011 |
+      | 7012 | User | user012 |
+      | 7013 | User | user013 |
+      | 7014 | User | user014 |
+      | 7015 | User | user015 |
+      | 7016 | User | user016 |
+      | 7017 | User | user017 |
+      | 7018 | User | user018 |
+      | 7019 | User | user019 |
+      | 7020 | User | user020 |
+      | 7021 | User | user021 |
+      | 7022 | User | user022 |
+      | 7023 | User | user023 |
+      | 7024 | User | user024 |
+      | 7025 | User | user025 |
+      | 7026 | User | user026 |
+      | 7027 | User | user027 |
+      | 7028 | User | user028 |
+      | 7029 | User | user029 |
+      | 7030 | User | user030 |
+      | 7031 | User | user031 |
+      | 7032 | User | user032 |
+      | 7033 | User | user033 |
+      | 7034 | User | user034 |
+      | 7035 | User | user035 |
+      | 7036 | User | user036 |
+      | 7037 | User | user037 |
+      | 7038 | User | user038 |
+      | 7039 | User | user039 |
+      | 7040 | User | user040 |
+      | 7041 | User | user041 |
+      | 7042 | User | user042 |
+      | 7043 | User | user043 |
+      | 7044 | User | user044 |
+      | 7045 | User | user045 |
+      | 7046 | User | user046 |
+      | 7047 | User | user047 |
+      | 7048 | User | user048 |
+      | 7049 | User | user049 |
+      | 7050 | User | user050 |
+      | 7051 | User | user051 |
+      | 7052 | User | user052 |
+      | 7053 | User | user053 |
+      | 7054 | User | user054 |
+      | 7055 | User | user055 |
+      | 7056 | User | user056 |
+      | 7057 | User | user057 |
+      | 7058 | User | user058 |
+      | 7059 | User | user059 |
+      | 7060 | User | user060 |
+      | 7061 | User | user061 |
+      | 7062 | User | user062 |
+      | 7063 | User | user063 |
+      | 7064 | User | user064 |
+      | 7065 | User | user065 |
+      | 7066 | User | user066 |
+      | 7067 | User | user067 |
+      | 7068 | User | user068 |
+      | 7069 | User | user069 |
+      | 7070 | User | user070 |
+      | 7071 | User | user071 |
+      | 7072 | User | user072 |
+      | 7073 | User | user073 |
+      | 7074 | User | user074 |
+      | 7075 | User | user075 |
+      | 7076 | User | user076 |
+      | 7077 | User | user077 |
+      | 7078 | User | user078 |
+      | 7079 | User | user079 |
+      | 7080 | User | user080 |
+      | 7081 | User | user081 |
+      | 7082 | User | user082 |
+      | 7083 | User | user083 |
+      | 7084 | User | user084 |
+      | 7085 | User | user085 |
+      | 7086 | User | user086 |
+      | 7087 | User | user087 |
+      | 7088 | User | user088 |
+      | 7089 | User | user089 |
+      | 7090 | User | user090 |
+      | 7091 | User | user091 |
+      | 7092 | User | user092 |
+      | 7093 | User | user093 |
+      | 7094 | User | user094 |
+      | 7095 | User | user095 |
+      | 7096 | User | user096 |
+      | 7097 | User | user097 |
+      | 7098 | User | user098 |
+      | 7099 | User | user099 |
+      | 7100 | User | user100 |
+    And the database has the following users:
+      | group_id | login | default_language |
+      | 21       | owner | en               |
+      | 7000 | user000 | fr |
+      | 7001 | user001 | fr |
+      | 7002 | user002 | fr |
+      | 7003 | user003 | fr |
+      | 7004 | user004 | fr |
+      | 7005 | user005 | fr |
+      | 7006 | user006 | fr |
+      | 7007 | user007 | fr |
+      | 7008 | user008 | fr |
+      | 7009 | user009 | fr |
+      | 7010 | user010 | fr |
+      | 7011 | user011 | fr |
+      | 7012 | user012 | fr |
+      | 7013 | user013 | fr |
+      | 7014 | user014 | fr |
+      | 7015 | user015 | fr |
+      | 7016 | user016 | fr |
+      | 7017 | user017 | fr |
+      | 7018 | user018 | fr |
+      | 7019 | user019 | fr |
+      | 7020 | user020 | fr |
+      | 7021 | user021 | fr |
+      | 7022 | user022 | fr |
+      | 7023 | user023 | fr |
+      | 7024 | user024 | fr |
+      | 7025 | user025 | fr |
+      | 7026 | user026 | fr |
+      | 7027 | user027 | fr |
+      | 7028 | user028 | fr |
+      | 7029 | user029 | fr |
+      | 7030 | user030 | fr |
+      | 7031 | user031 | fr |
+      | 7032 | user032 | fr |
+      | 7033 | user033 | fr |
+      | 7034 | user034 | fr |
+      | 7035 | user035 | fr |
+      | 7036 | user036 | fr |
+      | 7037 | user037 | fr |
+      | 7038 | user038 | fr |
+      | 7039 | user039 | fr |
+      | 7040 | user040 | fr |
+      | 7041 | user041 | fr |
+      | 7042 | user042 | fr |
+      | 7043 | user043 | fr |
+      | 7044 | user044 | fr |
+      | 7045 | user045 | fr |
+      | 7046 | user046 | fr |
+      | 7047 | user047 | fr |
+      | 7048 | user048 | fr |
+      | 7049 | user049 | fr |
+      | 7050 | user050 | fr |
+      | 7051 | user051 | fr |
+      | 7052 | user052 | fr |
+      | 7053 | user053 | fr |
+      | 7054 | user054 | fr |
+      | 7055 | user055 | fr |
+      | 7056 | user056 | fr |
+      | 7057 | user057 | fr |
+      | 7058 | user058 | fr |
+      | 7059 | user059 | fr |
+      | 7060 | user060 | fr |
+      | 7061 | user061 | fr |
+      | 7062 | user062 | fr |
+      | 7063 | user063 | fr |
+      | 7064 | user064 | fr |
+      | 7065 | user065 | fr |
+      | 7066 | user066 | fr |
+      | 7067 | user067 | fr |
+      | 7068 | user068 | fr |
+      | 7069 | user069 | fr |
+      | 7070 | user070 | fr |
+      | 7071 | user071 | fr |
+      | 7072 | user072 | fr |
+      | 7073 | user073 | fr |
+      | 7074 | user074 | fr |
+      | 7075 | user075 | fr |
+      | 7076 | user076 | fr |
+      | 7077 | user077 | fr |
+      | 7078 | user078 | fr |
+      | 7079 | user079 | fr |
+      | 7080 | user080 | fr |
+      | 7081 | user081 | fr |
+      | 7082 | user082 | fr |
+      | 7083 | user083 | fr |
+      | 7084 | user084 | fr |
+      | 7085 | user085 | fr |
+      | 7086 | user086 | fr |
+      | 7087 | user087 | fr |
+      | 7088 | user088 | fr |
+      | 7089 | user089 | fr |
+      | 7090 | user090 | fr |
+      | 7091 | user091 | fr |
+      | 7092 | user092 | fr |
+      | 7093 | user093 | fr |
+      | 7094 | user094 | fr |
+      | 7095 | user095 | fr |
+      | 7096 | user096 | fr |
+      | 7097 | user097 | fr |
+      | 7098 | user098 | fr |
+      | 7099 | user099 | fr |
+      | 7100 | user100 | fr |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_watch_members |
+      | 1        | 21         | true              |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id | is_team_membership |
+      | 1 | 11 | 0 |
+      | 11 | 7000 | 0 |
+      | 11 | 7001 | 0 |
+      | 11 | 7002 | 0 |
+      | 11 | 7003 | 0 |
+      | 11 | 7004 | 0 |
+      | 11 | 7005 | 0 |
+      | 11 | 7006 | 0 |
+      | 11 | 7007 | 0 |
+      | 11 | 7008 | 0 |
+      | 11 | 7009 | 0 |
+      | 11 | 7010 | 0 |
+      | 11 | 7011 | 0 |
+      | 11 | 7012 | 0 |
+      | 11 | 7013 | 0 |
+      | 11 | 7014 | 0 |
+      | 11 | 7015 | 0 |
+      | 11 | 7016 | 0 |
+      | 11 | 7017 | 0 |
+      | 11 | 7018 | 0 |
+      | 11 | 7019 | 0 |
+      | 11 | 7020 | 0 |
+      | 11 | 7021 | 0 |
+      | 11 | 7022 | 0 |
+      | 11 | 7023 | 0 |
+      | 11 | 7024 | 0 |
+      | 11 | 7025 | 0 |
+      | 11 | 7026 | 0 |
+      | 11 | 7027 | 0 |
+      | 11 | 7028 | 0 |
+      | 11 | 7029 | 0 |
+      | 11 | 7030 | 0 |
+      | 11 | 7031 | 0 |
+      | 11 | 7032 | 0 |
+      | 11 | 7033 | 0 |
+      | 11 | 7034 | 0 |
+      | 11 | 7035 | 0 |
+      | 11 | 7036 | 0 |
+      | 11 | 7037 | 0 |
+      | 11 | 7038 | 0 |
+      | 11 | 7039 | 0 |
+      | 11 | 7040 | 0 |
+      | 11 | 7041 | 0 |
+      | 11 | 7042 | 0 |
+      | 11 | 7043 | 0 |
+      | 11 | 7044 | 0 |
+      | 11 | 7045 | 0 |
+      | 11 | 7046 | 0 |
+      | 11 | 7047 | 0 |
+      | 11 | 7048 | 0 |
+      | 11 | 7049 | 0 |
+      | 11 | 7050 | 0 |
+      | 11 | 7051 | 0 |
+      | 11 | 7052 | 0 |
+      | 11 | 7053 | 0 |
+      | 11 | 7054 | 0 |
+      | 11 | 7055 | 0 |
+      | 11 | 7056 | 0 |
+      | 11 | 7057 | 0 |
+      | 11 | 7058 | 0 |
+      | 11 | 7059 | 0 |
+      | 11 | 7060 | 0 |
+      | 11 | 7061 | 0 |
+      | 11 | 7062 | 0 |
+      | 11 | 7063 | 0 |
+      | 11 | 7064 | 0 |
+      | 11 | 7065 | 0 |
+      | 11 | 7066 | 0 |
+      | 11 | 7067 | 0 |
+      | 11 | 7068 | 0 |
+      | 11 | 7069 | 0 |
+      | 11 | 7070 | 0 |
+      | 11 | 7071 | 0 |
+      | 11 | 7072 | 0 |
+      | 11 | 7073 | 0 |
+      | 11 | 7074 | 0 |
+      | 11 | 7075 | 0 |
+      | 11 | 7076 | 0 |
+      | 11 | 7077 | 0 |
+      | 11 | 7078 | 0 |
+      | 11 | 7079 | 0 |
+      | 11 | 7080 | 0 |
+      | 11 | 7081 | 0 |
+      | 11 | 7082 | 0 |
+      | 11 | 7083 | 0 |
+      | 11 | 7084 | 0 |
+      | 11 | 7085 | 0 |
+      | 11 | 7086 | 0 |
+      | 11 | 7087 | 0 |
+      | 11 | 7088 | 0 |
+      | 11 | 7089 | 0 |
+      | 11 | 7090 | 0 |
+      | 11 | 7091 | 0 |
+      | 11 | 7092 | 0 |
+      | 11 | 7093 | 0 |
+      | 11 | 7094 | 0 |
+      | 11 | 7095 | 0 |
+      | 11 | 7096 | 0 |
+      | 11 | 7097 | 0 |
+      | 11 | 7098 | 0 |
+      | 11 | 7099 | 0 |
+      | 11 | 7100 | 0 |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | type | default_language_tag |
+      | 800 | Task | fr                   |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_watch_generated |
+      | 21       | 800     | info               | answer              |
+    When I send a GET request to "/groups/11/group-progress-with-answers-zip?parent_item_ids=800"
+    Then the response code should be 400
+    And the response error message should contain "The number of users exceeds the limit (100)"

--- a/app/api/groups/get_team_progress.go
+++ b/app/api/groups/get_team_progress.go
@@ -122,7 +122,7 @@ func (srv *Service) getTeamProgress(responseWriter http.ResponseWriter, httpRequ
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	if len(itemParentIDs) == 0 {

--- a/app/api/groups/get_team_progress_csv.go
+++ b/app/api/groups/get_team_progress_csv.go
@@ -81,7 +81,7 @@ func (srv *Service) getTeamProgressCSV(responseWriter http.ResponseWriter, httpR
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	responseWriter.Header().Set("Content-Type", "text/csv")

--- a/app/api/groups/get_user_progress.go
+++ b/app/api/groups/get_user_progress.go
@@ -128,7 +128,7 @@ func (srv *Service) getUserProgress(responseWriter http.ResponseWriter, httpRequ
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	if len(itemParentIDs) == 0 {

--- a/app/api/groups/get_user_progress_csv.go
+++ b/app/api/groups/get_user_progress_csv.go
@@ -90,7 +90,7 @@ func (srv *Service) getUserProgressCSV(responseWriter http.ResponseWriter, httpR
 		return service.ErrAPIInsufficientAccessRights
 	}
 
-	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user)
+	itemParentIDs, err := resolveAndCheckParentIDs(store, httpRequest, user, "result")
 	service.MustNotBeError(err)
 
 	responseWriter.Header().Set("Content-Type", "text/csv")

--- a/app/api/groups/groups.go
+++ b/app/api/groups/groups.go
@@ -68,6 +68,8 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	router.Get("/groups/{group_id}/team-progress-csv", service.AppHandler(srv.getTeamProgressCSV).ServeHTTP)
 	router.Get("/groups/{group_id}/user-progress", service.AppHandler(srv.getUserProgress).ServeHTTP)
 	router.Get("/groups/{group_id}/user-progress-csv", service.AppHandler(srv.getUserProgressCSV).ServeHTTP)
+	router.Get("/groups/{group_id}/group-progress-with-answers-zip",
+		service.AppHandler(srv.getGroupProgressWithAnswersZIP).ServeHTTP)
 	router.With(service.ParticipantMiddleware(srv.Base)).
 		Get("/items/{item_id}/participant-progress", service.AppHandler(srv.getParticipantProgress).ServeHTTP)
 	router.Post("/groups/{parent_group_id}/join-requests/accept", service.AppHandler(srv.acceptJoinRequests).ServeHTTP)

--- a/testhelpers/feature_context.go
+++ b/testhelpers/feature_context.go
@@ -104,6 +104,10 @@ func InitializeScenario(scenarioContext *godog.ScenarioContext) {
 	scenarioContext.Step(`^the response error message should contain "(.*)"$`, ctx.TheResponseErrorMessageShouldContain)
 
 	scenarioContext.Step(`^the response should be a JSON array with (\d+) entr(?:ies|y)$`, ctx.ItShouldBeAJSONArrayWithEntries)
+	scenarioContext.Step(
+		`^the response should be a ZIP file containing the following files:$`,
+		ctx.ItShouldBeAZIPFileContainingTheFollowingFiles,
+	)
 	scenarioContext.Step(`^the response at ([^ ]+) should be "([^"]*)"$`, ctx.TheResponseAtShouldBeTheValue)
 	scenarioContext.Step("^the response at ([^ ]+) should be:$", ctx.TheResponseAtShouldBe)
 	scenarioContext.Step("^the response at ([^ ]+) in JSON should be:$", ctx.TheResponseAtInJSONShouldBe)

--- a/testhelpers/steps_response.go
+++ b/testhelpers/steps_response.go
@@ -3,9 +3,11 @@
 package testhelpers
 
 import (
+	"archive/zip"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -37,6 +39,59 @@ func (ctx *TestContext) ItShouldBeAJSONArrayWithEntries(count int) error { //nol
 	}
 
 	return nil
+}
+
+// ItShouldBeAZIPFileContainingTheFollowingFiles checks that the response is a ZIP file containing the described files.
+// The files are described by a JSON array with `filename` and `content` keys for each file.
+// `filename` is the path inside the ZIP separated by / (e.g. root/directory/file.txt).
+func (ctx *TestContext) ItShouldBeAZIPFileContainingTheFollowingFiles(body *godog.DocString) error {
+	zipReader, err := zip.NewReader(strings.NewReader(ctx.lastResponseBody), int64(len(ctx.lastResponseBody)))
+	if err != nil {
+		return err
+	}
+
+	actualResult := make([]interface{}, 0, len(zipReader.File))
+	for _, zipFile := range zipReader.File {
+		unzippedFileBytes, err := readZipFile(zipFile)
+		if err != nil {
+			return err
+		}
+
+		actualResult = append(actualResult, map[string]interface{}{
+			"filename": zipFile.Name,
+			"content":  string(unzippedFileBytes),
+		})
+	}
+
+	expectedContent := ctx.preprocessString(body.Content)
+
+	var expectedResult interface{}
+	err = json.Unmarshal([]byte(expectedContent), &expectedResult)
+	if err != nil {
+		return err
+	}
+
+	if !cmp.Equal(actualResult, expectedResult) {
+		return fmt.Errorf("%v doesn't match expected %v", actualResult, expectedResult)
+	}
+
+	return nil
+}
+
+func readZipFile(zipFile *zip.File) ([]byte, error) {
+	file, err := zipFile.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	defer func(f io.ReadCloser) {
+		err := f.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(file)
+
+	return io.ReadAll(file)
 }
 
 func (ctx *TestContext) getJSONPathOnResponse(jsonPath string) (interface{}, error) {


### PR DESCRIPTION
## Summary

Implements **#812**: a new endpoint `GET /groups/{group_id}/group-progress-with-answers-zip` that streams a ZIP export of group progress with submission answers.

The ZIP contains:
- `group_progress.csv` at the root (same content as the existing CSV endpoint)
- A **nested directory tree** of visible descendant items, named `{child_order}-{title}-{id}/` (titles sanitized; root parents use `child_order` 0)
- Under each item: `submissions/{login}/data.json` (progress fields) and `{number}-{attempt_id}-{score}-{answers.id}.txt` files (one per submission, ordered by `created_at`)

**Access control:** manager with `can_watch_members`, plus `can_watch >= answer` on each `parent_item_ids` root. Descendant items are included when `can_view >= info`.

**Limits:** max 100 users and 100 items in the visible subtree, each returning a distinct 400 error so the frontend can tell them apart.

**Supporting refactors:**
- `resolveAndCheckParentIDs` now takes a `canWatchPermission` parameter (`"result"` for existing progress endpoints, `"answer"` for the ZIP export)
- `writeGroupProgressCSV` extracted from the CSV handler for reuse

**Implementation notes:**
- Submissions fetched in a single batched query (not per user×item)
- Subtree built via BFS scoped to `parent_item_ids` descendants
- Path segments (titles and logins) sanitized against zip-slip
- ZIP assembled in memory before response write (correct error handling over streaming)
- `data.json` uses user-only progress (no team-result merging); documented in code

## Test plan

- [x] `./bin/golangci-lint run -v --timeout 2m`
- [x] `go build ./...`
- [x] Cucumber: `get_group_progress_with_answers_zip.feature` (2 scenarios — empty export, full nested export with CSV/data.json/submissions)
- [x] Cucumber: `get_group_progress_with_answers_zip.robustness.feature` (7 scenarios — 400/401/403, both limit errors)
- [ ] `make swagger-generate` (requires `swagger` CLI — handler docs are written inline)
- [ ] Manual: download a ZIP on staging for a real group with nested items and multiple users; verify directory layout and file contents
- [ ] Manual: confirm frontend handles the two distinct limit error messages correctly