### PR TITLE
fix pathological slowness on GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Patch
+
+- fix slow response on `GET /groups/{group_id}/requests`: replace the correlated `MAX(at)` subquery with a group-scoped pre-aggregated join, and add index `group_id_member_id_action_at` on `group_membership_changes`
+
 ## [v2.51.1](https://github.com/France-ioi/AlgoreaBackend/compare/v2.51.0...v2.51.1) - 2026-07-16
 
 - fix MySQL named locks colliding across schemas on the same server: lock names used by `WithNamedLock` are now namespaced by the connected schema (during a rolling deploy, old and new instances briefly use different lock names and will not mutually exclude; concurrent propagation in that window is considered tolerable)

--- a/app/api/groups/get_requests.feature
+++ b/app/api/groups/get_requests.feature
@@ -382,3 +382,79 @@ Feature: Get requests for group_id
       }
     ]
     """
+
+  Scenario: Only the latest invitation_created is returned when a member was re-invited
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id |
+      | 16 |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_manage  |
+      | 16       | 21         | memberships |
+    And the database has the following table "group_pending_requests":
+      | group_id | member_id | type       | at                  |
+      | 16       | 51        | invitation | 2019-05-30 12:00:00 |
+    And the database has the following table "group_membership_changes":
+      | group_id | member_id | action             | at                  | initiator_id |
+      | 16       | 51        | invitation_created | 2019-05-28 06:00:00 | 21           |
+      | 16       | 51        | invitation_refused | 2019-05-29 06:00:00 | null         |
+      | 16       | 51        | invitation_created | 2019-05-30 12:00:00 | 21           |
+    When I send a GET request to "/groups/16/requests"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "member_id": "51",
+        "inviting_user": {"first_name": "Jean-Michel", "group_id": "21", "last_name": "Blanquer", "login": "owner"},
+        "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
+        "at": "2019-05-30T12:00:00Z",
+        "action": "invitation_created"
+      },
+      {
+        "member_id": "51",
+        "inviting_user": null,
+        "joining_user": {"grade": 2, "group_id": "51", "login": "larry"},
+        "at": "2019-05-29T06:00:00Z",
+        "action": "invitation_refused"
+      }
+    ]
+    """
+
+  Scenario: Only the latest join_request_created is returned when a member re-requested
+    Given I am the user with id "21"
+    And the database has the following table "groups":
+      | id |
+      | 16 |
+    And the database has the following table "group_managers":
+      | group_id | manager_id | can_manage  |
+      | 16       | 21         | memberships |
+    And the database has the following table "group_pending_requests":
+      | group_id | member_id | type         | at                  | personal_info_view_approved |
+      | 16       | 31        | join_request | 2019-05-30 12:00:00 | true                        |
+    And the database has the following table "group_membership_changes":
+      | group_id | member_id | action               | at                  | initiator_id |
+      | 16       | 31        | join_request_created | 2019-05-28 06:00:00 | 31           |
+      | 16       | 31        | join_request_refused | 2019-05-29 06:00:00 | 21           |
+      | 16       | 31        | join_request_created | 2019-05-30 12:00:00 | 31           |
+    When I send a GET request to "/groups/16/requests"
+    Then the response code should be 200
+    And the response body should be, in JSON:
+    """
+    [
+      {
+        "member_id": "31",
+        "inviting_user": null,
+        "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
+        "at": "2019-05-30T12:00:00Z",
+        "action": "join_request_created"
+      },
+      {
+        "member_id": "31",
+        "inviting_user": null,
+        "joining_user": {"first_name": "Jane", "grade": 2, "group_id": "31", "last_name": "Doe", "login": "jane"},
+        "at": "2019-05-29T06:00:00Z",
+        "action": "join_request_refused"
+      }
+    ]
+    """

