### PR TITLE
new service to get the owners of an item

### DIFF
--- a/app/api/items/items.go
+++ b/app/api/items/items.go
@@ -65,6 +65,7 @@ func (srv *Service) SetRoutes(router chi.Router) {
 	routerWithAuthAndParticipant.Get("/items/log", service.AppHandler(srv.getActivityLogForAllItems).ServeHTTP)
 	routerWithAuth.Get("/items/{item_id}/participant/{participant_id}/thread/log", service.AppHandler(srv.getActivityLogForThread).ServeHTTP)
 	routerWithAuth.Get("/items/{item_id}/official-sessions", service.AppHandler(srv.listOfficialSessions).ServeHTTP)
+	routerWithAuth.Get("/items/{item_id}/owners", service.AppHandler(srv.listOwners).ServeHTTP)
 	routerWithAuth.Put("/items/{item_id}/strings/{language_tag}", service.AppHandler(srv.updateItemString).ServeHTTP)
 	routerWithAuth.Delete("/items/{item_id}/strings/{language_tag}", service.AppHandler(srv.deleteItemString).ServeHTTP)
 	routerWithAuth.Get("/items/{item_id}/entry-state",

--- a/app/api/items/list_owners.feature
+++ b/app/api/items/list_owners.feature
@@ -1,0 +1,97 @@
+Feature: List owner groups for an item
+  Background:
+    Given the database has the following table "groups":
+      | id | name        | type  |
+      | 9  | Class       | Class |
+      | 10 | Team Alpha  | Team  |
+      | 11 | Team Beta   | Team  |
+      | 25 | some class  | Class |
+    And the database has the following users:
+      | group_id | login | first_name  | last_name | default_language |
+      | 21       | owner | Jean-Michel | Blanquer  | fr               |
+    And the database has the following table "groups_groups":
+      | parent_group_id | child_group_id |
+      | 9               | 10             |
+      | 9               | 21             |
+    And the groups ancestors are computed
+    And the database has the following table "items":
+      | id  | default_language_tag | requires_explicit_entry | type    |
+      | 102 | fr                   | true                    | Chapter |
+    And the database has the following table "items_strings":
+      | item_id | language_tag | title      |
+      | 102     | fr           | Chapitre B |
+    And the database table "permissions_granted" also has the following rows:
+      | group_id | item_id | source_group_id | origin           | can_view | can_grant_view | can_watch | can_edit | is_owner | can_request_help_to | can_make_session_official | can_enter_from      | can_enter_until     |
+      | 9        | 102     | 25              | group_membership | none     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 25              | group_membership | none     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 10       | 102     | 9               | group_membership | none     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 11       | 102     | 25              | group_membership | none     | none           | none      | none     | false    | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 102     | 25              | group_membership | info     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+      | 25       | 102     | 9               | group_membership | none     | none           | none      | none     | true     | null                | false                     | 9999-12-31 23:59:59 | 9999-12-31 23:59:59 |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_edit_generated |
+      | 21       | 102     | all                |
+    And the generated permissions are computed
+
+  Scenario: List owner groups
+    Given I am the user with id "21"
+    When I send a GET request to "/items/102/owners"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "9", "name": "Class", "type": "Class"},
+      {"id": "25", "name": "some class", "type": "Class"},
+      {"id": "10", "name": "Team Alpha", "type": "Team"}
+    ]
+    """
+
+  Scenario: Empty list when no owner groups
+    Given the database has the following table "items":
+      | id  | default_language_tag | requires_explicit_entry | type    |
+      | 103 | fr                   | false                   | Chapter |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | can_edit_generated |
+      | 21       | 103     | all                |
+    And the generated permissions are computed
+    And I am the user with id "21"
+    When I send a GET request to "/items/103/owners"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    []
+    """
+
+  Scenario: Sort by name descending
+    Given I am the user with id "21"
+    When I send a GET request to "/items/102/owners?sort=-name"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "10", "name": "Team Alpha", "type": "Team"},
+      {"id": "25", "name": "some class", "type": "Class"},
+      {"id": "9", "name": "Class", "type": "Class"}
+    ]
+    """
+
+  Scenario: Group with is_owner_generated is listed
+    Given the database has the following table "groups":
+      | id | name             | type  |
+      | 12 | Generated owner  | Class |
+    And the database table "permissions_generated" also has the following rows:
+      | group_id | item_id | is_owner_generated |
+      | 12       | 102     | true               |
+    And the generated permissions are computed
+    And I am the user with id "21"
+    When I send a GET request to "/items/102/owners"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {"id": "9", "name": "Class", "type": "Class"},
+      {"id": "12", "name": "Generated owner", "type": "Class"},
+      {"id": "25", "name": "some class", "type": "Class"},
+      {"id": "10", "name": "Team Alpha", "type": "Team"}
+    ]
+    """

