### PR TITLE
fix MySQL named locks colliding across schemas on the same server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -261,7 +261,7 @@ store.WithForeignKeyChecksDisabled(func(s *DataStore) error {
     // ...
 })
 
-// With named lock
+// With named lock (lock names are namespaced by the connected MySQL schema)
 store.WithNamedLock("lock_name", timeout, func(s *DataStore) error {
     // ...
 })
@@ -272,6 +272,7 @@ store.WithNamedLock("lock_name", timeout, func(s *DataStore) error {
 - Nested transaction support via EnsureTransaction
 - Context cancellation support
 - Row-level locking: `WithExclusiveWriteLock()`, `WithSharedWriteLock()`
+- Named locks (`GET_LOCK`/`RELEASE_LOCK`) are namespaced by schema so multiple instances sharing a MySQL server but using different schemas do not collide (requires opening the DB with a DSN string so the schema name is known; opening from `*sql.DB`/`*sql.Tx` leaves namespacing off)
 
 ### Common Table Expressions (CTEs)
 
@@ -554,7 +555,7 @@ store.SetPropagationsModeToSync()
 4. **Repeat** until no more results to propagate
 
 **Concurrency Control**:
-- Named lock: `results_propagation` (10s timeout)
+- Named lock: `results_propagation` (10s timeout), namespaced by the connected MySQL schema
 - Prevents parallel propagation
 - Ensures consistency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- fix MySQL named locks colliding across schemas on the same server: lock names used by `WithNamedLock` are now namespaced by the connected schema (during a rolling deploy, old and new instances briefly use different lock names and will not mutually exclude; concurrent propagation in that window is considered tolerable)
+
 ## [v2.51.0](https://github.com/France-ioi/AlgoreaBackend/compare/v2.50.2...v2.51.0) - 2026-07-13
 
 - new endpoint: `GET /items/{item_id}/owners` lists groups with `is_owner_generated` on the item; requires `can_edit` = 'all' on the item

--- a/app/database/db.go
+++ b/app/database/db.go
@@ -3,8 +3,10 @@ package database
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
@@ -78,6 +80,8 @@ func OpenWithLogConfig(ctx context.Context, source interface{}, logConfig LogCon
 	var dbConn *gorm.DB
 	driverName := "mysql"
 
+	schemaName := schemaNameFromSource(source)
+
 	var rawConnection gorm.SQLCommon
 	var ownSQLDBConnection bool
 	var dbWrapper *sqlDBWrapper
@@ -88,14 +92,14 @@ func OpenWithLogConfig(ctx context.Context, source interface{}, logConfig LogCon
 		if err != nil {
 			return nil, err
 		}
-		dbWrapper = &sqlDBWrapper{sqlDB: sqlDB, ctx: ctx, logConfig: &logConfig}
+		dbWrapper = &sqlDBWrapper{sqlDB: sqlDB, ctx: ctx, logConfig: &logConfig, schemaName: schemaName}
 		rawConnection = dbWrapper
 		ownSQLDBConnection = true
 	case *sql.DB:
-		dbWrapper = &sqlDBWrapper{sqlDB: src, ctx: ctx, logConfig: &logConfig}
+		dbWrapper = &sqlDBWrapper{sqlDB: src, ctx: ctx, logConfig: &logConfig, schemaName: schemaName}
 		rawConnection = dbWrapper
 	case *sql.Tx:
-		rawConnection = &sqlTxWrapper{sqlTx: src, ctx: ctx, logConfig: &logConfig}
+		rawConnection = &sqlTxWrapper{sqlTx: src, ctx: ctx, logConfig: &logConfig, schemaName: schemaName}
 	default:
 		return nil, fmt.Errorf("unknown database source type: %T (%v)", src, src)
 	}
@@ -115,6 +119,46 @@ func OpenWithLogConfig(ctx context.Context, source interface{}, logConfig LogCon
 	dbConn.LogMode(false)
 
 	return newDB(dbConn, nil), nil
+}
+
+// schemaNameFromSource extracts the MySQL schema (database) name from a connection source.
+// For DSN strings it returns the DBName; for *sql.DB/*sql.Tx the DSN is not recoverable so "" is returned
+// (namespacing then stays off — production opens via a DSN string).
+// The DSN is parsed here independently of OpenRawDBConnection, which parses it again; that double parse
+// is once-per-open and intentional to keep OpenRawDBConnection unchanged.
+func schemaNameFromSource(source interface{}) string {
+	switch src := source.(type) {
+	case string:
+		cfg, err := mysql.ParseDSN(src)
+		if err != nil {
+			return ""
+		}
+		return cfg.DBName
+	case *sql.DB, *sql.Tx:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// mysqlNamedLockNameMaxLen is the maximum length of a named lock in MySQL 5.7.5+.
+const mysqlNamedLockNameMaxLen = 64
+
+// namespacedLockName prefixes lockName with schema so locks on different schemas of the same
+// MySQL server do not collide. Empty schema leaves lockName unchanged (e.g. sqlmock tests).
+// The plain form uses "schema/lockName" and assumes schema names contain no '/'.
+// Names longer than 64 bytes fall back to a deterministic 64-char hex SHA-256 digest
+// (len is byte-based intentionally: conservative vs MySQL's character limit).
+func namespacedLockName(schema, lockName string) string {
+	if schema == "" {
+		return lockName
+	}
+	namespaced := schema + "/" + lockName
+	if len(namespaced) <= mysqlNamedLockNameMaxLen {
+		return namespaced
+	}
+	sum := sha256.Sum256([]byte(schema + "\x00" + lockName))
+	return hex.EncodeToString(sum[:])
 }
 
 // OpenRawDBConnection creates a new DB connection.
@@ -634,7 +678,9 @@ func (conn *DB) GetContext() context.Context {
 // releases the connection afterward.
 func (conn *DB) WithFixedConnection(funcToCall func(*DB) error) (err error) {
 	sqlDB := conn.GetSQLDB()
-	sqlDBWrapped := &sqlDBWrapper{sqlDB: sqlDB, ctx: conn.ctx(), logConfig: conn.logConfig()}
+	sqlDBWrapped := &sqlDBWrapper{
+		sqlDB: sqlDB, ctx: conn.ctx(), logConfig: conn.logConfig(), schemaName: conn.schemaName(),
+	}
 
 	contextWithCancel, cancelFunc := context.WithCancel(sqlDBWrapped.ctx)
 	fixedConn, err := sqlDBWrapped.conn(contextWithCancel)
@@ -661,6 +707,11 @@ func (conn *DB) ctx() context.Context {
 func (conn *DB) logConfig() *LogConfig {
 	//nolint:forcetypeassert // panic if conn.db doesn't implement logConfigGetter: both sqlDBWrapper and sqlTxWrapper do
 	return conn.db.CommonDB().(logConfigGetter).getLogConfig()
+}
+
+func (conn *DB) schemaName() string {
+	//nolint:forcetypeassert // panic if conn.db doesn't implement schemaNameGetter: sqlDBWrapper, sqlConnWrapper and sqlTxWrapper do
+	return conn.db.CommonDB().(schemaNameGetter).getSchemaName()
 }
 
 func (conn *DB) inTransaction(txFunc func(*DB) error, txOptions ...*sql.TxOptions) (err error) {
@@ -801,8 +852,12 @@ func retryOnRetriableError(ctx context.Context, funcToCall func() error) error {
 func (conn *DB) withNamedLock(lockName string, timeout time.Duration, funcToCall func(*DB) error) (err error) {
 	initGetLockTime := time.Now()
 
+	effectiveName := namespacedLockName(conn.schemaName(), lockName)
+
 	sqlDB := conn.GetSQLDB()
-	sqlDBWrapped := &sqlDBWrapper{sqlDB: sqlDB, ctx: conn.ctx(), logConfig: conn.logConfig()}
+	sqlDBWrapped := &sqlDBWrapper{
+		sqlDB: sqlDB, ctx: conn.ctx(), logConfig: conn.logConfig(), schemaName: conn.schemaName(),
+	}
 
 	var shouldDiscardNamedLockDBConnection bool
 	namedLockDBConnection, err := sqlDBWrapped.conn(conn.ctx())
@@ -816,7 +871,9 @@ func (conn *DB) withNamedLock(lockName string, timeout time.Duration, funcToCall
 	}()
 
 	var getLockResult *int64
-	err = namedLockDBConnection.QueryRowContext(conn.ctx(), "SELECT GET_LOCK(?, ?)", lockName, int64(timeout/time.Second)).Scan(&getLockResult)
+	err = namedLockDBConnection.QueryRowContext(
+		conn.ctx(), "SELECT GET_LOCK(?, ?)", effectiveName, int64(timeout/time.Second),
+	).Scan(&getLockResult)
 	if err != nil {
 		return err
 	}
@@ -829,18 +886,19 @@ func (conn *DB) withNamedLock(lockName string, timeout time.Duration, funcToCall
 		// call RELEASE_LOCK() even if the context is canceled or timed out
 		releaseErr := namedLockDBConnection.QueryRowContext(
 			log.ContextWithLogger(context.Background(), log.LoggerFromContext(conn.ctx())),
-			"SELECT RELEASE_LOCK(?)", lockName).Scan(&releaseLockResult)
+			"SELECT RELEASE_LOCK(?)", effectiveName).Scan(&releaseLockResult)
 		if releaseErr != nil || releaseLockResult == nil || *releaseLockResult != 1 {
 			// on error we just close the connection to release the lock
 			shouldDiscardNamedLockDBConnection = true
 			// do not return an error, it should not affect the result
 			logDBError(conn.ctx(),
-				fmt.Errorf("failed to release the lock %q, closing the DB connection to release the lock", lockName))
+				fmt.Errorf("failed to release the lock %q [effective=%s], closing the DB connection to release the lock",
+					lockName, effectiveName))
 		}
 	}()
 
 	log.EntryFromContext(conn.ctx()).WithField("type", "db").
-		Debugf("Duration for GET_LOCK(%s, %v): %v", lockName, timeout, time.Since(initGetLockTime))
+		Debugf("Duration for GET_LOCK(%s, %v) [effective=%s]: %v", lockName, timeout, effectiveName, time.Since(initGetLockTime))
 
 	return funcToCall(conn)
 }

--- a/app/database/db_test.go
+++ b/app/database/db_test.go
@@ -27,7 +27,10 @@ import (
 	"github.com/France-ioi/AlgoreaBackend/v2/testhelpers/testoutput"
 )
 
-const someName = "some name"
+const (
+	someName       = "some name"
+	testSchemaName = "algorea_prod"
+)
 
 func TestDB_inTransaction_NoErrors(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
@@ -1766,6 +1769,130 @@ func TestDB_withNamedLock_ReleasesLockOnSuccess(t *testing.T) {
 	assert.NoError(t, dbMock.ExpectationsWereMet())
 }
 
+func TestDB_withNamedLock_NamespacesLockNameBySchema(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, dbMock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	dbWrapper, ok := db.db.CommonDB().(*sqlDBWrapper)
+	require.True(t, ok)
+	dbWrapper.schemaName = testSchemaName
+
+	lockName := someName
+	timeout := 1234 * time.Millisecond
+	expectedTimeout := int(timeout.Round(time.Second).Seconds())
+	expectedLockName := testSchemaName + "/" + lockName
+
+	dbMock.ExpectQuery("^"+regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")+"$").
+		WithArgs(expectedLockName, expectedTimeout).
+		WillReturnRows(sqlmock.NewRows([]string{"GET_LOCK(?, ?)"}).AddRow(int64(1)))
+	dbMock.ExpectQuery("^" + regexp.QuoteMeta("SELECT RELEASE_LOCK(?)") + "$").
+		WithArgs(expectedLockName).
+		WillReturnRows(sqlmock.NewRows([]string{"RELEASE_LOCK(?)"}).AddRow(int64(1)))
+
+	err := db.withNamedLock(lockName, timeout, func(*DB) error {
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+func TestDB_schemaName_PropagatesToConnWrapper(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, dbMock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	dbWrapper, ok := db.db.CommonDB().(*sqlDBWrapper)
+	require.True(t, ok)
+	dbWrapper.schemaName = testSchemaName
+
+	require.NoError(t, db.WithFixedConnection(func(fixedDB *DB) error {
+		assert.Equal(t, testSchemaName, fixedDB.schemaName())
+		connWrapper, ok := fixedDB.db.CommonDB().(*sqlConnWrapper)
+		require.True(t, ok)
+		assert.Equal(t, testSchemaName, connWrapper.getSchemaName())
+		return nil
+	}))
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+func TestDB_schemaName_PropagatesToTxWrapper(t *testing.T) {
+	testoutput.SuppressIfPasses(t)
+
+	db, dbMock := NewDBMock()
+	defer func() { _ = db.Close() }()
+
+	dbWrapper, ok := db.db.CommonDB().(*sqlDBWrapper)
+	require.True(t, ok)
+	dbWrapper.schemaName = testSchemaName
+
+	lockName := someName
+	timeout := 1234 * time.Millisecond
+	expectedTimeout := int(timeout.Round(time.Second).Seconds())
+	expectedLockName := testSchemaName + "/" + lockName
+
+	dbMock.ExpectBegin()
+	dbMock.ExpectQuery("^"+regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")+"$").
+		WithArgs(expectedLockName, expectedTimeout).
+		WillReturnRows(sqlmock.NewRows([]string{"GET_LOCK(?, ?)"}).AddRow(int64(1)))
+	dbMock.ExpectQuery("^" + regexp.QuoteMeta("SELECT RELEASE_LOCK(?)") + "$").
+		WithArgs(expectedLockName).
+		WillReturnRows(sqlmock.NewRows([]string{"RELEASE_LOCK(?)"}).AddRow(int64(1)))
+	dbMock.ExpectCommit()
+
+	err := db.inTransaction(func(txDB *DB) error {
+		assert.Equal(t, testSchemaName, txDB.schemaName())
+		txWrapper, ok := txDB.db.CommonDB().(*sqlTxWrapper)
+		require.True(t, ok)
+		assert.Equal(t, testSchemaName, txWrapper.getSchemaName())
+
+		return txDB.withNamedLock(lockName, timeout, func(inner *DB) error {
+			assert.Equal(t, testSchemaName, inner.schemaName())
+			return nil
+		})
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+}
+
+func Test_namespacedLockName(t *testing.T) {
+	t.Run("empty schema leaves name unchanged", func(t *testing.T) {
+		assert.Equal(t, "results_propagation", namespacedLockName("", "results_propagation"))
+	})
+	t.Run("fits within 64 chars", func(t *testing.T) {
+		assert.Equal(t, "algorea/results_propagation", namespacedLockName("algorea", "results_propagation"))
+	})
+	t.Run("hash fallback when longer than 64", func(t *testing.T) {
+		schema := "very_long_schema_name_that_takes_space"
+		lockName := "also_a_quite_long_lock_name_for_hashing"
+		got := namespacedLockName(schema, lockName)
+		assert.Len(t, got, 64)
+		assert.NotEqual(t, schema+"/"+lockName, got)
+		assert.Equal(t, namespacedLockName(schema, lockName), got)
+		assert.NotEqual(t, namespacedLockName(schema+"x", lockName), got)
+	})
+}
+
+func Test_schemaNameFromSource(t *testing.T) {
+	t.Run("valid DSN", func(t *testing.T) {
+		assert.Equal(t, "algorea", schemaNameFromSource("user:pass@tcp(localhost:3306)/algorea?parseTime=true"))
+	})
+	t.Run("invalid DSN", func(t *testing.T) {
+		assert.Empty(t, schemaNameFromSource("://bad"))
+	})
+	t.Run("sql.DB", func(t *testing.T) {
+		assert.Empty(t, schemaNameFromSource((*sql.DB)(nil)))
+	})
+	t.Run("sql.Tx", func(t *testing.T) {
+		assert.Empty(t, schemaNameFromSource((*sql.Tx)(nil)))
+	})
+	t.Run("unknown type", func(t *testing.T) {
+		assert.Empty(t, schemaNameFromSource(42))
+	})
+}
+
 func TestDB_withNamedLock_ReleasesLockOnError(t *testing.T) {
 	testoutput.SuppressIfPasses(t)
 
@@ -1878,7 +2005,7 @@ func TestDB_withNamedLock_HandlesReleaseError(t *testing.T) {
 			if test.logsShouldContain != "" {
 				assert.Contains(t, logs, test.logsShouldContain)
 			}
-			assert.Contains(t, logs, "failed to release the lock \"some name\", closing the DB connection to release the lock")
+			assert.Contains(t, logs, "failed to release the lock \"some name\" [effective=some name], closing the DB connection to release the lock")
 		})
 	}
 }

--- a/app/database/sql_conn_wrapper.go
+++ b/app/database/sql_conn_wrapper.go
@@ -14,8 +14,9 @@ type sqlConnWrapper struct {
 	conn *sql.Conn
 	//nolint:containedctx // We store the context here because Gorm v1 does not support contexts
 	//                    // as arguments for Exec, Query, and QueryRow methods.
-	ctx       context.Context
-	logConfig *LogConfig
+	ctx        context.Context
+	logConfig  *LogConfig
+	schemaName string
 }
 
 // Exec executes a query without returning any rows.
@@ -174,7 +175,7 @@ func (c *sqlConnWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql
 		logDBError(ctx, err)
 		return nil, err
 	}
-	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, logConfig: c.logConfig}, nil
+	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, logConfig: c.logConfig, schemaName: c.schemaName}, nil
 }
 
 /*
@@ -197,7 +198,7 @@ var _ queryRowWithoutLogging = &sqlConnWrapper{}
 var _ txBeginner = &sqlConnWrapper{}
 
 func (c *sqlConnWrapper) withContext(ctx context.Context) gorm.SQLCommon {
-	return &sqlConnWrapper{conn: c.conn, ctx: ctx, logConfig: c.logConfig}
+	return &sqlConnWrapper{conn: c.conn, ctx: ctx, logConfig: c.logConfig, schemaName: c.schemaName}
 }
 
 var _ withContexter = &sqlConnWrapper{}
@@ -213,6 +214,12 @@ func (c *sqlConnWrapper) getLogConfig() *LogConfig {
 }
 
 var _ logConfigGetter = &sqlConnWrapper{}
+
+func (c *sqlConnWrapper) getSchemaName() string {
+	return c.schemaName
+}
+
+var _ schemaNameGetter = &sqlConnWrapper{}
 
 func (c *sqlConnWrapper) close(err error) error {
 	return sqlConnCloseWithError(c.conn, err)

--- a/app/database/sql_db_wrapper.go
+++ b/app/database/sql_db_wrapper.go
@@ -14,8 +14,9 @@ type sqlDBWrapper struct {
 	sqlDB *sql.DB
 	//nolint:containedctx // We store the context here because Gorm v1 does not support contexts
 	//                    // as arguments for Exec, Query, and QueryRow methods.
-	ctx       context.Context
-	logConfig *LogConfig
+	ctx        context.Context
+	logConfig  *LogConfig
+	schemaName string
 }
 
 // Exec executes a query without returning any rows.
@@ -151,7 +152,7 @@ func (sqlDB *sqlDBWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*s
 		return nil, err
 	}
 	newLogConfig := *sqlDB.logConfig // clone logConfig to avoid changing the original one when setting LogRetryableErrorsAsInfo
-	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, logConfig: &newLogConfig}, nil
+	return &sqlTxWrapper{sqlTx: tx, ctx: ctx, logConfig: &newLogConfig, schemaName: sqlDB.schemaName}, nil
 }
 
 // We intentionally do not implement the 'sqlDb' interface to avoid Gorm from calling 'Begin' method.
@@ -184,7 +185,7 @@ type withContexter interface {
 }
 
 func (sqlDB *sqlDBWrapper) withContext(ctx context.Context) gorm.SQLCommon {
-	return &sqlDBWrapper{sqlDB: sqlDB.sqlDB, ctx: ctx, logConfig: sqlDB.logConfig}
+	return &sqlDBWrapper{sqlDB: sqlDB.sqlDB, ctx: ctx, logConfig: sqlDB.logConfig, schemaName: sqlDB.schemaName}
 }
 
 var _ withContexter = &sqlDBWrapper{}
@@ -209,11 +210,21 @@ func (sqlDB *sqlDBWrapper) getLogConfig() *LogConfig {
 
 var _ logConfigGetter = &sqlDBWrapper{}
 
+type schemaNameGetter interface {
+	getSchemaName() string
+}
+
+func (sqlDB *sqlDBWrapper) getSchemaName() string {
+	return sqlDB.schemaName
+}
+
+var _ schemaNameGetter = &sqlDBWrapper{}
+
 func (sqlDB *sqlDBWrapper) conn(ctx context.Context) (*sqlConnWrapper, error) {
 	conn, err := sqlDB.sqlDB.Conn(ctx)
 	if err != nil {
 		logDBError(sqlDB.ctx, err)
 		return nil, err
 	}
-	return &sqlConnWrapper{conn: conn, ctx: ctx, logConfig: sqlDB.logConfig}, nil
+	return &sqlConnWrapper{conn: conn, ctx: ctx, logConfig: sqlDB.logConfig, schemaName: sqlDB.schemaName}, nil
 }

--- a/app/database/sql_tx_wrapper.go
+++ b/app/database/sql_tx_wrapper.go
@@ -33,8 +33,9 @@ type sqlTxWrapper struct {
 	//                    //
 	//                    // As we normally do not want to have different deadlines for the transaction and the queries,
 	//                    // it doesn't seem to be a good idea to set a new deadline in the sqlTxWrapper.ctx.
-	ctx       context.Context
-	logConfig *LogConfig
+	ctx        context.Context
+	logConfig  *LogConfig
+	schemaName string
 }
 
 // Exec executes a query that doesn't return rows.
@@ -181,7 +182,7 @@ func (sqlTX *sqlTxWrapper) queryRowWithoutLogging(query string, args ...interfac
 var _ queryRowWithoutLogging = &sqlTxWrapper{}
 
 func (sqlTX *sqlTxWrapper) withContext(ctx context.Context) gorm.SQLCommon {
-	return &sqlTxWrapper{sqlTx: sqlTX.sqlTx, ctx: ctx, logConfig: sqlTX.logConfig}
+	return &sqlTxWrapper{sqlTx: sqlTX.sqlTx, ctx: ctx, logConfig: sqlTX.logConfig, schemaName: sqlTX.schemaName}
 }
 
 var _ withContexter = &sqlTxWrapper{}
@@ -197,3 +198,9 @@ func (sqlTX *sqlTxWrapper) getLogConfig() *LogConfig {
 }
 
 var _ logConfigGetter = &sqlTxWrapper{}
+
+func (sqlTX *sqlTxWrapper) getSchemaName() string {
+	return sqlTX.schemaName
+}
+
+var _ schemaNameGetter = &sqlTxWrapper{}


### PR DESCRIPTION
## Summary
- MySQL `GET_LOCK`/`RELEASE_LOCK` names are server-global, so AlgoreaBackend instances on different schemas of the same MySQL server were serializing each other on shared logical names (`results_propagation`, `session_<id>`, etc.).
- Lock names are now namespaced by the connected schema inside `withNamedLock` (single choke point): `schema/lockName`, or a deterministic SHA-256 hex digest when the prefixed name exceeds MySQL’s 64-byte limit.
- Schema is taken from the DSN at open time and stored on the SQL wrappers (same pattern as `logConfig`). Public `WithNamedLock` API is unchanged. Opening from `*sql.DB`/`*sql.Tx` (test helpers) leaves namespacing off.

## Deploy note
During a rolling upgrade, old instances still use bare lock names while new ones use `schema/...`, so they will **not** mutually exclude for the duration of the deploy. Concurrent `results_propagation` in that window is considered tolerable (idempotent / short-lived).

## Test plan
- [x] Unit tests: `./app/database/` (namespaced helpers, `withNamedLock` with schema set, tx-wrapper propagation)
- [x] Lint: `./bin/golangci-lint run --timeout 2m`
- [ ] Smoke: two instances on **different** schemas of the same MySQL can hold the same logical lock concurrently
- [ ] Smoke: two instances on the **same** schema still serialize on `results_propagation`
- [ ] Optional: with DB debug logging, confirm `GET_LOCK(...) [effective=schema/name]` in logs