--- a/app/api/groups/get_requests.go
+++ b/app/api/groups/get_requests.go
@@ -145,7 +145,15 @@ func (srv *Service) getRequests(responseWriter http.ResponseWriter, httpRequest 
 
 	service.MustNotBeError(checkThatUserCanManageTheGroupMemberships(store, user, groupID))
 
+	// Pre-aggregate latest invitation/join-request creation times for this group so the
+	// pending-request join is a hash/index match instead of a correlated MAX(at) per row.
 	query := store.GroupMembershipChanges().
+		With("latest_created_membership_changes",
+			store.GroupMembershipChanges().
+				Select("member_id, action, MAX(at) AS at").
+				Where("group_id = ?", groupID).
+				Where("action IN ('invitation_created', 'join_request_created')").
+				Group("member_id, action")).
 		Select(`
 			group_membership_changes.member_id,
 			group_membership_changes.at,
@@ -164,16 +172,19 @@ func (srv *Service) getRequests(responseWriter http.ResponseWriter, httpRequest 
 			LEFT JOIN users AS inviting_user
 				ON inviting_user.group_id = initiator_id AND group_membership_changes.action = 'invitation_created'`).
 		Joins(`JOIN users AS joining_user ON joining_user.group_id = member_id`).
+		// CTE is already scoped to {group_id}, so omitting group_id from the join ON is intentional.
+		Joins(`
+			LEFT JOIN latest_created_membership_changes
+				ON latest_created_membership_changes.member_id = group_membership_changes.member_id AND
+					latest_created_membership_changes.action = group_membership_changes.action AND
+					latest_created_membership_changes.at = group_membership_changes.at`).
 		Joins(`
 			LEFT JOIN group_pending_requests
 				ON group_pending_requests.group_id = group_membership_changes.group_id AND
 					group_pending_requests.member_id = group_membership_changes.member_id AND
 					IF(group_pending_requests.type = 'invitation', 'invitation_created', 'join_request_created') =
 						group_membership_changes.action AND
-					(SELECT MAX(latest_change.at) FROM group_membership_changes AS latest_change
-					 WHERE latest_change.group_id = group_pending_requests.group_id AND
-						latest_change.member_id = group_pending_requests.member_id AND
-						latest_change.action = group_membership_changes.action) = group_membership_changes.at`).
+					latest_created_membership_changes.member_id IS NOT NULL`).
 		Where("group_membership_changes.action IN ('join_request_refused', 'invitation_refused') OR group_pending_requests.group_id IS NOT NULL").
 		Where("group_membership_changes.action IN ('invitation_created', 'join_request_created', 'invitation_refused', 'join_request_refused')").
 		Where("group_membership_changes.group_id = ?", groupID)

--- a/db/migrations/2607231341_add_index_on_group_membership_changes_group_member_action_at.sql
+++ b/db/migrations/2607231341_add_index_on_group_membership_changes_group_member_action_at.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE `group_membership_changes`
+  ADD INDEX `group_id_member_id_action_at` (`group_id`,`member_id`,`action`,`at`);
+
+-- +goose Down
+ALTER TABLE `group_membership_changes`
+  DROP INDEX `group_id_member_id_action_at`;


### PR DESCRIPTION
## Summary
- Fix pathological slowness on `GET /groups/{group_id}/requests` caused by a per-row correlated `MAX(at)` subquery over `group_membership_changes` with no supporting index on `action`.
- Replace that subquery with a group-scoped CTE that pre-aggregates latest `invitation_created` / `join_request_created` events, then joins them so a pending request is only associated with the latest created event (same semantics as before; refused rows still flow through the existing `LEFT JOIN` + `WHERE`).
- Add index `group_id_member_id_action_at` on `group_membership_changes (group_id, member_id, action, at)` so the CTE/`MAX(at)` path is index-friendly.

## Test plan
- [ ] Apply migration `2607231341_add_index_on_group_membership_changes_group_member_action_at` and confirm index exists
- [ ] `get_requests.feature` / `get_requests.robustness.feature` pass (incl. new re-invite / re-join-request scenarios)
- [ ] On an environment with the pathological data (viewer `670968966872011405`, group `4433009959583369709`), run `EXPLAIN ANALYZE` and confirm the query is sub-second
- [ ] Smoke `GET /groups/{group_id}/requests` for a group with pending invites and recent refusals after deploy