--- a/app/api/items/list_owners.go
+++ b/app/api/items/list_owners.go
@@ -1,0 +1,115 @@
+package items
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/France-ioi/AlgoreaBackend/v2/app/service"
+)
+
+// swagger:model itemOwnersResponseRow
+type itemOwnersResponseRow struct {
+	// required: true
+	ID int64 `json:"id,string"`
+	// required: true
+	Name string `json:"name"`
+	// required: true
+	Type string `json:"type"`
+}
+
+// swagger:operation GET /items/{item_id}/owners items itemOwnersList
+//
+//	---
+//	summary: List owner groups for an item
+//	description: >
+//	 Lists the groups having `is_owner_generated` = true in `permissions_generated` for the given item.
+//
+//
+//	 Restrictions:
+//		 * the current user should have at least `can_edit` = 'all' permission on the item,
+//
+//	 otherwise the 'forbidden' error is returned.
+//	parameters:
+//		- name: item_id
+//			in: path
+//			type: integer
+//			format: int64
+//			required: true
+//		- name: from.id
+//			description: Start the page from the group next to the group with `id` = `{from.id}`
+//			in: query
+//			type: integer
+//			format: int64
+//		- name: sort
+//			in: query
+//			default: [name,id]
+//			type: array
+//			items:
+//				type: string
+//				enum: [name,-name,id,-id]
+//		- name: limit
+//			description: Display first N owner groups
+//			in: query
+//			type: integer
+//			maximum: 1000
+//			default: 500
+//	responses:
+//		"200":
+//			description: OK. Success response with an array of owner groups
+//			schema:
+//				type: array
+//				items:
+//					"$ref": "#/definitions/itemOwnersResponseRow"
+//		"400":
+//			"$ref": "#/responses/badRequestResponse"
+//		"401":
+//			"$ref": "#/responses/unauthorizedResponse"
+//		"403":
+//			"$ref": "#/responses/forbiddenResponse"
+//		"408":
+//			"$ref": "#/responses/requestTimeoutResponse"
+//		"500":
+//			"$ref": "#/responses/internalErrorResponse"
+func (srv *Service) listOwners(responseWriter http.ResponseWriter, httpRequest *http.Request) error {
+	itemID, err := service.ResolveURLQueryPathInt64Field(httpRequest, "item_id")
+	if err != nil {
+		return service.ErrInvalidRequest(err)
+	}
+
+	user := srv.GetUser(httpRequest)
+	store := srv.GetStore(httpRequest)
+	found, err := store.Permissions().MatchingUserAncestors(user).
+		Where("item_id = ?", itemID).
+		WherePermissionIsAtLeast("edit", "all").
+		HasRows()
+	service.MustNotBeError(err)
+	if !found {
+		return service.ErrAPIInsufficientAccessRights
+	}
+
+	query := store.Groups().
+		Joins("JOIN permissions_generated ON permissions_generated.group_id = groups.id").
+		Where("permissions_generated.item_id = ?", itemID).
+		Where("permissions_generated.is_owner_generated = 1").
+		Select("groups.id, groups.name, groups.type")
+
+	query = service.NewQueryLimiter().Apply(httpRequest, query)
+	query, err = service.ApplySortingAndPaging(
+		httpRequest, query,
+		&service.SortingAndPagingParameters{
+			Fields: service.SortingAndPagingFields{
+				"name": {ColumnName: "groups.name"},
+				"id":   {ColumnName: "groups.id"},
+			},
+			DefaultRules: "name,id",
+			TieBreakers:  service.SortingAndPagingTieBreakers{"id": service.FieldTypeInt64},
+		})
+	service.MustNotBeError(err)
+
+	result := make([]itemOwnersResponseRow, 0)
+	service.MustNotBeError(query.Scan(&result).Error())
+
+	render.Respond(responseWriter, httpRequest, result)
+	return nil
+}

--- a/app/api/items/list_owners.robustness.feature
+++ b/app/api/items/list_owners.robustness.feature
@@ -1,0 +1,39 @@
+Feature: List owner groups for an item - robustness
+  Background:
+    Given the database has the following user:
+      | group_id | login |
+      | 11       | jdoe  |
+    And the database has the following table "items":
+      | id | default_language_tag |
+      | 21 | en                   |
+      | 22 | en                   |
+      | 50 | en                   |
+    And the database has the following table "permissions_generated":
+      | group_id | item_id | can_view_generated | can_edit_generated |
+      | 11       | 21      | solution           | children           |
+      | 11       | 22      | info               | none               |
+      | 11       | 50      | solution           | all                |
+
+  Scenario: User not found
+    Given I am the user with id "404"
+    When I send a GET request to "/items/50/owners"
+    Then the response code should be 401
+    And the response error message should contain "Invalid access token"
+
+  Scenario: Wrong item_id
+    Given I am the user with id "11"
+    When I send a GET request to "/items/abc/owners"
+    Then the response code should be 400
+    And the response error message should contain "Wrong value for item_id (should be int64)"
+
+  Scenario: Insufficient can_edit (children)
+    Given I am the user with id "11"
+    When I send a GET request to "/items/21/owners"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"
+
+  Scenario: Insufficient can_edit (view-only)
+    Given I am the user with id "11"
+    When I send a GET request to "/items/22/owners"
+    Then the response code should be 403
+    And the response error message should contain "Insufficient access rights"


### PR DESCRIPTION
## Summary

Adds `GET /items/{item_id}/owners` to list groups that own a given item.

- Returns `{ id, name, type }` for each owner group
- Reads from `permissions_generated` where `is_owner_generated = 1` (one row per group-item, no dedup needed)
- Restricted to callers with `can_edit >= all` on the item

## Test plan

- [x] `GET /items/{item_id}/owners` as a user with `can_edit = all` returns owner groups
- [x] Returns `[]` when the item has no owners
- [x] Returns `403` when `can_edit < all` (e.g. `children` or view-only)
- [x] Returns `401` / `400` for unauthenticated or invalid `item_id`
- [x] `sort` and pagination query params work as documented
- [x] BDD: `go test -gcflags=all=-l ./app/api/items/ -run TestBDD/list_owners`